### PR TITLE
Move SslErrorDialog into Application

### DIFF
--- a/src/mirall/application.h
+++ b/src/mirall/application.h
@@ -18,6 +18,7 @@
 #include <QApplication>
 #include <QSystemTrayIcon>
 #include <QNetworkReply>
+#include <QSslError>
 
 #include "qtsingleapplication.h"
 
@@ -40,6 +41,7 @@ class FolderWizard;
 class StatusDialog;
 class OwncloudSetupWizard;
 class ownCloudInfo;
+class SslErrorDialog;
 class UpdateDetector;
 
 class Application : public SharedTools::QtSingleApplication
@@ -84,6 +86,7 @@ protected slots:
     void slotCheckAuthentication();
     void slotAuthCheck( const QString& ,QNetworkReply* );
     void slotOpenLogBrowser();
+    void slotSSLFailed( QNetworkReply *reply, QList<QSslError> errors );
 
     void slotStartUpdateDetector();
 
@@ -105,6 +108,7 @@ private:
 
     FolderWizard  *_folderWizard;
     OwncloudSetupWizard *_owncloudSetupWizard;
+    SslErrorDialog *_sslErrorDialog;
 
     // tray's menu
     QMenu *_contextMenu;

--- a/src/mirall/owncloudinfo.cpp
+++ b/src/mirall/owncloudinfo.cpp
@@ -47,7 +47,7 @@ ownCloudInfo* ownCloudInfo::instance()
 }
 
 ownCloudInfo::ownCloudInfo( const QString& connectionName, QObject *parent ) :
-    QObject(parent), _sslErrorDialog(0)
+    QObject(parent)
 {
     if( connectionName.isEmpty() )
         _connection = QLatin1String( "ownCloud");
@@ -62,7 +62,7 @@ ownCloudInfo::ownCloudInfo( const QString& connectionName, QObject *parent ) :
     QSslSocket::addDefaultCaCertificates(QSslCertificate::fromData(certs));
 
     connect( _manager, SIGNAL( sslErrors(QNetworkReply*, QList<QSslError>)),
-             this, SLOT(slotSSLFailed(QNetworkReply*, QList<QSslError>)) );
+             this, SIGNAL(sslFailed(QNetworkReply*, QList<QSslError>)) );
 
     connect( _manager, SIGNAL(authenticationRequired(QNetworkReply*, QAuthenticator*)),
              this, SLOT(slotAuthentication(QNetworkReply*,QAuthenticator*)));
@@ -72,7 +72,6 @@ ownCloudInfo::ownCloudInfo( const QString& connectionName, QObject *parent ) :
 
 ownCloudInfo::~ownCloudInfo()
 {
-    delete _sslErrorDialog;
 }
 
 void ownCloudInfo::setCustomConfigHandle( const QString& handle )
@@ -255,52 +254,14 @@ void ownCloudInfo::slotAuthentication( QNetworkReply *reply, QAuthenticator *aut
 
 }
 
-void ownCloudInfo::slotSSLFailed( QNetworkReply *reply, QList<QSslError> errors )
+QString ownCloudInfo::configHandle(QNetworkReply *reply)
 {
-    qDebug() << "SSL-Warnings happened for url " << reply->url().toString();
-
     QString configHandle;
-
-    // an empty config handle is ok for the default config.
     if( _configHandleMap.contains(reply) ) {
         configHandle = _configHandleMap[reply];
-        qDebug() << "SSL: Have a custom config handle: " << configHandle;
     }
-    if( !configHandle.isEmpty() ) {
-        qDebug() << "Custom config handle: " << configHandle;
-    }
-
-    if( _certsUntrusted ) {
-        // User decided once to untrust. Honor this decision.
-        qDebug() << "Untrusted by user decision, returning.";
-        return;
-    }
-
-    if( _sslErrorDialog == 0 ) {
-        _sslErrorDialog = new SslErrorDialog;
-    }
-
-    // make the ssl dialog aware of the custom config. It loads known certs.
-    _sslErrorDialog->setCustomConfigHandle( configHandle );
-
-    if( _sslErrorDialog->setErrorList( errors ) ) {
-        // all ssl certs are known and accepted. We can ignore the problems right away.
-        qDebug() << "Certs are already known and trusted, Warnings are not valid.";
-        reply->ignoreSslErrors();
-    } else {
-        if( _sslErrorDialog->exec() == QDialog::Accepted ) {
-            if( _sslErrorDialog->trustConnection() ) {
-                reply->ignoreSslErrors();
-            } else {
-                // User does not want to trust.
-                _certsUntrusted = true;
-            }
-        } else {
-            _certsUntrusted = true;
-        }
-    }
+    return configHandle;
 }
-
 
 QUrl ownCloudInfo::redirectUrl(const QUrl& possibleRedirectUrl,
                                const QUrl& oldRedirectUrl) const {
@@ -444,6 +405,16 @@ void ownCloudInfo::slotReplyFinished()
 void ownCloudInfo::resetSSLUntrust()
 {
     _certsUntrusted = false;
+}
+
+void ownCloudInfo::setCertsUntrusted(bool donttrust)
+{
+    _certsUntrusted = donttrust;
+}
+
+bool ownCloudInfo::certsUntrusted()
+{
+    return _certsUntrusted;
 }
 
 void ownCloudInfo::slotError( QNetworkReply::NetworkError err)

--- a/src/mirall/owncloudinfo.h
+++ b/src/mirall/owncloudinfo.h
@@ -27,8 +27,6 @@
 namespace Mirall
 {
 
-class SslErrorDialog;
-
 class ownCloudInfo : public QObject
 {
     Q_OBJECT
@@ -61,6 +59,16 @@ public:
     void resetSSLUntrust();
 
     /**
+      * Set wether or not to trust errorneus SSL certificates
+      */
+    void setCertsUntrusted(bool donttrust);
+
+    /**
+      * Do we trust the certificate?.
+      */
+    bool certsUntrusted();
+
+    /**
       * Create a collection via owncloud. Provide a relative path.
       */
     void mkdirRequest( const QString& );
@@ -70,6 +78,11 @@ public:
      */
     void setCustomConfigHandle( const QString& );
 
+    /**
+     * Accessor to the config handle.
+     */
+    QString configHandle(QNetworkReply *reply = 0);
+
 signals:
     // result signal with url- and version string.
     void ownCloudInfoFound( const QString&, const QString&, const QString&, const QString& );
@@ -77,6 +90,7 @@ signals:
     void ownCloudDirExists( const QString&, QNetworkReply* );
 
     void webdavColCreated( QNetworkReply::NetworkError );
+    void sslFailed( QNetworkReply *reply, QList<QSslError> errors );
 
 public slots:
 
@@ -84,7 +98,6 @@ protected slots:
     void slotReplyFinished( );
     void slotError( QNetworkReply::NetworkError );
     void slotAuthentication( QNetworkReply*, QAuthenticator *);
-    void slotSSLFailed( QNetworkReply *reply, QList<QSslError> errors );
 
 #if QT46_IMPL
     void qhttpRequestFinished(int id, bool success );
@@ -116,7 +129,6 @@ private:
     QUrl                           _urlRedirectedTo;
     QHash<QNetworkReply*, QString> _directories;
     QHash<QNetworkReply*, QString> _configHandleMap;
-    SslErrorDialog                *_sslErrorDialog;
     bool                           _certsUntrusted;
     int                            _authAttempts;
 };


### PR DESCRIPTION
This patch makes it possible to cut out a large piece from the lib. We
want to avoid having GUI code in the daemon. For Mirall, this is now
handled in Application. for other clients, they can do whatever they
want with this signal, and implement their own SSL Error handling.

The patch isn't exactly a beauty queen, since it involves some
back-and-forth between application and owncloudinfo objects, but it
seems the only way to properly separate and abstract the UI out of
owncloudinfo, and cuts down a huge part of the dependency chain,
especially QWidget-based classes.

I haven't been able to properly test this, but if anyone can give me a
login to a server that has wrong or untrusted SSL certificates, I'll
happily do it.

Merge? _puppy eyes_
