### PR TITLE
Add setter for remotePollInterval

### DIFF
--- a/src/mirall/mirallconfigfile.cpp
+++ b/src/mirall/mirallconfigfile.cpp
@@ -255,6 +255,18 @@ QString MirallConfigFile::ownCloudUser( const QString& connection ) const
     return user;
 }
 
+void MirallConfigFile::setRemotePollIntval(int interval, const QString &connection )
+{
+    QString con( connection );
+    if( connection.isEmpty() ) con = defaultConnection();
+
+    QSettings settings( configFile(), QSettings::IniFormat );
+    settings.setIniCodec( "UTF-8" );
+    settings.beginGroup( con );
+    settings.setValue("remotePollInterval", interval );
+    settings.sync();
+}
+
 int MirallConfigFile::remotePollInterval( const QString& connection ) const
 {
   QString con( connection );

--- a/src/mirall/mirallconfigfile.h
+++ b/src/mirall/mirallconfigfile.h
@@ -76,6 +76,7 @@ public:
 
     /* Poll intervals in milliseconds */
     int localPollInterval ( const QString& connection = QString() ) const;
+    void setRemotePollIntval(int interval, const QString& connection = QString() );
     int remotePollInterval( const QString& connection = QString() ) const;
     int pollTimerExceedFactor( const QString& connection = QString() ) const;
 


### PR DESCRIPTION
With this patch, the client app gets some control over the synching
policy. Without it the remote polling interval is hardcoded to 30
seconds, which is undesirable in certain situations, for example on
battery, or mobile connections.
