### PR TITLE
Return QNetworkReply from getRequests

### DIFF
--- a/src/mirall/owncloudinfo.cpp
+++ b/src/mirall/owncloudinfo.cpp
@@ -93,12 +93,12 @@ void ownCloudInfo::checkInstallation()
     getRequest( QLatin1String("status.php"), false );
 }
 
-void ownCloudInfo::getWebDAVPath( const QString& path )
+QNetworkReply* ownCloudInfo::getWebDAVPath( const QString& path )
 {
-    getRequest( path, true );
+    return getRequest( path, true );
 }
 
-void ownCloudInfo::getRequest( const QString& path, bool webdav )
+QNetworkReply* ownCloudInfo::getRequest( const QString& path, bool webdav )
 {
     qDebug() << "Get Request to " << path;
 
@@ -119,6 +119,7 @@ void ownCloudInfo::getRequest( const QString& path, bool webdav )
 
     connect( reply, SIGNAL( error(QNetworkReply::NetworkError )),
              this, SLOT(slotError( QNetworkReply::NetworkError )));
+    return reply;
 }
 
 #if QT46_IMPL

--- a/src/mirall/owncloudinfo.h
+++ b/src/mirall/owncloudinfo.h
@@ -47,12 +47,12 @@ public:
       * a general GET request to the ownCloud. If the second bool parameter is
       * true, the WebDAV server is queried.
       */
-    void getRequest( const QString&, bool );
+    QNetworkReply* getRequest( const QString&, bool );
 
     /**
       * convenience: GET request to the WebDAV server.
       */
-    void getWebDAVPath( const QString& );
+    QNetworkReply* getWebDAVPath( const QString& );
 
     /**
       * There is a global flag here if the user once decided against trusting the


### PR DESCRIPTION
This patch allows the client implementation to react to specific
getRequests, such as folder checks, etc. It allows to connect
client-specific slots to requests, catch its errors and handle them
separately.

I need this patch to be able to check more than one remote folder on the
server, and not mix up their job's signal handling.
