### PR TITLE
Return QNetworkReply from remote mkdir

### DIFF
--- a/src/mirall/owncloudinfo.cpp
+++ b/src/mirall/owncloudinfo.cpp
@@ -185,7 +185,7 @@ void ownCloudInfo::qhttpRequestFinished(int id, bool success )
      }
 }
 #else
-void ownCloudInfo::mkdirRequest( const QString& dir )
+QNetworkReply* ownCloudInfo::mkdirRequest( const QString& dir )
 {
     qDebug() << "OCInfo Making dir " << dir;
     _authAttempts = 0;
@@ -206,6 +206,7 @@ void ownCloudInfo::mkdirRequest( const QString& dir )
     connect( reply, SIGNAL(finished()), SLOT(slotMkdirFinished()) );
     connect( reply, SIGNAL( error(QNetworkReply::NetworkError )),
              this, SLOT(slotError(QNetworkReply::NetworkError )));
+    return reply;
 }
 
 void ownCloudInfo::slotMkdirFinished()

--- a/src/mirall/owncloudinfo.h
+++ b/src/mirall/owncloudinfo.h
@@ -63,7 +63,11 @@ public:
     /**
       * Create a collection via owncloud. Provide a relative path.
       */
+#if QT46_IMPL
     void mkdirRequest( const QString& );
+#else
+    QNetworkReply* mkdirRequest( const QString& );
+#endif
 
     /**
      * Use a custom ownCloud configuration file identified by handle


### PR DESCRIPTION
This patch allows the client implementation to react to specific results
of mkdir requests

I need this patch to be able to catch errors from creating remote
folders.
