### PR TITLE
Owncloud client status dialog Pause/Resume buttons etc. remain disabled.

### DIFF
--- a/src/mirall/statusdialog.cpp
+++ b/src/mirall/statusdialog.cpp
@@ -198,7 +198,7 @@ StatusDialog::StatusDialog( Theme *theme, QWidget *parent) :
   _ButtonAdd->setEnabled(true);
 
 #if defined Q_WS_X11 
-  connect(_folderList, SIGNAL(activated(QModelIndex)), SLOT(slotFolderActivated(QModelIndex)));
+  connect(_folderList, SIGNAL(clicked(QModelIndex)), SLOT(slotFolderActivated(QModelIndex)));
   connect( _folderList,SIGNAL(doubleClicked(QModelIndex)),SLOT(slotDoubleClicked(QModelIndex)));
 #endif
 #if defined Q_WS_WIN || defined Q_WS_MAC


### PR DESCRIPTION
QListView::activated() is currently used by the status dialog to determine which folder is selected (thereby also the state of the Pause/Resume button etc.). According to the docs, "how to activate items depends on the platform; e.g., by single- or double-clicking the item, or by pressing the Return or Enter key when the item is current." On Ubuntu 12.04 64-bit with Qt 4.8.1, left-clicking does not activate items, leaving the buttons disabled. Using QListView::clicked() instead of QListView::activated() fixes this issue, and makes the buttons change state as intended.
