### PR TITLE
Allow setting the configuration directory on command line

### DIFF
--- a/src/mirall/application.cpp
+++ b/src/mirall/application.cpp
@@ -63,10 +63,6 @@ void mirallLogCatcher(QtMsgType type, const char *msg)
 
 // ----------------------------------------------------------------------------------
 
-Application *Application::getInstance() {
-    return dynamic_cast<Application*>(qApp);
-}
-
 Application::Application(int &argc, char **argv) :
     SharedTools::QtSingleApplication(argc, argv),
     _tray(0),
@@ -78,7 +74,6 @@ Application::Application(int &argc, char **argv) :
     _theme(Theme::instance()),
     _updateDetector(0),
     _logBrowser(0),
-    _dataLocation(QDesktopServices::storageLocation(QDesktopServices::DataLocation)),
     _showLogWindow(false),
     _logFlush(false),
     _helpOnly(false)
@@ -184,11 +179,6 @@ Application::~Application()
 {
     delete _tray; // needed, see ctor
     qDebug() << "* Mirall shutdown";
-}
-
-const QString &Application::getDataLocation() const
-{
-    return _dataLocation;
 }
 
 void Application::slotStartUpdateDetector()
@@ -960,7 +950,7 @@ void Application::parseOptions(const QStringList &options)
             _theme->setSystrayUseMonoIcons(true); 
         } else if (option == QLatin1String("--confdir")) {
             if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                _dataLocation=it.next();
+                MirallConfigFile::setConfDir(it.next());
             } else {
                 showHelp();
             }

--- a/src/mirall/application.h
+++ b/src/mirall/application.h
@@ -53,10 +53,6 @@ public:
 
     bool giveHelp();
 
-    static Application *getInstance();
-
-    const QString &getDataLocation() const;
-
 signals:
 
 protected slots:
@@ -132,7 +128,6 @@ private:
     QMap<QString, QString> _overallStatusStrings;
     LogBrowser *_logBrowser;
     QString _logFile;
-    QString _dataLocation;
     bool _showLogWindow;
     bool _logFlush;
     bool _helpOnly;

--- a/src/mirall/folderman.cpp
+++ b/src/mirall/folderman.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #include <QtCore>
-#include "application.h"
 
 namespace Mirall {
 
@@ -38,9 +37,10 @@ FolderMan::FolderMan(QObject *parent) :
 {
     // if QDir::mkpath would not be so stupid, I would not need to have this
     // duplication of folderConfigPath() here
-    QDir storageDir(Application::getInstance()->getDataLocation());
+    MirallConfigFile cfg;
+    QDir storageDir(cfg.configPath());
     storageDir.mkpath(QLatin1String("folders"));
-    _folderConfigPath = Application::getInstance()->getDataLocation() + QLatin1String("/folders");
+    _folderConfigPath = cfg.configPath() + QLatin1String("folders");
 
     _folderChangeSignalMapper = new QSignalMapper(this);
     connect(_folderChangeSignalMapper, SIGNAL(mapped(const QString &)),

--- a/src/mirall/mirallconfigfile.cpp
+++ b/src/mirall/mirallconfigfile.cpp
@@ -18,7 +18,6 @@
 #include "mirall/owncloudtheme.h"
 #include "mirall/miralltheme.h"
 #include "mirall/credentialstore.h"
-#include "mirall/application.h"
 
 #include <QtCore>
 #include <QtGui>
@@ -32,6 +31,7 @@
 namespace Mirall {
 
 QString MirallConfigFile::_oCVersion;
+QString MirallConfigFile::_confDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 bool    MirallConfigFile::_askedUser = false;
 
 MirallConfigFile::MirallConfigFile( const QString& appendix )
@@ -39,9 +39,14 @@ MirallConfigFile::MirallConfigFile( const QString& appendix )
 {
 }
 
+void MirallConfigFile::setConfDir(const QString &value)
+{
+  _confDir=value;
+}
+
 QString MirallConfigFile::configPath() const
 {
-    QString dir = Application::getInstance()->getDataLocation();
+    QString dir = _confDir;
     if( !dir.endsWith(QLatin1Char('/')) ) dir.append(QLatin1Char('/'));
     return dir;
 }

--- a/src/mirall/mirallconfigfile.h
+++ b/src/mirall/mirallconfigfile.h
@@ -97,6 +97,8 @@ public:
     int proxyPort() const;
     QString proxyUser() const;
     QString proxyPassword() const;
+    
+    static void setConfDir(const QString &value);
 
 protected:
     // these classes can only be access from CredentialStore as a friend class.
@@ -112,6 +114,7 @@ private:
 private:
     static bool    _askedUser;
     static QString _oCVersion;
+    static QString _confDir;
     QString        _customHandle;
 
 };


### PR DESCRIPTION
This allows a workaround for issue https://github.com/owncloud/mirall/issues/166

Running multiple instances of the owncloud client with different configuration directories allows to connect to multiple servers without the client having to directly support it.
So it's a workaround and a quick solution for those like me that need to connect to multiple servers.

I implemented it and ran the client but unfortunatelly I couldn't test the functionality, because the git HEAD version aborts wth a segfault on my computer (also without my changes).
So I ask you to test it before accepting the pull request. I think it should work for I didn't change much.
