### PR TITLE
API additions for the Plasma client

### DIFF
--- a/src/mirall/mirallconfigfile.cpp
+++ b/src/mirall/mirallconfigfile.cpp
@@ -297,6 +297,18 @@ QString MirallConfigFile::ownCloudUser( const QString& connection ) const
     return user;
 }
 
+void MirallConfigFile::setRemotePollInterval(int interval, const QString &connection )
+{
+    QString con( connection );
+    if( connection.isEmpty() ) con = defaultConnection();
+
+    QSettings settings( configFile(), QSettings::IniFormat );
+    settings.setIniCodec( "UTF-8" );
+    settings.beginGroup( con );
+    settings.setValue("remotePollInterval", interval );
+    settings.sync();
+}
+
 int MirallConfigFile::remotePollInterval( const QString& connection ) const
 {
   QString con( connection );

--- a/src/mirall/mirallconfigfile.h
+++ b/src/mirall/mirallconfigfile.h
@@ -75,6 +75,7 @@ public:
 
     /* Server poll interval in milliseconds */
     int remotePollInterval( const QString& connection = QString() ) const;
+    void setRemotePollInterval(int interval, const QString& connection = QString() );
 
     // Custom Config: accept the custom config to become the main one.
     void acceptCustomConfig();

--- a/src/mirall/owncloudinfo.h
+++ b/src/mirall/owncloudinfo.h
@@ -45,12 +45,12 @@ public:
       * a general GET request to the ownCloud. If the second bool parameter is
       * true, the WebDAV server is queried.
       */
-    void getRequest( const QString&, bool );
+    QNetworkReply* getRequest( const QString&, bool );
 
     /**
       * convenience: GET request to the WebDAV server.
       */
-    void getWebDAVPath( const QString& );
+    QNetworkReply* getWebDAVPath( const QString& );
 
     /**
       * There is a global flag here if the user once decided against trusting the
@@ -69,9 +69,17 @@ public:
     bool certsUntrusted();
 
     /**
+     * Set a NetworkAccessManager to be used
+     *
+     * This method will take ownership of the NetworkAccessManager, so you can just
+     * set it initially and forget about its memory management.
+     */
+    void setNetworkAccessManager( QNetworkAccessManager *qnam );
+
+    /**
       * Create a collection via owncloud. Provide a relative path.
       */
-    void mkdirRequest( const QString& );
+    QNetworkReply* mkdirRequest( const QString& );
 
     /**
      * Use a custom ownCloud configuration file identified by handle


### PR DESCRIPTION
This patch contains a few (source-compatible) API additions needed for
the Plasma client.
- return QNetworkReply\* to caller for tracking status and error of
  requests such as mkdir, getWebDAVPath and getRequest
- Add a setter for the QNetworkAccessManager. This allows us to route at
  least some of the network requests through KIO in the Plasma client
- Add a setter for the remotePollInterval. This should be enough API to
- make it possible to adapt the polling interval to the client's machine
  state, e.g. sync less often on battery, or somesuch
