### PR TITLE
Improve command line argument handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,10 @@ int main(int argc, char **argv)
         return 0;
     }
     // if help requested, show on command line and exit.
-    if( ! app.giveHelp() )
+    if( ! app.giveHelp() ) {
         return app.exec();
-
+    } else {
+        app.showHelp();
+    }
 }
 

--- a/src/mirall/application.cpp
+++ b/src/mirall/application.cpp
@@ -185,7 +185,7 @@ Application::~Application()
 {
     delete _tray; // needed, see ctor
     if( _fileItemDialog) delete _fileItemDialog;
-    if( _statusDialog )  delete _statusDialog;
+    if( _statusDialog && ! _helpOnly)  delete _statusDialog;
     qDebug() << "* Mirall shutdown";
 }
 
@@ -880,10 +880,12 @@ void Application::parseOptions(const QStringList &options)
     // skip file name;
     if (it.hasNext()) it.next();
 
+    //parse options; if help or bad option exit
     while (it.hasNext()) {
         QString option = it.next();
-        if (option == QLatin1String("--help")) {
-            showHelp();
+       	if (option == QLatin1String("--help") || option == QLatin1String("-h")) {
+            setHelp();
+            break;
         } else if (option == QLatin1String("--logwindow") ||
                 option == QLatin1String("-l")) {
             _showLogWindow = true;
@@ -891,13 +893,17 @@ void Application::parseOptions(const QStringList &options)
             if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
                 _logFile = it.next();
             } else {
-                showHelp();
+                setHelp();
             }
         } else if (option == QLatin1String("--logflush")) {
             _logFlush = true;
         } else if (option == QLatin1String("--monoicons")) {
             _theme->setSystrayUseMonoIcons(true); 
-        }
+	} else {
+	    setHelp();
+	    std::cout << "Option not recognized:  " << option.toStdString() << std::endl;
+	    break;
+	}
     }
 }
 
@@ -985,10 +991,12 @@ void Application::computeOverallSyncStatus()
 
 void Application::showHelp()
 {
+setHelp();
     std::cout << _theme->appName().toLatin1().constData() << " version " <<
                  _theme->version().toLatin1().constData() << std::endl << std::endl;
     std::cout << "File synchronisation desktop utility." << std::endl << std::endl;
     std::cout << "Options:" << std::endl;
+    std::cout << "  -h --help            : show this help screen." << std::endl;
     std::cout << "  --logwindow          : open a window to show log output." << std::endl;
     std::cout << "  --logfile <filename> : write log output to file <filename>." << std::endl;
     std::cout << "  --logflush           : flush the log file after every write." << std::endl;
@@ -996,6 +1004,10 @@ void Application::showHelp()
     std::cout << std::endl;
     if (_theme->appName() == QLatin1String("ownCloud"))
         std::cout << "For more information, see http://www.owncloud.org" << std::endl;
+}
+
+void Application::setHelp()
+{
     _helpOnly = true;
 }
 

--- a/src/mirall/application.h
+++ b/src/mirall/application.h
@@ -53,6 +53,7 @@ public:
     ~Application();
 
     bool giveHelp();
+    void showHelp();
 
 signals:
 
@@ -98,7 +99,7 @@ protected slots:
     void slotStartUpdateDetector();
 
 private:
-    void showHelp();
+    void setHelp();
     void raiseDialog( QWidget* );
 
     // configuration file -> folder


### PR DESCRIPTION
Fix a segmentation fault with Owncloud --help. 
Changes to handling of command line options to be better: Add -h as help short. If a command line argument isn't recognized, print that it isn't recognized, print help, and abort.
