### PR TITLE
creating doc to default target

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,13 +14,9 @@ if(SPHINX_FOUND)
 
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in" conf.py @ONLY)
 
-    if(CREATEDOC)
-	    add_custom_target(doc ALL DEPENDS doc-html doc-man COMMENT "Building documentation...")
-	    install(DIRECTORY ${SPHINX_HTML_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-	    install(DIRECTORY ${SPHINX_MAN_DIR} DESTINATION ${CMAKE_INSTALL_MANDIR})
-    else()
-	    add_custom_target(doc DEPENDS doc-html doc-man COMMENT "Building documentation...")
-    endif()
+    add_custom_target(doc ALL DEPENDS doc-html doc-man COMMENT "Building documentation...")
+    install(DIRECTORY ${SPHINX_HTML_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+    install(DIRECTORY ${SPHINX_MAN_DIR} DESTINATION ${CMAKE_INSTALL_MANDIR})
 
     if(PDFLATEX_FOUND)
         # if this still fails on Debian/Ubuntu, run
@@ -34,9 +30,7 @@ if(SPHINX_FOUND)
         add_custom_target(doc-pdf make -C ${SPHINX_PDF_DIR} all-pdf
 		                  DEPENDS doc-latex )
         add_dependencies(doc doc-pdf)
-	if(CREATEDOC)
-		install(DIRECTORY ${SPHINX_PDF_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-	endif()
+	install(DIRECTORY ${SPHINX_PDF_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
     endif(PDFLATEX_FOUND)
     if (EXISTS ${QT_QCOLLECTIONGENERATOR_EXECUTABLE})
         add_custom_target( doc-qch-sphinx ${SPHINX_EXECUTABLE}
@@ -48,9 +42,7 @@ if(SPHINX_FOUND)
 		                   ${SPHINX_QCH_DIR}/*.qhcp
 				   DEPENDS doc-qch-sphinx )
         add_dependencies(doc doc-qch)
-	if(CREATEDOC)
-		install(DIRECTORY ${SPHINX_QCH_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-	endif()
+	install(DIRECTORY ${SPHINX_QCH_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
     endif()
     add_custom_target( doc-html ${SPHINX_EXECUTABLE}
 	                        -q -c . -b html


### PR DESCRIPTION
For creating debian pacakges it is necessary, that the documentation is created with the default target.

Closes: Issue #183 "oc-623 - [desktop client] no man page"
