### PR TITLE
adding WITH_DOC parameter to cmake

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,11 +14,13 @@ if(SPHINX_FOUND)
 
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in" conf.py @ONLY)
 
-    add_custom_target(doc DEPENDS doc-html doc-man COMMENT "Building documentation...")
-    if (UNIX AND (NOT APPLE))
-        install(DIRECTORY ${SPHINX_HTML_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-        install(DIRECTORY ${SPHINX_MAN_DIR} DESTINATION ${CMAKE_INSTALL_MANDIR})
-    endif (UNIX AND (NOT APPLE))
+    if(WITH_DOC)
+       add_custom_target(doc ALL DEPENDS doc-html doc-man COMMENT "Building documentation...")
+       install(DIRECTORY ${SPHINX_HTML_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+       install(DIRECTORY ${SPHINX_MAN_DIR} DESTINATION ${CMAKE_INSTALL_MANDIR})
+    else(WITH_DOC)
+       add_custom_target(doc DEPENDS doc-html doc-man COMMENT "Building documentation...")
+    endif(WITH_DOC)
 
     if(PDFLATEX_FOUND)
         # if this still fails on Debian/Ubuntu, run
@@ -32,9 +34,9 @@ if(SPHINX_FOUND)
         add_custom_target(doc-pdf make -C ${SPHINX_PDF_DIR} all-pdf
 		                  DEPENDS doc-latex )
         add_dependencies(doc doc-pdf)
-        if (UNIX AND (NOT APPLE))
-	    install(DIRECTORY ${SPHINX_PDF_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-        endif (UNIX AND (NOT APPLE))
+        if (WITH_DOC)
+           install(DIRECTORY ${SPHINX_PDF_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+        endif (WITH_DOC)
     endif(PDFLATEX_FOUND)
     if (EXISTS ${QT_QCOLLECTIONGENERATOR_EXECUTABLE})
         add_custom_target( doc-qch-sphinx ${SPHINX_EXECUTABLE}
@@ -46,9 +48,9 @@ if(SPHINX_FOUND)
 		                   ${SPHINX_QCH_DIR}/*.qhcp
 				   DEPENDS doc-qch-sphinx )
         add_dependencies(doc doc-qch)
-        if (UNIX AND (NOT APPLE))
-	    install(DIRECTORY ${SPHINX_QCH_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
-        endif (UNIX AND (NOT APPLE))
+        if (WITH_DOC)
+            install(DIRECTORY ${SPHINX_QCH_DIR} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+        endif (WITH_DOC)
     endif()
     add_custom_target( doc-html ${SPHINX_EXECUTABLE}
 	                        -q -c . -b html

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -151,6 +151,10 @@ To build in installer (requires the mingw32-cross-nsis packages)::
 
   make package
 
+Known cmake parameters:
+
+* WITH_DOC=TRUE: create doc and manpages via running ``make``; also adds install statements to be able to install it via ``make install``.
+
 .. _`ownCloud repository from OBS`: http://software.opensuse.org/download/package?project=isv:ownCloud:devel&package=owncloud-client
 .. _CSync: http://www.csync.org
 .. _`Client Download Page`: http://owncloud.org/sync-clients/


### PR DESCRIPTION
This patch makes it possible to choose, either to build and install the doc with `make`, `make install` or not.

Fixes #412
