### PR TITLE
Fix Issue #382 (Minor Windows Installer Issue: Missing descriptions on the "Choose Components" screen).

### DIFF
--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -267,7 +267,7 @@ FunctionEnd
 #   INSTALLER SECTIONS                                                       #
 #                                                                            #
 ##############################################################################
-Section "${APPLICATION_NAME}" SEC_OWNCLOUD
+Section "${APPLICATION_NAME}" SEC_APPLICATION
    SectionIn 1 2 3 RO
    SetDetailsPrint listonly
 
@@ -462,7 +462,7 @@ SectionGroupEnd
       DetailPrint "Creating Windows Start Entry"
       SetDetailsPrint listonly
       WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Run" \
-               "${APPLICATION_NAME}" "$INSTDIR\${APPLICATION_EXECUTABLE}" 
+               "${APPLICATION_NAME}" "$INSTDIR\${APPLICATION_EXECUTABLE}"
   ${MementoSectionEnd}
 !endif
 
@@ -475,7 +475,7 @@ ${MementoSectionDone}
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_START_MENU} "${APPLICATION_NAME} program group."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_DESKTOP} "Desktop shortcut for ${APPLICATION_NAME}."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_QUICK_LAUNCH} "Quick Launch shortcut for ${APPLICATION_NAME}."
-!insertmacro MUI_DESCRIPTION_TEXT ${SEC_QUICK_AUTOSTART} "Register ${APPLICATION_NAME} to run on Windows startup."
+!insertmacro MUI_DESCRIPTION_TEXT ${SEC_AUTOSTART} "Register ${APPLICATION_NAME} to run on Windows startup."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Section -post


### PR DESCRIPTION
Just a couple of typo/cut-and-paste errors (and one line with trailing whitespace that was caught by my editor).

NOTE: I am having trouble setting up a build environment (this is my first time using these tools), so **I have not built the code.**  I am uncomfortable submitting untested changes -- even changes as simple as this -- but Daniel has already been very patient, and I do not want to make him wait even longer while I struggle with the toolchain.
