### PR TITLE
Documentation Update cross-compiling section to include all libs needed to build the Windows Package

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -94,10 +94,9 @@ the following differences:
 
 1. For building ``libocsync``, you need to use ``mingw32-cmake`` instead
    of cmake.
-2. Since there is no cross-compiled LOG4C, the parameter ``-DWITH_LOG4C=OFF`` needs to be used
-3. for building ``mirall``, you need to use ``cmake`` again, but make sure
+2. for building ``mirall``, you need to use ``cmake`` again, but make sure
    to append the following parameter::
-4. Also, you need to specify *absolute pathes* for ``CSYNC_LIBRARY_PATH``
+3. Also, you need to specify *absolute pathes* for ``CSYNC_LIBRARY_PATH``
    and ``CSYNC_LIBRARY_PATH`` when running ``cmake`` on mirall.
 
   ``-DCMAKE_TOOLCHAIN_FILE=../mirall/admin/win/Toolchain-mingw32-openSUSE.cmake``


### PR DESCRIPTION
@danimo maybe you want to cross-check this. I was able to build the Windows Installer package on a fresh opensuse 12.2 after installing all libraries mentioned in my update. 

Regards, Mario
