### PR TITLE
Fix messed formatting in build documentation

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -51,30 +51,26 @@ if you do not have it installed already.
 In order to cross-compile, the following repositories need to be added
 via YaST or ``zypper ar`` (adjust when using openSUSE 12.2)::
 
-``
   zypper ar http://download.opensuse.org/repositories/isv:/ownCloud:/devel:/mingw:/win32/openSUSE_12.1/isv:ownCloud:devel:mingw:win32.repo
   zypper ar http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_12.1/windows:mingw:win32.repo
   zypper ar http://download.opensuse.org/repositories/windows:/mingw/openSUSE_12.1/windows:mingw.repo
-``
 
 Next, install the cross-compiler packages and the cross-compiled dependencies::
 
-``
-  zypper install  cmake make mingw32-cross-binutils mingw32-cross-cpp mingw32-cross-gcc \
-                mingw32-cross-gcc-c++ mingw32-cross-pkg-config mingw32-filesystem \
-                mingw32-headers  mingw32-runtime site-config mingw32-iniparser-devel \
-                mingw32-libsqlite-devel mingw32-dlfcn-devel mingw32-libssh2-devel \
-                kdewin-png2ico mingw32-libqt4 mingw32-libqt4-devel mingw32-libgcrypt \
-                mingw32-libgnutls mingw32-libneon mingw32-libneon-devel mingw32-libbeecrypt \
-                mingw32-libopenssl mingw32-openssl mingw32-libpng-devel mingw32-libsqlite \
-                mingw32-qtkeychain mingw32-qtkeychain-devel mingw32-iniparser mingw32-dlfcn \
-                mingw32-libintl-devel mingw32-libneon-devel mingw32-libopenssl-devel \
-                mingw32-libproxy-devel mingw32-libxml2-devel mingw32-zlib-devel
-``
+  zypper install cmake make mingw32-cross-binutils mingw32-cross-cpp mingw32-cross-gcc \
+                 mingw32-cross-gcc-c++ mingw32-cross-pkg-config mingw32-filesystem \
+                 mingw32-headers  mingw32-runtime site-config mingw32-iniparser-devel \
+                 mingw32-libsqlite-devel mingw32-dlfcn-devel mingw32-libssh2-devel \
+                 kdewin-png2ico mingw32-libqt4 mingw32-libqt4-devel mingw32-libgcrypt \
+                 mingw32-libgnutls mingw32-libneon mingw32-libneon-devel mingw32-libbeecrypt \
+                 mingw32-libopenssl mingw32-openssl mingw32-libpng-devel mingw32-libsqlite \
+                 mingw32-qtkeychain mingw32-qtkeychain-devel mingw32-iniparser mingw32-dlfcn \
+                 mingw32-libintl-devel mingw32-libneon-devel mingw32-libopenssl-devel \
+                 mingw32-libproxy-devel mingw32-libxml2-devel mingw32-zlib-devel
 
 For the installer, the NSIS installer package is also required::
 
-``zypper install mingw32-cross-nsis``
+  zypper install mingw32-cross-nsis
 
 ..  Usually, the following would be needed as well, but due to a bug in mingw, they
     will currently not build properly from source.
@@ -84,10 +80,8 @@ For the installer, the NSIS installer package is also required::
 You will also need to manually download and install the following files with
 ``rpm -ivh <package>`` (They will also work with OpenSUSE 12.2)::
 
-``
   rpm -ihv http://pmbs.links2linux.org/download/mingw:/32/openSUSE_12.1/x86_64/mingw32-cross-nsis-plugin-processes-0-1.1.x86_64.rpm
   rpm -ihv http://pmbs.links2linux.org/download/mingw:/32/openSUSE_12.1/x86_64/mingw32-cross-nsis-plugin-uac-0-3.1.x86_64.rpm
-``
 
 Now, follow the `generic build instructions`_, but pay attention to
 the following differences:


### PR DESCRIPTION
@danimo I mistakenly used github-like formatting (which looked very good in github preview) and messed up the build documentation. I am very sorry for that :-(
