### PR TITLE
Fixes for windows client when setup server url customization

### DIFF
--- a/src/mirall/owncloudwizard.cpp
+++ b/src/mirall/owncloudwizard.cpp
@@ -148,6 +148,7 @@ void OwncloudSetupPage::setupCustomization()
 
     QString fixUrl = theme->overrideServerUrl();
     if( !fixUrl.isEmpty() ) {
+        _ui.label_2->hide();
         setServerUrl( fixUrl );
         _ui.leUrl->setEnabled( false );
         _ui.leUrl->hide();


### PR DESCRIPTION
2 Patches:
1 - A signal have been connected before customization that makes windows breaks the client
2 - Hide the label when the url of the server is customized in the wizard (because the field is also hidden)
