### PR TITLE
Don't add empty entries in hidden files editor with an empty string or when cancel is clicked

### DIFF
--- a/src/mirall/ignorelisteditor.cpp
+++ b/src/mirall/ignorelisteditor.cpp
@@ -101,7 +101,14 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
 
 void IgnoreListEditor::slotAddPattern()
 {
-    QString pattern = QInputDialog::getText(this, tr("Add Ignore Pattern"), tr("Add a new ignore pattern:"));
+    bool okClicked;
+    QString pattern = QInputDialog::getText(this, tr("Add Ignore Pattern"),
+                                            tr("Add a new ignore pattern:"),
+                                            QLineEdit::Normal, QString(), &okClicked);
+
+    if (!okClicked || pattern.isEmpty())
+        return;
+
     QListWidgetItem *item = new QListWidgetItem;
     setupItemFlags(item);
     if (pattern.startsWith("]")) {


### PR DESCRIPTION
This commit avoids ghost entries in the hidden files editor when cancel is clicked or when an empty string is inserted on the "add pattern" dialog.
