### PR TITLE
Adding "Type=Application" to desktop file (to fix autostart in Ubuntu)

### DIFF
--- a/src/mirall/utility.cpp
+++ b/src/mirall/utility.cpp
@@ -300,6 +300,7 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString& guiName,
            << QLatin1String("Terminal=") << "false" << endl
            << QLatin1String("Icon=") << appName << endl
            << QLatin1String("Categories=") << QLatin1String("Network") << endl
+           << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl
            << QLatin1String("X-GNOME-Autostart-enabled=") << "true" << endl
             ;


### PR DESCRIPTION
Fix for autostart problem in Ubuntu. I hope I did it in the correct branch.
