### PR TITLE
Don't ship doc/scripts/README.rst via sphinx

### DIFF
--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -64,7 +64,7 @@ release = '@VERSION@'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build','scripts/*']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
doc/scripts/README.rst is a valid .rst, but the file has nothing to do with the documentation.
