### PR TITLE
Add *.tmp to exclude list

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -33,4 +33,4 @@ desktop.ini
 
 ~$*
 .~lock.*
-~*.tmp
+*.tmp


### PR DESCRIPTION
I have several applications which use *.tmp files.
