### PR TITLE
Close dialog if button was clicked not just pressed

### DIFF
--- a/src/mirall/settingsdialog.cpp
+++ b/src/mirall/settingsdialog.cpp
@@ -98,7 +98,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
             _ui->stack, SLOT(setCurrentIndex(int)));
 
     QPushButton *closeButton = _ui->buttonBox->button(QDialogButtonBox::Close);
-    connect(closeButton, SIGNAL(pressed()), SLOT(accept()));
+    connect(closeButton, SIGNAL(clicked()), SLOT(accept()));
 
     QAction *showLogWindow = new QAction(this);
     showLogWindow->setShortcut(QKeySequence("F12"));


### PR DESCRIPTION
Click on close button and hold mouse button - the dialog closes, however, one expects that the dialog stays open (until one releases the mouse button on the button element).
