### PR TITLE
remove superfluous tooltip from server address input field

### DIFF
--- a/src/wizard/owncloudsetupnocredspage.ui
+++ b/src/wizard/owncloudsetupnocredspage.ui
@@ -95,9 +95,6 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="toolTip">
-            <string>Enter the URL of the server that you want to connect to (without http or https).</string>
-           </property>
            <property name="placeholderText">
             <string>https://...</string>
            </property>


### PR DESCRIPTION
The text »Enter the URL of the server that you want to connect to (without http or https).« is not really useful.
The label is already »Server address« already, and the client handles any address, be it with http, https or no protocol at all.

So I just removed it. :)
