### PR TITLE
remove 'File' word from notification

### DIFF
--- a/src/mirall/folder.cpp
+++ b/src/mirall/folder.cpp
@@ -313,8 +313,8 @@ void Folder::bubbleUpSyncResult()
 
     foreach (const SyncFileItem &item, _syncResult.syncFileItemVector() ) {
         if( item._status == SyncFileItem::FatalError || item._status == SyncFileItem::NormalError ) {
-            slotCSyncError( tr("File %1: %2").arg(item._file).arg(item._errorString) );
-            logger->postOptionalGuiLog(tr("File %1").arg(item._file), item._errorString);
+            slotCSyncError( QString::fromLatin1("%1: %2").arg(item._file).arg(item._errorString) );
+            logger->postOptionalGuiLog(item._file, item._errorString);
 
         } else {
             // add new directories or remove gone away dirs to the watcher


### PR DESCRIPTION
Just removes the »File« in front of the actual file name in the notifications. Not really needed, especially we could be more specific – is it a picture, a document, etc. Better just not have it.
