### PR TITLE
Added Debian version to info box and point to Debian website

### DIFF
--- a/OWNCLOUD.cmake
+++ b/OWNCLOUD.cmake
@@ -2,6 +2,8 @@ set( APPLICATION_NAME       "ownCloud" )
 #set( APPLICATION_SHORTNAME  ${APPLICATION_NAME} )
 set( APPLICATION_EXECUTABLE "owncloud" )
 set( APPLICATION_DOMAIN     "owncloud.com" )
+set( DEBIAN_URL        "https://packages.debian.org/unstable/owncloud-client" )
+set( DEBIAN_DOMAIN     "packages.debian.org/owncloud-client" )
 set( APPLICATION_VENDOR     "ownCloud" )
 set( APPLICATION_UPDATE_URL "https://updates.owncloud.com/client/" CACHE string "URL for updater" )
 

--- a/config.h.in
+++ b/config.h.in
@@ -19,6 +19,11 @@
 #cmakedefine SYSCONFDIR "@SYSCONFDIR@"
 #cmakedefine DATADIR "@DATADIR@"
 
+//debian specific
+#cmakedefine DEBIAN_VERSION "@DEBIAN_VERSION@"
+#cmakedefine DEBIAN_URL "@DEBIAN_URL@"
+#cmakedefine DEBIAN_DOMAIN "@DEBIAN_DOMAIN@"
+
 #ifndef NEON_WITH_LFS
 #cmakedefine NEON_WITH_LFS "@NEON_WITH_LFS@"
 #endif

--- a/src/mirall/owncloudtheme.cpp
+++ b/src/mirall/owncloudtheme.cpp
@@ -60,9 +60,9 @@ QString ownCloudTheme::about() const
                "Based on Mirall by Duncan Mac-Vicar P.</small></p>"
                "%7"
                )
-            .arg(MIRALL_VERSION_STRING)
-            .arg("http://" MIRALL_STRINGIFY(APPLICATION_DOMAIN))
-            .arg(MIRALL_STRINGIFY(APPLICATION_DOMAIN))
+            .arg(DEBIAN_VERSION)
+            .arg(DEBIAN_URL)
+            .arg(MIRALL_STRINGIFY(DEBIAN_DOMAIN))
             .arg(devString);
 
 }


### PR DESCRIPTION
I think it makes sense to have an possibility to define a specific vender version, domain and url in the info box. I created three different parameters, 'cause it is unclear, if APPLICATION_DOMAIN is allowd to change. Btw. APPLICATION_VENDOR is not used in the owncloudtheme.

this patch is not ready to merge :)

For those, who ask DEBIAN_VERSION is setted via direct cmake parameter.
