### PR TITLE
Phoning-home version checks should be possible to disable.

### DIFF
--- a/src/mirall/mirallconfigfile.cpp
+++ b/src/mirall/mirallconfigfile.cpp
@@ -344,11 +344,14 @@ bool MirallConfigFile::skipUpdateCheck( const QString& connection ) const
     QString con( connection );
     if( connection.isEmpty() ) con = defaultConnection();
 
-    QVariant fallback = getValue(QLatin1String(skipUpdateCheckC), con, false);
+    QVariant fallback = getValue(QLatin1String(skipUpdateCheckC), con, true);
     fallback = getValue(QLatin1String(skipUpdateCheckC), QString(), fallback);
 
     QVariant value = getPolicySetting(QLatin1String(skipUpdateCheckC), fallback);
-    return value.toBool();
+    if ( !value.toBool() )
+        qDebug() << "debian disabled the UpdateCheck mechanism.";
+
+    return true;
 }
 
 void MirallConfigFile::setSkipUpdateCheck( bool skip, const QString& connection )

--- a/src/updater/ocupdater.cpp
+++ b/src/updater/ocupdater.cpp
@@ -84,7 +84,7 @@ QString OCUpdater::statusString() const
     case UpdateOnlyAvailableThroughSystem:
         return tr("New version %1 available. Please use the systems update tool to install it.").arg(updateVersion);
     case Unknown:
-        return tr("Checking update server...");
+        return tr("Disabled for Debian. You hve to use your package management to update.");
     case UpToDate:
         // fall through
     default:


### PR DESCRIPTION
For a debian packages an application is not allowed to phone home to check for updates. Maybe we find a solution, to make it switchable on/off.

occupdater.cpp should get an additional state, that there will be no update process.

This patch is not ready to merge.
