### PR TITLE
Fix icon name in autostart desktop file (issue #1642)

### DIFF
--- a/src/mirall/utility_unix.cpp
+++ b/src/mirall/utility_unix.cpp
@@ -55,7 +55,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString& guiName, 
            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
            << QLatin1String("Exec=") << QCoreApplication::applicationFilePath() << endl
            << QLatin1String("Terminal=") << "false" << endl
-           << QLatin1String("Icon=") << appName << endl
+           << QLatin1String("Icon=") << "owncloud" << endl
            << QLatin1String("Categories=") << QLatin1String("Network") << endl
            << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl


### PR DESCRIPTION
Using 'appName' resulted in the icon name 'ownCloud' while the
actual name of the icon is 'owncloud'.
