### PR TITLE
Space fix

### DIFF
--- a/src/mirall/owncloudsetupwizard.cpp
+++ b/src/mirall/owncloudsetupwizard.cpp
@@ -355,7 +355,7 @@ bool OwncloudSetupWizard::ensureStartFromScratch(const QString &localFolder) {
             QMessageBox::StandardButton but;
             but = QMessageBox::question( 0, tr("Folder rename failed"),
                                          tr("Can't remove and back up the folder because the folder or a file in it is open in another program."
-                                            "Please close the folder or file and hit retry or cancel the setup."), QMessageBox::Retry | QMessageBox::Abort, QMessageBox::Retry);
+                                            " Please close the folder or file and hit retry or cancel the setup."), QMessageBox::Retry | QMessageBox::Abort, QMessageBox::Retry);
             if( but == QMessageBox::Abort ) {
                 break;
             }


### PR DESCRIPTION
This will fix the concatenated string:

"Can't remove and back up the folder because the folder or a file in it is open in another program.Please close the folder or file and hit retry or cancel the setup."
