### PR TITLE
Make Debian GNU/kFreeBSD compile

### DIFF
--- a/src/mirall/application.cpp
+++ b/src/mirall/application.cpp
@@ -64,14 +64,12 @@ static const char optionsC[] =
 
 QString applicationTrPath()
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    return QString::fromLatin1(DATADIR"/"APPLICATION_EXECUTABLE"/i18n/");
-#endif
-#ifdef Q_OS_MAC
-    return QApplication::applicationDirPath()+QLatin1String("/../Resources/Translations"); // path defaults to app dir.
-#endif
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
    return QApplication::applicationDirPath();
+#elif defined(Q_OS_MAC)
+    return QApplication::applicationDirPath()+QLatin1String("/../Resources/Translations"); // path defaults to app dir.
+#elif defined(Q_OS_UNIX)
+    return QString::fromLatin1(DATADIR"/"APPLICATION_EXECUTABLE"/i18n/");
 #endif
 }
 }

--- a/src/mirall/folderwatcher.cpp
+++ b/src/mirall/folderwatcher.cpp
@@ -29,7 +29,7 @@
 #include "mirall/folderwatcher_win.h"
 #elif defined(Q_OS_MAC)
 #include "mirall/folderwatcher_mac.h"
-#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#elif defined(Q_OS_UNIX)
 #include "mirall/folderwatcher_linux.h"
 #endif
 

--- a/src/mirall/utility.cpp
+++ b/src/mirall/utility.cpp
@@ -143,7 +143,7 @@ QString Utility::platform()
     return QLatin1String("Linux");
 #elif defined(__DragonFly__) // Q_OS_FREEBSD also defined
     return QLatin1String("DragonFlyBSD");
-#elif defined(Q_OS_FREEBSD)
+#elif defined(Q_OS_FREEBSD) || defined(Q_OS_FREEBSD_KERNEL)
     return QLatin1String("FreeBSD");
 #elif defined(Q_OS_NETBSD)
     return QLatin1String("NetBSD");
@@ -199,7 +199,7 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString& guiName,
 
 qint64 Utility::freeDiskSpace(const QString &path, bool *ok)
 {
-#if defined(Q_OS_MAC) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_MAC) || defined(Q_OS_FREEBSD) || defined(Q_OS_FREEBSD_KERNEL)
     struct statvfs stat;
     statvfs(path.toUtf8().data(), &stat);
     return (qint64) stat.f_bavail * stat.f_frsize;


### PR DESCRIPTION
Debian uses a BSD Kernel in a GNU enviroment. That's why Q_OS_FREEBSD is not setted at this system.
So we have to use **FreeBSD_kernel** to test.
