### PR TITLE
Fix folder status ui ignore new line inoverall text

### DIFF
--- a/src/mirall/folderstatusmodel.cpp
+++ b/src/mirall/folderstatusmodel.cpp
@@ -254,7 +254,7 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
       painter->save();
 
       // Sizes-Text
-      QRect octetRect = progressFm.boundingRect(QRect(0,0,0,0), 0, overallString );
+      QRect octetRect = progressFm.boundingRect(QRect(), 0, overallString );
       int progressTextWidth = octetRect.width() + 2;
 
       // Overall Progress Bar.


### PR DESCRIPTION
Found a bug in  code that was  applied to fix issue [142](https://github.com/owncloud/mirall/pull/1717).
This is a fix for that bug.
