### PR TITLE
Fix issue#2004 -- mandir must be man1, not man

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,7 +4,7 @@ if(SPHINX_FOUND)
     set(SPHINX_CACHE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_doctrees")
     # HTML output directory
     set(SPHINX_HTML_DIR     "${CMAKE_CURRENT_BINARY_DIR}/html")
-    set(SPHINX_MAN_DIR      "${CMAKE_CURRENT_BINARY_DIR}/man")
+    set(SPHINX_MAN_DIR      "${CMAKE_CURRENT_BINARY_DIR}/man1")
     set(SPHINX_PDF_DIR      "${CMAKE_CURRENT_BINARY_DIR}/latex")
     set(SPHINX_QCH_DIR      "${CMAKE_CURRENT_BINARY_DIR}/qthelp")
     set(SPHINX_HTMLHELP_DIR "${CMAKE_CURRENT_BINARY_DIR}/htmlhelp")


### PR DESCRIPTION
This is already in master, but bites us for 1.6.x branches...
Obsoletes https://build.opensuse.org/request/show/242877

@felixboehm @danimo @dragotin please review.
