### PR TITLE
Clean up stale journal entries and temporaries. #2057

### DIFF
--- a/src/mirall/owncloudpropagator.cpp
+++ b/src/mirall/owncloudpropagator.cpp
@@ -399,6 +399,11 @@ bool OwncloudPropagator::localFileNameClash( const QString& relFile )
     return re;
 }
 
+QString OwncloudPropagator::getFilePath(const QString& tmp_file_name) const
+{
+    return _localDir + tmp_file_name;
+}
+
 // ================================================================================
 
 void PropagateDirectory::start()

--- a/src/mirall/owncloudpropagator.h
+++ b/src/mirall/owncloudpropagator.h
@@ -220,6 +220,7 @@ public:
 
     bool isInSharedDirectory(const QString& file);
     bool localFileNameClash(const QString& relfile);
+    QString getFilePath(const QString& tmp_file_name) const;
 
     void abort() {
         _abortRequested.fetchAndStoreOrdered(true);

--- a/src/mirall/propagator_legacy.cpp
+++ b/src/mirall/propagator_legacy.cpp
@@ -62,7 +62,7 @@ void PropagateUploadFileLegacy::start()
     if (_propagator->_abortRequested.fetchAndAddRelaxed(0))
         return;
 
-    QFile file(_propagator->_localDir + _item._file);
+    QFile file(_propagator->getFilePath(_item._file));
     if (!file.open(QIODevice::ReadOnly)) {
         done(SyncFileItem::NormalError, file.errorString());
         return;
@@ -189,7 +189,7 @@ void PropagateUploadFileLegacy::start()
                 return;
         }
 
-        _propagator->_journal->setFileRecord(SyncJournalFileRecord(_item, _propagator->_localDir + _item._file));
+        _propagator->_journal->setFileRecord(SyncJournalFileRecord(_item, _propagator->getFilePath(_item._file)));
         // Remove from the progress database:
         _propagator->_journal->setUploadInfo(_item._file, SyncJournalDb::UploadInfo());
         _propagator->_journal->commit("upload file start");
@@ -498,7 +498,7 @@ void PropagateDownloadFileLegacy::start()
     if (progressInfo._valid) {
         // if the etag has changed meanwhile, remove the already downloaded part.
         if (progressInfo._etag != _item._etag) {
-            QFile::remove(_propagator->_localDir + progressInfo._tmpfile);
+            QFile::remove(_propagator->getFilePath(progressInfo._tmpfile));
             _propagator->_journal->setDownloadInfo(_item._file, SyncJournalDb::DownloadInfo());
         } else {
             tmpFileName = progressInfo._tmpfile;
@@ -516,7 +516,7 @@ void PropagateDownloadFileLegacy::start()
         tmpFileName += ".~" + QString::number(uint(qrand()), 16);
     }
 
-    QFile tmpFile(_propagator->_localDir + tmpFileName);
+    QFile tmpFile(_propagator->getFilePath(tmpFileName));
     _file = &tmpFile;
     if (!tmpFile.open(QIODevice::Append | QIODevice::Unbuffered)) {
         done(SyncFileItem::NormalError, tmpFile.errorString());
@@ -610,7 +610,7 @@ void PropagateDownloadFileLegacy::start()
 
     tmpFile.close();
     tmpFile.flush();
-    QString fn = _propagator->_localDir + _item._file;
+    QString fn = _propagator->getFilePath(_item._file);
 
 
     bool isConflict = _item._instruction == CSYNC_INSTRUCTION_CONFLICT

--- a/src/mirall/syncengine.h
+++ b/src/mirall/syncengine.h
@@ -107,6 +107,16 @@ private:
     int treewalkFile( TREE_WALK_FILE*, bool );
     bool checkBlacklisting( SyncFileItem *item );
 
+    // Cleans up unnecessary downloadinfo entries in the journal as well
+    // as their temporary files.
+    void deleteStaleDownloadInfos();
+
+    // Removes stale uploadinfos from the journal.
+    void deleteStaleUploadInfos();
+
+    // Removes stale blacklist entries from the journal.
+    void deleteStaleBlacklistEntries();
+
     // cleanup and emit the finished signal
     void finalize();
 

--- a/src/mirall/syncjournaldb.h
+++ b/src/mirall/syncjournaldb.h
@@ -68,9 +68,15 @@ public:
 
     DownloadInfo getDownloadInfo(const QString &file);
     void setDownloadInfo(const QString &file, const DownloadInfo &i);
+    QVector<DownloadInfo> getAndDeleteStaleDownloadInfos(const QSet<QString>& keep);
+
     UploadInfo getUploadInfo(const QString &file);
     void setUploadInfo(const QString &file, const UploadInfo &i);
+    bool deleteStaleUploadInfos(const QSet<QString>& keep);
+
     SyncJournalBlacklistRecord blacklistEntry( const QString& );
+    bool deleteStaleBlacklistEntries(const QSet<QString>& keep);
+
     void avoidRenamesOnNextSync(const QString &path);
 
     /**


### PR DESCRIPTION
This is a fix for #2057: Clean up journal entries and temporaries for files that are no longer relevant.
- Downloadinfo entries for files that no longer need to be downloaded
  are useless and can be removed. In particular, the temporary files
  holding partially retrieved files are now deleted when no longer
  necessary.
- The same is true for blacklist entries for paths that are no longer
  being discovered.
- Same for uploadinfos for files that no longer need to be uploaded.
