### PR TITLE
mtime of local folders is not set, so we should not check on it either.

### DIFF
--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -237,7 +237,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
             goto out;
         }
         if((ctx->current == REMOTE_REPLICA && !c_streq(fs->etag, tmp->etag ))
-            || (ctx->current == LOCAL_REPLICA && (fs->mtime != tmp->modtime
+            || (ctx->current == LOCAL_REPLICA && ((fs->mtime != tmp->modtime && tmp->type != 2)
                                                   // zero size in statedb can happen during migration
                                                   || (tmp->size != 0 && fs->size != tmp->size)
 #if 0


### PR DESCRIPTION
As mentioned in https://github.com/owncloud/core/issues/7009#issuecomment-36616528 the modification time of a local folder is never touched. But in csync_update there is a check if the local mtime matches with the one from the database.

This commit doesn't trigger any action when the local modification time of a folder and the database differ. In the old scenario a CSYNC_INSTRUCTION_EVAL was triggered, resulting in a lot of additional useless propfinds for the folders.