### PR TITLE
Switch monochrome systray icon color depending on systray brightness

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -15,6 +15,7 @@
 #include "theme.h"
 #include "version.h"
 #include "config.h"
+#include "utility.h"
 
 #include <QtCore>
 #ifndef TOKEN_AUTH_ONLY
@@ -184,11 +185,7 @@ QString Theme::systrayIconFlavor(bool mono) const
 {
     QString flavor;
     if (mono) {
-#ifdef Q_OS_MAC
-        flavor = QLatin1String("black");
-#else
-        flavor = QLatin1String("white");
-#endif
+        flavor = Utility::hasDarkSystray() ? QLatin1String("white") : QLatin1String("black");
     } else {
         flavor = QLatin1String("colored");
     }

--- a/src/libsync/utility.cpp
+++ b/src/libsync/utility.cpp
@@ -335,6 +335,11 @@ QString Utility::timeToDescriptiveString(QList<QPair<QString,quint32> > &timeMap
     return retStr;
 }
 
+bool Utility::hasDarkSystray()
+{
+    return hasDarkSystray_private();
+}
+
 
 bool Utility::isWindows()
 {

--- a/src/libsync/utility.h
+++ b/src/libsync/utility.h
@@ -71,7 +71,19 @@ namespace Utility
      */
     OWNCLOUDSYNC_EXPORT QString timeToDescriptiveString(QList<QPair<QString,quint32> > &timeMapping, quint64 msecs, quint8 precision, QString separator, bool specific);
     OWNCLOUDSYNC_EXPORT QString timeToDescriptiveString(quint64 msecs, quint8 precision, QString separator, bool specific);
-    
+
+    /**
+     * @brief hasDarkSystray - determines whether the systray is dark or light.
+     *
+     * Use this to check if the OS has a dark or a light systray.
+     *
+     * The value might change during the execution of the program
+     * (e.g. on OS X 10.10).
+     *
+     * @return bool which is true for systems with dark systray.
+     */
+    OWNCLOUDSYNC_EXPORT bool hasDarkSystray();
+
     // convinience OS detection methods
     OWNCLOUDSYNC_EXPORT bool isWindows();
     OWNCLOUDSYNC_EXPORT bool isMac();

--- a/src/libsync/utility_mac.cpp
+++ b/src/libsync/utility_mac.cpp
@@ -108,3 +108,18 @@ void setLaunchOnStartup_private(const QString &appName, const QString& guiName, 
     CFRelease(urlRef);
 }
 
+static bool hasDarkSystray_private()
+{
+    bool returnValue = false;
+    CFStringRef interfaceStyleKey = CFSTR("AppleInterfaceStyle");
+    CFStringRef interfaceStyle = NULL;
+    CFStringRef darkInterfaceStyle = CFSTR("Dark");
+    interfaceStyle = (CFStringRef)CFPreferencesCopyAppValue(interfaceStyleKey,
+                                                            kCFPreferencesCurrentApplication);
+    if (interfaceStyle != NULL) {
+        returnValue = (kCFCompareEqualTo == CFStringCompare(interfaceStyle, darkInterfaceStyle, 0));
+        CFRelease(interfaceStyle);
+    }
+    return returnValue;
+}
+

--- a/src/libsync/utility_unix.cpp
+++ b/src/libsync/utility_unix.cpp
@@ -86,3 +86,8 @@ void setLaunchOnStartup_private(const QString &appName, const QString& guiName, 
         }
     }
 }
+
+static inline bool hasDarkSystray_private()
+{
+    return true;
+}

--- a/src/libsync/utility_win.cpp
+++ b/src/libsync/utility_win.cpp
@@ -47,3 +47,8 @@ void setLaunchOnStartup_private(const QString &appName, const QString& guiName, 
         settings.remove(appName);
     }
 }
+
+static inline bool hasDarkSystray_private()
+{
+    return true;
+}


### PR DESCRIPTION
I am working on issue #2215 in this branch.

As of version 10.10 Yosemite, Mac OS X offers the user the option to use a dark version of the dock and menu bar. The systray icon was black even on the dark menu bar ![black-on-dark](https://cloud.githubusercontent.com/assets/2794645/4776282/55b2777e-5bc0-11e4-8e30-df6062cf05c2.png), thus rendering it nearly impossible to spot.

This patch checks the NSUserDefaults to check whether the user has chosen the black dock and if so, will use the white monochrome versions for the systray icons.
White icon on dark menu bar: ![white-on-dark](https://cloud.githubusercontent.com/assets/2794645/4776258/0ebf38fc-5bc0-11e4-98e0-9292846a8c64.png)

Right now, the systray icon will not change "live", that is it will stay in the old color when the user changes the dock/menu bar brightness during execution of the app until either the icon image changes (because of state change) or the app is restarted.

The patch needs to be tested on Unix and Windows systems, unfortunately I don't have a development machine setup for those operating systems at the moment. The systray icon behaviour should be unchanged for those operating systems and for earlier versions of OS X.
