### PR TITLE
Do not show the HTTP-reconnect popup when its not warranted

### DIFF
--- a/src/wizard/owncloudsetuppage.cpp
+++ b/src/wizard/owncloudsetuppage.cpp
@@ -224,12 +224,12 @@ void OwncloudSetupPage::setAuthType (WizardCommon::AuthType type)
   stopSpinner();
 }
 
-void OwncloudSetupPage::setErrorString( const QString& err )
+void OwncloudSetupPage::setErrorString( const QString& err, bool retryHTTPonly )
 {
     if( err.isEmpty()) {
         _ui.errorLabel->setVisible(false);
     } else {
-        if (_ui.leUrl->text().startsWith("https://")) {
+        if (retryHTTPonly) {
             QString msg = tr("<p>Could not connect securely:</p><p>%1</p><p>Do you want to connect unencrypted instead (not recommended)?</p>").arg(err);
             QString title = tr("Connection failed");
             if (QMessageBox::question(this, title, msg, QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes) {

--- a/src/wizard/owncloudsetuppage.h
+++ b/src/wizard/owncloudsetuppage.h
@@ -46,7 +46,7 @@ public:
   void setAuthType(WizardCommon::AuthType type);
 
 public slots:
-  void setErrorString( const QString&  );
+  void setErrorString( const QString&, bool retryHTTPonly = false );
   void setConfigExists(  bool );
   void startSpinner();
   void stopSpinner();

--- a/src/wizard/owncloudwizard.cpp
+++ b/src/wizard/owncloudwizard.cpp
@@ -182,11 +182,11 @@ void OwncloudWizard::slotCurrentPageChanged( int id )
     setOption(QWizard::HaveCustomButton1, id == WizardCommon::Page_AdvancedSetup);
 }
 
-void OwncloudWizard::displayError( const QString& msg )
+void OwncloudWizard::displayError( const QString& msg, bool retryHTTPonly )
 {
     switch (currentId()) {
     case WizardCommon::Page_ServerSetup:
-        _setupPage->setErrorString( msg );
+        _setupPage->setErrorString( msg, retryHTTPonly );
         break;
 
     case WizardCommon::Page_HttpCreds:

--- a/src/wizard/owncloudwizard.h
+++ b/src/wizard/owncloudwizard.h
@@ -54,7 +54,7 @@ public:
 
     void enableFinishOnResultWidget(bool enable);
 
-    void displayError( const QString& );
+    void displayError( const QString&, bool retryHTTPonly = true);
     void setMultipleFoldersExist( bool );
     void setConfigExists( bool );
     bool configExists();


### PR DESCRIPTION
Fixes usability issues in the workaround of #2607