### PR TITLE
Hide Ignored files in context menu

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -486,7 +486,7 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const Progress::Info
 
     _actionRecent->setIcon( QIcon() ); // Fixme: Set a "in-progress"-item eventually.
 
-    if (!progress._lastCompletedItem.isEmpty()) {
+    if (!progress._lastCompletedItem.isEmpty() && !Progress::isIgnoredKind(progress._lastCompletedItem._status)) {
 
         if (Progress::isWarningKind(progress._lastCompletedItem._status)) {
             // display a warn icon if warnings happend.

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -88,6 +88,12 @@ bool Progress::isWarningKind( SyncFileItem::Status kind)
 
 }
 
+bool Progress::isIgnoredKind( SyncFileItem::Status kind)
+{
+    return  kind == SyncFileItem::FileIgnored;
+
+}
+
 ProgressDispatcher* ProgressDispatcher::instance() {
     if (!_instance) {
         _instance = new ProgressDispatcher();

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -168,6 +168,7 @@ namespace Progress
     OWNCLOUDSYNC_EXPORT QString asResultString(  const SyncFileItem& item );
 
     OWNCLOUDSYNC_EXPORT bool isWarningKind( SyncFileItem::Status );
+    OWNCLOUDSYNC_EXPORT bool isIgnoredKind( SyncFileItem::Status );
 
 }
 


### PR DESCRIPTION
This small patch hides ignored files in the recent changes context menu. It is a potential fix for issue #1865, but still needs to be tested thoroughly.