### PR TITLE
Manged folder list in the tray icon is now sorted

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -323,7 +323,13 @@ void ownCloudGui::setupContextMenu()
         if ( folderCnt > 1) {
             _contextMenu->addAction(tr("Managed Folders:"))->setDisabled(true);
         }
-        foreach (Folder *folder, folderMan->map() ) {
+
+        // Put everything first in a QMap to properly sort
+        QMap<QString, Folder*> folders;
+        for( auto i = folderMan->map().constBegin(); i != folderMan->map().constEnd(); i++) {
+            folders.insert(i.key(), i.value());
+        }
+        foreach (auto folder, folders) {
             QAction *action = new QAction( tr("Open folder '%1'").arg(folder->alias()), this );
             connect( action, SIGNAL(triggered()),_folderOpenActionMapper,SLOT(map()));
             _folderOpenActionMapper->setMapping( action, folder->alias() );


### PR DESCRIPTION
We are using a QHash to store all the folder objects. This does not allow for
easy sorting and looks weird to the user. Now they are first inserted into a
temp QMap to sort them properly.

This should (at least partly) solve #1529 