### PR TITLE
Sharedialog: 404 is also an acceptable response when retriving shares

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -192,7 +192,7 @@ void ShareDialog::slotSharesFetched(const QString &reply)
     int code = checkJsonReturnCode(reply, message);
 
     qDebug() << Q_FUNC_INFO << "Status code: " << code;
-    if (code != 100) {
+    if (code != 100 & code != 404) {
         displayError(code);
     }
 


### PR DESCRIPTION
When we try to get the shares for a file/dir that has no shares yet 404 is an
acceptable response from the server.