### PR TITLE
Update Toolchain-mingw32-openSUSE.cmake

### DIFF
--- a/admin/win/Toolchain-mingw32-openSUSE.cmake
+++ b/admin/win/Toolchain-mingw32-openSUSE.cmake
@@ -22,8 +22,8 @@ SET(QMAKESPEC               win32-g++-cross)
 
 # dirs
 SET(QT_LIBRARY_DIR          /usr/${MINGW_PREFIX}/bin)
-SET(QT_PLUGINS_DIR          ${CMAKE_FIND_ROOT_PATH}/lib/qt4/plugins)
-SET(QT_MKSPECS_DIR          ${CMAKE_FIND_ROOT_PATH}/share/qt4/mkspecs)
+SET(QT_PLUGINS_DIR          ${CMAKE_FIND_ROOT_PATH}/lib/qt5/plugins)
+SET(QT_MKSPECS_DIR          ${CMAKE_FIND_ROOT_PATH}/share/qt5/mkspecs)
 SET(QT_QT_INCLUDE_DIR       ${CMAKE_FIND_ROOT_PATH}/include)
 
 # qt tools


### PR DESCRIPTION
Fix cross-compiling for windows. change qt4 to qt5 since windows and OSX require Qt5 now.