### PR TITLE
Add dialog to connection wizard for client-side TLS certificates

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -27,6 +27,7 @@ set(client_UI
     owncloudsetuppage.ui
     addcertificatedialog.ui
     wizard/owncloudadvancedsetuppage.ui
+    wizard/owncloudconnectionmethoddialog.ui
     wizard/owncloudhttpcredspage.ui
     wizard/owncloudsetupnocredspage.ui
     wizard/owncloudwizardresultpage.ui
@@ -64,6 +65,7 @@ set(client_SRCS
     addcertificatedialog.cpp
     wizard/abstractcredswizardpage.cpp
     wizard/owncloudadvancedsetuppage.cpp
+    wizard/owncloudconnectionmethoddialog.cpp
     wizard/owncloudhttpcredspage.cpp
     wizard/owncloudsetuppage.cpp
     wizard/owncloudshibbolethcredspage.cpp

--- a/src/gui/wizard/owncloudconnectionmethoddialog.cpp
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.cpp
@@ -1,0 +1,32 @@
+#include "wizard/owncloudconnectionmethoddialog.h"
+
+OwncloudConnectionMethodDialog::OwncloudConnectionMethodDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::OwncloudConnectionMethodDialog)
+{
+    ui->setupUi(this);
+
+    connect(ui->btnNoTLS, SIGNAL(clicked(bool)), this, SLOT(returnNoTLS()));
+    connect(ui->btnClientSideTLS, SIGNAL(clicked(bool)), this, SLOT(returnClientSideTLS()));
+    connect(ui->btnBack, SIGNAL(clicked(bool)), this, SLOT(returnBack()));
+}
+
+void OwncloudConnectionMethodDialog::returnNoTLS()
+{
+    done(No_TLS);
+}
+
+void OwncloudConnectionMethodDialog::returnClientSideTLS()
+{
+    done(Client_Side_TLS);
+}
+
+void OwncloudConnectionMethodDialog::returnBack()
+{
+    done(Back);
+}
+
+OwncloudConnectionMethodDialog::~OwncloudConnectionMethodDialog()
+{
+    delete ui;
+}

--- a/src/gui/wizard/owncloudconnectionmethoddialog.h
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.h
@@ -1,0 +1,34 @@
+#ifndef OWNCLOUDCONNECTIONMETHODDIALOG_H
+#define OWNCLOUDCONNECTIONMETHODDIALOG_H
+
+#include <QDialog>
+
+#include "ui_owncloudconnectionmethoddialog.h"
+
+namespace Ui {
+class OwncloudConnectionMethodDialog;
+}
+
+class OwncloudConnectionMethodDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit OwncloudConnectionMethodDialog(QWidget *parent = 0);
+    ~OwncloudConnectionMethodDialog();
+    enum {
+        No_TLS,
+        Client_Side_TLS,
+        Back
+    };
+
+public slots:
+    void returnNoTLS();
+    void returnClientSideTLS();
+    void returnBack();
+
+private:
+    Ui::OwncloudConnectionMethodDialog *ui;
+};
+
+#endif // OWNCLOUDCONNECTIONMETHODDIALOG_H

--- a/src/gui/wizard/owncloudconnectionmethoddialog.ui
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OwncloudConnectionMethodDialog</class>
+ <widget class="QDialog" name="OwncloudConnectionMethodDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>401</width>
+    <height>205</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Connection failed</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="topMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <property name="bottomMargin">
+      <number>9</number>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Failed to connect to the secure server address specified. How do you wish to proceed?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QPushButton" name="btnNoTLS">
+         <property name="text">
+          <string>Try without TLS (not very secure)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnClientSideTLS">
+         <property name="text">
+          <string>Configure client-side TLS certificate</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnBack">
+         <property name="text">
+          <string>Use a different URL</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -22,6 +22,7 @@
 #include "wizard/owncloudwizard.h"
 
 #include "../addcertificatedialog.h"
+#include "wizard/owncloudconnectionmethoddialog.h"
 
 #include "ui_owncloudsetupnocredspage.h"
 


### PR DESCRIPTION
## What

When connecting to a https:// URL fails, present the user with three choices:

 * Try again with a http:// URL
 * Configure client-side TLS certificates
 * Go back and enter a different URL

This allows users connecting with an ownCloud server secured with client-side TLS certificates to start the certificate import wizard manually instead of relying on a custom server error message.

## Why

#69 introduces support for client-side TLS certificates, but relies on the server to return an error message `SSL handshake failed`. However, it is not always possible or desirable to modify the server's error messages (e.g., when the TLS-layer is handled by a proxy server serving as a gateway for several hosted services).

## Code quality

This seems to work.

That said, this is the first time I've touched software written in C++/Qt. Caveat emptor.

Criticism welcome! This is intended as a working example of a possible solution for the problem described above and in some of the comments in #69. Could do with some polish I suspect.