### PR TITLE
use touch from path

### DIFF
--- a/test/testfolderwatcher.h
+++ b/test/testfolderwatcher.h
@@ -103,7 +103,7 @@ private slots:
         Utility::writeRandomFile(QString("%1/a1/random.bin").arg(_root));
 #else
         QString cmd;
-        cmd = QString("/usr/bin/touch %1").arg(file);
+        cmd = QString("touch %1").arg(file);
         qDebug() << "Command: " << cmd;
         system(cmd.toLocal8Bit());
 #endif


### PR DESCRIPTION
on some systems touch(1) is in /bin, not /usr/bin.
instead hardcoding another path, take it from $PATH, like other commands used here (rm, echo)