### PR TITLE
Reset _public_share_id after we delete the share

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -265,6 +265,7 @@ void ShareDialog::slotDeleteShareFetched(const QString &reply)
         displayError(code);
     }
 
+    _public_share_id = 0;
     _pi_link->stopAnimation();
     _ui->lineEdit_password->clear();
     _ui->lineEdit_shareLink->clear();


### PR DESCRIPTION
One tiny statement missing from 4849c31addc1d1c6b9a45a5487c22511d5cac83c

When a user deletes a public link and then recreates it and password sharing is enforced things did not go as expected. They do now.