### PR TITLE
Explanation of "Crash now" for the translators

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -432,7 +432,7 @@ void ownCloudGui::setupActions()
     connect(_actionLogout, SIGNAL(triggered()), _app, SLOT(slotLogout()));
 
     if(_app->debugMode()) {
-        _actionCrash = new QAction(tr("Crash now"), this);
+        _actionCrash = new QAction(tr("Crash now", "Notes for the translators"), this);
         connect(_actionCrash, SIGNAL(triggered()), _app, SLOT(slotCrash()));
     } else {
         _actionCrash = 0;


### PR DESCRIPTION
I am working on the Danish translation of ownCloud through Transifex, so basically I'm a translator and not used to Github and submitting patches.

The issue:
I am not sure what "Crash now" does. Is it possible to add a comment, so that the translator will know in which context "Crash now" is used?

Comment on the format:
I'm very new to suggesting code changes, and I know the format differs depending on the translation frameworks. From what I understood from the documentation below, that giving text string as a second argument will provide the translators with information related to the function. 
Sorry if the suggested format is completely wrong. 

Also: "Notes for the translators" should be replaced with something meaningful. :)

Documentation:
http://qt-project.org/doc/qt-4.8/linguist-programmers.html

Best regards!