### PR TITLE
static member QFileInfo::exists is not available on 4.8

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -284,7 +284,8 @@ bool FileSystem::fileExists(const QString& filename)
         return fileExistsWin(filename);
     }
 #endif
-    return QFileInfo::exists(filename);
+    QFileInfo file(filename);
+    return file.exists();
 }
 
 bool FileSystem::fileExists(const QFileInfo& fi)


### PR DESCRIPTION
Fix to make the client compile with Qt-4.8 again.