### PR TITLE
added adler32 implementation; use OC-Checksum header instead of OC-MD5

### DIFF
--- a/src/mirall/filesystem.h
+++ b/src/mirall/filesystem.h
@@ -55,4 +55,5 @@ bool renameReplace(const QString &originFileName, const QString &destinationFile
  */
 QByteArray calcMd5( const QString& fileName );
 QByteArray calcSha1( const QString& fileName );
+QByteArray calcAdler32( const QString& fileName );
 }}


### PR DESCRIPTION
for testing env variable OWNCLOUD_CHECKSUM_TYPE may be set to Adler32, otherwise default is MD5

This aligns better with the protocol specified in: https://github.com/cernbox/smashbox/blob/master/protocol/checksum.md
