### PR TITLE
make the remaining time string translatable and support plural forms

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -645,7 +645,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
             //: Example text: "uploading foobar.png (1MB of 2MB) time left 2 minutes at a rate of 24Kb/s"
             fileProgressString = tr("%1 %2 (%3 of %4) %5 left at a rate of %6/s")
                 .arg(kindString, itemFileName, s1, s2,
-                    Utility::timeToDescriptiveString(progress.fileProgress(curItem).estimatedEta, 3, " ", true),
+                    Utility::durationToDescriptiveString(progress.fileProgress(curItem).estimatedEta),
                     Utility::octetsToString(estimatedBw) );
         } else {
             //: Example text: "uploading foobar.png (2MB of 2MB)"
@@ -672,7 +672,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
         overallSyncString = tr("%1 of %2, file %3 of %4\nTotal time left %5")
             .arg(s1, s2)
             .arg(currentFile).arg(totalFileCount)
-            .arg( Utility::timeToDescriptiveString(progress.totalProgress().estimatedEta, 3, " ", true) );
+            .arg( Utility::durationToDescriptiveString(progress.totalProgress().estimatedEta) );
     } else if (totalFileCount > 0) {
         // Don't attemt to estimate the time left if there is no kb to transfer.
         overallSyncString = tr("file %1 of %2") .arg(currentFile).arg(totalFileCount);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -476,12 +476,11 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const ProgressInfo& 
         quint64 totalFileCount = qMax(progress.totalFiles(), currentFile);
         _actionStatus->setText( tr("Syncing %1 of %2  (%3 left)")
             .arg( currentFile ).arg( totalFileCount )
-            .arg( Utility::timeToDescriptiveString(progress.totalProgress().estimatedEta, 2, " ",true) ) );
+            .arg( Utility::durationToDescriptiveString(progress.totalProgress().estimatedEta) ) );
     } else {
         QString totalSizeStr = Utility::octetsToString( progress.totalSize() );
         _actionStatus->setText( tr("Syncing %1 (%2 left)")
-            .arg( totalSizeStr )
-            .arg( Utility::timeToDescriptiveString(progress.totalProgress().estimatedEta, 2, " ",true) ) );
+            .arg( totalSizeStr, Utility::durationToDescriptiveString(progress.totalProgress().estimatedEta) ) );
     }
 
 

--- a/src/libsync/utility.h
+++ b/src/libsync/utility.h
@@ -61,13 +61,11 @@ namespace Utility
     OWNCLOUDSYNC_EXPORT qint64 qDateTimeToTime_t(const QDateTime &t);
 
     /**
-     * @brief Convert milliseconds to HMS string.
+     * @brief Convert milliseconds duration to human readable string.
      * @param quint64 msecs the milliseconds to convert to string.
-     * @param uint precision the amount of sub dviving scale to include in the result.
      * @return an HMS representation of the milliseconds value.
      */
-    OWNCLOUDSYNC_EXPORT QString timeToDescriptiveString(QList<QPair<QString,quint32> > &timeMapping, quint64 msecs, quint8 precision, QString separator, bool specific);
-    OWNCLOUDSYNC_EXPORT QString timeToDescriptiveString(quint64 msecs, quint8 precision, QString separator, bool specific);
+    OWNCLOUDSYNC_EXPORT QString durationToDescriptiveString(quint64 msecs);
 
     /**
      * @brief hasDarkSystray - determines whether the systray is dark or light.

--- a/test/testutility.h
+++ b/test/testutility.h
@@ -75,6 +75,34 @@ private slots:
         QVERIFY(toCSyncScheme("https://example.com/owncloud/") ==
                               "ownclouds://example.com/owncloud/");
     }
+
+    void testDurationToDescriptiveString()
+    {
+        QLocale::setDefault(QLocale("C"));
+        //NOTE: in order for the plural to work we would need to load the english translation
+
+        quint64 sec = 1000;
+        quint64 hour = 3600 * sec;
+
+        QDateTime current = QDateTime::currentDateTime();
+
+        QCOMPARE(durationToDescriptiveString(0), QString("0 seconds") );
+        QCOMPARE(durationToDescriptiveString(5), QString("0 seconds") );
+        QCOMPARE(durationToDescriptiveString(1000), QString("1 second(s)") );
+        QCOMPARE(durationToDescriptiveString(1005), QString("1 second(s)") );
+        QCOMPARE(durationToDescriptiveString(56123), QString("56 second(s)") );
+        QCOMPARE(durationToDescriptiveString(90*sec), QString("1 minute(s) 30 second(s)") );
+        QCOMPARE(durationToDescriptiveString(3*hour), QString("3 hour(s)") );
+        QCOMPARE(durationToDescriptiveString(3*hour + 20*sec), QString("3 hour(s)") );
+        QCOMPARE(durationToDescriptiveString(3*hour + 70*sec), QString("3 hour(s) 1 minute(s)") );
+        QCOMPARE(durationToDescriptiveString(3*hour + 100*sec), QString("3 hour(s) 2 minute(s)") );
+        QCOMPARE(durationToDescriptiveString(current.msecsTo(current.addYears(4).addMonths(5).addDays(2).addSecs(23*60*60))),
+                 QString("4 year(s) 5 month(s)") );
+        QCOMPARE(durationToDescriptiveString(current.msecsTo(current.addDays(2).addSecs(23*60*60))),
+                 QString("2 day(s) 23 hour(s)") );
+
+
+    }
 };
 
 #endif


### PR DESCRIPTION
To fix https://github.com/owncloud/client/issues/2672 just need translations

@danimo is that how to solve it?

(It builds and shows the time string still properly in English)