### PR TITLE
Windows Explorer: fix issues when syncing whole drive.

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -180,10 +180,20 @@ QString Folder::alias() const
 QString Folder::path() const
 {
     QString p(_path);
-    if( ! p.endsWith(QLatin1Char('/')) ) {
-        p.append(QLatin1Char('/'));
+    if( ! p.endsWith(QDir::separator()) ) {
+        p.append(QDir::separator());
     }
     return p;
+}
+
+QString Folder::cleanPath(QString path)
+{
+    QString cleanedPath = QDir::cleanPath(path);
+
+    if(cleanedPath.length() == 3 && cleanedPath.endsWith(":/"))
+        return cleanedPath.left(2);
+
+    return cleanedPath;
 }
 
 bool Folder::isBusy() const

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -186,12 +186,12 @@ QString Folder::path() const
     return p;
 }
 
-QString Folder::cleanPath(QString path)
+QString Folder::cleanPath()
 {
-    QString cleanedPath = QDir::cleanPath(path);
+    QString cleanedPath = QDir::cleanPath(_path);
 
     if(cleanedPath.length() == 3 && cleanedPath.endsWith(":/"))
-        return cleanedPath.left(2);
+        cleanedPath.remove(2,1);
 
     return cleanedPath;
 }

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -74,7 +74,7 @@ public:
     /**
      * wrapper for QDir::cleanPath("Z:\\"), which returns "Z:\\", but we need "Z:" instead
      */
-    static QString cleanPath(QString path);
+    QString cleanPath();
 
     /**
      * remote folder path

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -72,6 +72,11 @@ public:
     QString path() const;
 
     /**
+     * wrapper for QDir::cleanPath("Z:\\"), which returns "Z:\\", but we need "Z:" instead
+     */
+    static QString cleanPath(QString path);
+
+    /**
      * remote folder path
      */
     QString remotePath() const;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -736,7 +736,7 @@ Folder *FolderMan::folderForPath(const QString &path)
     QString absolutePath = QDir::cleanPath(path)+QLatin1Char('/');
 
     foreach(Folder* folder, this->map().values()) {
-        const QString folderPath = QDir::cleanPath(folder->path())+QLatin1Char('/');
+        const QString folderPath = Folder::cleanPath(folder->path())+QLatin1Char('/');
 
         if(absolutePath.startsWith(folderPath)) {
             //qDebug() << "found folder: " << folder->path() << " for " << absolutePath;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -736,7 +736,7 @@ Folder *FolderMan::folderForPath(const QString &path)
     QString absolutePath = QDir::cleanPath(path)+QLatin1Char('/');
 
     foreach(Folder* folder, this->map().values()) {
-        const QString folderPath = Folder::cleanPath(folder->path())+QLatin1Char('/');
+        const QString folderPath = folder->cleanPath()+QLatin1Char('/');
 
         if(absolutePath.startsWith(folderPath)) {
             //qDebug() << "found folder: " << folder->path() << " for " << absolutePath;

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -402,7 +402,7 @@ void SocketApi::command_RETRIEVE_FILE_STATUS(const QString& argument, QLocalSock
         DEBUG << "folder offline or not watched:" << argument;
         statusString = QLatin1String("NOP");
     } else {
-        const QString file = QDir::cleanPath(argument).mid(Folder::cleanPath(syncFolder->path()).length()+1);
+        const QString file = QDir::cleanPath(argument).mid(syncFolder->cleanPath().length()+1);
         SyncFileStatus fileStatus = this->fileStatus(syncFolder, file, _excludes);
 
         statusString = fileStatus.toSocketAPIString();

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -402,7 +402,7 @@ void SocketApi::command_RETRIEVE_FILE_STATUS(const QString& argument, QLocalSock
         DEBUG << "folder offline or not watched:" << argument;
         statusString = QLatin1String("NOP");
     } else {
-        const QString file = QDir::cleanPath(argument).mid(QDir::cleanPath(syncFolder->path()).length()+1);
+        const QString file = QDir::cleanPath(argument).mid(Folder::cleanPath(syncFolder->path()).length()+1);
         SyncFileStatus fileStatus = this->fileStatus(syncFolder, file, _excludes);
 
         statusString = fileStatus.toSocketAPIString();


### PR DESCRIPTION
When the local sync target is just a drive letter (e.g. "X:\"), neither
the display of the sync status via file icon overlay, nor the creation of a
share link works. In the latter case no pop-up comes up and no server
request is done.

[QDir::cleanPath() usually removes trailing slashes, but not if the path to
be cleaned is just "X:\" and the OS it is running on is Windows](http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qdir.cpp?id=9ae7e33f28f972ec566d62ab110e173ebe933520#n2167). In that case the trailing slash is kept.

Addendum: I tried to keep number of changes as small as possible. But the change to `Folder::path()` was necessary, so that the local sync target `X:\` would not end up as `X:\/`. [Which would result in the construction of a wrong remote path for a file](https://github.com/owncloud/client/blob/ae17f58b80208df0e6318dbabbfabd7ae842332e/src/gui/socketapi.cpp#L436) when trying to retrieve the share link for the file.

The patch was developed and tested on Windows with the version behind tag `v1.8.0`. I just rebased it to `master`. I encountered no conflicts during rebase, but did no tests since compilation of `master` aborts with `client\src\gui\accountsettings.cpp:625: Fehler: undefined reference to 'OCC::ProgressInfo::Progress::completed() const'` and 24 other "undefined reference" errors, all related to `OCC::ProgressInfo`.