### PR TITLE
Use predefined function macro from C99.

### DIFF
--- a/csync/src/csync_log.h
+++ b/csync/src/csync_log.h
@@ -61,7 +61,7 @@ enum csync_log_priority_e {
 };
 
 #define CSYNC_LOG(priority, ...) \
-  csync_log(priority, __FUNCTION__, __VA_ARGS__)
+  csync_log(priority, __func__, __VA_ARGS__)
 
 void csync_log(int verbosity,
                const char *function,

--- a/csync/src/httpbf/src/httpbf.c
+++ b/csync/src/httpbf/src/httpbf.c
@@ -42,7 +42,7 @@
 #define DEBUG_HBF(...) { if(transfer->log_cb) { \
         char buf[1024];                         \
         snprintf(buf, 1024, __VA_ARGS__);       \
-        transfer->log_cb(__FUNCTION__, buf, transfer->user_data);    \
+        transfer->log_cb(__func__, buf, transfer->user_data);    \
   }  }
 
 // #endif

--- a/csync/tests/csync_tests/check_csync_log.c
+++ b/csync/tests/csync_tests/check_csync_log.c
@@ -131,7 +131,7 @@ static void check_logging(void **state)
     rc = csync_set_log_callback(check_log_callback);
     assert_int_equal(rc, 0);
 
-    csync_log(1, __FUNCTION__, "rc = %d", rc);
+    csync_log(1, __func__, "rc = %d", rc);
 
     rc = _tstat(path, &sb);
 

--- a/shell_integration/MacOSX/OwnCloudFinder/GCDAsyncSocket.m
+++ b/shell_integration/MacOSX/OwnCloudFinder/GCDAsyncSocket.m
@@ -87,7 +87,7 @@
 #define LogCVerbose(frmt, ...)  LogC(LOG_FLAG_VERBOSE, (@"%@: " frmt), THIS_FILE, ##__VA_ARGS__)
 
 #define LogTrace()              LogObjc(LOG_FLAG_VERBOSE, @"%@: %@", THIS_FILE, THIS_METHOD)
-#define LogCTrace()             LogC(LOG_FLAG_VERBOSE, @"%@: %s", THIS_FILE, __FUNCTION__)
+#define LogCTrace()             LogC(LOG_FLAG_VERBOSE, @"%@: %s", THIS_FILE, __func__)
 
 // Log levels : off, error, warn, info, verbose
 static const int logLevel = LOG_LEVEL_VERBOSE;


### PR DESCRIPTION
Fixes compilation with gcc 5.1 which uses --std=gnu11 as default.