### PR TITLE
Add 'Content-Length: 0' header to MKCOL request; fixes #3256

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -307,8 +307,12 @@ MkColJob::MkColJob(AccountPtr account, const QString &path, QObject *parent)
 
 void MkColJob::start()
 {
-    // assumes ownership
-   QNetworkReply *reply = davRequest("MKCOL", path());
+   // add 'Content-Length: 0' header (see https://github.com/owncloud/client/issues/3256)
+   QNetworkRequest req;
+   req.setRawHeader("Content-Length", "0");
+
+   // assumes ownership
+   QNetworkReply *reply = davRequest("MKCOL", path(), req);
    setReply(reply);
    setupConnections(reply);
    AbstractNetworkJob::start();


### PR DESCRIPTION
This fix solves #3256 by adding 'Content-Length: 0' to the MKCOL request. It does not violate the [WebDAV spec](http://www.webdav.org/specs/rfc2518.html#METHOD_MKCOL) and it is compatible with Apache. It works on the Linux client. The Windows client is being tested as we speak.