### PR TITLE
Confirm feature (sync engine part only)

### DIFF
--- a/csync/src/csync_private.h
+++ b/csync/src/csync_private.h
@@ -90,6 +90,11 @@ struct csync_s {
       csync_update_callback update_callback;
       void *update_callback_userdata;
 
+      /* hooks for checking the white list (uses the update_callback_userdata) */
+      int (*checkSelectiveSyncBlackListHook)(void*, const char*);
+      int (*checkSelectiveSyncNewShareHook)(void*, const char*);
+
+
       csync_vio_opendir_hook remote_opendir_hook;
       csync_vio_readdir_hook remote_readdir_hook;
       csync_vio_closedir_hook remote_closedir_hook;
@@ -165,9 +170,6 @@ struct csync_s {
 
   struct csync_owncloud_ctx_s *owncloud_context;
 
-  /* hooks for checking the white list */
-  void *checkSelectiveSyncBlackListData;
-  int (*checkSelectiveSyncBlackListHook)(void*, const char*);
 };
 
 

--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -188,8 +188,8 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
     }
   }
 
-  if (ctx->current == REMOTE_REPLICA && ctx->checkSelectiveSyncBlackListHook) {
-      if (ctx->checkSelectiveSyncBlackListHook(ctx->checkSelectiveSyncBlackListData, path)) {
+  if (ctx->current == REMOTE_REPLICA && ctx->callbacks.checkSelectiveSyncBlackListHook) {
+      if (ctx->callbacks.checkSelectiveSyncBlackListHook(ctx->callbacks.update_callback_userdata, path)) {
           return 1;
       }
   }
@@ -398,6 +398,15 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
             } else {
                 /* file not found in statedb */
                 st->instruction = CSYNC_INSTRUCTION_NEW;
+
+                if (fs->type == CSYNC_VIO_FILE_TYPE_DIRECTORY && ctx->current == REMOTE_REPLICA && ctx->callbacks.checkSelectiveSyncNewShareHook) {
+                    if (strchr(fs->remotePerm, 'S') != NULL) { /* check that the directory is shared */
+                        if (ctx->callbacks.checkSelectiveSyncNewShareHook(ctx->callbacks.update_callback_userdata, path)) {
+                            SAFE_FREE(st);
+                            return 1;
+                        }
+                    }
+                }
                 goto out;
             }
         }

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -443,8 +443,9 @@ restart_sync:
 
     Cmd cmd;
     SyncJournalDb db(options.source_dir);
-    if (!selectiveSyncList.empty())
+    if (!selectiveSyncList.empty()) {
         selectiveSyncFixup(&db, selectiveSyncList);
+    }
 
     SyncEngine engine(account, _csync_ctx, options.source_dir, QUrl(options.target_url).path(), folder, &db);
     QObject::connect(&engine, SIGNAL(finished()), &app, SLOT(quit()));

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -820,7 +820,6 @@ void Folder::startSync(const QStringList &pathList)
     connect(_engine.data(), SIGNAL(syncItemDiscovered(const SyncFileItem &)), this, SLOT(slotSyncItemDiscovered(const SyncFileItem &)));
 
     setDirtyNetworkLimits();
-    _engine->setSelectiveSyncBlackList(selectiveSyncBlackList());
 
     QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
 
@@ -847,16 +846,6 @@ void Folder::setDirtyNetworkLimits()
         }
 
         _engine->setNetworkLimits(uploadLimit, downloadLimit);
-    }
-}
-
-void Folder::setSelectiveSyncBlackList(const QStringList& blackList)
-{
-    _selectiveSyncBlackList = blackList;
-    for (int i = 0; i < _selectiveSyncBlackList.count(); ++i) {
-        if (!_selectiveSyncBlackList.at(i).endsWith(QLatin1Char('/'))) {
-            _selectiveSyncBlackList[i].append(QLatin1Char('/'));
-        }
     }
 }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -131,9 +131,6 @@ public:
      // Used by the Socket API
      SyncJournalDb *journalDb() { return &_journal; }
 
-     QStringList selectiveSyncBlackList() { return _selectiveSyncBlackList; }
-     void setSelectiveSyncBlackList(const QStringList &blackList);
-
      bool estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s);
 
      RequestEtagJob *etagJob() { return _requestEtagJob; }
@@ -222,7 +219,6 @@ private:
     SyncResult _syncResult;
     QScopedPointer<SyncEngine> _engine;
     QStringList  _errors;
-    QStringList _selectiveSyncBlackList;
     bool         _csyncError;
     bool         _csyncUnavail;
     bool         _wipeDb;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -339,7 +339,6 @@ Folder* FolderMan::setupFolderFromConfigFile(const QString &file) {
     QString backend = settings.value(QLatin1String("backend")).toString();
     QString targetPath = settings.value( QLatin1String("targetPath")).toString();
     bool paused = settings.value( QLatin1String("paused"), false).toBool();
-    QStringList blackList = settings.value( QLatin1String("blackList")).toStringList();
     // QString connection = settings.value( QLatin1String("connection") ).toString();
     QString alias = unescapeAlias( escapedAlias );
 
@@ -361,7 +360,6 @@ Folder* FolderMan::setupFolderFromConfigFile(const QString &file) {
 
     folder = new Folder( accountState, alias, path, targetPath, this );
     folder->setConfigFile(cfgFile.absoluteFilePath());
-    folder->setSelectiveSyncBlackList(blackList);
     qDebug() << "Adding folder to Folder Map " << folder;
     _folderMap[alias] = folder;
     if (paused) {
@@ -378,6 +376,12 @@ Folder* FolderMan::setupFolderFromConfigFile(const QString &file) {
     _folderChangeSignalMapper->setMapping( folder, folder->alias() );
 
     registerFolderMonitor(folder);
+    QStringList blackList = settings.value( QLatin1String("blackList")).toStringList();
+    if (!blackList.empty()) {
+        //migrate settings
+        folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, blackList);
+        settings.remove(QLatin1String("blackList"));
+    }
     return folder;
 }
 

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -597,7 +597,7 @@ SyncFileStatus SocketApi::fileStatus(Folder *folder, const QString& systemFileNa
     }
 
     // Error if it is in the selective sync blacklistr
-    foreach(const auto &s, folder->selectiveSyncBlackList()) {
+    foreach(const auto &s, folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList)) {
         if (fileNameSlash.startsWith(s)) {
             return SyncFileStatus(SyncFileStatus::STATUS_ERROR);
         }

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -23,7 +23,7 @@
 namespace OCC {
 
 
-/* Given a sorted list of paths ending with '/', return weather or not the given path is within one of the paths of the list*/
+/* Given a sorted list of paths ending with '/', return whether or not the given path is within one of the paths of the list*/
 static bool findPathInList(const QStringList &list, const QString &path)
 {
     Q_ASSERT(std::is_sorted(list.begin(), list.end()));
@@ -84,12 +84,13 @@ bool DiscoveryJob::checkSelectiveSyncNewShare(const QString& path)
     }
 
     auto limit = _newSharedFolderSizeLimit;
-    if (true || result > limit) {
+    if (result > limit) {
         // we tell the UI there is a new folder
         emit newSharedFolder(path);
         return true;
     } else {
-        // it is not too big, but it in the white list and do not block
+        // it is not too big, put it in the white list (so we will not do more query for the children)
+        // and and do not block.
         auto p = path;
         if (!p.endsWith(QLatin1Char('/'))) { p += QLatin1Char('/'); }
         _selectiveSyncWhiteList.insert(std::upper_bound(_selectiveSyncWhiteList.begin(),

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -69,6 +69,11 @@ bool DiscoveryJob::checkSelectiveSyncNewShare(const QString& path)
         return false;
     }
 
+    if (_newSharedFolderSizeLimit < 0) {
+        // no limit, everything is allowed;
+        return false;
+    }
+
     // Go in the main thread to do a PROPFIND to know the size of this directory
     qint64 result = -1;
 
@@ -78,7 +83,7 @@ bool DiscoveryJob::checkSelectiveSyncNewShare(const QString& path)
         _vioWaitCondition.wait(&_vioMutex);
     }
 
-    auto limit = 100*1000*1000L; // 100 MB; (FIXME, make it cnfigurable)
+    auto limit = _newSharedFolderSizeLimit;
     if (true || result > limit) {
         // we tell the UI there is a new folder
         emit newSharedFolder(path);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -178,6 +178,7 @@ public:
 
     QStringList _selectiveSyncBlackList;
     QStringList _selectiveSyncWhiteList;
+    qint64 _newSharedFolderSizeLimit = 0;
     Q_INVOKABLE void start();
 signals:
     void finished(int result);

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -711,7 +711,7 @@ bool PropfindJob::finished()
             QXmlStreamReader::TokenType type = reader.readNext();
             if (type == QXmlStreamReader::StartElement) {
                 if (!curElement.isEmpty() && curElement.top() == QLatin1String("prop")) {
-                    items.insert(reader.name().toString(), reader.readElementText());
+                    items.insert(reader.name().toString(), reader.readElementText(QXmlStreamReader::SkipChildElements));
                 } else {
                     curElement.push(reader.name().toString());
                 }

--- a/src/libsync/ownsql.cpp
+++ b/src/libsync/ownsql.cpp
@@ -207,7 +207,7 @@ int SqlQuery::prepare( const QString& sql)
 
         if( _errId != SQLITE_OK ) {
             _error = QString::fromUtf8(sqlite3_errmsg(_db));
-            qDebug() << "Sqlite prepare statement error:" << _error << "in" <<_sql;
+            qWarning() << "Sqlite prepare statement error:" << _error << "in" <<_sql;
         }
     }
     return _errId;
@@ -260,6 +260,7 @@ bool SqlQuery::next()
 void SqlQuery::bindValue(int pos, const QVariant& value)
 {
     int res = -1;
+    Q_ASSERT(_stmt);
     if( _stmt ) {
         switch (value.type()) {
         case QVariant::Int:

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -638,10 +638,16 @@ void SyncEngine::startSync()
 
     DiscoveryJob *discoveryJob = new DiscoveryJob(_csync_ctx);
     discoveryJob->_selectiveSyncBlackList = selectiveSyncBlackList;
+    discoveryJob->_selectiveSyncWhiteList =
+        _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList);
     discoveryJob->moveToThread(&_thread);
     connect(discoveryJob, SIGNAL(finished(int)), this, SLOT(slotDiscoveryJobFinished(int)));
     connect(discoveryJob, SIGNAL(folderDiscovered(bool,QString)),
             this, SIGNAL(folderDiscovered(bool,QString)));
+
+    connect(discoveryJob, SIGNAL(newSharedFolder(QString)),
+            this, SIGNAL(newSharedFolder(QString)));
+
 
     // This is used for the DiscoveryJob to be able to request the main thread/
     // to read in directory contents.

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -640,6 +640,7 @@ void SyncEngine::startSync()
     discoveryJob->_selectiveSyncBlackList = selectiveSyncBlackList;
     discoveryJob->_selectiveSyncWhiteList =
         _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList);
+    discoveryJob->_newSharedFolderSizeLimit = _newSharedFolderSizeLimit;
     discoveryJob->moveToThread(&_thread);
     connect(discoveryJob, SIGNAL(finished(int)), this, SLOT(slotDiscoveryJobFinished(int)));
     connect(discoveryJob, SIGNAL(folderDiscovered(bool,QString)),

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -107,6 +107,9 @@ signals:
 
     void aboutToRemoveAllFiles(SyncFileItem::Direction direction, bool *cancel);
 
+    // A new shared folder was discovered and was not synced because of the confirmation feature
+    void newSharedFolder(const QString &folder);
+
 private slots:
     void slotRootEtagReceived(QString);
     void slotJobCompleted(const SyncFileItem& item);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -64,8 +64,6 @@ public:
 
     Utility::StopWatch &stopWatch() { return _stopWatch; }
 
-    void setSelectiveSyncBlackList(const QStringList &list);
-
     /* Return true if we detected that another sync is needed to complete the sync */
     bool isAnotherSyncNeeded() { return _anotherSyncNeeded; }
 
@@ -199,8 +197,6 @@ private:
 
     // hash containing the permissions on the remote directory
     QHash<QString, QByteArray> _remotePerms;
-
-    QStringList _selectiveSyncBlackList;
 
     bool _anotherSyncNeeded;
 };

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -62,6 +62,11 @@ public:
     /* Abort the sync.  Called from the main thread */
     void abort();
 
+    /* Set the maximum size a shared folder can have without asking for confirmation
+     * -1 means infinite
+     */
+    void setNewSharedFolderSizeLimit(qint64 limit) { _newSharedFolderSizeLimit = limit; }
+
     Utility::StopWatch &stopWatch() { return _stopWatch; }
 
     /* Return true if we detected that another sync is needed to complete the sync */
@@ -197,6 +202,8 @@ private:
 
     int _uploadLimit;
     int _downloadLimit;
+    /* maximum size a shared folder can have without asking for confirmation: -1 means infinite */
+    qint64 _newSharedFolderSizeLimit = -1;
 
     // hash containing the permissions on the remote directory
     QHash<QString, QByteArray> _remotePerms;

--- a/src/libsync/syncjournaldb.cpp
+++ b/src/libsync/syncjournaldb.cpp
@@ -1259,7 +1259,7 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo& info)
     }
 }
 
-QStringList SyncJournalDb::selectiveSyncList(SyncJournalDb::SelectiveSyncListType type)
+QStringList SyncJournalDb::getSelectiveSyncList(SyncJournalDb::SelectiveSyncListType type)
 {
     QStringList result;
 

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -97,7 +97,7 @@ public:
         SelectiveSyncUndecidedList = 3
     };
     /* return the specified list from the database */
-    QStringList selectiveSyncList(SelectiveSyncListType type);
+    QStringList getSelectiveSyncList(SelectiveSyncListType type);
     /* Write the selective sync list (remove all other entries of that list */
     void setSelectiveSyncList(SelectiveSyncListType type, const QStringList &list);
 

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -91,6 +91,16 @@ public:
     void setPollInfo(const PollInfo &);
     QVector<PollInfo> getPollInfos();
 
+    enum SelectiveSyncListType {
+        SelectiveSyncBlackList = 1,
+        SelectiveSyncWhiteList = 2,
+        SelectiveSyncUndecidedList = 3
+    };
+    /* return the specified list from the database */
+    QStringList selectiveSyncList(SelectiveSyncListType type);
+    /* Write the selective sync list (remove all other entries of that list */
+    void setSelectiveSyncList(SelectiveSyncListType type, const QStringList &list);
+
     /**
      * Make sure that on the next sync, filName is not read from the DB but use the PROPFIND to
      * get the info from the server
@@ -140,6 +150,7 @@ private:
     QScopedPointer<SqlQuery> _deleteFileRecordRecursively;
     QScopedPointer<SqlQuery> _getErrorBlacklistQuery;
     QScopedPointer<SqlQuery> _setErrorBlacklistQuery;
+    QScopedPointer<SqlQuery> _getSelectiveSyncListQuery;
 
     /* This is the list of paths we called avoidReadFromDbOnNextSync on.
      * It means that they should not be written to the DB in any case since doing

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -92,8 +92,16 @@ public:
     QVector<PollInfo> getPollInfos();
 
     enum SelectiveSyncListType {
+        /** The black list is the list of folders that are unselected in the selective sync dialog.
+         * For the sync engine, those folders are considered as if they were not there, so the local
+         * folders will be deleted */
         SelectiveSyncBlackList = 1,
+        /** When a shared flder has a size bigger than a configured size, it is by default not sync'ed
+         * Unless it is in the white list, in which case the folder is sync'ed and all its children.
+         * If a folder is both on the black and the white list, the black list wins */
         SelectiveSyncWhiteList = 2,
+        /** List of big sync folder that have not been confirmed by the user yet and that the UI
+         * should notify about */
         SelectiveSyncUndecidedList = 3
     };
     /* return the specified list from the database */


### PR DESCRIPTION
The idea is that the UI would set SyncEngine->setNewSharedFolderSizeLimit and listen to the newSharedFolder signal.  It would then add the new folder in the blacklist, and the unconfirmed list.  Then from the UI we can move the unconfirmed item to the white list when the selective sync dialog is closed.