### PR TITLE
Abort the request and reset the QNAM if user does not ACK a new cert.

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -503,6 +503,11 @@ void Account::slotHandleErrors(QNetworkReply *reply , QList<QSslError> errors)
         reply->ignoreSslErrors();
     } else {
         _treatSslErrorsAsFailure = true;
+        // if during normal operation, a new certificate was MITM'ed, and the user does not
+        // ACK it, the running request must be aborted and the QNAM must be reset, to not
+        // treat the new cert as granted. See bug #3283
+        reply->abort();
+        resetNetworkAccessManager();
         return;
     }
 }


### PR DESCRIPTION
This is supposed to fix bug #3283