### PR TITLE
Add travis file for coverity_scan branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ install:
 - curl --form token=$token --form email=lukas@statuscode.ch --form file=@$PWD/client.tgz --form version="$checkout" --form description="$checkout" https://scan.coverity.com/builds?project=owncloud%2Fmirall
 
 # Hack to stop processing
-script: time
+script: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: cpp
+branches:
+  only:
+  - coverity_scan 
+
+env:
+  global:
+    secure: "heviCPZymO/3impAjVchArRIjP/UdWdIapTkK8eX1KL+dDNNJiDDXCGi9ZCHoZW1CzIEc3QWcG7jn4wyPesMiDuMsGcvZFIVMx1E1KQNJ+D2Wu+EST9bRicAx+7knEosEVVFeWbXtL3QqVtza3qQ1EhryOUz6dMGIvoIZkLhWiI="
+
+before_install:
+- sudo sh -c "echo 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/xUbuntu_12.04/
+  /' >> /etc/apt/sources.list.d/owncloud-client.list"
+- sudo sh -c "echo 'deb-src http://download.opensuse.org/repositories/isv:/ownCloud:/desktop/xUbuntu_12.04/
+  /' >> /etc/apt/sources.list.d/owncloud-client.list"
+- wget http://download.opensuse.org/repositories/isv:ownCloud:desktop/xUbuntu_12.04/Release.key
+- sudo apt-key add - < Release.key
+- sudo apt-get update
+- sudo apt-get build-dep owncloud-client
+- checkout=$(git show-ref --head --hash head)
+- cd ../
+- wget https://scan.coverity.com/download/linux-64 --post-data "token=$token&project=owncloud%2Fmirall" -O coverity_tool.tgz
+- mkdir coverity
+- tar -xvf coverity_tool.tgz -C coverity --strip-components=1
+- export PATH=$PATH:$PWD/coverity/bin/
+- cd $TRAVIS_BUILD_DIR
+
+install:
+- cd ../
+- mkdir client-build
+- cd client-build
+- cmake -DCMAKE_BUILD_TYPE="Debug" $TRAVIS_BUILD_DIR
+- cov-build --dir cov-int make
+- tar czvf client.tgz cov-int 
+- curl --form token=$token --form email=lukas@statuscode.ch --form file=@$PWD/client.tgz --form version="$checkout" --form description="$checkout" https://scan.coverity.com/builds?project=owncloud%2Fmirall
+
+# Hack to stop processing
+script: time


### PR DESCRIPTION
All things pushed to the "coverity_scan" branch will now get build by Travis and the resulting binary is pushed to Coverity and analyzed automatically.

Since Coverity has a fair usage policy which allows us up to 8 builds per week with a maximum of 2 builds per day we cannot run this automatedly on every push. Which also doesn't make that much sense.

Currently this can be used by reating a "coverity_scan" branch and force-pushing the new code to analyze. If all went well the Travis build should pass and Coverity should display the new information (give it some time to process the build though). In Coverity the SHA of the processed build will be used as version number as well as descriptive text.
(we can automate this though in the future as well if we want that too)

This will fail at the moment on master since Qt4 builds are failing as per https://ci.owncloud.org/job/client-build-matrix-linux/ - probably something that should get fixed. 1.8 branch worked fine though.

@DeepDiver1975 @danimo