### PR TITLE
csync: Do not ignore hard links anymore

### DIFF
--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -100,7 +100,6 @@ enum csync_status_codes_e {
   CSYNC_STATUS_ABORTED,
     /* Codes for file individual status: */
     CSYNC_STATUS_INDIVIDUAL_IS_SYMLINK,
-    CSYNC_STATUS_INDIVIDUAL_IS_HARDLINK,
     CSYNC_STATUS_INDIVIDUAL_IGNORE_LIST,
     CSYNC_STATUS_INDIVIDUAL_IS_INVALID_CHARS,
     CSYNC_STATUS_INDIVIDUAL_EXCLUDE_LONG_FILENAME,
@@ -174,7 +173,7 @@ enum csync_vio_file_stat_fields_e {
   CSYNC_VIO_FILE_STAT_FIELDS_FLAGS = 1 << 2,
   CSYNC_VIO_FILE_STAT_FIELDS_DEVICE = 1 << 3,
   CSYNC_VIO_FILE_STAT_FIELDS_INODE = 1 << 4,
-  CSYNC_VIO_FILE_STAT_FIELDS_LINK_COUNT = 1 << 5,
+//  CSYNC_VIO_FILE_STAT_FIELDS_LINK_COUNT = 1 << 5,
   CSYNC_VIO_FILE_STAT_FIELDS_SIZE = 1 << 6,
 //  CSYNC_VIO_FILE_STAT_FIELDS_BLOCK_COUNT = 1 << 7, /* will be removed */
 //  CSYNC_VIO_FILE_STAT_FIELDS_BLOCK_SIZE = 1 << 8,  /* will be removed */
@@ -213,7 +212,6 @@ struct csync_vio_file_stat_s {
 
   dev_t device;
   uint64_t inode;
-  nlink_t nlink;
 
   int fields; // actually enum csync_vio_file_stat_fields_e fields;
   enum csync_vio_file_type_e type;

--- a/csync/src/csync_private.h
+++ b/csync/src/csync_private.h
@@ -183,7 +183,6 @@ struct csync_file_stat_s {
   size_t pathlen;   /* u64 */
   uint64_t inode;   /* u64 */
   mode_t mode;      /* u32 */
-  int nlink;        /* u32 */
   int type;         /* u32 */
   int child_modified;/*bool*/
   int should_update_etag; /*bool */

--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -210,11 +210,6 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
 
   /* check hardlink count */
   if (type == CSYNC_FTW_TYPE_FILE ) {
-    if( fs->nlink > 1) {
-      st->instruction = CSYNC_INSTRUCTION_IGNORE;
-      st->error_status = CSYNC_STATUS_INDIVIDUAL_IS_HARDLINK;
-      goto out;
-    }
 
     if (fs->mtime == 0) {
       CSYNC_LOG(CSYNC_LOG_PRIORITY_TRACE, "file: %s - mtime is zero!", path);
@@ -442,7 +437,6 @@ out:
   st->mode  = fs->mode;
   st->size  = fs->size;
   st->modtime = fs->mtime;
-  st->nlink = fs->nlink;
   st->type  = type;
   st->etag   = NULL;
   if( fs->etag ) {

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -338,9 +338,6 @@ int csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf) {
   buf->ctime = sb.st_ctime;
   buf->fields |= CSYNC_VIO_FILE_STAT_FIELDS_CTIME;
 
-  buf->nlink = sb.st_nlink;
-  buf->fields |= CSYNC_VIO_FILE_STAT_FIELDS_LINK_COUNT;
-
   buf->size = sb.st_size;
   buf->fields |= CSYNC_VIO_FILE_STAT_FIELDS_SIZE;
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -367,9 +367,6 @@ int SyncEngine::treewalkFile( TREE_WALK_FILE *file, bool remote )
     case CSYNC_STATUS_INDIVIDUAL_IS_SYMLINK:
         item->_errorString = tr("Symbolic links are not supported in syncing.");
         break;
-    case CSYNC_STATUS_INDIVIDUAL_IS_HARDLINK:
-        item->_errorString = tr("Hard links are not supported in syncing.");
-        break;
     case CSYNC_STATUS_INDIVIDUAL_IGNORE_LIST:
         item->_errorString = tr("File is listed on the ignore list.");
         break;


### PR DESCRIPTION
There is no reason to ignore them. Downloading a file that is hardlinked
will break the link.

Will solve syncing NTFS directories #3241