### PR TITLE
Enable long file names in windows (longer than 250 bytes)

### DIFF
--- a/cmake/modules/AddCMockaTest.cmake
+++ b/cmake/modules/AddCMockaTest.cmake
@@ -20,4 +20,15 @@ function (ADD_CMOCKA_TEST _testName _testSource)
     add_executable(${_testName} ${_testSource})
     target_link_libraries(${_testName} ${ARGN})
     add_test(${_testName} ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
+
+  if(UNIT_TESTING)
+  INSTALL(
+  TARGETS
+    ${_testName}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  endif(UNIT_TESTING)
+
 endfunction (ADD_CMOCKA_TEST)

--- a/csync/src/csync_exclude.c
+++ b/csync/src/csync_exclude.c
@@ -81,7 +81,7 @@ int csync_exclude_load(const char *fname, c_strlist_t **list) {
   _fmode = _O_BINARY;
 #endif
 
-  w_fname = c_utf8_to_locale(fname);
+  w_fname = c_utf8_path_to_locale(fname);
   if (w_fname == NULL) {
       return -1;
   }

--- a/csync/src/csync_misc.c
+++ b/csync/src/csync_misc.c
@@ -64,10 +64,10 @@ int csync_fnmatch(__const char *__pattern, __const char *__name, int __flags) {
 
     (void) __flags;
 
-    name = c_utf8_to_locale(__name);
-    pat = c_utf8_to_locale(__pattern);
+    name = c_utf8_path_to_locale(__name);
+    pat = c_utf8_string_to_locale(__pattern);
 
-    match = PathMatchSpec(name, pat);
+    match = PathMatchSpecW(name, pat);
 
     c_free_locale_string(pat);
     c_free_locale_string(name);

--- a/csync/src/csync_misc.c
+++ b/csync/src/csync_misc.c
@@ -64,8 +64,8 @@ int csync_fnmatch(__const char *__pattern, __const char *__name, int __flags) {
 
     (void) __flags;
 
-    name = c_utf8_path_to_locale(__name);
-    pat = c_utf8_string_to_locale(__pattern);
+    name = c_utf8_string_to_locale(__name);
+    pat  = c_utf8_string_to_locale(__pattern);
 
     match = PathMatchSpecW(name, pat);
 

--- a/csync/src/csync_util.c
+++ b/csync/src/csync_util.c
@@ -103,7 +103,7 @@ void csync_memstat_check(void) {
   CSYNC_LOG(CSYNC_LOG_PRIORITY_INFO, "Memory: %dK total size, %dK resident, %dK shared",
                  m.size * 4, m.resident * 4, m.shared * 4);
 }
-
+#if 0
 void csync_win32_set_file_hidden( const char *file, bool h ) {
 #ifdef _WIN32
   const mbchar_t *fileName;
@@ -127,6 +127,7 @@ void csync_win32_set_file_hidden( const char *file, bool h ) {
     (void) file;
 #endif
 }
+#endif
 
 bool (*csync_file_locked_or_open_ext) (const char*) = 0; // filled in by library user
 void set_csync_file_locked_or_open_ext(bool (*f) (const char*));

--- a/csync/src/csync_util.c
+++ b/csync/src/csync_util.c
@@ -103,31 +103,6 @@ void csync_memstat_check(void) {
   CSYNC_LOG(CSYNC_LOG_PRIORITY_INFO, "Memory: %dK total size, %dK resident, %dK shared",
                  m.size * 4, m.resident * 4, m.shared * 4);
 }
-#if 0
-void csync_win32_set_file_hidden( const char *file, bool h ) {
-#ifdef _WIN32
-  const mbchar_t *fileName;
-  DWORD dwAttrs;
-  if( !file ) return;
-
-  fileName = c_utf8_to_locale( file );
-  dwAttrs = GetFileAttributesW(fileName);
-
-  if (dwAttrs != INVALID_FILE_ATTRIBUTES) {
-      if (h && !(dwAttrs & FILE_ATTRIBUTE_HIDDEN)) {
-          SetFileAttributesW(fileName, dwAttrs | FILE_ATTRIBUTE_HIDDEN );
-      } else if (!h && (dwAttrs & FILE_ATTRIBUTE_HIDDEN)) {
-          SetFileAttributesW(fileName, dwAttrs & ~FILE_ATTRIBUTE_HIDDEN );
-      }
-  }
-
-  c_free_locale_string(fileName);
-#else
-    (void) h;
-    (void) file;
-#endif
-}
-#endif
 
 bool (*csync_file_locked_or_open_ext) (const char*) = 0; // filled in by library user
 void set_csync_file_locked_or_open_ext(bool (*f) (const char*));

--- a/csync/src/csync_util.h
+++ b/csync/src/csync_util.h
@@ -30,7 +30,7 @@ const char *csync_instruction_str(enum csync_instructions_e instr);
 
 void csync_memstat_check(void);
 
-void csync_win32_set_file_hidden( const char *file, bool hidden );
+// void csync_win32_set_file_hidden( const char *file, bool hidden );
 
 bool csync_file_locked_or_open( const char *dir, const char *fname);
 #endif /* _CSYNC_UTIL_H */

--- a/csync/src/csync_util.h
+++ b/csync/src/csync_util.h
@@ -30,7 +30,5 @@ const char *csync_instruction_str(enum csync_instructions_e instr);
 
 void csync_memstat_check(void);
 
-// void csync_win32_set_file_hidden( const char *file, bool hidden );
-
 bool csync_file_locked_or_open( const char *dir, const char *fname);
 #endif /* _CSYNC_UTIL_H */

--- a/csync/src/std/c_path.c
+++ b/csync/src/std/c_path.c
@@ -389,3 +389,49 @@ int c_parse_uri(const char *uri,
   return -1;
 }
 
+
+/*
+ * This function takes a path and converts it to a UNC representation of the
+ * string. That means that it prepends a \\?\ and convertes all slashes to
+ * backslashes.
+ *
+ * Note the following:
+ *  - The string must be absolute.
+ *  - it needs to contain a drive character to be a valid UNC
+ *  - A conversion is only done if the path len is larger than 245. Otherwise
+ *    the windows API functions work with the normal "unixoid" representation too.
+ *
+ * Since the function reallocs memory that it can not free itself, the number of
+ * newly allocated bytes are returned in parameter mem_reserved. The calling
+ * function will call free on the result pointer if mem_reserved is > 0.
+ *
+ */
+ const char *c_path_to_UNC(const char *str)
+ {
+     int len = 0;
+     char *longStr = NULL;
+     int i = 4; // index where to start changing "/"=>"\"
+
+     len = strlen(str);
+     longStr = c_malloc(len+5);
+     *longStr = '\0';
+
+     // prepend \\?\ and convert '/' => '\' to support long names
+     if( str[0] == '/' ) {
+         strncpy( longStr, "\\\\?", 4);
+         i=3;
+     } else {
+         strncpy( longStr, "\\\\?\\", 5); // prepend string by this four magic chars.
+     }
+     strncat( longStr, str, len );
+
+     /* replace all occurences of / with the windows native \ */
+     while(longStr[i] != '\0') {
+         if(longStr[i] == '/') {
+             longStr[i] = '\\';
+         }
+         i++;
+     }
+     return longStr;
+ }
+

--- a/csync/src/std/c_path.c
+++ b/csync/src/std/c_path.c
@@ -32,6 +32,7 @@
 #include "c_private.h"
 #include "c_alloc.h"
 #include "c_path.h"
+#include "c_string.h"
 
 /*
  * dirname - parse directory component.
@@ -435,3 +436,18 @@ int c_parse_uri(const char *uri,
      return longStr;
  }
 
+ mbchar_t* c_utf8_path_to_locale(const char *str)
+ {
+     if( str == NULL ) {
+         return NULL;
+     } else {
+ #ifdef _WIN32
+         const char *unc_str = c_path_to_UNC(str);
+         mbchar_t *dst = c_utf8_string_to_locale(unc_str);
+         SAFE_FREE(unc_str);
+         return dst;
+ #else
+         return c_utf8_string_to_locale(str);
+ #endif
+     }
+ }

--- a/csync/src/std/c_path.c
+++ b/csync/src/std/c_path.c
@@ -402,10 +402,7 @@ int c_parse_uri(const char *uri,
  *  - A conversion is only done if the path len is larger than 245. Otherwise
  *    the windows API functions work with the normal "unixoid" representation too.
  *
- * Since the function reallocs memory that it can not free itself, the number of
- * newly allocated bytes are returned in parameter mem_reserved. The calling
- * function will call free on the result pointer if mem_reserved is > 0.
- *
+ *  This function allocates memory that must be freed by the caller.
  */
  const char *c_path_to_UNC(const char *str)
  {

--- a/csync/src/std/c_path.h
+++ b/csync/src/std/c_path.h
@@ -33,6 +33,7 @@
 #define _C_PATH_H
 
 #include "c_macro.h"
+#include "c_private.h"
 
 /**
  * @brief Parse directory component.
@@ -96,9 +97,9 @@ int c_parse_uri(const char *uri, char **scheme, char **user, char **passwd,
  * @param directory '\0' terminated path including the final '/'
  *
  * @param filename '\0' terminated string
- * 
+ *
  * @param extension '\0' terminated string
- * 
+ *
  */
 typedef struct
 {
@@ -120,6 +121,19 @@ typedef struct
  * @return a pointer to the converted string. Caller has to free it.
  */
 const char *c_path_to_UNC(const char *str);
+
+/**
+ * @brief c_utf8_path_to_locale converts a unixoid path to the locale aware format
+ *
+ * On windows, it converts to UNC and multibyte.
+ * On Mac, it converts to the correct utf8 using iconv.
+ * On Linux, it returns utf8
+ *
+ * @param str The path to convert
+ *
+ * @return a pointer to the converted string. Caller has to free it.
+ */
+mbchar_t* c_utf8_path_to_locale(const char *str);
 
 /**
  * }@

--- a/csync/src/std/c_path.h
+++ b/csync/src/std/c_path.h
@@ -107,6 +107,19 @@ typedef struct
     char * extension;
 } C_PATHINFO;
 
+/**
+ * @brief c_path_to_UNC converts a unixoid path to UNC format.
+ *
+ * It converts the '/' to '\' and prepends \\?\ to the path.
+ *
+ * A proper windows path has to have a drive letter, otherwise it is not
+ * valid UNC.
+ *
+ * @param str The path to convert
+ *
+ * @return a pointer to the converted string. Caller has to free it.
+ */
+const char *c_path_to_UNC(const char *str);
 
 /**
  * }@

--- a/csync/src/std/c_private.h
+++ b/csync/src/std/c_private.h
@@ -41,10 +41,18 @@
 #ifdef _WIN32
 #define EDQUOT 0
 #define ENODATA 0
+#ifndef S_IRGRP
 #define S_IRGRP 0
+#endif
+#ifndef S_IROTH
 #define S_IROTH 0
+#endif
+#ifndef S_IXGRP
 #define S_IXGRP 0
+#endif
+#ifndef S_IXOTH
 #define S_IXOTH 0
+#endif
 
 #define S_IFSOCK 10000 /* dummy val on Win32 */
 #define S_IFLNK 10001  /* dummy val on Win32 */

--- a/csync/src/std/c_private.h
+++ b/csync/src/std/c_private.h
@@ -110,7 +110,6 @@ typedef struct stat csync_stat_t;
 typedef  wchar_t         mbchar_t;
 #define _topen           _wopen
 #define _tdirent         _wdirent
-#define _TDIR            _WDIR
 #define _topendir        _wopendir
 #define _tclosedir       _wclosedir
 #define _treaddir        _wreaddir
@@ -130,7 +129,6 @@ typedef  wchar_t         mbchar_t;
 typedef char           mbchar_t;
 #define _tdirent       dirent
 #define _topen         open
-#define _TDIR          DIR
 #define _topendir      opendir
 #define _tclosedir     closedir
 #define _treaddir      readdir

--- a/csync/src/std/c_private.h
+++ b/csync/src/std/c_private.h
@@ -125,6 +125,8 @@ typedef  wchar_t         mbchar_t;
 #define _tchmod          _wchmod
 #define _trewinddir      _wrewinddir
 #define _tchown(X, Y, Z)  0 /* no chown on Win32 */
+#define _tchdir          _wchdir
+#define _tgetcwd         _wgetcwd
 #else
 typedef char           mbchar_t;
 #define _tdirent       dirent
@@ -144,6 +146,8 @@ typedef char           mbchar_t;
 #define _tchmod        chmod
 #define _trewinddir    rewinddir
 #define _tchown(X,Y,Z) chown(X,Y,Z)
+#define _tchdir        chdir
+#define _tgetcwd       getcwd
 #endif
 
 #ifdef WITH_ICONV

--- a/csync/src/std/c_string.c
+++ b/csync/src/std/c_string.c
@@ -282,7 +282,7 @@ char* c_utf8_from_locale(const mbchar_t *wstr)
 
     len = strlen(str);
     // prepend \\?\ and convert '/' => '\' to support long names
-    if( len > 2 ) {
+    if( len > 2 ) {  // FIXME set this to 250 or so
         int i = 4;
         // reserve mem for a new string with the prefix
         mem_reserved = len + 5;

--- a/csync/src/std/c_string.c
+++ b/csync/src/std/c_string.c
@@ -32,6 +32,7 @@
 #include <wchar.h>
 
 #include "c_string.h"
+#include "c_path.h"
 #include "c_alloc.h"
 #include "c_macro.h"
 
@@ -274,63 +275,6 @@ char* c_utf8_from_locale(const mbchar_t *wstr)
   return dst;
 }
 
-/*
- * This function takes a path and converts it to a UNC representation of the
- * string. That means that it prepends a \\?\ and convertes all slashes to
- * backslashes.
- *
- * Note the following:
- *  - The string must be absolute.
- *  - it needs to contain a drive character to be a valid UNC
- *  - A conversion is only done if the path len is larger than 245. Otherwise
- *    the windows API functions work with the normal "unixoid" representation too.
- *
- * Since the function reallocs memory that it can not free itself, the number of
- * newly allocated bytes are returned in parameter mem_reserved. The calling
- * function will call free on the result pointer if mem_reserved is > 0.
- *
- */
- const char *makeLongWinPath(const char *str, int *mem_reserved)
-{
-    int len = 0;
-    char *longStr = NULL;
-
-    if( mem_reserved ) {
-        *mem_reserved = 0;
-    }
-
-    len = strlen(str);
-    // prepend \\?\ and convert '/' => '\' to support long names
-    if( len > 245 ) {  // Only do realloc for long pathes. Shorter pathes are fine.
-        int i = 4;
-        // reserve mem for a new string with the prefix
-        if( mem_reserved ) {
-            *mem_reserved = len + 5;
-        }
-        longStr = c_malloc(len+5);
-        *longStr = '\0';
-
-        if( str[0] == '/' ) {
-            strcpy( longStr, "\\\\?");
-            i=3;
-        } else {
-            strcpy( longStr, "\\\\?\\"); // prepend string by this four magic chars.
-        }
-        strcat( longStr, str );
-
-        /* replace all occurences of / with the windows native \ */
-        while(longStr[i] != '\0') {
-            if(longStr[i] == '/') {
-                longStr[i] = '\\';
-            }
-            i++;
-        }
-        return longStr;
-    } else {
-        return str;
-    }
-}
-
 /* Convert a an UTF8 string to multibyte */
 mbchar_t* c_utf8_to_locale(const char *str)
 {
@@ -339,7 +283,6 @@ mbchar_t* c_utf8_to_locale(const char *str)
   size_t len = 0;
   int size_needed = 0;
   const char *longStr = NULL;
-  int mem_reserved = 0;
 #endif
 
   if (str == NULL ) {
@@ -347,7 +290,7 @@ mbchar_t* c_utf8_to_locale(const char *str)
   }
 
 #ifdef _WIN32
-  longStr = makeLongWinPath(str, &mem_reserved);
+  longStr = c_path_to_UNC(str);
   if( longStr ) {
       len = strlen(longStr);
 
@@ -359,9 +302,7 @@ mbchar_t* c_utf8_to_locale(const char *str)
           MultiByteToWideChar(CP_UTF8, 0, longStr, -1, dst, size_needed);
       }
 
-      if( mem_reserved > 0 ) { // Free mem reserved in hte makeLongWinPath function
-          SAFE_FREE(longStr);
-      }
+      SAFE_FREE(longStr);
   }
 #else
 #ifdef WITH_ICONV

--- a/csync/src/std/c_string.c
+++ b/csync/src/std/c_string.c
@@ -276,40 +276,34 @@ char* c_utf8_from_locale(const mbchar_t *wstr)
 }
 
 /* Convert a an UTF8 string to multibyte */
-mbchar_t* c_utf8_to_locale(const char *str)
+mbchar_t* c_utf8_string_to_locale(const char *str)
 {
-  mbchar_t *dst = NULL;
+    mbchar_t *dst = NULL;
 #ifdef _WIN32
-  size_t len = 0;
-  int size_needed = 0;
-  const char *longStr = NULL;
+    size_t len;
+    int size_needed;
 #endif
 
-  if (str == NULL ) {
-    return NULL;
-  }
+    if (str == NULL ) {
+        return NULL;
+    }
 
 #ifdef _WIN32
-  longStr = c_path_to_UNC(str);
-  if( longStr ) {
-      len = strlen(longStr);
-
-      size_needed = MultiByteToWideChar(CP_UTF8, 0, longStr, len, NULL, 0);
-      if (size_needed > 0) {
-          int size_char = (size_needed + 1) * sizeof(mbchar_t);
-          dst = c_malloc(size_char);
-          memset((void*)dst, 0, size_char);
-          MultiByteToWideChar(CP_UTF8, 0, longStr, -1, dst, size_needed);
-      }
-
-      SAFE_FREE(longStr);
-  }
+    len = strlen(str);
+    size_needed = MultiByteToWideChar(CP_UTF8, 0, str, len, NULL, 0);
+    if (size_needed > 0) {
+        int size_char = (size_needed + 1) * sizeof(mbchar_t);
+        dst = c_malloc(size_char);
+        memset((void*)dst, 0, size_char);
+        MultiByteToWideChar(CP_UTF8, 0, str, -1, dst, size_needed);
+    }
 #else
 #ifdef WITH_ICONV
-  dst = c_iconv(str, iconv_to_native);
+    dst = c_iconv(str, iconv_to_native);
 #else
-  dst = (_TCHAR*) str;
+    dst = (_TCHAR*) str;
 #endif
 #endif
-  return dst;
+    return dst;
 }
+

--- a/csync/src/std/c_string.h
+++ b/csync/src/std/c_string.h
@@ -154,6 +154,9 @@ void c_strlist_destroy(c_strlist_t *strlist);
  */
  char*   c_utf8_from_locale(const mbchar_t *str);
 
+
+ const char *makeLongWinPath(const char *str);
+
 /**
  * @brief Convert a utf8 encoded string to platform specific locale.
  *

--- a/csync/src/std/c_string.h
+++ b/csync/src/std/c_string.h
@@ -155,7 +155,7 @@ void c_strlist_destroy(c_strlist_t *strlist);
  char*   c_utf8_from_locale(const mbchar_t *str);
 
 
- const char *makeLongWinPath(const char *str);
+ const char *makeLongWinPath(const char *str, int *mem_reserved);
 
 /**
  * @brief Convert a utf8 encoded string to platform specific locale.

--- a/csync/src/std/c_string.h
+++ b/csync/src/std/c_string.h
@@ -154,9 +154,6 @@ void c_strlist_destroy(c_strlist_t *strlist);
  */
  char*   c_utf8_from_locale(const mbchar_t *str);
 
-
- const char *makeLongWinPath(const char *str, int *mem_reserved);
-
 /**
  * @brief Convert a utf8 encoded string to platform specific locale.
  *
@@ -166,11 +163,13 @@ void c_strlist_destroy(c_strlist_t *strlist);
  * Instead of using the standard file operations the multi platform aliases
  * defined in c_private.h have to be used instead.
  *
- * To convert path names as input for the cross platform functions from the
+ * To convert strings as input for the cross platform functions from the
  * internally used utf8 format, this function has to be used.
  * The returned string has to be freed by c_free_locale_string(). On some
  * platforms this method allocates memory and on others not but it has never
  * sto be cared about.
+ *
+ * If the string to convert is a path, consider using c_utf8_path_to_locale().
  *
  * @param  str     The utf8 string to convert.
  *
@@ -180,7 +179,7 @@ void c_strlist_destroy(c_strlist_t *strlist);
  * @see c_utf8_from_locale()
  *
  */
-mbchar_t* c_utf8_to_locale(const char *wstr);
+mbchar_t* c_utf8_string_to_locale(const char *wstr);
 
 #if defined(_WIN32) || defined(WITH_ICONV)
 

--- a/csync/src/std/c_time.c
+++ b/csync/src/std/c_time.c
@@ -22,7 +22,7 @@
 #include "c_private.h"
 #include "c_string.h"
 
-#include "c_string.h"
+#include "c_path.h"
 #include "c_time.h"
 
 struct timespec c_tspecdiff(struct timespec time1, struct timespec time0) {
@@ -69,7 +69,7 @@ double c_secdiff(struct timespec clock1, struct timespec clock0) {
 
 #ifdef HAVE_UTIMES
 int c_utimes(const char *uri, const struct timeval *times) {
-    mbchar_t *wuri = c_utf8_to_locale(uri);
+    mbchar_t *wuri = c_utf8_path_to_locale(uri);
     int ret = utimes(wuri, times);
     c_free_locale_string(wuri);
     return ret;
@@ -97,7 +97,7 @@ int c_utimes(const char *uri, const struct timeval *times) {
     FILETIME LastModificationTime;
     HANDLE hFile;
 
-    mbchar_t *wuri = c_utf8_to_locale( uri );
+    mbchar_t *wuri = c_utf8_path_to_locale( uri );
 
     if(times) {
         UnixTimevalToFileTime(times[0], &LastAccessTime);

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -56,9 +56,40 @@ typedef struct dhandle_s {
 
 csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
   dhandle_t *handle = NULL;
-  mbchar_t *dirname = c_utf8_to_locale(name);
+  mbchar_t *dirname = NULL;
 
   handle = c_malloc(sizeof(dhandle_t));
+
+#ifdef _WIN32
+  // the file wildcard has to be attached
+  int len_name = strlen(name);
+  if( len_name ) {
+      char *h = NULL;
+
+      // alloc an enough large buffer to take the name + '/*' + the closing zero.
+      h = c_malloc(len_name+3);
+      strcpy( h, name);
+      strcat(h, "/*");
+
+      dirname = c_utf8_to_locale(h);
+      SAFE_FREE(h);
+  }
+
+  if( dirname ) {
+      handle->hFind = FindFirstFile(dirname, &(handle->ffd));
+  }
+
+  if (!dirname || handle->hFind == INVALID_HANDLE_VALUE) {
+      SAFE_FREE(handle);
+      return NULL;
+  }
+  // FIXME: Handle the case of no files in a dir.
+  // dwError = GetLastError();
+  // if (dwError != ERROR_NO_MORE_FILES) {
+  handle->firstFind = 1; // Set a flag that there first fileinfo is available.
+  // }
+#else
+  dirname = c_utf8_to_locale(name);
 
   handle->dh = _topendir( dirname );
   if (handle->dh == NULL) {
@@ -66,7 +97,7 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
     SAFE_FREE(handle);
     return NULL;
   }
-
+#endif
   handle->path = c_strdup(name);
   c_free_locale_string(dirname);
 
@@ -83,7 +114,14 @@ int csync_vio_local_closedir(csync_vio_handle_t *dhandle) {
   }
 
   handle = (dhandle_t *) dhandle;
+#ifdef _WIN32
+  // FindClose returns non-zero on success
+  if( FindClose(handle->hFind) != 0 ) {
+      rc = 0;
+  }
+#else
   rc = _tclosedir(handle->dh);
+#endif
 
   SAFE_FREE(handle->path);
   SAFE_FREE(handle);
@@ -100,6 +138,39 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
   handle = (dhandle_t *) dhandle;
 
   errno = 0;
+  file_stat = csync_vio_file_stat_new();
+  if (file_stat == NULL) {
+    goto err;
+  }
+  file_stat->fields = CSYNC_VIO_FILE_STAT_FIELDS_NONE;
+
+#ifdef _WIN32
+  // the win32 functions get the first valid entry with the opendir
+  // thus we must not jump to next entry if it was the first find.
+  if( handle->firstFind ) {
+      handle->firstFind = 0;
+  } else {
+      if( FindNextFile(handle->hFind, &(handle->ffd)) == 0 ) {
+          // might be error, check!
+          int dwError = GetLastError();
+          if (dwError != ERROR_NO_MORE_FILES) {
+              errno = EACCES; // FIXME: Is this a good errno?
+              goto err;
+          } else {
+              // Normal case that no more is in the dir.
+              return NULL;
+          }
+      }
+  }
+  file_stat->name = c_utf8_from_locale(handle->ffd.cFileName);
+
+  file_stat->fields |= CSYNC_VIO_FILE_STAT_FIELDS_TYPE;
+  if (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+      file_stat->type = CSYNC_VIO_FILE_TYPE_DIRECTORY;
+  } else {
+      file_stat->type = CSYNC_VIO_FILE_TYPE_REGULAR;
+  }
+#else
   dirent = _treaddir(handle->dh);
   if (dirent == NULL) {
     if (errno) {
@@ -108,14 +179,7 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
       return NULL;
     }
   }
-
-  file_stat = csync_vio_file_stat_new();
-  if (file_stat == NULL) {
-    goto err;
-  }
-
   file_stat->name = c_utf8_from_locale(dirent->d_name);
-  file_stat->fields = CSYNC_VIO_FILE_STAT_FIELDS_NONE;
 
   /* Check for availability of d_type, see manpage. */
 #ifdef _DIRENT_HAVE_D_TYPE
@@ -141,6 +205,8 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
       break;
   }
 #endif
+
+#endif // non WIN32
 
   return file_stat;
 

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -44,7 +44,13 @@
  */
 
 typedef struct dhandle_s {
-  _TDIR *dh;
+#if defined _WIN32
+  WIN32_FIND_DATA ffd;
+  HANDLE hFind;
+  int firstFind;
+#else
+  DIR *dh;
+#endif
   char *path;
 } dhandle_t;
 

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -130,7 +130,6 @@ int csync_vio_local_closedir(csync_vio_handle_t *dhandle) {
 }
 
 csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
-  struct _tdirent *dirent = NULL;
 
   dhandle_t *handle = NULL;
   csync_vio_file_stat_t *file_stat = NULL;
@@ -171,6 +170,8 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
       file_stat->type = CSYNC_VIO_FILE_TYPE_REGULAR;
   }
 #else
+  struct _tdirent *dirent = NULL;
+
   dirent = _treaddir(handle->dh);
   if (dirent == NULL) {
     if (errno) {

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -69,7 +69,7 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
       // alloc an enough large buffer to take the name + '/*' + the closing zero.
       h = c_malloc(len_name+3);
       strncpy( h, name, 1+len_name);
-      strncat(h, "/*",3);
+      strncat(h, "/*", 2);
 
       dirname = c_utf8_path_to_locale(h);
       SAFE_FREE(h);

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -150,12 +150,9 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
           // might be error, check!
           int dwError = GetLastError();
           if (dwError != ERROR_NO_MORE_FILES) {
-              errno = EACCES; // FIXME: Is this a good errno?
-              goto err;
-          } else {
-              // Normal case that no more is in the dir.
-              return NULL;
+              errno = EACCES; // no more files is fine. Otherwise EACCESS
           }
+          goto err;
       }
   }
   file_stat->name = c_utf8_from_locale(handle->ffd.cFileName);
@@ -171,11 +168,7 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
 
   dirent = _treaddir(handle->dh);
   if (dirent == NULL) {
-    if (errno) {
       goto err;
-    } else {
-      return NULL;
-    }
   }
   file_stat->name = c_utf8_from_locale(dirent->d_name);
 

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -68,8 +68,8 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
 
       // alloc an enough large buffer to take the name + '/*' + the closing zero.
       h = c_malloc(len_name+3);
-      strncpy( h, name, len_name);
-      strncat(h, "/*",2);
+      strncpy( h, name, 1+len_name);
+      strncat(h, "/*",3);
 
       dirname = c_utf8_path_to_locale(h);
       SAFE_FREE(h);

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -71,7 +71,7 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
       strcpy( h, name);
       strcat(h, "/*");
 
-      dirname = c_utf8_to_locale(h);
+      dirname = c_utf8_path_to_locale(h);
       SAFE_FREE(h);
   }
 
@@ -89,7 +89,7 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
   handle->firstFind = 1; // Set a flag that there first fileinfo is available.
   // }
 #else
-  dirname = c_utf8_to_locale(name);
+  dirname = c_utf8_path_to_locale(name);
 
   handle->dh = _topendir( dirname );
   if (handle->dh == NULL) {
@@ -243,7 +243,7 @@ int csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf) {
     BY_HANDLE_FILE_INFORMATION fileInfo;
     WIN32_FIND_DATAW FindFileData;
     ULARGE_INTEGER FileIndex;
-    mbchar_t *wuri = c_utf8_to_locale( uri );
+    mbchar_t *wuri = c_utf8_path_to_locale( uri );
 
     h = CreateFileW( wuri, 0, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                      FILE_ATTRIBUTE_NORMAL+FILE_FLAG_BACKUP_SEMANTICS, NULL );
@@ -336,7 +336,7 @@ int csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf) {
 int csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf) {
   csync_stat_t sb;
 
-  mbchar_t *wuri = c_utf8_to_locale( uri );
+  mbchar_t *wuri = c_utf8_path_to_locale( uri );
 
   if( _tstat(wuri, &sb) < 0) {
     c_free_locale_string(wuri);

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -68,8 +68,8 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
 
       // alloc an enough large buffer to take the name + '/*' + the closing zero.
       h = c_malloc(len_name+3);
-      strcpy( h, name);
-      strcat(h, "/*");
+      strncpy( h, name, len_name);
+      strncat(h, "/*",2);
 
       dirname = c_utf8_path_to_locale(h);
       SAFE_FREE(h);

--- a/csync/src/vio/csync_vio_local.c
+++ b/csync/src/vio/csync_vio_local.c
@@ -83,11 +83,8 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
       SAFE_FREE(handle);
       return NULL;
   }
-  // FIXME: Handle the case of no files in a dir.
-  // dwError = GetLastError();
-  // if (dwError != ERROR_NO_MORE_FILES) {
+
   handle->firstFind = 1; // Set a flag that there first fileinfo is available.
-  // }
 #else
   dirname = c_utf8_path_to_locale(name);
 

--- a/csync/tests/CMakeLists.txt
+++ b/csync/tests/CMakeLists.txt
@@ -57,4 +57,7 @@ add_cmocka_test(check_encoding_functions encoding_tests/check_encoding.c ${TEST_
 set(TEST_HTTPBF_LIBRARIES ${TEST_TARGET_LIBRARIES} ${NEON_LIBRARIES})
 add_cmocka_test(check_httpbf httpbf_tests/hbf_send_test.c ${TEST_HTTPBF_LIBRARIES} )
 
+if(UNIT_TESTING)
+    INSTALL( FILES "${CMOCKA_LIBRARIES}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif(UNIT_TESTING)
 

--- a/csync/tests/CMakeLists.txt
+++ b/csync/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_cmocka_test(check_csync_commit csync_tests/check_csync_commit.c ${TEST_TARGE
 # vio
 add_cmocka_test(check_vio_file_stat vio_tests/check_vio_file_stat.c ${TEST_TARGET_LIBRARIES})
 add_cmocka_test(check_vio vio_tests/check_vio.c ${TEST_TARGET_LIBRARIES})
+add_cmocka_test(check_vio_ext vio_tests/check_vio_ext.c ${TEST_TARGET_LIBRARIES})
 
 # sync
 add_cmocka_test(check_csync_update csync_tests/check_csync_update.c ${TEST_TARGET_LIBRARIES})

--- a/csync/tests/csync_tests/check_csync_log.c
+++ b/csync/tests/csync_tests/check_csync_log.c
@@ -119,7 +119,7 @@ static void check_logging(void **state)
     int rc;
     csync_stat_t sb;
     mbchar_t *path;
-    path = c_utf8_to_locale("/tmp/check_csync1/cb_called");
+    path = c_utf8_path_to_locale("/tmp/check_csync1/cb_called");
 
     (void) state; /* unused */
 

--- a/csync/tests/csync_tests/check_csync_statedb_load.c
+++ b/csync/tests/csync_tests/check_csync_statedb_load.c
@@ -80,7 +80,7 @@ static void check_csync_statedb_close(void **state)
     CSYNC *csync = *state;
     csync_stat_t sb;
     time_t modtime;
-    mbchar_t *testdb = c_utf8_to_locale(TESTDB);
+    mbchar_t *testdb = c_utf8_path_to_locale(TESTDB);
     int rc;
 
     /* statedb not written */

--- a/csync/tests/encoding_tests/check_encoding.c
+++ b/csync/tests/encoding_tests/check_encoding.c
@@ -178,7 +178,6 @@ int torture_run_tests(void)
 {
     const UnitTest tests[] = {
         unit_test_setup_teardown(check_long_win_path,                    setup, teardown),
-
         unit_test_setup_teardown(check_to_multibyte,                    setup, teardown),
         unit_test_setup_teardown(check_iconv_ascii,                     setup, teardown),
         unit_test_setup_teardown(check_iconv_to_native_normalization,   setup, teardown),

--- a/csync/tests/encoding_tests/check_encoding.c
+++ b/csync/tests/encoding_tests/check_encoding.c
@@ -20,6 +20,7 @@
 #include "torture.h"
 #include <stdio.h>
 #include "c_string.h"
+#include "c_path.h"
 
 #ifdef _WIN32
 #include <string.h>
@@ -145,14 +146,13 @@ static void check_to_multibyte(void **state)
 
 static void check_long_win_path(void **state)
 {
-    int mem_reserved = 0;
     const char *path = "C://DATA/FILES/MUSIC/MY_MUSIC.mp3"; // check a short path
-    const char *new_short = makeLongWinPath(path, &mem_reserved);
+    const char *exp_path = "\\\\?\\C:\\\\DATA\\FILES\\MUSIC\\MY_MUSIC.mp3";
+    const char *new_short = c_path_to_UNC(path);
 
     (void) state; /* unused */
 
-    assert_string_equal(new_short, path);
-    assert_int_equal(mem_reserved, 0);
+    assert_string_equal(new_short, exp_path);
 
     const char *longPath = "D://alonglonglonglong/blonglonglonglong/clonglonglonglong/dlonglonglonglong/"
             "elonglonglonglong/flonglonglonglong/glonglonglonglong/hlonglonglonglong/ilonglonglonglong/"
@@ -163,11 +163,10 @@ static void check_long_win_path(void **state)
             "jlonglonglonglong\\klonglonglonglong\\llonglonglonglong\\mlonglonglonglong\\nlonglonglonglong\\"
             "olonglonglonglong\\file.txt";
 
-    const char *new_long = makeLongWinPath(longPath, &mem_reserved);
+    const char *new_long = c_path_to_UNC(longPath);
     // printf( "XXXXXXXXXXXX %s %d\n", new_long, mem_reserved);
 
     assert_string_equal(new_long, longPathConv);
-    assert_int_equal(mem_reserved, 287);
 
     // printf( "YYYYYYYYYYYY %ld\n", strlen(new_long));
     assert_int_equal( strlen(new_long), 286);

--- a/csync/tests/encoding_tests/check_encoding.c
+++ b/csync/tests/encoding_tests/check_encoding.c
@@ -18,12 +18,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "torture.h"
-
+#include <stdio.h>
 #include "c_string.h"
 
 #ifdef _WIN32
 #include <string.h>
 #endif
+
 
 static void setup(void **state)
 {
@@ -142,13 +143,27 @@ static void check_to_multibyte(void **state)
     c_free_locale_string(mb_null);
 }
 
+static void check_long_win_path(void **state)
+{
+    const char *path = "C://DATA/FILES/MUSIC/MY_MUSIC.mp3";
+    const char *new = makeLongWinPath(path);
+
+    assert_string_equal(new, "\\\\?\\C:\\\\DATA\\FILES\\MUSIC\\MY_MUSIC.mp3");
+    printf( "XXXXXXXXXXXX %s\n", new);
+    assert_int_equal( strlen(new), 37);
+
+}
+
 int torture_run_tests(void)
 {
     const UnitTest tests[] = {
+        unit_test_setup_teardown(check_long_win_path,                    setup, teardown),
+
         unit_test_setup_teardown(check_to_multibyte,                    setup, teardown),
         unit_test_setup_teardown(check_iconv_ascii,                     setup, teardown),
         unit_test_setup_teardown(check_iconv_to_native_normalization,   setup, teardown),
         unit_test_setup_teardown(check_iconv_from_native_normalization, setup, teardown),
+
     };
 
     return run_tests(tests);

--- a/csync/tests/encoding_tests/check_encoding.c
+++ b/csync/tests/encoding_tests/check_encoding.c
@@ -65,7 +65,7 @@ static void check_iconv_to_native_normalization(void **state)
     const char *exp_out = "\x48\xc3\xa4"; // UTF8
 #endif
 
-    out = c_utf8_to_locale(in);
+    out = c_utf8_path_to_locale(in);
     assert_string_equal(out, exp_out);
 
     c_free_locale_string(out);
@@ -127,8 +127,8 @@ static void check_to_multibyte(void **state)
 {
     int rc = -1;
 
-    mbchar_t *mb_string = c_utf8_to_locale( TESTSTRING );
-    mbchar_t *mb_null   = c_utf8_to_locale( NULL );
+    mbchar_t *mb_string = c_utf8_path_to_locale( TESTSTRING );
+    mbchar_t *mb_null   = c_utf8_path_to_locale( NULL );
 
     (void) state;
 

--- a/csync/tests/encoding_tests/check_encoding.c
+++ b/csync/tests/encoding_tests/check_encoding.c
@@ -145,12 +145,32 @@ static void check_to_multibyte(void **state)
 
 static void check_long_win_path(void **state)
 {
-    const char *path = "C://DATA/FILES/MUSIC/MY_MUSIC.mp3";
-    const char *new = makeLongWinPath(path);
+    int mem_reserved = 0;
+    const char *path = "C://DATA/FILES/MUSIC/MY_MUSIC.mp3"; // check a short path
+    const char *new_short = makeLongWinPath(path, &mem_reserved);
 
-    assert_string_equal(new, "\\\\?\\C:\\\\DATA\\FILES\\MUSIC\\MY_MUSIC.mp3");
-    printf( "XXXXXXXXXXXX %s\n", new);
-    assert_int_equal( strlen(new), 37);
+    (void) state; /* unused */
+
+    assert_string_equal(new_short, path);
+    assert_int_equal(mem_reserved, 0);
+
+    const char *longPath = "D://alonglonglonglong/blonglonglonglong/clonglonglonglong/dlonglonglonglong/"
+            "elonglonglonglong/flonglonglonglong/glonglonglonglong/hlonglonglonglong/ilonglonglonglong/"
+            "jlonglonglonglong/klonglonglonglong/llonglonglonglong/mlonglonglonglong/nlonglonglonglong/"
+            "olonglonglonglong/file.txt";
+    const char *longPathConv = "\\\\?\\D:\\\\alonglonglonglong\\blonglonglonglong\\clonglonglonglong\\dlonglonglonglong\\"
+            "elonglonglonglong\\flonglonglonglong\\glonglonglonglong\\hlonglonglonglong\\ilonglonglonglong\\"
+            "jlonglonglonglong\\klonglonglonglong\\llonglonglonglong\\mlonglonglonglong\\nlonglonglonglong\\"
+            "olonglonglonglong\\file.txt";
+
+    const char *new_long = makeLongWinPath(longPath, &mem_reserved);
+    // printf( "XXXXXXXXXXXX %s %d\n", new_long, mem_reserved);
+
+    assert_string_equal(new_long, longPathConv);
+    assert_int_equal(mem_reserved, 287);
+
+    // printf( "YYYYYYYYYYYY %ld\n", strlen(new_long));
+    assert_int_equal( strlen(new_long), 286);
 
 }
 

--- a/csync/tests/vio_tests/check_vio.c
+++ b/csync/tests/vio_tests/check_vio.c
@@ -59,7 +59,7 @@ static void setup(void **state)
 
 static void setup_dir(void **state) {
     int rc;
-    mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+    mbchar_t *dir = c_utf8_path_to_locale(CSYNC_TEST_DIR);
 
     setup(state);
 
@@ -121,7 +121,7 @@ static void check_csync_vio_opendir_perm(void **state)
     CSYNC *csync = *state;
     csync_vio_handle_t *dh;
     int rc;
-    mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+    mbchar_t *dir = c_utf8_path_to_locale(CSYNC_TEST_DIR);
 
     assert_non_null(dir);
 

--- a/csync/tests/vio_tests/check_vio_ext.c
+++ b/csync/tests/vio_tests/check_vio_ext.c
@@ -1,0 +1,335 @@
+/*
+ * libcsync -- a library to sync a directory with another
+ *
+ * Copyright (c) 2015-2013 by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdio.h>
+
+#include "torture.h"
+
+#include "csync_private.h"
+#include "vio/csync_vio.h"
+
+#ifdef _WIN32
+#define CSYNC_TEST_DIR "C:/tmp/csync_test"
+#else
+#define CSYNC_TEST_DIR "/tmp/csync_test"
+#endif
+#define MKDIR_MASK (S_IRWXU |S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)
+
+#define WD_BUFFER_SIZE 255
+
+static mbchar_t wd_buffer[WD_BUFFER_SIZE];
+
+typedef struct {
+    CSYNC *csync;
+    char  *result;
+} statevar;
+
+/* remove the complete test dir */
+static int wipe_testdir()
+{
+  int rc = 0;
+
+#ifdef _WIN32
+   /* The windows system call to rd bails out if the dir is not existing
+    * Check first.
+    */
+   WIN32_FIND_DATA FindFileData;
+
+   mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+   HANDLE handle = FindFirstFile(dir, &FindFileData);
+   c_free_locale_string(dir);
+   int found = handle != INVALID_HANDLE_VALUE;
+
+   if(found) {
+       FindClose(handle);
+       rc = system("rd /s /q C:\\tmp\\csync_test");
+   }
+#else
+    rc = system("rm -rf /tmp/csync_test/");
+#endif
+    return rc;
+}
+
+static void setup_testenv(void **state) {
+    int rc;
+
+    rc = wipe_testdir();
+    assert_int_equal(rc, 0);
+
+    mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+
+    rc = _tmkdir(dir, MKDIR_MASK);
+    assert_int_equal(rc, 0);
+
+    assert_non_null(_tgetcwd(wd_buffer, WD_BUFFER_SIZE));
+
+    rc = _tchdir(dir);
+    assert_int_equal(rc, 0);
+
+    c_free_locale_string(dir);
+
+    /* --- initialize csync */
+    statevar *mystate = malloc( sizeof(statevar) );
+    mystate->result = NULL;
+
+    rc = csync_create(&(mystate->csync), "/tmp/csync1", "/tmp/csync2");
+    assert_int_equal(rc, 0);
+
+    mystate->csync->replica = LOCAL_REPLICA;
+
+    *state = mystate;
+}
+
+static void teardown(void **state) {
+    statevar *sv = (statevar*) *state;
+    CSYNC *csync = sv->csync;
+    int rc;
+
+    printf("================== Tearing down!\n");
+
+    rc = csync_destroy(csync);
+    assert_int_equal(rc, 0);
+
+    rc = _tchdir(wd_buffer);
+    assert_int_equal(rc, 0);
+
+    rc = wipe_testdir();
+    assert_int_equal(rc, 0);
+
+    *state = NULL;
+}
+
+/* This function takes a relative path, prepends it with the CSYNC_TEST_DIR
+ * and creates each sub directory.
+ */
+static void create_dirs( const char *path )
+{
+  int rc;
+  char *mypath = c_malloc( 2+strlen(CSYNC_TEST_DIR)+strlen(path));
+  *mypath = '\0';
+  strcat(mypath, CSYNC_TEST_DIR);
+  strcat(mypath, "/");
+  strcat(mypath, path);
+
+  char *p = mypath+strlen(CSYNC_TEST_DIR)+1; /* start behind the offset */
+  int i = 0;
+
+  assert_non_null(path);
+
+  while( *(p+i) ) {
+    if( *(p+i) == '/' ) {
+      p[i] = '\0';
+
+      mbchar_t *mb_dir = c_utf8_to_locale(mypath);
+      /* wprintf(L"OOOO %ls (%ld)\n", mb_dir, strlen(mypath)); */
+      rc = _tmkdir(mb_dir, MKDIR_MASK);
+      c_free_locale_string(mb_dir);
+
+      assert_int_equal(rc, 0);
+      p[i] = '/';
+    }
+    i++;
+  }
+  SAFE_FREE(mypath);
+}
+
+/*
+ * This function uses the vio_opendir, vio_readdir and vio_closedir functions
+ * to traverse a file tree that was created before by the create_dir function.
+ *
+ * It appends a listing to the result member of the incoming struct in *state
+ * that can be compared later to what was expected in the calling functions.
+ *
+ */
+static void traverse_dir(void **state, const char *dir)
+{
+    csync_vio_handle_t *dh;
+    csync_vio_file_stat_t *dirent;
+    statevar *sv = (statevar*) *state;
+    CSYNC *csync = sv->csync;
+    char *subdir;
+    char *subdir_out;
+    int rc;
+    int is_dir;
+
+    /* Format: Smuggle in the C: for unix platforms as its urgently needed
+     * on Windows and the test can be nicely cross platform this way. */
+#ifdef _WIN32
+    const char *format_str = "%s %s";
+#else
+    const char *format_str = "%s C:%s";
+#endif
+
+    dh = csync_vio_opendir(csync, dir);
+    assert_non_null(dh);
+
+    while( (dirent = csync_vio_readdir(csync, dh)) ) {
+        assert_non_null(dirent->name);
+
+        assert_int_equal( dirent->fields & CSYNC_VIO_FILE_STAT_FIELDS_TYPE, CSYNC_VIO_FILE_STAT_FIELDS_TYPE );
+
+        if( c_streq( dirent->name, "..") || c_streq( dirent->name, "." )) {
+          continue;
+        }
+
+        is_dir = (dirent->type == CSYNC_VIO_FILE_TYPE_DIRECTORY) ? 1:0;
+
+        assert_int_not_equal( asprintf( &subdir, "%s/%s", dir, dirent->name ), -1 );
+
+        assert_int_not_equal( asprintf( &subdir_out, format_str,
+                                        is_dir ? "<DIR>":"    ",
+                                        subdir), -1 );
+
+        if( !sv->result ) {
+            sv->result = c_strdup( subdir_out);
+        } else {
+            int newlen = 1+strlen(sv->result)+strlen(subdir_out);
+            char *tmp = sv->result;
+            sv->result = c_malloc(newlen);
+            strcpy( sv->result, tmp);
+            SAFE_FREE(tmp);
+
+            strcat( sv->result, subdir_out );
+        }
+        printf("%s\n", subdir_out);
+        traverse_dir( state, subdir);
+
+        SAFE_FREE(subdir);
+        SAFE_FREE(subdir_out);
+    }
+
+    csync_vio_file_stat_destroy(dirent);
+    rc = csync_vio_closedir(csync, dh);
+    assert_int_equal(rc, 0);
+
+}
+
+static void check_readdir_shorttree(void **state)
+{
+    statevar *sv = (statevar*) *state;
+
+    const char *t1 = "alibaba/und/die/vierzig/räuber/";
+    create_dirs( t1 );
+
+    traverse_dir(state, CSYNC_TEST_DIR);
+
+    assert_string_equal( sv->result,
+                         "<DIR> C:/tmp/csync_test/alibaba"
+                         "<DIR> C:/tmp/csync_test/alibaba/und"
+                         "<DIR> C:/tmp/csync_test/alibaba/und/die"
+                         "<DIR> C:/tmp/csync_test/alibaba/und/die/vierzig"
+                         "<DIR> C:/tmp/csync_test/alibaba/und/die/vierzig/räuber" );
+}
+
+static void check_readdir_longtree(void **state)
+{
+    statevar *sv = (statevar*) *state;
+
+    /* Strange things here: Compilers only support strings with length of 4k max.
+     * The expected result string is longer, so it needs to be split up in r1, r2 and r3
+     */
+
+    /* create the test tree */
+    const char *t1 = "vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER/ZWEI/Butteln/VOLL RUM/";
+    create_dirs( t1 );
+
+    const char  *r1 =
+"<DIR> C:/tmp/csync_test/vierzig"
+"<DIR> C:/tmp/csync_test/vierzig/mann"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum";
+
+
+    const char *r2 =
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH";
+
+
+    const char *r3 =
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER/ZWEI"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER/ZWEI/Butteln"
+"<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER/ZWEI/Butteln/VOLL RUM";
+
+    /* assemble the result string ... */
+    int overall_len = 1+strlen(r1)+strlen(r2)+strlen(r3);
+    printf("OO Overall expected result len %d\n", overall_len);
+
+    char *result = c_malloc(overall_len);
+    *result = '\0';
+
+    strcat(result, r1);
+    strcat(result, r2);
+    strcat(result, r3);
+
+    traverse_dir(state, CSYNC_TEST_DIR);
+
+    int result_len = strlen(sv->result);
+    printf("OO Overall real result string len %d\n", result_len);
+
+    /* and compare. */
+    assert_string_equal( sv->result, result);
+}
+
+int torture_run_tests(void)
+{
+    const UnitTest tests[] = {
+        unit_test_setup_teardown(check_readdir_shorttree, setup_testenv, teardown),
+        unit_test_setup_teardown(check_readdir_longtree, setup_testenv, teardown),
+
+    };
+
+    return run_tests(tests);
+}

--- a/csync/tests/vio_tests/check_vio_ext.c
+++ b/csync/tests/vio_tests/check_vio_ext.c
@@ -57,7 +57,7 @@ static int wipe_testdir()
     */
    WIN32_FIND_DATA FindFileData;
 
-   mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+   mbchar_t *dir = c_utf8_path_to_locale(CSYNC_TEST_DIR);
    HANDLE handle = FindFirstFile(dir, &FindFileData);
    c_free_locale_string(dir);
    int found = handle != INVALID_HANDLE_VALUE;
@@ -78,7 +78,7 @@ static void setup_testenv(void **state) {
     rc = wipe_testdir();
     assert_int_equal(rc, 0);
 
-    mbchar_t *dir = c_utf8_to_locale(CSYNC_TEST_DIR);
+    mbchar_t *dir = c_utf8_path_to_locale(CSYNC_TEST_DIR);
 
     rc = _tmkdir(dir, MKDIR_MASK);
     assert_int_equal(rc, 0);
@@ -142,7 +142,7 @@ static void create_dirs( const char *path )
     if( *(p+i) == '/' ) {
       p[i] = '\0';
 
-      mbchar_t *mb_dir = c_utf8_to_locale(mypath);
+      mbchar_t *mb_dir = c_utf8_path_to_locale(mypath);
       /* wprintf(L"OOOO %ls (%ld)\n", mb_dir, strlen(mypath)); */
       rc = _tmkdir(mb_dir, MKDIR_MASK);
       c_free_locale_string(mb_dir);

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -15,6 +15,7 @@
 #include <QDebug>
 #include <QDir>
 
+#include "filesystem.h"
 #include "folderwatcher.h"
 #include "folderwatcher_win.h"
 
@@ -28,9 +29,10 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
                                  bool* increaseBufferSize)
 {
     *increaseBufferSize = false;
+    QString longPath = FileSystem::longWinPath(_path);
 
     _handle = CreateFileW(
-        (wchar_t*)_path.utf16(),
+        (wchar_t*) longPath.utf16(),
         FILE_LIST_DIRECTORY,
         FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE,
         NULL,

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -266,7 +266,6 @@ bool FileSystem::uncheckedRenameReplace(const QString& originFileName,
     QString orig = longWinPath(originFileName);
     QString dest = longWinPath(destinationFileName);
 
-    qDebug() << "** MOVE: " << orig;
     ok = MoveFileEx((wchar_t*)orig.utf16(),
                     (wchar_t*)dest.utf16(),
                     MOVEFILE_REPLACE_EXISTING+MOVEFILE_COPY_ALLOWED+MOVEFILE_WRITE_THROUGH);

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -42,6 +42,7 @@ extern "C" void csync_win32_set_file_hidden( const char *file, bool h );
 extern "C" {
 #include "csync.h"
 #include "vio/csync_vio_local.h"
+#include "std/c_path.h"
 }
 
 namespace OCC {
@@ -50,9 +51,9 @@ QString FileSystem::longWinPath( const QString& inpath )
 {
     QString path(inpath);
 
-    path.replace('/', '\\');
-    path.prepend(QLatin1String("\\\\?\\"));
-
+#ifdef Q_OS_WIN
+    path = QString::fromWCharArray( static_cast<wchar_t*>( c_utf8_path_to_locale(inpath.toUtf8() ) ) );
+#endif
     return path;
 }
 

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -38,6 +38,8 @@ bool fileEquals(const QString &fn1, const QString &fn2);
 /** Mark the file as hidden  (only has effects on windows) */
 void OWNCLOUDSYNC_EXPORT setFileHidden(const QString& filename, bool hidden);
 
+/** convert a "normal" windows path into a path that can be 32k chars long. */
+QString longWinPath( const QString& inpath );
 
 /** Get the mtime for a filepath.
  *

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -39,7 +39,7 @@ bool fileEquals(const QString &fn1, const QString &fn2);
 void OWNCLOUDSYNC_EXPORT setFileHidden(const QString& filename, bool hidden);
 
 /** convert a "normal" windows path into a path that can be 32k chars long. */
-QString longWinPath( const QString& inpath );
+QString OWNCLOUDSYNC_EXPORT longWinPath( const QString& inpath );
 
 /** Get the mtime for a filepath.
  *

--- a/src/libsync/syncjournalfilerecord.cpp
+++ b/src/libsync/syncjournalfilerecord.cpp
@@ -14,6 +14,7 @@
 #include "syncjournalfilerecord.h"
 #include "syncfileitem.h"
 #include "utility.h"
+#include "filesystem.h"
 
 #include <qfileinfo.h>
 #include <qdebug.h>
@@ -46,7 +47,8 @@ SyncJournalFileRecord::SyncJournalFileRecord(const SyncFileItem &item, const QSt
     /* Query the inode:
        based on code from csync_vio_local.c (csync_vio_local_stat)
        Get the Windows file id as an inode replacement. */
-    HANDLE h = CreateFileW( (wchar_t*)localFileName.utf16(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+
+    HANDLE h = CreateFileW( (wchar_t*) FileSystem::longWinPath(localFileName).utf16(), 0, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                      FILE_ATTRIBUTE_NORMAL+FILE_FLAG_BACKUP_SEMANTICS, NULL );
 
     if( h == INVALID_HANDLE_VALUE ) {


### PR DESCRIPTION
This patch converts pathes to UNC format if the path length exceeds 250 bytes.

This would fix bug #60 