### PR TITLE
Use server capabilities

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -138,6 +138,22 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     _ui->errorLabel->setFrameShape(QFrame::Box);
     _ui->errorLabel->setContentsMargins(QMargins(12,12,12,12));
     _ui->errorLabel->hide();
+
+
+    // Parse capabilities
+
+    // If password is enforced make don't allow users to disable it
+    if (_account->capabilities()["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool()) {
+        _ui->checkBox_password->setEnabled(false);
+    }
+
+    // If expiredate is enforced do not allow disable and set max days
+    if (_account->capabilities()["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enforced"].toBool()) {
+        _ui->checkBox_expire->setEnabled(false);
+        _ui->calendar->setMaximumDate(QDate::currentDate().addDays(
+            _account->capabilities()["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt()
+            ));
+    }
 }
 
 void ShareDialog::done( int r ) {

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -23,6 +23,7 @@
 #include "theme.h"
 #include "syncresult.h"
 #include "configfile.h"
+#include "capabilities.h"
 
 #include "QProgressIndicator.h"
 #include <QBuffer>
@@ -142,15 +143,15 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     // Parse capabilities
 
     // If password is enforced make don't allow users to disable it
-    if (_account->capabilities()["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool()) {
+    if (_account->capabilities()->publicLinkEnforcePassword()) {
         _ui->checkBox_password->setEnabled(false);
     }
 
     // If expiredate is enforced do not allow disable and set max days
-    if (_account->capabilities()["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enforced"].toBool()) {
+    if (_account->capabilities()->publicLinkEnforceExpireDate()) {
         _ui->checkBox_expire->setEnabled(false);
         _ui->calendar->setMaximumDate(QDate::currentDate().addDays(
-            _account->capabilities()["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt()
+            _account->capabilities()->publicLinkExpireDateDays()
             ));
     }
 }
@@ -448,7 +449,7 @@ void ShareDialog::slotCheckBoxShareLinkClicked()
          * Check the capabilities if the server requires a password for a share
          * Ask for it directly
          */
-        if (_account->capabilities()["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool()) {
+        if (_account->capabilities()->publicLinkEnforcePassword()) {
             _ui->checkBox_password->setChecked(true);
             _ui->checkBox_password->setEnabled(false);
             _ui->checkBox_password->setText(tr("Public sh&aring requires a password"));

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 set(libsync_SRCS
     account.cpp
     bandwidthmanager.cpp
+    capabilities.cpp
     clientproxy.cpp
     connectionvalidator.cpp
     cookiejar.cpp

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -18,6 +18,7 @@
 #include "accessmanager.h"
 #include "creds/abstractcredentials.h"
 #include "../3rdparty/certificates/p12topem.h"
+#include "capabilities.h"
 
 #include <QSettings>
 #include <QMutex>
@@ -35,6 +36,7 @@ namespace OCC {
 
 Account::Account(QObject *parent)
     : QObject(parent)
+    , _capabilities(QVariantMap())
     , _am(0)
     , _credentials(0)
     , _treatSslErrorsAsFailure(false)
@@ -434,14 +436,14 @@ void Account::setMigrated(bool mig)
     _wasMigrated = mig;
 }
 
-QVariantMap Account::capabilities()
+const Capabilities * Account::capabilities() const
 {
-    return _capabilities;
+    return &_capabilities;
 }
 
 void Account::setCapabilities(const QVariantMap &caps)
 {
-    _capabilities = caps;
+    _capabilities = Capabilities(caps);
 }
 
 QString Account::serverVersion()

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -26,6 +26,7 @@
 #include <QSharedPointer>
 #include "utility.h"
 #include <memory>
+#include "capabilities.h"
 
 class QSettings;
 class QNetworkReply;
@@ -139,7 +140,7 @@ public:
     void setCertificate(const QByteArray certficate = QByteArray(), const QString privateKey = QString());
 
     void setCapabilities(const QVariantMap &caps);
-    QVariantMap capabilities();
+    const Capabilities * capabilities() const;
     void setServerVersion(const QString &version);
     QString serverVersion();
 
@@ -170,7 +171,7 @@ private:
     QUrl _url;
     QList<QSslCertificate> _approvedCerts;
     QSslConfiguration _sslConfiguration;
-    QVariantMap _capabilities;
+    Capabilities _capabilities;
     QString _serverVersion;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
     QuotaInfo *_quotaInfo;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "capabilities.h"
+
+#include <QVariantMap>
+
+namespace OCC {
+
+
+Capabilities::Capabilities(const Capabilities &capabilities) {
+    _capabilities = capabilities._capabilities;
+}
+
+Capabilities::Capabilities(const QVariantMap capabilities)
+    : _capabilities(capabilities)
+{
+}
+
+bool Capabilities::publicLinkEnforcePassword() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool();
+}
+
+bool Capabilities::publicLinkEnforceExpireDate() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enforced"].toBool();
+}
+
+int Capabilities::publicLinkExpireDateDays() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt();
+}
+
+}

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+
+#ifndef CAPABILITIES_H
+#define CAPABILITIES_H
+
+#include "owncloudlib.h"
+
+#include <QVariantMap>
+
+namespace OCC {
+
+/**
+ * @brief The Capabilities class represent the capabilities of an ownCloud
+ * server
+ * @ingroup libsync
+ */
+class Capabilities {
+
+public:
+    Capabilities(const Capabilities& capabilities);
+    Capabilities(const QVariantMap capabilities);
+
+    bool publicLinkEnforcePassword() const;
+    bool publicLinkEnforceExpireDate() const;
+    int  publicLinkExpireDateDays() const;
+
+private:
+    QVariantMap _capabilities;
+};
+
+}
+
+#endif //CAPABILITIES_H


### PR DESCRIPTION
Replaces #2943
Should fix: #2815

By making use of the capabilities provided by the server we can provide a better UX.

1. Do not allow a user to remove expire date/password if the admin enforces it
2. Require a password from the user if this is enforced.

