### PR TITLE
If the OCS Share API returns an url use that

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -329,8 +329,11 @@ void ShareDialog::slotSharesFetched(const QVariantMap &reply)
             }
 
             QString url;
-            // From ownCloud server version 8 on, a different share link scheme is used.
-            if (versionString.contains('.') && versionString.split('.')[0].toInt() >= 8) {
+            // From ownCloud server 8.2 the url field is always set for public shares
+            if (data.contains("url")) {
+                url = data.value("url").toString();
+            } else if (versionString.contains('.') && versionString.split('.')[0].toInt() >= 8) {
+                // From ownCloud server version 8 on, a different share link scheme is used.
                 url = Account::concatUrlPath(_account->url(), QString("index.php/s/%1").arg(data.value("token").toString())).toString();
             } else {
                 QList<QPair<QString, QString>> queryArgs;


### PR DESCRIPTION
To avoid us having to construct the URL for public shares just rely on the server to do it.

This makes it easier to maintain. For example if (in the not do distant future) the index.php part is removed the server would just server this new url.

Pretty simple fix, and should not break for people not on 8.2 since then the url element is simply not present.