### PR TITLE
Don't allow sharing of the root folder

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -420,6 +420,13 @@ void SocketApi::command_SHARE(const QString& localFile, QIODevice* socket)
         const QString folderForPath = shareFolder->path();
         const QString remotePath = shareFolder->remotePath() + localFile.right(localFile.count()-folderForPath.count()+1);
 
+        // Can't share root folder
+        if (QDir::cleanPath(remotePath) == "/") {
+           const QString message = QLatin1String("SHARE:CANNOTSHAREROOT:")+QDir::toNativeSeparators(localFile);
+            sendMessage(socket, message);
+            return;
+        }
+
         SyncJournalFileRecord rec = dbFileRecord_capi(shareFolder, localFile);
 
         bool allowReshare = true; // lets assume the good


### PR DESCRIPTION
Sharing the root folder is not possible so don't allow the user to do this. Fixes #3482 and #3483 

Note that this is just a quick fix.
For better UX we should have a way to tell the plugins that the registered path is the root folder. That way they can simply grey out the menu item on the root folder.