### PR TITLE
Notify of big folders that are greater than or equal to the limit

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -84,7 +84,7 @@ bool DiscoveryJob::checkSelectiveSyncNewFolder(const QString& path)
     }
 
     auto limit = _newBigFolderSizeLimit;
-    if (result > limit) {
+    if (result >= limit) {
         // we tell the UI there is a new folder
         emit newBigFolder(path);
         return true;


### PR DESCRIPTION
This should allow for the case when a user has set the limit to 0 and a new empty folder appears on the server. The folder will have size 0 (no files in it). Doing the >= test here will mean that the user will be prompted about the new folder, which I think is the behaviour they would expect.
The side-effect of this change is that if the user has a limit of, for example, 10,000,000 bytes (10 MB) and a new folder comes along with exactly 10,000,000 bytes of content then they will now be prompted about it. Before the change such a new folder would have been auto-synced without prompting the user. I do not think this is a big deal - I cannot believe that users will be counting exact bytes for this limit, they are just setting a rough number of MB at the UI.
Should fix https://github.com/owncloud/client/issues/3542