### PR TITLE
Utility: use SI units for the sizes in bytes

### DIFF
--- a/src/libsync/utility.cpp
+++ b/src/libsync/utility.cpp
@@ -103,24 +103,24 @@ void Utility::setupFavLink(const QString &folder)
 
 QString Utility::octetsToString( qint64 octets )
 {
-    static const qint64 kb = 1024;
-    static const qint64 mb = 1024 * kb;
-    static const qint64 gb = 1024 * mb;
-    static const qint64 tb = 1024 * gb;
+    static const qint64 kb = 1000;
+    static const qint64 mb = 1000 * kb;
+    static const qint64 gb = 1000 * mb;
+    static const qint64 tb = 1000 * gb;
 
     QString s;
     qreal value = octets;
     if (octets >= tb) {
-        s = QCoreApplication::translate("Utility", "%L1 TiB");
+        s = QCoreApplication::translate("Utility", "%L1 TB");
         value /= tb;
     } else if (octets >= gb) {
-        s = QCoreApplication::translate("Utility", "%L1 GiB");
+        s = QCoreApplication::translate("Utility", "%L1 GB");
         value /= gb;
     } else if (octets >= mb) {
-        s = QCoreApplication::translate("Utility", "%L1 MiB");
+        s = QCoreApplication::translate("Utility", "%L1 MB");
         value /= mb;
     } else if (octets >= kb) {
-        s = QCoreApplication::translate("Utility", "%L1 KiB");
+        s = QCoreApplication::translate("Utility", "%L1 kB");
         value /= kb;
     } else  {
         s = QCoreApplication::translate("Utility", "%L1 B");

--- a/test/testutility.h
+++ b/test/testutility.h
@@ -28,29 +28,26 @@ private slots:
     {
         QLocale::setDefault(QLocale("en"));
         QCOMPARE(octetsToString(999) , QString("999 B"));
-        QCOMPARE(octetsToString(1000) , QString("1,000 B"));
-        QCOMPARE(octetsToString(1010) , QString("1,010 B"));
-        QCOMPARE(octetsToString(1024) , QString("1 KiB"));
-        QCOMPARE(octetsToString(1110) , QString("1.1 KiB"));
+        QCOMPARE(octetsToString(1024) , QString("1 kB"));
+        QCOMPARE(octetsToString(1110) , QString("1.1 kB"));
 
-        QCOMPARE(octetsToString(9110) , QString("8.9 KiB"));
-        QCOMPARE(octetsToString(9910) , QString("9.7 KiB"));
-        QCOMPARE(octetsToString(9999) , QString("9.8 KiB"));
-        QCOMPARE(octetsToString(10240) , QString("10 KiB"));
+        QCOMPARE(octetsToString(9110) , QString("9.1 kB"));
+        QCOMPARE(octetsToString(9910) , QString("9.9 kB"));
+        QCOMPARE(octetsToString(9999) , QString("10 kB"));
+        QCOMPARE(octetsToString(10240) , QString("10 kB"));
 
-        QCOMPARE(octetsToString(123456) , QString("121 KiB"));
-        QCOMPARE(octetsToString(1234567) , QString("1.2 MiB"));
-        QCOMPARE(octetsToString(12345678) , QString("12 MiB"));
-        QCOMPARE(octetsToString(123456789) , QString("118 MiB"));
-        QCOMPARE(octetsToString(1000LL*1000*1000 * 5) , QString("4.7 GiB"));
-        QCOMPARE(octetsToString(1024LL*1024*1024 * 5) , QString("5 GiB"));
+        QCOMPARE(octetsToString(123456) , QString("123 kB"));
+        QCOMPARE(octetsToString(1234567) , QString("1.2 MB"));
+        QCOMPARE(octetsToString(12345678) , QString("12 MB"));
+        QCOMPARE(octetsToString(123456789) , QString("123 MB"));
+        QCOMPARE(octetsToString(1000LL*1000*1000 * 5) , QString("5 GB"));
 
         QCOMPARE(octetsToString(1), QString("1 B"));
         QCOMPARE(octetsToString(2), QString("2 B"));
-        QCOMPARE(octetsToString(1024), QString("1 KiB"));
-        QCOMPARE(octetsToString(1024*1024), QString("1 MiB"));
-        QCOMPARE(octetsToString(1024LL*1024*1024), QString("1 GiB"));
-        QCOMPARE(octetsToString(1024LL*1024*1024*1024), QString("1 TiB"));
+        QCOMPARE(octetsToString(1000), QString("1 kB"));
+        QCOMPARE(octetsToString(1000*1000), QString("1 MB"));
+        QCOMPARE(octetsToString(1000LL*1000*1000), QString("1 GB"));
+        QCOMPARE(octetsToString(1000LL*1000*1000*1000), QString("1 TB"));
     }
 
     void testLaunchOnStartup()


### PR DESCRIPTION
SI units make more sens because users are used to compute with powers of 10