### PR TITLE
Propagator: do not use parallelism when we have bandwidth limit

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -51,6 +51,11 @@ OwncloudPropagator::~OwncloudPropagator()
 /* The maximum number of active job in parallel  */
 int OwncloudPropagator::maximumActiveJob()
 {
+    if (_downloadLimit != 0 || _uploadLimit != 0) {
+        // disable parallelism when there is a network limit.
+        return 1;
+    }
+
     static int max = qgetenv("OWNCLOUD_MAX_PARALLEL").toUInt();
     if (!max) {
         max = 3; //default


### PR DESCRIPTION
When user wants to limit the bandwidth, he does not care about speed
anymore. And parallelism on slow network might cause problems.

For issue #3382
Will also help for #3095