### PR TITLE
Use SHAREDIR for i18n dir

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -222,7 +222,7 @@ if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)
         endforeach( _file )
     endif(NOT WIN32)
 
-    install(FILES ${client_I18N} DESTINATION ${DATADIR}/${APPLICATION_EXECUTABLE}/i18n)
+    install(FILES ${client_I18N} DESTINATION ${SHAREDIR}/${APPLICATION_EXECUTABLE}/i18n)
 
     # we may not add MACOSX_BUNDLE here, if not building one
 


### PR DESCRIPTION
SHAREDIR is used in src/gui/application.cpp and should also use that in
CMakeLists.txt.