### PR TITLE
Autoupdate Doc bullet point rendering 2.0

### DIFF
--- a/doc/autoupdate.rst
+++ b/doc/autoupdate.rst
@@ -106,7 +106,7 @@ using the system-wide ``.plist`` file.  To access this file:
 
  	/Library/Preferences/
 
- 2. Locate and open the following file::
+2. Locate and open the following file::
 
  	com.owncloud.desktopclient.plist
 


### PR DESCRIPTION
A space at the start of the bullet point about "Locate and open the following file" seems to be causing that bullet point to not line up nicely on the rendered page.