### PR TITLE
[2.0] don't show share menu item for top level folders

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -157,13 +157,18 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         # internal or external file?!
         syncedFile = False
         for reg_path in socketConnect.registered_paths:
+            topLevelFolder=False
             filename = get_local_path(file.get_uri())
             #check if its a folder (ends with an /), if yes add a "/" otherwise it will not find the entry in the table
             if os.path.isdir(filename+"/"):
                 filename=filename+"/"
+                #check if toplevel folder, we need to ignore those as they cannot be shared
+                if filename.count("/") < (reg_path.count("/")+2):
+                    topLevelFolder=True                
             # only show the menu extension if the file is synced and the sync
             # status is ok. Not for ignored files etc.
-            if filename.startswith(reg_path) and socketConnect.nautilusVFSFile_table[filename]['state'] == 'OK':
+            # ignore top level folders
+            if filename.startswith(reg_path) and topLevelFolder == False and socketConnect.nautilusVFSFile_table[filename]['state'] == 'OK':
                 syncedFile = True
 
         # if it is neither in a synced folder or is a directory


### PR DESCRIPTION
Top level folders cannot be shared. If you try you receive an 403 error.
So we should not show the "Share with Owncloud" menu item for them

back-port of #3663 
fixes #3662