### PR TITLE
Support for sandstorm.io server URLs

### DIFF
--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -78,6 +78,10 @@ void OwncloudHttpCredsPage::initializePage()
         if (!user.isEmpty()) {
             _ui.leUsername->setText(user);
         }
+        const QString password = httpCreds->password();
+        if (!password.isEmpty()) {
+            _ui.lePassword->setText(password);
+        }
     }
     _ui.leUsername->setFocus();
 }


### PR DESCRIPTION
This pull request is intended to support owncloud/client connecting to a server running under http://sandstorm.io.

Sandstorm apps can generate web keys to give API access to a third party or client app. Web keys are of the form:

http://api.local.sandstorm.io:6080#WHLMLAAPFg1uHZOAcIxXsPKbYAUjM6GFALDzl5H9f_w

From that URL, one can connect to api.local.sandstorm.io with basic auth with the URL fragment as the password and anything as the username. Sandstorm tokens act as both authentication and routing.

I chose to go the route of detecting sandstorm URLs and prefilling http user/pass rather than coming up with a whole different SandstormCreds class/wizard page (a la Shibboleth) because it was a much smaller change, but that's another way this could be implemented.