### PR TITLE
Split sharedialog code

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -50,6 +50,8 @@ set(client_SRCS
     ignorelisteditor.cpp
     logbrowser.cpp
     networksettings.cpp
+    ocsjob.cpp
+    ocssharejob.cpp
     openfilemanager.cpp
     owncloudgui.cpp
     owncloudsetupwizard.cpp
@@ -62,6 +64,7 @@ set(client_SRCS
     sslerrordialog.cpp
     syncrunfilelog.cpp
     systray.cpp
+    thumbnailjob.cpp
     quotainfo.cpp
     accountstate.cpp
     addcertificatedialog.cpp

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "ocsjob.h"
+#include "networkjobs.h"
+#include "account.h"
+#include "json.h"
+
+#include <QBuffer>
+
+namespace OCC {
+
+OCSJob::OCSJob(AccountPtr account, QObject* parent)
+: AbstractNetworkJob(account, "", parent)
+{
+    _passStatusCodes.append(100);
+    setIgnoreCredentialFailure(true);
+}
+
+void OCSJob::setVerb(const QByteArray &verb)
+{
+    _verb = verb;
+}
+
+void OCSJob::setUrl(const QUrl &url)
+{
+    _url = url;
+}
+
+void OCSJob::setGetParams(const QList<QPair<QString, QString> >& getParams)
+{
+    _url.setQueryItems(getParams);
+}
+
+void OCSJob::setPostParams(const QList<QPair<QString, QString> >& postParams)
+{
+    _postParams = postParams;
+}
+
+void OCSJob::addPassStatusCode(int code)
+{
+    _passStatusCodes.append(code);
+}
+
+void OCSJob::start()
+{
+    QNetworkRequest req;
+    req.setRawHeader("OCS-APIREQUEST", "true");
+    req.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
+
+    // Url encode the _postParams and put them in a buffer.
+    QByteArray postData;
+    Q_FOREACH(auto tmp2, _postParams) {
+        if (! postData.isEmpty()) {
+            postData.append("&");
+        }
+        postData.append(QUrl::toPercentEncoding(tmp2.first));
+        postData.append("=");
+        postData.append(QUrl::toPercentEncoding(tmp2.second));
+    }
+    QBuffer *buffer = new QBuffer;
+    buffer->setData(postData);
+
+    auto queryItems = _url.queryItems();
+    queryItems.append(qMakePair(QString::fromLatin1("format"), QString::fromLatin1("json")));
+    _url.setQueryItems(queryItems);
+
+    setReply(davRequest(_verb, _url, req, buffer));
+    setupConnections(reply());
+    buffer->setParent(reply());
+    AbstractNetworkJob::start();
+}
+
+bool OCSJob::finished()
+{
+    const QString replyData = reply()->readAll();
+
+    bool success;
+    QVariantMap json = QtJson::parse(replyData, success).toMap();
+    if (!success) {
+        qDebug() << "Could not parse reply to" << _verb << _url << _postParams
+                 << ":" << replyData;
+    }
+
+    QString message;
+    const int statusCode = getJsonReturnCode(json, message);
+    if (!_passStatusCodes.contains(statusCode)) {
+        qDebug() << "Reply to" << _verb << _url << _postParams
+                 << "has unexpected status code:" << statusCode << replyData;
+    }
+
+    emit jobFinished(json);
+    return true;
+}
+
+int OCSJob::getJsonReturnCode(const QVariantMap &json, QString &message)
+{
+    //TODO proper checking
+    int code = json.value("ocs").toMap().value("meta").toMap().value("statuscode").toInt();
+    message = json.value("ocs").toMap().value("meta").toMap().value("message").toString();
+
+    return code;
+}
+
+}

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -42,6 +42,11 @@ void OcsJob::addPassStatusCode(int code)
     _passStatusCodes.append(code);
 }
 
+void OcsJob::appendPath(int id)
+{
+    setPath(path() + QString("/%1").arg(id));
+}
+
 void OcsJob::start()
 {
     QNetworkRequest req;

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -20,42 +20,42 @@
 
 namespace OCC {
 
-OCSJob::OCSJob(AccountPtr account, QObject* parent)
+OcsJob::OcsJob(AccountPtr account, QObject* parent)
 : AbstractNetworkJob(account, "", parent)
 {
     _passStatusCodes.append(100);
     setIgnoreCredentialFailure(true);
 }
 
-void OCSJob::setVerb(const QByteArray &verb)
+void OcsJob::setVerb(const QByteArray &verb)
 {
     _verb = verb;
 }
 
-void OCSJob::setUrl(const QUrl &url)
+void OcsJob::setUrl(const QUrl &url)
 {
     _url = url;
 }
 
-void OCSJob::setGetParams(const QList<QPair<QString, QString> >& getParams)
+void OcsJob::setGetParams(const QList<QPair<QString, QString> >& getParams)
 {
     _url.setQueryItems(getParams);
 }
 
-void OCSJob::setPostParams(const QList<QPair<QString, QString> >& postParams)
+void OcsJob::setPostParams(const QList<QPair<QString, QString> >& postParams)
 {
     _postParams = postParams;
 }
 
-void OCSJob::addPassStatusCode(int code)
+void OcsJob::addPassStatusCode(int code)
 {
     _passStatusCodes.append(code);
 }
 
-void OCSJob::start()
+void OcsJob::start()
 {
     QNetworkRequest req;
-    req.setRawHeader("OCS-APIREQUEST", "true");
+    req.setRawHeader("Ocs-APIREQUEST", "true");
     req.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
 
     // Url encode the _postParams and put them in a buffer.
@@ -81,7 +81,7 @@ void OCSJob::start()
     AbstractNetworkJob::start();
 }
 
-bool OCSJob::finished()
+bool OcsJob::finished()
 {
     const QString replyData = reply()->readAll();
 
@@ -103,7 +103,7 @@ bool OCSJob::finished()
     return true;
 }
 
-int OCSJob::getJsonReturnCode(const QVariantMap &json, QString &message)
+int OcsJob::getJsonReturnCode(const QVariantMap &json, QString &message)
 {
     //TODO proper checking
     int code = json.value("ocs").toMap().value("meta").toMap().value("statuscode").toInt();

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -48,18 +48,13 @@ protected:
     void setVerb(const QByteArray& verb);
 
     /**
-     * The url of the OCS endpoint
+     * Add a new parameter to the request.
+     * Depending on the verb this is GET or POST parameter
      *
-     * @param url
+     * @param name The name of the parameter
+     * @param value The value of the parameter
      */
-    void setUrl(const QUrl& url);
-
-    /**
-     * Set the get parameters to the url
-     *
-     * @param getParams list of pairs to add to the url
-     */
-    void setGetParams(const QList<QPair<QString, QString> >& getParams);
+    void addParam(const QString& name, const QString &value);
 
     /**
      * Set the post parameters
@@ -110,8 +105,7 @@ private slots:
 
 private:
     QByteArray _verb;
-    QUrl _url;
-    QList<QPair<QString, QString> > _postParams;
+    QList<QPair<QString, QString> > _params;
     QVector<int> _passStatusCodes;
 };
 

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -27,13 +27,18 @@ namespace OCC {
 /**
  * @brief The OcsShareJob class
  * @ingroup gui
+ *
+ * Base class for jobs that talk to the OCS endpoints on the server.
+ * All the comminication logic is handled in this class.
+ *
+ * All OCS jobs (e.g. sharing) should extend this class.
  */
-class OCSJob : public AbstractNetworkJob {
+class OcsJob : public AbstractNetworkJob {
     Q_OBJECT
 
 protected:
 
-    explicit OCSJob(AccountPtr account, QObject* parent = 0);
+    explicit OcsJob(AccountPtr account, QObject* parent = 0);
 
     /**
      * Set the verb for the job

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef OCSJOB_H
+#define OCSJOB_H
+
+#include "accountfwd.h"
+#include "abstractnetworkjob.h"
+
+#include <QVector>
+#include <QList>
+#include <QPair>
+#include <QUrl>
+
+namespace OCC {
+
+/**
+ * @brief The OcsShareJob class
+ * @ingroup gui
+ */
+class OCSJob : public AbstractNetworkJob {
+    Q_OBJECT
+
+protected:
+
+    explicit OCSJob(AccountPtr account, QObject* parent = 0);
+
+    /**
+     * Set the verb for the job
+     *
+     * @param verb currently supported PUT POST DELETE
+     */
+    void setVerb(const QByteArray& verb);
+
+    /**
+     * The url of the OCS endpoint
+     *
+     * @param url
+     */
+    void setUrl(const QUrl& url);
+
+    /**
+     * Set the get parameters to the url
+     *
+     * @param getParams list of pairs to add to the url
+     */
+    void setGetParams(const QList<QPair<QString, QString> >& getParams);
+
+    /**
+     * Set the post parameters
+     *
+     * @param postParams list of pairs to add (urlEncoded) to the body of the
+     * request
+     */
+    void setPostParams(const QList<QPair<QString, QString> >& postParams);
+
+    /**
+     * List of expected statuscodes for this request
+     * A warning will be printed to the debug log if a different status code is
+     * encountered
+     *
+     * @param code Accepted status code
+     */
+    void addPassStatusCode(int code);
+
+public:
+    /**
+     * Parse the response and return the status code and the message of the
+     * reply (metadata)
+     *
+     * @param json The reply from OCS
+     * @param message The message that is set in the metadata
+     * @return The statuscode of the OCS response
+     */
+    static int getJsonReturnCode(const QVariantMap &json, QString &message);
+
+protected slots:
+
+    /**
+     * Start the OCS request
+     */
+    void start() Q_DECL_OVERRIDE;
+
+signals:
+
+    /**
+     * Result of the OCS request
+     *
+     * @param reply the reply
+     */
+    void jobFinished(QVariantMap reply);
+
+private slots:
+    virtual bool finished() Q_DECL_OVERRIDE;
+
+private:
+    QByteArray _verb;
+    QUrl _url;
+    QList<QPair<QString, QString> > _postParams;
+    QVector<int> _passStatusCodes;
+};
+
+}
+
+#endif // OCSJOB_H

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -29,7 +29,7 @@ namespace OCC {
  * @ingroup gui
  *
  * Base class for jobs that talk to the OCS endpoints on the server.
- * All the comminication logic is handled in this class.
+ * All the communication logic is handled in this class.
  *
  * All OCS jobs (e.g. sharing) should extend this class.
  */
@@ -74,10 +74,10 @@ protected:
     void addPassStatusCode(int code);
 
     /**
-     * The base path for an OcsJob is always the same. But it could be that case that
+     * The base path for an OcsJob is always the same. But it could be the case that
      * certain operations need to append something to the URL.
      *
-     * This functions appends the common id. so <PATH>/<ID>
+     * This function appends the common id. so <PATH>/<ID>
      */
     void appendPath(int id);
 

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -73,6 +73,14 @@ protected:
      */
     void addPassStatusCode(int code);
 
+    /**
+     * The base path for an OcsJob is always the same. But it could be that case that
+     * certain operations need to append something to the URL.
+     *
+     * This functions appends the common id. so <PATH>/<ID>
+     */
+    void appendPath(int id);
+
 public:
     /**
      * Parse the response and return the status code and the message of the

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -23,27 +23,23 @@ namespace OCC {
 OcsShareJob::OcsShareJob(AccountPtr account, QObject* parent)
 : OcsJob(account, parent)
 {
-    setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares")));
+    setPath("ocs/v1.php/apps/files_sharing/api/v1/shares");
 }
 
 OcsShareJob::OcsShareJob(int shareId, AccountPtr account, QObject* parent)
 : OcsJob(account, parent)
 {
-    setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(shareId)));
+    setPath(QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(shareId));
 }
 
 void OcsShareJob::getShares(const QString &path)
 {
     setVerb("GET");
-    
-    QList<QPair<QString, QString> > getParams;
-    getParams.append(qMakePair(QString::fromLatin1("path"), path));
-    setGetParams(getParams);
 
+    addParam(QString::fromLatin1("path"), path);
     addPassStatusCode(404);
 
     start();
-
 }
 
 void OcsShareJob::deleteShare()
@@ -57,15 +53,12 @@ void OcsShareJob::setExpireDate(const QDate &date)
 {
     setVerb("PUT");
 
-    QList<QPair<QString, QString> > postParams;
-
     if (date.isValid()) {
-        postParams.append(qMakePair(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd")));
+        addParam(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd"));
     } else {
-        postParams.append(qMakePair(QString::fromLatin1("expireDate"), QString()));
+        addParam(QString::fromLatin1("expireDate"), QString());
     }
 
-    setPostParams(postParams);
     start();
 }
 
@@ -73,10 +66,8 @@ void OcsShareJob::setPassword(const QString &password)
 {
     setVerb("PUT");
 
-    QList<QPair<QString, QString> > postParams;
-    postParams.append(qMakePair(QString::fromLatin1("password"), password));
+    addParam(QString::fromLatin1("password"), password);
 
-    setPostParams(postParams);
     start();
 }
 
@@ -84,11 +75,9 @@ void OcsShareJob::setPublicUpload(bool publicUpload)
 {
     setVerb("PUT");
 
-    QList<QPair<QString, QString> > postParams;
     const QString value = QString::fromLatin1(publicUpload ? "true" : "false");
-    postParams.append(qMakePair(QString::fromLatin1("publicUpload"), value));
+    addParam(QString::fromLatin1("publicUpload"), value);
 
-    setPostParams(postParams);
     start();
 }
 
@@ -96,19 +85,16 @@ void OcsShareJob::createShare(const QString &path, SHARETYPE shareType, const QS
 {
     setVerb("POST");
 
-    QList<QPair<QString, QString> > postParams;
-    postParams.append(qMakePair(QString::fromLatin1("path"), path));
-    postParams.append(qMakePair(QString::fromLatin1("shareType"), QString::number(static_cast<int>(shareType))));
+    addParam(QString::fromLatin1("path"), path);
+    addParam(QString::fromLatin1("shareType"), QString::number(static_cast<int>(shareType)));
 
     if (!password.isEmpty()) {
-        postParams.append(qMakePair(QString::fromLatin1("shareType"), password));
+        addParam(QString::fromLatin1("shareType"), password);
     }
 
     if (date.isValid()) {
-        postParams.append(qMakePair(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd")));
+        addParam(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd"));
     }
-
-    setPostParams(postParams);
 
     addPassStatusCode(403);
 

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -26,12 +26,6 @@ OcsShareJob::OcsShareJob(AccountPtr account, QObject* parent)
     setPath("ocs/v1.php/apps/files_sharing/api/v1/shares");
 }
 
-OcsShareJob::OcsShareJob(int shareId, AccountPtr account, QObject* parent)
-: OcsJob(account, parent)
-{
-    setPath(QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(shareId));
-}
-
 void OcsShareJob::getShares(const QString &path)
 {
     setVerb("GET");
@@ -42,15 +36,17 @@ void OcsShareJob::getShares(const QString &path)
     start();
 }
 
-void OcsShareJob::deleteShare()
+void OcsShareJob::deleteShare(int shareId)
 {
+    appendPath(shareId);
     setVerb("DELETE");
 
     start();
 }
 
-void OcsShareJob::setExpireDate(const QDate &date)
+void OcsShareJob::setExpireDate(int shareId, const QDate &date)
 {
+    appendPath(shareId);
     setVerb("PUT");
 
     if (date.isValid()) {
@@ -62,8 +58,9 @@ void OcsShareJob::setExpireDate(const QDate &date)
     start();
 }
 
-void OcsShareJob::setPassword(const QString &password)
+void OcsShareJob::setPassword(int shareId, const QString &password)
 {
+    appendPath(shareId);
     setVerb("PUT");
 
     addParam(QString::fromLatin1("password"), password);
@@ -71,8 +68,9 @@ void OcsShareJob::setPassword(const QString &password)
     start();
 }
 
-void OcsShareJob::setPublicUpload(bool publicUpload)
+void OcsShareJob::setPublicUpload(int shareId, bool publicUpload)
 {
+    appendPath(shareId);
     setVerb("PUT");
 
     const QString value = QString::fromLatin1(publicUpload ? "true" : "false");

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -80,6 +80,18 @@ void OcsShareJob::setPassword(const QString &password)
     start();
 }
 
+void OcsShareJob::setPublicUpload(bool publicUpload)
+{
+    setVerb("PUT");
+
+    QList<QPair<QString, QString> > postParams;
+    const QString value = QString::fromLatin1(publicUpload ? "true" : "false");
+    postParams.append(qMakePair(QString::fromLatin1("publicUpload"), value));
+
+    setPostParams(postParams);
+    start();
+}
+
 void OcsShareJob::createShare(const QString &path, SHARETYPE shareType, const QString &password, const QDate &date)
 {
     setVerb("POST");

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "ocssharejob.h"
+#include "networkjobs.h"
+#include "account.h"
+#include "json.h"
+
+#include <QBuffer>
+
+namespace OCC {
+
+OcsShareJob::OcsShareJob(AccountPtr account, QObject* parent)
+: OCSJob(account, parent)
+{
+    setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares")));
+}
+
+OcsShareJob::OcsShareJob(int shareId, AccountPtr account, QObject* parent)
+: OCSJob(account, parent)
+{
+    setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(shareId)));
+}
+
+void OcsShareJob::getShares(const QString &path)
+{
+    setVerb("GET");
+    
+    QList<QPair<QString, QString> > getParams;
+    getParams.append(qMakePair(QString::fromLatin1("path"), path));
+    setGetParams(getParams);
+
+    addPassStatusCode(404);
+
+    start();
+
+}
+
+void OcsShareJob::deleteShare()
+{
+    setVerb("DELETE");
+
+    start();
+}
+
+void OcsShareJob::setExpireDate(const QDate &date)
+{
+    setVerb("PUT");
+
+    QList<QPair<QString, QString> > postParams;
+
+    if (date.isValid()) {
+        postParams.append(qMakePair(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd")));
+    } else {
+        postParams.append(qMakePair(QString::fromLatin1("expireDate"), QString()));
+    }
+
+    setPostParams(postParams);
+    start();
+}
+
+void OcsShareJob::setPassword(const QString &password)
+{
+    setVerb("PUT");
+
+    QList<QPair<QString, QString> > postParams;
+    postParams.append(qMakePair(QString::fromLatin1("password"), password));
+
+    setPostParams(postParams);
+    start();
+}
+
+void OcsShareJob::createShare(const QString &path, SHARETYPE shareType, const QString &password, const QDate &date)
+{
+    setVerb("POST");
+
+    QList<QPair<QString, QString> > postParams;
+    postParams.append(qMakePair(QString::fromLatin1("path"), path));
+    postParams.append(qMakePair(QString::fromLatin1("shareType"), QString::number(static_cast<int>(shareType))));
+
+    if (!password.isEmpty()) {
+        postParams.append(qMakePair(QString::fromLatin1("shareType"), password));
+    }
+
+    if (date.isValid()) {
+        postParams.append(qMakePair(QString::fromLatin1("expireDate"), date.toString("yyyy-MM-dd")));
+    }
+
+    setPostParams(postParams);
+
+    addPassStatusCode(403);
+
+    start();
+}
+
+}

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -21,13 +21,13 @@
 namespace OCC {
 
 OcsShareJob::OcsShareJob(AccountPtr account, QObject* parent)
-: OCSJob(account, parent)
+: OcsJob(account, parent)
 {
     setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares")));
 }
 
 OcsShareJob::OcsShareJob(int shareId, AccountPtr account, QObject* parent)
-: OCSJob(account, parent)
+: OcsJob(account, parent)
 {
     setUrl(Account::concatUrlPath(account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(shareId)));
 }

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -85,7 +85,7 @@ public:
     void setPassword(int shareId, const QString& password);
 
     /**
-     * Void set the a share to be public upload
+     * Void set the share to be public upload
      * 
      * @param publicUpload Set or remove public upload
      */

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef OCSSHAREJOB_H
+#define OCSSHAREJOB_H
+
+#include "ocsjob.h"
+#include <QVector>
+#include <QList>
+#include <QPair>
+
+namespace OCC {
+
+/**
+ * @brief The OcsShareJob class
+ * @ingroup gui
+ */
+class OcsShareJob : public OCSJob {
+    Q_OBJECT
+public:
+
+    /**
+     * Support sharetypes
+     */
+    enum class SHARETYPE : int {
+        LINK = 3
+    };
+
+    /**
+     * Constructor for new shares or listing of shares
+     */
+    explicit OcsShareJob(AccountPtr account, QObject *parent = 0);
+
+    /**
+     * Constructors for existing shares of which we know the shareId
+     */
+    explicit OcsShareJob(int shareId, AccountPtr account, QObject *parent = 0);
+
+    /**
+     * Get all the shares
+     *
+     * @param path Path to request shares for (default all shares)
+     */
+    void getShares(const QString& path = "");
+
+    /**
+     * Delete the current Share
+     */
+    void deleteShare();
+
+    /**
+     * Set the expiration date of a share
+     *
+     * @param date The expire date, if this date is invalid the expire date
+     * will be removed
+     */
+    void setExpireDate(const QDate& date);
+
+    /**
+     * Set the password of a share
+     *
+     * @param password The password of the share, if the password is empty the
+     * share will be removed
+     */
+    void setPassword(const QString& password);
+
+    /**
+     * Create a new share
+     *
+     * @param path The path of the file/folder to share
+     * @param shareType The type of share (user/group/link/federated)
+     * @param password Optionally a password for the share
+     * @param date Optionally an expire date for the share
+     */
+    void createShare(const QString& path, SHARETYPE shareType, const QString& password = "", const QDate& date = QDate());
+};
+
+}
+
+#endif // OCSSHAREJOB_H

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -75,6 +75,13 @@ public:
     void setPassword(const QString& password);
 
     /**
+     * Void set the a share to be public upload
+     * 
+     * @param publicUpload Set or remove public upload
+     */
+    void setPublicUpload(bool publicUpload);
+
+    /**
      * Create a new share
      *
      * @param path The path of the file/folder to share

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -57,11 +57,6 @@ public:
     explicit OcsShareJob(AccountPtr account, QObject *parent = 0);
 
     /**
-     * Constructors for existing shares of which we know the shareId
-     */
-    explicit OcsShareJob(int shareId, AccountPtr account, QObject *parent = 0);
-
-    /**
      * Get all the shares
      *
      * @param path Path to request shares for (default all shares)
@@ -71,7 +66,7 @@ public:
     /**
      * Delete the current Share
      */
-    void deleteShare();
+    void deleteShare(int shareId);
 
     /**
      * Set the expiration date of a share
@@ -79,7 +74,7 @@ public:
      * @param date The expire date, if this date is invalid the expire date
      * will be removed
      */
-    void setExpireDate(const QDate& date);
+    void setExpireDate(int shareId, const QDate& date);
 
     /**
      * Set the password of a share
@@ -87,14 +82,14 @@ public:
      * @param password The password of the share, if the password is empty the
      * share will be removed
      */
-    void setPassword(const QString& password);
+    void setPassword(int shareId, const QString& password);
 
     /**
      * Void set the a share to be public upload
      * 
      * @param publicUpload Set or remove public upload
      */
-    void setPublicUpload(bool publicUpload);
+    void setPublicUpload(int shareId, bool publicUpload);
 
     /**
      * Create a new share

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -24,8 +24,11 @@ namespace OCC {
 /**
  * @brief The OcsShareJob class
  * @ingroup gui
+ *
+ * Handle talking to the OCS Share API. 
+ * For creation, deletion and modification of shares.
  */
-class OcsShareJob : public OCSJob {
+class OcsShareJob : public OcsJob {
     Q_OBJECT
 public:
 

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -40,6 +40,18 @@ public:
     };
 
     /**
+     * Possible permissions
+     */
+    enum class PERMISSION : int {
+        READ = 1,
+        UPDATE = 2,
+        CREATE = 4,
+        DELETE = 8,
+        SHARE = 16,
+        ALL = 31
+    };
+
+    /**
      * Constructor for new shares or listing of shares
      */
     explicit OcsShareJob(AccountPtr account, QObject *parent = 0);

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -201,7 +201,7 @@ void ShareDialog::setExpireDate(const QDate &date)
 void ShareDialog::slotExpireSet(const QVariantMap &reply)
 {
     QString message;
-    int code = OCSJob::getJsonReturnCode(reply, message);
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
     if (code != 100) {
         displayError(code);
     } 

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -32,15 +32,6 @@
 #include <QClipboard>
 #include <QFileInfo>
 
-namespace {
-//    int PERMISSION_READ = 1;
-    int PERMISSION_UPDATE = 2;
-    int PERMISSION_CREATE = 4;
-//    int PERMISSION_DELETE = 8;
-//    int PERMISSION_SHARE = 16;
-//    int PERMISSION_ALL = 31;
-}
-
 namespace OCC {
 
 ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QString &localPath, bool resharingAllowed, QWidget *parent) :
@@ -348,7 +339,9 @@ void ShareDialog::slotSharesFetched(const QVariantMap &reply)
                  * Only directories can have public upload set
                  * For public links the server sets CREATE and UPDATE permissions.
                  */
-                if (!_isFile && (permissions & PERMISSION_UPDATE) && (permissions & PERMISSION_CREATE)) {
+                if (!_isFile && 
+                       (permissions & static_cast<int>(OcsShareJob::PERMISSION::UPDATE)) && 
+                       (permissions & static_cast<int>(OcsShareJob::PERMISSION::CREATE))) {
                     _ui->checkBox_editing->setChecked(true);
                 }
             }

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -33,8 +33,6 @@
 #include <QFileInfo>
 
 namespace {
-    int SHARETYPE_PUBLIC = 3;
-
 //    int PERMISSION_READ = 1;
     int PERMISSION_UPDATE = 2;
     int PERMISSION_CREATE = 4;
@@ -564,23 +562,15 @@ void ShareDialog::setPublicUpload(bool publicUpload)
     _ui->checkBox_editing->setEnabled(false);
     _pi_editing->startAnimation();
 
-    const QUrl url = Account::concatUrlPath(_account->url(), QString("ocs/v1.php/apps/files_sharing/api/v1/shares/%1").arg(_public_share_id));
-
-    QList<QPair<QString, QString> > requestParams;
-    const QString value = QString::fromLatin1(publicUpload ? "true" : "false");
-    requestParams.append(qMakePair(QString::fromLatin1("publicUpload"), value));
-
-    OcsShareJob *job = new OcsShareJob("PUT", url, _account, this);
-    job->setPostParams(requestParams);
+    OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
     connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPublicUploadSet(QVariantMap)));
-
-    job->start();
+    job->setPublicUpload(publicUpload);
 }
 
 void ShareDialog::slotPublicUploadSet(const QVariantMap &reply)
 {
     QString message;
-    int code = getJsonReturnCode(reply, message);
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
     if (code == 100) {
         _ui->checkBox_editing->setEnabled(true);
     } else {

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -184,9 +184,9 @@ void ShareDialog::setExpireDate(const QDate &date)
     }
     _pi_date->startAnimation();
 
-    OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
+    OcsShareJob *job = new OcsShareJob(_account, this);
     connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotExpireSet(QVariantMap)));
-    job->setExpireDate(date);
+    job->setExpireDate(_public_share_id, date);
 }
 
 void ShareDialog::slotExpireSet(const QVariantMap &reply)
@@ -235,11 +235,11 @@ void ShareDialog::setPassword(const QString &password)
     QString path;
 
     if( _public_share_id > 0 ) {
-        OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
+        OcsShareJob *job = new OcsShareJob(_account, this);
         connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPasswordSet(QVariantMap)));
-        job->setPassword(password);
+        job->setPassword(_public_share_id, password);
     } else {
-        OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
+        OcsShareJob *job = new OcsShareJob(_account, this);
         connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPasswordSet(QVariantMap)));
         connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotCreateShareFetched(QVariantMap)));
 
@@ -471,9 +471,9 @@ void ShareDialog::slotCheckBoxShareLinkClicked()
         job->createShare(_sharePath, OcsShareJob::SHARETYPE::LINK);
     } else {
         _pi_link->startAnimation();
-        OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
+        OcsShareJob *job = new OcsShareJob(_account, this);
         connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotDeleteShareFetched(QVariantMap)));
-        job->deleteShare();
+        job->deleteShare(_public_share_id);
     }
 }
 
@@ -553,9 +553,9 @@ void ShareDialog::setPublicUpload(bool publicUpload)
     _ui->checkBox_editing->setEnabled(false);
     _pi_editing->startAnimation();
 
-    OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);
+    OcsShareJob *job = new OcsShareJob(_account, this);
     connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPublicUploadSet(QVariantMap)));
-    job->setPublicUpload(publicUpload);
+    job->setPublicUpload(_public_share_id, publicUpload);
 }
 
 void ShareDialog::slotPublicUploadSet(const QVariantMap &reply)

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -242,8 +242,6 @@ void ShareDialog::setPassword(const QString &password)
     _pi_link->startAnimation();
     _pi_password->startAnimation();
     QString path;
-    QList<QPair<QString, QString> > requestParams;
-    QByteArray verb("PUT");
 
     if( _public_share_id > 0 ) {
         OcsShareJob *job = new OcsShareJob(_public_share_id, _account, this);

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -15,54 +15,12 @@
 #ifndef SHAREDIALOG_H
 #define SHAREDIALOG_H
 
-#include "networkjobs.h"
 #include "accountfwd.h"
 #include "QProgressIndicator.h"
 #include <QDialog>
-#include <QTreeWidgetItem>
+#include <QVariantMap>
 
 namespace OCC {
-
-/**
- * @brief The OcsShareJob class
- * @ingroup gui
- */
-class OcsShareJob : public AbstractNetworkJob {
-    Q_OBJECT
-public:
-    explicit OcsShareJob(const QByteArray& verb, const QUrl& url, AccountPtr account, QObject* parent = 0);
-
-    void setPostParams(const QList<QPair<QString, QString> >& postParams);
-    void addPassStatusCode(int code);
-
-public slots:
-    void start() Q_DECL_OVERRIDE;
-signals:
-    void jobFinished(QVariantMap reply);
-private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
-private:
-    QByteArray _verb;
-    QUrl _url;
-    QList<QPair<QString, QString> > _postParams;
-    QVector<int> _passStatusCodes;
-};
-
-
-class ThumbnailJob : public AbstractNetworkJob {
-    Q_OBJECT
-public:
-    explicit ThumbnailJob(const QString& path, AccountPtr account, QObject* parent = 0);
-public slots:
-    void start() Q_DECL_OVERRIDE;
-signals:
-    void jobFinished(int statusCode, QByteArray reply);
-private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
-private:
-    QUrl _url;
-};
-
 
 namespace Ui {
 class ShareDialog;

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "thumbnailjob.h"
+#include "networkjobs.h"
+#include "account.h"
+#include "json.h"
+
+namespace OCC {
+
+ThumbnailJob::ThumbnailJob(const QString &path, AccountPtr account, QObject* parent)
+: AbstractNetworkJob(account, "", parent)
+{
+    _url = Account::concatUrlPath(account->url(), QLatin1String("index.php/apps/files/api/v1/thumbnail/150/150/") + path);
+    setIgnoreCredentialFailure(true);
+}
+
+void ThumbnailJob::start()
+{
+    qDebug() << Q_FUNC_INFO;
+    setReply(getRequest(_url));
+    setupConnections(reply());
+    AbstractNetworkJob::start();
+}
+
+bool ThumbnailJob::finished()
+{
+    emit jobFinished(reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), reply()->readAll());
+    return true;
+}
+
+}

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -26,7 +26,7 @@ ThumbnailJob::ThumbnailJob(const QString &path, AccountPtr account, QObject* par
 
 void ThumbnailJob::start()
 {
-    setReply(getRequest(Account::concatUrlPath(account()->url(), path())));
+    setReply(getRequest(path()));
     setupConnections(reply());
     AbstractNetworkJob::start();
 }

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -19,16 +19,14 @@
 namespace OCC {
 
 ThumbnailJob::ThumbnailJob(const QString &path, AccountPtr account, QObject* parent)
-: AbstractNetworkJob(account, "", parent)
+: AbstractNetworkJob(account, QLatin1String("index.php/apps/files/api/v1/thumbnail/150/150/") + path, parent)
 {
-    _url = Account::concatUrlPath(account->url(), QLatin1String("index.php/apps/files/api/v1/thumbnail/150/150/") + path);
     setIgnoreCredentialFailure(true);
 }
 
 void ThumbnailJob::start()
 {
-    qDebug() << Q_FUNC_INFO;
-    setReply(getRequest(_url));
+    setReply(getRequest(Account::concatUrlPath(account()->url(), path())));
     setupConnections(reply());
     AbstractNetworkJob::start();
 }

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef THUMBNAILJOB_H
+#define THUMBNAILJOB_H
+
+#include "networkjobs.h"
+#include "accountfwd.h"
+
+namespace OCC {
+
+class ThumbnailJob : public AbstractNetworkJob {
+    Q_OBJECT
+public:
+    explicit ThumbnailJob(const QString& path, AccountPtr account, QObject* parent = 0);
+public slots:
+    void start() Q_DECL_OVERRIDE;
+signals:
+    void jobFinished(int statusCode, QByteArray reply);
+private slots:
+    virtual bool finished() Q_DECL_OVERRIDE;
+private:
+    QUrl _url;
+};
+
+}
+
+#endif // THUMBNAILJOB_H

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -24,7 +24,7 @@ namespace OCC {
  * @ingroup gui
  *
  * Job that allows fetching a preview (of 150x150 for now) of a given file.
- * Once the job finished the jobFinished signal will be emitted.
+ * Once the job has finished the jobFinished signal will be emitted.
  */
 class ThumbnailJob : public AbstractNetworkJob {
     Q_OBJECT

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -19,6 +19,13 @@
 
 namespace OCC {
 
+/**
+ * @brief Job to fetch a thumbnail for a file
+ * @ingroup gui
+ *
+ * Job that allows fetching a preview (of 150x150 for now) of a given file.
+ * Once the job finished the jobFinished signal will be emitted.
+ */
 class ThumbnailJob : public AbstractNetworkJob {
     Q_OBJECT
 public:
@@ -26,11 +33,17 @@ public:
 public slots:
     void start() Q_DECL_OVERRIDE;
 signals:
+    /**
+     * @param statusCode the HTTP status code
+     * @param reply the content of the reply
+     *
+     * Signal that the job is done. If the statusCode is 200 (success) reply
+     * will contain the image data in PNG. If the status code is different the content
+     * of reply is undefined.
+     */
     void jobFinished(int statusCode, QByteArray reply);
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
-private:
-    QUrl _url;
 };
 
 }


### PR DESCRIPTION
In preparation of the full desktop sharing (https://github.com/owncloud/client/issues/3737) the sharedialog code had to be somewhat unentangled.

There now is more code in libsync and the gui is cleaned up a bit.

* OCSJob class added. To allow a nice abstraction also for the new sharee endpoint code (which is required)
* OcsShareJob class is now in libsync and has more generic functions like createShare, setPassword etc. So the GUI part can just say do this.
* ShareDialog is cleaned up

My tests show that everything still works as expected but please run your own tests to make sure I did not break anything!

CC: @dragotin @guruz @ogoffart and others that want to test!