### PR TITLE
Adjust message box text for account removal

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -519,7 +519,7 @@ void AccountSettings::slotDeleteAccount()
     // the QMessageBox should be destroyed before that happens.
     {
         QMessageBox messageBox(QMessageBox::Question,
-                               tr("Confirm Account Delete"),
+                               tr("Confirm Account Removal"),
                                tr("<p>Do you really want to remove the connection to the account <i>%1</i>?</p>"
                                   "<p><b>Note:</b> This will <b>not</b> delete any files.</p>")
                                  .arg(_accountState->account()->displayName()),


### PR DESCRIPTION
Since the context menu text was changed to "Remove Account" it seems sensible to also change the title of this message box to match.
https://github.com/owncloud/client/issues/3793