### PR TITLE
OCUpdater description text

### DIFF
--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -160,7 +160,7 @@ private:
 /**
  *  @brief Updater that only implements notification for use in settings
  *
- *  The implementation does how show popups
+ *  The implementation does not show popups
  *
  *  @ingroup gui
  */


### PR DESCRIPTION
Make it say something understandable. Looking at previous versions with git blame, the word "not" fits here.
Issue #3809 