### PR TITLE
csync header installation

### DIFF
--- a/csync/src/CMakeLists.txt
+++ b/csync/src/CMakeLists.txt
@@ -89,9 +89,7 @@ configure_file(csync_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/csync_version.h)
 set(csync_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/csync_version.h
   csync.h
-  vio/csync_vio.h
-  vio/csync_vio_method.h
-  vio/csync_vio_module.h
+  csync_private.h
 )
 
 # Statically include sqlite
@@ -142,12 +140,12 @@ else()
   RUNTIME DESTINATION
     ${BIN_INSTALL_DIR}/${APPLICATION_EXECUTABLE}
   )
+  INSTALL(
+  FILES
+    ${csync_HDRS}
+  DESTINATION
+    ${INCLUDE_INSTALL_DIR}/${APPLICATION_NAME}
+  )
 endif()
 
-# INSTALL(
-#   FILES
-#     ${csync_HDRS}
-#   DESTINATION
-#     ${INCLUDE_INSTALL_DIR}/${APPLICATION_NAME}
-# )
 

--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -563,5 +563,6 @@ time_t oc_httpdate_parse( const char *date );
 /**
  * }@
  */
+#include <csync_private.h>
 #endif /* _CSYNC_H */
 /* vim: set ft=c.doxygen ts=8 sw=2 et cindent: */

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "discoveryphase.h"
-#include <csync_private.h>
 #include <qdebug.h>
 
 #include <QUrl>

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -21,7 +21,6 @@
 #include "discoveryphase.h"
 #include "creds/abstractcredentials.h"
 #include "syncfilestatus.h"
-#include "csync_private.h"
 
 #ifdef Q_OS_WIN
 #include <windows.h>

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -28,9 +28,6 @@
 
 #include <csync.h>
 
-// when do we go away with this private/public separation?
-#include <csync_private.h>
-
 #include "syncfileitem.h"
 #include "progressdispatcher.h"
 #include "utility.h"


### PR DESCRIPTION
This branch contains a few patches to allow building libsync against an installed csync.

I'm basically installing the csync headers that are used, and hides the _private.h from the includes.

These headers are included from libsync headers, so they need to be installed if anyone wants to use libsync from outside of this repo.