### PR TITLE
fix multiarch library path for Debian/Ubuntu

### DIFF
--- a/cmake/modules/GNUInstallDirs.cmake
+++ b/cmake/modules/GNUInstallDirs.cmake
@@ -134,13 +134,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR OR (_libdir_set
       AND NOT CMAKE_CROSSCOMPILING)
     if (EXISTS "/etc/debian_version") # is this a debian system ?
       if(CMAKE_LIBRARY_ARCHITECTURE)
-        if("${CMAKE_INSTALL_PREFIX}" MATCHES "^/usr/?$")
-          set(_LIBDIR_DEFAULT "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
-        endif()
-        if(DEFINED _GNUInstallDirs_LAST_CMAKE_INSTALL_PREFIX
-            AND "${_GNUInstallDirs_LAST_CMAKE_INSTALL_PREFIX}" MATCHES "^/usr/?$")
-          set(__LAST_LIBDIR_DEFAULT "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
-        endif()
+        set(_LIBDIR_DEFAULT "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
       endif()
     else() # not debian, rely on CMAKE_SIZEOF_VOID_P:
       if(NOT DEFINED CMAKE_SIZEOF_VOID_P)


### PR DESCRIPTION
Simplification taken from upstream cmake to make the ocsync library behave correctly on Debian and Ubuntu multiarch systems.