### PR TITLE
Fix linkname in architecture.rst.

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -108,7 +108,7 @@ ownCloud Client 1.1 or later. Using an incompatible time stamp-based
 synchronization mechanism can lead to data loss in rare cases, especially when
 multiple clients are involved and one utilizes a non-synchronized NTP time.
 
-.. _`NTP time synchronisation`: http://en.wikipedia.org/wiki/Network_Time_Protocol
+.. _`NTP time synchronization`: http://en.wikipedia.org/wiki/Network_Time_Protocol
 .. _Etag: http://en.wikipedia.org/wiki/HTTP_ETag
 
 Comparison and Conflict Cases


### PR DESCRIPTION
Typo causing a broken link in https://doc.owncloud.org/desktop/2.0/architecture.html#synchronization-by-time-versus-etag