### PR TITLE
Provide information about share availablity for files

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -143,15 +143,15 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     // Parse capabilities
 
     // If password is enforced then don't allow users to disable it
-    if (_account->capabilities().publicLinkEnforcePassword()) {
+    if (_account->capabilities().sharePublicLinkEnforcePassword()) {
         _ui->checkBox_password->setEnabled(false);
     }
 
     // If expiredate is enforced do not allow disable and set max days
-    if (_account->capabilities().publicLinkEnforceExpireDate()) {
+    if (_account->capabilities().sharePublicLinkEnforceExpireDate()) {
         _ui->checkBox_expire->setEnabled(false);
         _ui->calendar->setMaximumDate(QDate::currentDate().addDays(
-            _account->capabilities().publicLinkExpireDateDays()
+            _account->capabilities().sharePublicLinkExpireDateDays()
             ));
     }
 }
@@ -466,7 +466,7 @@ void ShareDialog::slotCheckBoxShareLinkClicked()
          * Check the capabilities if the server requires a password for a share
          * Ask for it directly
          */
-        if (_account->capabilities().publicLinkEnforcePassword()) {
+        if (_account->capabilities().sharePublicLinkEnforcePassword()) {
             _pi_link->stopAnimation();
             _ui->checkBox_password->setChecked(true);
             _ui->checkBox_password->setEnabled(false);

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -77,6 +77,7 @@ private:
 
     Q_INVOKABLE void command_VERSION(const QString& argument, QIODevice* socket);
 
+    Q_INVOKABLE void command_SHARE_STATUS(const QString& localFile, QIODevice *socket);
     Q_INVOKABLE void command_SHARE_MENU_TITLE(const QString& argument, QIODevice* socket);
     QString buildRegisterPathMessage(const QString& path);
 

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -23,19 +23,39 @@ Capabilities::Capabilities(const QVariantMap &capabilities)
 {
 }
 
-bool Capabilities::publicLinkEnforcePassword() const
+bool Capabilities::shareAPI() const
+{
+    if (_capabilities["files_sharing"].toMap().contains("api_enabled")) {
+        return _capabilities["files_sharing"].toMap()["api_enabled"].toBool();
+    } else {
+        // This was later added so if it is not present just assume the API is enabled.
+        return true;
+    }
+}
+
+bool Capabilities::sharePublicLink() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["enabled"].toBool();
+}
+
+bool Capabilities::sharePublicLinkEnforcePassword() const
 {
     return _capabilities["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool();
 }
 
-bool Capabilities::publicLinkEnforceExpireDate() const
+bool Capabilities::sharePublicLinkEnforceExpireDate() const
 {
     return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enforced"].toBool();
 }
 
-int Capabilities::publicLinkExpireDateDays() const
+int Capabilities::sharePublicLinkExpireDateDays() const
 {
     return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt();
+}
+
+bool Capabilities::shareResharing() const
+{
+    return _capabilities["files_sharing"].toMap()["resharing"].toBool();
 }
 
 QStringList Capabilities::supportedChecksumTypes() const

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -32,9 +32,12 @@ class OWNCLOUDSYNC_EXPORT Capabilities {
 public:
     Capabilities(const QVariantMap &capabilities);
 
-    bool publicLinkEnforcePassword() const;
-    bool publicLinkEnforceExpireDate() const;
-    int  publicLinkExpireDateDays() const;
+    bool shareAPI() const;
+    bool sharePublicLink() const;
+    bool sharePublicLinkEnforcePassword() const;
+    bool sharePublicLinkEnforceExpireDate() const;
+    int  sharePublicLinkExpireDateDays() const;
+    bool shareResharing() const;
     QStringList supportedChecksumTypes() const;
 
 private:


### PR DESCRIPTION
For #3879

The socketAPI `SHARE_STATUS` allows to retrieve the share status for the current file. So can it be shared or not. And if it can how (UserGroup, Link).

We will need additional fixes in the shell_intergration stuff.

CC: @dragotin 