### PR TITLE
Increased fileID size to 36 bytes

### DIFF
--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -144,7 +144,7 @@ enum csync_ftw_type_e {
 };
 
 
-#define FILE_ID_BUF_SIZE 21
+#define FILE_ID_BUF_SIZE 36
 
 // currently specified at https://github.com/owncloud/core/issues/8322 are 9 to 10
 #define REMOTE_PERM_BUF_SIZE 15


### PR DESCRIPTION
Right now the fileID is created using the SQL DB as a central auto-incremental fileID generator.
Some storages can provide their own FileID or use de-centralised fileID generators like UUIDs or checksums.

The sync client is limited to 21 byte size fileID, so when using UUIDs in string format (36 bytes), the FileID is not respected and the client cannot track remote moves.

See https://github.com/owncloud/client/blob/524aa507e6ac0331a6cd909fa8bed297ae0f3bfb/csync/src/vio/csync_vio_file_stat.c#L74