### PR TITLE
Use monochrome icons by default for OS X

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -587,8 +587,13 @@ void ConfigFile::setNewBigFolderSizeLimit(bool isChecked, quint64 mbytes)
 
 bool ConfigFile::monoIcons() const
 {
+    bool defaultValue = false;
+    #if defined(Q_OS_MAC)
+        defaultValue = true;
+    #endif
+
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(monoIconsC), false).toBool();
+    return settings.value(QLatin1String(monoIconsC), defaultValue).toBool();
 }
 
 void ConfigFile::setMonoIcons(bool useMonoIcons)


### PR DESCRIPTION
The color ones do look absolutely misplaced as the OS X design guidelines do recommend to use the monochrome ones. With all users that I know this is the one of the first things they changed.

Fixes https://github.com/owncloud/client/issues/2342 for OS X

@jancborchardt @MorrisJobke For feedback.
@danimo For merge :stuck_out_tongue_winking_eye: 