### PR TITLE
AccountState: Avoid ConnectionCheck if ETag job was just done.

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -16,6 +16,7 @@
 #include "account.h"
 #include "creds/abstractcredentials.h"
 #include "logger.h"
+#include "configfile.h"
 
 #include <QDebug>
 #include <QSettings>
@@ -154,8 +155,11 @@ void AccountState::checkConnectivity(CredentialFetchMode credentialsFetchMode)
 
     // IF the account is connected the connection check can be skipped
     // if the last successful etag check job is not so long ago.
+    ConfigFile cfg;
+    int polltime = cfg.remotePollInterval();
+
     if (isConnected() && _timeSinceLastETagCheck.isValid()
-            && _timeSinceLastETagCheck.elapsed() < 30*1000) {
+            && _timeSinceLastETagCheck.elapsed() < polltime) {
         qDebug() << "The last ETag check succeeded within the last 30 secs. No connection check needed!";
         return;
     }

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -39,6 +39,7 @@ AccountState::AccountState(AccountPtr account)
             SLOT(slotCredentialsFetched(AbstractCredentials*)));
     connect(account.data(), SIGNAL(credentialsAsked(AbstractCredentials*)),
             SLOT(slotCredentialsAsked(AbstractCredentials*)));
+    _timeSinceLastETagCheck.invalidate();
 }
 
 AccountState::~AccountState()
@@ -135,6 +136,11 @@ bool AccountState::isConnectedOrTemporarilyUnavailable() const
     return isConnected() || _state == ServiceUnavailable;
 }
 
+void AccountState::tagLastSuccessfullETagRequest()
+{
+    _timeSinceLastETagCheck.restart();
+}
+
 void AccountState::checkConnectivity(CredentialFetchMode credentialsFetchMode)
 {
     if (isSignedOut() || _waitingForNewCredentials) {
@@ -145,6 +151,15 @@ void AccountState::checkConnectivity(CredentialFetchMode credentialsFetchMode)
         qDebug() << "ConnectionValidator already running, ignoring";
         return;
     }
+
+    // IF the account is connected the connection check can be skipped
+    // if the last successful etag check job is not so long ago.
+    if (isConnected() && _timeSinceLastETagCheck.isValid()
+            && _timeSinceLastETagCheck.elapsed() < 30*1000) {
+        qDebug() << "The last ETag check succeeded within the last 30 secs. No connection check needed!";
+        return;
+    }
+
     _credentialsFetchMode = credentialsFetchMode;
     ConnectionValidator * conValidator = new ConnectionValidator(account());
     _connectionValidator = conValidator;

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -95,6 +95,14 @@ public:
      */
     QString shortDisplayNameForSettings(int width = 0) const;
 
+    /** Mark the timestamp when the last successful ETag check happened for
+     *  this account.
+     *  The checkConnectivity() method uses the timestamp to save a call to
+     *  the server to validate the connection if the last successful etag job
+     *  is not so lang away.
+     */
+    void tagLastSuccessfullETagRequest();
+
 private:
     void setState(State state);
 
@@ -114,6 +122,7 @@ private:
     QStringList _connectionErrors;
     bool _waitingForNewCredentials;
     CredentialFetchMode _credentialsFetchMode;
+    QElapsedTimer _timeSinceLastETagCheck;
     QPointer<ConnectionValidator> _connectionValidator;
 };
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -365,6 +365,10 @@ void Folder::etagRetreived(const QString& etag)
         _lastEtag = etag;
         emit scheduleToSync(this);
     }
+
+    if( _accountState ) {
+        _accountState->tagLastSuccessfullETagRequest();
+    }
 }
 
 void Folder::etagRetreivedFromSyncEngine(const QString& etag)


### PR DESCRIPTION
This patch lets a successful etag job check mark a timestamp.
If next time a connection check is requested, it is checked if
the last ETag happened within the last 30 seconds and if so the
connection check can be checked.

This way we avoid half of the PROPFINDs if all goes well.

@ckamm @ogoffart @guruz please check.