### PR TITLE
Exclude .nfs temporary files by default

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -37,3 +37,5 @@ desktop.ini
 .sync.ffs_db
 .symform
 .symform-store
+
+.nfs*


### PR DESCRIPTION
Whenever a file is deleted while being still opened in another host in a NFS, it will create temporary .nfsNNNNN files, so that the file still remains accessible for as long as the process needs it.
There is no logic in syncing those files in owncloud, so they should be excluded by default.