### PR TITLE
Add share manager and the share objects

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -58,6 +58,7 @@ set(client_SRCS
     protocolwidget.cpp
     selectivesyncdialog.cpp
     settingsdialog.cpp
+    share.cpp
     sharedialog.cpp
     socketapi.cpp
     sslbutton.cpp

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -42,9 +42,9 @@ void OcsJob::addPassStatusCode(int code)
     _passStatusCodes.append(code);
 }
 
-void OcsJob::appendPath(int id)
+void OcsJob::appendPath(const QString &id)
 {
-    setPath(path() + QString("/%1").arg(id));
+    setPath(path() + "/" + id);
 }
 
 void OcsJob::start()

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -105,9 +105,10 @@ bool OcsJob::finished()
                  << Account::concatUrlPath(account()->url(), path())
                  << _params
                  << "has unexpected status code:" << statusCode << replyData;
+        emit ocsError(statusCode, message);
+    } else {
+        emit jobFinished(json);
     }
-
-    emit jobFinished(json);
     deleteLater();
     return true;
 }

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -108,6 +108,7 @@ bool OcsJob::finished()
     }
 
     emit jobFinished(json);
+    deleteLater();
     return true;
 }
 

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -44,7 +44,7 @@ void OcsJob::addPassStatusCode(int code)
 
 void OcsJob::appendPath(const QString &id)
 {
-    setPath(path() + "/" + id);
+    setPath(path() + QLatin1Char('/') + id);
 }
 
 void OcsJob::start()

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -108,6 +108,15 @@ signals:
      */
     void jobFinished(QVariantMap reply);
 
+    /**
+     * The status code was not one of the expected (passing)
+     * status code for this command
+     *
+     * @param statusCode The actual status code
+     * @param message The message provided by the server
+     */
+    void ocsError(int statusCode, const QString &message);
+
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
 

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -79,7 +79,7 @@ protected:
      *
      * This function appends the common id. so <PATH>/<ID>
      */
-    void appendPath(int id);
+    void appendPath(const QString &id);
 
 public:
     /**

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -24,6 +24,7 @@ OcsShareJob::OcsShareJob(AccountPtr account, QObject* parent)
 : OcsJob(account, parent)
 {
     setPath("ocs/v1.php/apps/files_sharing/api/v1/shares");
+    connect(this, SIGNAL(jobFinished(QVariantMap)), this, SLOT(jobDone(QVariantMap)));
 }
 
 void OcsShareJob::getShares(const QString &path)
@@ -36,7 +37,7 @@ void OcsShareJob::getShares(const QString &path)
     start();
 }
 
-void OcsShareJob::deleteShare(int shareId)
+void OcsShareJob::deleteShare(const QString &shareId)
 {
     appendPath(shareId);
     setVerb("DELETE");
@@ -44,7 +45,7 @@ void OcsShareJob::deleteShare(int shareId)
     start();
 }
 
-void OcsShareJob::setExpireDate(int shareId, const QDate &date)
+void OcsShareJob::setExpireDate(const QString &shareId, const QDate &date)
 {
     appendPath(shareId);
     setVerb("PUT");
@@ -54,27 +55,30 @@ void OcsShareJob::setExpireDate(int shareId, const QDate &date)
     } else {
         addParam(QString::fromLatin1("expireDate"), QString());
     }
+    _value = date;
 
     start();
 }
 
-void OcsShareJob::setPassword(int shareId, const QString &password)
+void OcsShareJob::setPassword(const QString &shareId, const QString &password)
 {
     appendPath(shareId);
     setVerb("PUT");
 
     addParam(QString::fromLatin1("password"), password);
+    _value = password;
 
     start();
 }
 
-void OcsShareJob::setPublicUpload(int shareId, bool publicUpload)
+void OcsShareJob::setPublicUpload(const QString &shareId, bool publicUpload)
 {
     appendPath(shareId);
     setVerb("PUT");
 
     const QString value = QString::fromLatin1(publicUpload ? "true" : "false");
     addParam(QString::fromLatin1("publicUpload"), value);
+    _value = publicUpload;
 
     start();
 }
@@ -97,6 +101,11 @@ void OcsShareJob::createShare(const QString &path, ShareType shareType, const QS
     addPassStatusCode(403);
 
     start();
+}
+
+void OcsShareJob::jobDone(QVariantMap reply)
+{
+    emit shareJobFinished(reply, _value);
 }
 
 }

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -83,7 +83,7 @@ void OcsShareJob::setPublicUpload(const QString &shareId, bool publicUpload)
     start();
 }
 
-void OcsShareJob::createShare(const QString &path, ShareType shareType, const QString &password, const QDate &date)
+void OcsShareJob::createShare(const QString &path, Share::ShareType shareType, const QString &password, const QDate &date)
 {
     setVerb("POST");
 

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -91,7 +91,7 @@ void OcsShareJob::createShare(const QString &path, ShareType shareType, const QS
     addParam(QString::fromLatin1("shareType"), QString::number(static_cast<int>(shareType)));
 
     if (!password.isEmpty()) {
-        addParam(QString::fromLatin1("shareType"), password);
+        addParam(QString::fromLatin1("password"), password);
     }
 
     if (date.isValid()) {

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -15,6 +15,7 @@
 #define OCSSHAREJOB_H
 
 #include "ocsjob.h"
+#include "share.h"
 #include <QVector>
 #include <QList>
 #include <QPair>
@@ -31,25 +32,6 @@ namespace OCC {
 class OcsShareJob : public OcsJob {
     Q_OBJECT
 public:
-
-    /**
-     * Support sharetypes
-     */
-    enum ShareType : int {
-        Link = 3
-    };
-
-    /**
-     * Possible permissions
-     */
-    enum Permission : int {
-        Read = 1,
-        Update = 2,
-        Create = 4,
-        Delete = 8,
-        Share = 16,
-        All = 31
-    };
 
     /**
      * Constructor for new shares or listing of shares
@@ -99,7 +81,7 @@ public:
      * @param password Optionally a password for the share
      * @param date Optionally an expire date for the share
      */
-    void createShare(const QString& path, ShareType shareType, const QString& password = "", const QDate& date = QDate());
+    void createShare(const QString& path, Share::ShareType shareType, const QString& password = "", const QDate& date = QDate());
 
 signals:
     /**

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -35,14 +35,14 @@ public:
     /**
      * Support sharetypes
      */
-    enum class ShareType : int {
+    enum ShareType : int {
         Link = 3
     };
 
     /**
      * Possible permissions
      */
-    enum class Permission : int {
+    enum Permission : int {
         Read = 1,
         Update = 2,
         Create = 4,
@@ -66,7 +66,7 @@ public:
     /**
      * Delete the current Share
      */
-    void deleteShare(int shareId);
+    void deleteShare(const QString &shareId);
 
     /**
      * Set the expiration date of a share
@@ -74,7 +74,7 @@ public:
      * @param date The expire date, if this date is invalid the expire date
      * will be removed
      */
-    void setExpireDate(int shareId, const QDate& date);
+    void setExpireDate(const QString &shareId, const QDate& date);
 
     /**
      * Set the password of a share
@@ -82,14 +82,14 @@ public:
      * @param password The password of the share, if the password is empty the
      * share will be removed
      */
-    void setPassword(int shareId, const QString& password);
+    void setPassword(const QString &shareId, const QString& password);
 
     /**
      * Void set the share to be public upload
      * 
      * @param publicUpload Set or remove public upload
      */
-    void setPublicUpload(int shareId, bool publicUpload);
+    void setPublicUpload(const QString &shareId, bool publicUpload);
 
     /**
      * Create a new share
@@ -100,6 +100,24 @@ public:
      * @param date Optionally an expire date for the share
      */
     void createShare(const QString& path, ShareType shareType, const QString& password = "", const QDate& date = QDate());
+
+signals:
+    /**
+     * Result of the OCS request
+     * The value parameter is only set if this was a put request.
+     * e.g. if we set the password to 'foo' the QVariant will hold a QString with 'foo'.
+     * This is needed so we can update the share objects properly
+     *
+     * @param reply The reply
+     * @param value To what did we set a varialble (if we set any).
+     */
+    void shareJobFinished(QVariantMap reply, QVariant value);
+
+private slots:
+    void jobDone(QVariantMap reply);
+
+private:
+    QVariant _value;
 };
 
 }

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -109,7 +109,7 @@ signals:
      * This is needed so we can update the share objects properly
      *
      * @param reply The reply
-     * @param value To what did we set a varialble (if we set any).
+     * @param value To what did we set a variable (if we set any).
      */
     void shareJobFinished(QVariantMap reply, QVariant value);
 

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -96,6 +96,12 @@ LinkShare::LinkShare(AccountPtr account,
 
 }
 
+bool LinkShare::getPublicUpload()
+{
+    return ((_permissions & OcsShareJob::Permission::Update) &&
+            (_permissions & OcsShareJob::Permission::Create));
+}
+
 void LinkShare::setPublicUpload(bool publicUpload)
 {
     OcsShareJob *job = new OcsShareJob(_account, this);

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "share.h"
+#include "ocssharejob.h"
+#include "account.h"
+
+#include <QUrl>
+
+namespace OCC {
+
+Share::Share(AccountPtr account, const QString& id, const QString& path, int shareType,
+             int permissions, QObject *parent)
+: QObject(parent),
+  _account(account),
+  _id(id),
+  _path(path),
+  _shareType(shareType),
+  _permissions(permissions)
+{
+
+}
+
+const QString Share::getId()
+{
+    return _id;
+}
+
+int Share::getShareType()
+{
+    return _shareType;
+}
+
+int Share::getPermissions()
+{
+    return _permissions;
+}
+
+void Share::deleteShare()
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotDeleted(QVariantMap)));
+    job->deleteShare(getId());
+}
+
+void Share::slotDeleted(const QVariantMap &reply)
+{
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+    if (code != 100) {
+        //emit error!
+    }
+
+    emit shareDeleted();
+}
+
+const QUrl LinkShare::getLink()
+{
+    return _url;
+}
+
+const QDate LinkShare::getExpireDate()
+{
+    return _expireDate;
+}
+
+bool LinkShare::isPasswordSet()
+{
+    return _passwordSet;
+}
+
+LinkShare::LinkShare(AccountPtr account,
+                     const QString& id,
+                     const QString& path,
+                     int shareType,
+                     int permissions,
+                     bool passwordSet,
+                     const QUrl& url,
+                     const QDate& expireDate,
+                     QObject *parent)
+: Share(account, id, path, shareType, permissions, parent),
+  _passwordSet(passwordSet),
+  _expireDate(expireDate),
+  _url(url)
+{
+
+}
+
+void LinkShare::setPublicUpload(bool publicUpload)
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(shareJobFinished(QVariantMap, QVariant)), this, SLOT(slotPublicUploadSet(QVariantMap, QVariant)));
+    job->setPublicUpload(getId(), publicUpload);
+}
+
+void LinkShare::slotPublicUploadSet(const QVariantMap &reply, const QVariant &value)
+{
+    qDebug() << Q_FUNC_INFO << reply;
+    qDebug() << Q_FUNC_INFO << value;
+
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+    if (code != 100) {
+        //emit error
+    }
+
+    //TODO FIX permission with names
+    if (value.toBool()) {
+        _permissions = 7;
+    } else {
+        _permissions = 1;
+    }
+
+    emit publicUploadSet();
+}
+
+void LinkShare::setPassword(const QString &password)
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(shareJobFinished(QVariantMap, QVariant)), this, SLOT(slotPasswordSet(QVariantMap, QVariant)));
+    job->setPassword(getId(), password);
+}
+
+void LinkShare::slotPasswordSet(const QVariantMap &reply, const QVariant &value)
+{
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+    if (code != 100) {
+        //emit error
+    }
+
+    _passwordSet = value.toString() == "";
+    emit passwordSet();
+}
+
+void LinkShare::setExpireDate(const QDate &date)
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(shareJobFinished(QVariantMap, QVariant)), this, SLOT(slotExpireDateSet(QVariantMap, QVariant)));
+    job->setExpireDate(getId(), date);
+}
+
+void LinkShare::slotExpireDateSet(const QVariantMap &reply, const QVariant &value)
+{
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+    if (code != 100) {
+        //emit error
+    }
+
+    _expireDate = value.toDate();
+    emit expireDateSet();
+}
+
+ShareManager::ShareManager(AccountPtr account, QObject *parent)
+: QObject(parent),
+  _account(account)
+{
+
+}
+
+void ShareManager::createLinkShare(const QString &path,
+                                   const QString &password)
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotLinkShareCreated(QVariantMap)));
+    job->createShare(path, OcsShareJob::ShareType::Link, password);
+}
+
+void ShareManager::slotLinkShareCreated(const QVariantMap &reply)
+{
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+
+    /*
+     * Before we had decent sharing capabilities on the server a 403 "generally"
+     * ment that a share was password protected
+     */
+    if (code == 403) {
+        emit linkShareRequiresPassword();
+    } else if (code != 100) {
+        //emit error
+    }
+
+    //Parse share
+    auto data = reply.value("ocs").toMap().value("data").toMap();
+    QSharedPointer<LinkShare> share(parseLinkShare(data));
+
+    emit linkShareCreated(share);
+}
+
+void ShareManager::fetchShares(const QString &path)
+{
+    OcsShareJob *job = new OcsShareJob(_account, this);
+    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotSharesFetched(QVariantMap)));
+    job->getShares(path);
+}
+
+void ShareManager::slotSharesFetched(const QVariantMap &reply)
+{
+    QString message;
+    int code = OcsShareJob::getJsonReturnCode(reply, message);
+    if (code != 100 && code != 404) {
+        //emit error!
+    }
+
+    auto tmpShares = reply.value("ocs").toMap().value("data").toList();
+    const QString versionString = _account->serverVersion();
+    qDebug() << Q_FUNC_INFO << versionString << "Fetched" << tmpShares.count() << "shares";
+
+    QList<QSharedPointer<Share>> shares;
+
+    Q_FOREACH(auto share, tmpShares) {
+        auto data = share.toMap();
+
+        auto shareType = data.value("share_type").toInt();
+
+        Share *newShare = NULL;
+
+        if (shareType == OcsShareJob::ShareType::Link) {
+            newShare = parseLinkShare(data);
+        } else {
+            newShare = new Share(_account,
+                                 data.value("id").toString(),
+                                 data.value("path").toString(),
+                                 shareType,
+                                 data.value("permissions").toInt(),
+                                 this);
+        }
+
+        shares.append(QSharedPointer<Share>(newShare));    
+    }
+
+    qDebug() << Q_FUNC_INFO << "Sending " << shares.count() << "shares";
+    emit sharesFetched(shares);
+}
+
+LinkShare *ShareManager::parseLinkShare(const QVariantMap &data) {
+    QUrl url;
+    const QString versionString = _account->serverVersion();
+
+    // From ownCloud server 8.2 the url field is always set for public shares
+    if (data.contains("url")) {
+        url = QUrl(data.value("url").toString());
+    } else if (versionString.contains('.') && versionString.split('.')[0].toInt() >= 8) {
+        // From ownCloud server version 8 on, a different share link scheme is used.
+        url = QUrl(Account::concatUrlPath(_account->url(), QString("index.php/s/%1").arg(data.value("token").toString())).toString());
+    } else {
+        QList<QPair<QString, QString>> queryArgs;
+        queryArgs.append(qMakePair(QString("service"), QString("files")));
+        queryArgs.append(qMakePair(QString("t"), data.value("token").toString()));
+        url = QUrl(Account::concatUrlPath(_account->url(), QLatin1String("public.php"), queryArgs).toString());
+    }
+
+    QDate expireDate;
+    if (data.value("expiration").isValid()) {
+       expireDate = QDate::fromString(data.value("expiration").toString(), "yyyy-MM-dd 00:00:00");
+    }
+
+    return new LinkShare(_account,
+                         data.value("id").toString(),
+                         data.value("path").toString(),
+                         data.value("share_type").toInt(),
+                         data.value("permissions").toInt(),
+                         data.value("share_with").isValid(),
+                         url,
+                         expireDate,
+                         this);
+}
+
+}

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -190,7 +190,7 @@ void ShareManager::slotLinkShareCreated(const QVariantMap &reply)
 
     /*
      * Before we had decent sharing capabilities on the server a 403 "generally"
-     * ment that a share was password protected
+     * meant that a share was password protected
      */
     if (code == 403) {
         emit linkShareRequiresPassword();

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -194,6 +194,7 @@ void ShareManager::slotLinkShareCreated(const QVariantMap &reply)
      */
     if (code == 403) {
         emit linkShareRequiresPassword();
+        return;
     } else if (code != 100) {
         //emit error
     }

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -227,7 +227,7 @@ void ShareManager::slotSharesFetched(const QVariantMap &reply)
 
     QList<QSharedPointer<Share>> shares;
 
-    Q_FOREACH(auto share, tmpShares) {
+    foreach(const auto &share, tmpShares) {
         auto data = share.toMap();
 
         auto shareType = data.value("share_type").toInt();

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -31,17 +31,17 @@ Share::Share(AccountPtr account, const QString& id, const QString& path, int sha
 
 }
 
-const QString Share::getId()
+QString Share::getId() const
 {
     return _id;
 }
 
-int Share::getShareType()
+int Share::getShareType() const
 {
     return _shareType;
 }
 
-int Share::getPermissions()
+int Share::getPermissions() const
 {
     return _permissions;
 }
@@ -64,17 +64,17 @@ void Share::slotDeleted(const QVariantMap &reply)
     emit shareDeleted();
 }
 
-const QUrl LinkShare::getLink()
+QUrl LinkShare::getLink() const
 {
     return _url;
 }
 
-const QDate LinkShare::getExpireDate()
+QDate LinkShare::getExpireDate() const
 {
     return _expireDate;
 }
 
-bool LinkShare::isPasswordSet()
+bool LinkShare::isPasswordSet() const
 {
     return _passwordSet;
 }
@@ -254,12 +254,11 @@ void ShareManager::slotSharesFetched(const QVariantMap &reply)
 
 LinkShare *ShareManager::parseLinkShare(const QVariantMap &data) {
     QUrl url;
-    const QString versionString = _account->serverVersion();
 
     // From ownCloud server 8.2 the url field is always set for public shares
     if (data.contains("url")) {
         url = QUrl(data.value("url").toString());
-    } else if (versionString.contains('.') && versionString.split('.')[0].toInt() >= 8) {
+    } else if (_account->serverVersionInt() >= (8 << 16)) {
         // From ownCloud server version 8 on, a different share link scheme is used.
         url = QUrl(Account::concatUrlPath(_account->url(), QString("index.php/s/%1").arg(data.value("token").toString())).toString());
     } else {

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -37,8 +37,7 @@ public:
                    const QString& id,
                    const QString& path,
                    int shareType,
-                   int permissions,
-                   QObject *parent = NULL);
+                   int permissions);
 
     /*
      * Get the id
@@ -104,8 +103,7 @@ public:
                        int permissions,
                        bool passwordSet,
                        const QUrl& url,
-                       const QDate& expireDate,
-                       QObject *parent = NULL);
+                       const QDate& expireDate);
 
     /*
      * Get the share link
@@ -202,9 +200,9 @@ public:
     void fetchShares(const QString& path);
 
 signals:
-    void linkShareCreated(const QSharedPointer<LinkShare> share);
+    void linkShareCreated(const QSharedPointer<LinkShare> &share);
     void linkShareRequiresPassword();
-    void sharesFetched(QList<QSharedPointer<Share>>);
+    void sharesFetched(const QList<QSharedPointer<Share>> &shares);
     void serverError(int code, const QString &message);
 
 private slots:
@@ -212,7 +210,7 @@ private slots:
     void slotLinkShareCreated(const QVariantMap &reply);
 
 private:
-    LinkShare *parseLinkShare(const QVariantMap &data);
+    QSharedPointer<LinkShare> parseLinkShare(const QVariantMap &data);
 
     AccountPtr _account;
 };

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -31,7 +31,7 @@ class Share : public QObject {
 public:
 
     /*
-     * Constructor for link shares
+     * Constructor for shares
      */
     explicit Share(AccountPtr account,
                    const QString& id,
@@ -43,17 +43,17 @@ public:
     /*
      * Get the id
      */
-    const QString getId();
+    QString getId() const;
 
     /*
      * Get the shareType
      */
-    int getShareType();
+    int getShareType() const;
 
     /*
      * Get permissions
      */
-    int getPermissions();
+    int getPermissions() const;
 
     /*
      * Set the permissions of a share
@@ -110,7 +110,7 @@ public:
     /*
      * Get the share link
      */
-    const QUrl getLink();
+    QUrl getLink() const;
 
     /*
      * Get the publicUpload status of this share
@@ -137,12 +137,12 @@ public:
     /*
      * Is the password set?
      */
-    bool isPasswordSet();
+    bool isPasswordSet() const;
 
     /*
      * Get the expiration date
      */
-    const QDate getExpireDate();
+    QDate getExpireDate() const;
 
     /*
      * Set the expiration date

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -67,7 +67,7 @@ public:
      * Deletes a share
      *
      * On success the shareDeleted signal is emitted
-     * In case of a server rror the serverError signal is emitted.
+     * In case of a server error the serverError signal is emitted.
      */
     void deleteShare();
 

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -82,8 +82,11 @@ protected:
     int _shareType;
     int _permissions;
 
+protected slots:
+    void slotOcsError(int statusCode, const QString &message);
+
 private slots:
-    void slotDeleted(const QVariantMap &reply);
+    void slotDeleted();
 
 };
 
@@ -156,9 +159,9 @@ signals:
     void passwordSet();
 
 private slots:
-    void slotPasswordSet(const QVariantMap &reply, const QVariant &value);
-    void slotPublicUploadSet(const QVariantMap &reply, const QVariant &value);
-    void slotExpireDateSet(const QVariantMap &reply, const QVariant &value);
+    void slotPasswordSet(const QVariantMap&, const QVariant &value);
+    void slotPublicUploadSet(const QVariantMap&, const QVariant &value);
+    void slotExpireDateSet(const QVariantMap&, const QVariant &value);
 
 private:
     bool _passwordSet;
@@ -208,6 +211,7 @@ signals:
 private slots:
     void slotSharesFetched(const QVariantMap &reply);
     void slotLinkShareCreated(const QVariantMap &reply);
+    void slotOcsError(int statusCode, const QString &message);
 
 private:
     QSharedPointer<LinkShare> parseLinkShare(const QVariantMap &data);

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -113,6 +113,11 @@ public:
     const QUrl getLink();
 
     /*
+     * Get the publicUpload status of this share
+     */
+    bool getPublicUpload();
+
+    /*
      * Set a share to be public upload
      * This function can only be called on link shares
      *

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef SHARE_H
+#define SHARE_H
+
+#include "accountfwd.h"
+
+#include <QObject>
+#include <QDate>
+#include <QString>
+#include <QList>
+#include <QSharedPointer>
+#include <QUrl>
+
+namespace OCC {
+
+class Share : public QObject {
+    Q_OBJECT
+
+public:
+
+    /*
+     * Constructor for link shares
+     */
+    explicit Share(AccountPtr account,
+                   const QString& id,
+                   const QString& path,
+                   int shareType,
+                   int permissions,
+                   QObject *parent = NULL);
+
+    /*
+     * Get the id
+     */
+    const QString getId();
+
+    /*
+     * Get the shareType
+     */
+    int getShareType();
+
+    /*
+     * Get permissions
+     */
+    int getPermissions();
+
+    /*
+     * Set the permissions of a share
+     *
+     * On success the permissionsSet signal is emitted
+     * In case of a server error the serverError signal is emitted.
+     */
+    void setPermissions(int permissions);
+
+    /**
+     * Deletes a share
+     *
+     * On success the shareDeleted signal is emitted
+     * In case of a server rror the serverError signal is emitted.
+     */
+    void deleteShare();
+
+signals:
+    void permissionsSet();
+    void shareDeleted();
+    void serverError(int code, const QString &message);
+
+protected:
+    AccountPtr _account;
+    QString _id;
+    QString _path;
+    int _shareType;
+    int _permissions;
+
+private slots:
+    void slotDeleted(const QVariantMap &reply);
+
+};
+
+/**
+ * A Link share is just like a regular share but then slightly different.
+ * There are several methods in the API that either work differently for
+ * link shares or are only available to link shares.
+ */
+class LinkShare : public Share {
+    Q_OBJECT
+public:
+ 
+    explicit LinkShare(AccountPtr account,
+                       const QString& id,
+                       const QString& path,
+                       int shareType,
+                       int permissions,
+                       bool passwordSet,
+                       const QUrl& url,
+                       const QDate& expireDate,
+                       QObject *parent = NULL);
+
+    /*
+     * Get the share link
+     */
+    const QUrl getLink();
+
+    /*
+     * Set a share to be public upload
+     * This function can only be called on link shares
+     *
+     * On success the publicUploadSet signal is emitted
+     * In case of a server error the serverError signal is emitted.
+     */
+    void setPublicUpload(bool publicUpload);
+    
+    /*
+     * Set the password
+     *
+     * On success the passwordSet signal is emitted
+     * In case of a server error the serverError signal is emitted.
+     */
+    void setPassword(const QString& password);
+
+    /*
+     * Is the password set?
+     */
+    bool isPasswordSet();
+
+    /*
+     * Get the expiration date
+     */
+    const QDate getExpireDate();
+
+    /*
+     * Set the expiration date
+     *
+     * On success the expireDateSet signal is emitted
+     * In case of a server error the serverError signal is emitted.
+     */
+    void setExpireDate(const QDate& expireDate);
+
+signals:
+    void expireDateSet();
+    void publicUploadSet();
+    void passwordSet();
+
+private slots:
+    void slotPasswordSet(const QVariantMap &reply, const QVariant &value);
+    void slotPublicUploadSet(const QVariantMap &reply, const QVariant &value);
+    void slotExpireDateSet(const QVariantMap &reply, const QVariant &value);
+
+private:
+    bool _passwordSet;
+    QDate _expireDate;
+    QUrl _url;
+};
+
+/**
+ * The share manager allows for creating, retrieving and deletion
+ * of shares. It abstracts away from the OCS Share API, all the usages
+ * shares should talk to this manager and not use OCS Share Job directly
+ */
+class ShareManager : public QObject {
+    Q_OBJECT
+public:
+    explicit ShareManager(AccountPtr _account, QObject *parent = NULL);
+
+    /**
+     * Tell the manager to create a link share
+     *
+     * @param path The path of the linkshare relative to the user folder on the server
+     * @param password The password of the share
+     *
+     * On success the signal linkShareCreated is emitted
+     * For older server the linkShareRequiresPassword signal is emitted when it seems appropiate
+     * In case of a server error the serverError signal is emitted
+     */
+    void createLinkShare(const QString& path,
+                         const QString& password="");
+
+    /**
+     * Fetch all the shares for path
+     *
+     * @param path The path to get the shares for relative to the users folder on the server
+     *
+     * On success the sharesFetched signal is emitted
+     * In case of a server error the serverError signal is emitted
+     */
+    void fetchShares(const QString& path);
+
+signals:
+    void linkShareCreated(const QSharedPointer<LinkShare> share);
+    void linkShareRequiresPassword();
+    void sharesFetched(QList<QSharedPointer<Share>>);
+    void serverError(int code, const QString &message);
+
+private slots:
+    void slotSharesFetched(const QVariantMap &reply);
+    void slotLinkShareCreated(const QVariantMap &reply);
+
+private:
+    LinkShare *parseLinkShare(const QVariantMap &data);
+
+    AccountPtr _account;
+};
+
+
+}
+
+#endif // SHARE_H

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -30,14 +30,37 @@ class Share : public QObject {
 
 public:
 
+    /**
+     * Possible share types
+     */
+    enum ShareType {
+        TypeUser   = 0,
+        TypeGroup  = 1,
+        TypeLink   = 3,
+        TypeRemote = 6,
+    };
+    Q_DECLARE_FLAGS(ShareTypes, ShareType)
+
+    /**
+     * Possible permissions
+     */
+    enum Permission {
+        PermissionRead   =  1,
+        PermissionUpdate =  2,
+        PermissionCreate =  4,
+        PermissionDelete =  8,
+        PermissionShare  = 16
+    };
+    Q_DECLARE_FLAGS(Permissions, Permission)
+
     /*
      * Constructor for shares
      */
     explicit Share(AccountPtr account,
                    const QString& id,
                    const QString& path,
-                   int shareType,
-                   int permissions);
+                   ShareType shareType,
+                   Permissions permissions);
 
     /*
      * Get the id
@@ -47,12 +70,12 @@ public:
     /*
      * Get the shareType
      */
-    int getShareType() const;
+    ShareType getShareType() const;
 
     /*
      * Get permissions
      */
-    int getPermissions() const;
+    Permissions getPermissions() const;
 
     /*
      * Set the permissions of a share
@@ -79,8 +102,8 @@ protected:
     AccountPtr _account;
     QString _id;
     QString _path;
-    int _shareType;
-    int _permissions;
+    ShareType _shareType;
+    Permissions _permissions;
 
 protected slots:
     void slotOcsError(int statusCode, const QString &message);
@@ -102,8 +125,7 @@ public:
     explicit LinkShare(AccountPtr account,
                        const QString& id,
                        const QString& path,
-                       int shareType,
-                       int permissions,
+                       Permissions permissions,
                        bool passwordSet,
                        const QUrl& url,
                        const QDate& expireDate);
@@ -168,6 +190,7 @@ private:
     QDate _expireDate;
     QUrl _url;
 };
+Q_DECLARE_OPERATORS_FOR_FLAGS(Share::Permissions)
 
 /**
  * The share manager allows for creating, retrieving and deletion

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -25,6 +25,7 @@
 
 #include "ocssharejob.h"
 #include "thumbnailjob.h"
+#include "share.h"
 
 #include "QProgressIndicator.h"
 #include <QBuffer>
@@ -41,7 +42,8 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     _sharePath(sharePath),
     _localPath(localPath),
     _passwordJobRunning(false),
-    _public_share_id(0),
+    _manager(NULL),
+    _share(NULL),
     _resharingAllowed(resharingAllowed)
 {
     setAttribute(Qt::WA_DeleteOnClose);
@@ -90,7 +92,6 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     _ui->lineEdit_password->hide();
     _ui->pushButton_setPassword->hide();
 
-    _ui->calendar->setDate(QDate::currentDate().addDays(1));
     _ui->calendar->setEnabled(false);
 
     QFileInfo f_info(_localPath);
@@ -168,6 +169,15 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
             _ui->checkBox_editing->setEnabled(false);
         }
     }
+
+    /*
+     * Create the share manager and connect it properly
+     */
+    _manager = QSharedPointer<ShareManager>(new ShareManager(_account, this));
+
+    connect(_manager.data(), SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), this, SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
+    connect(_manager.data(), SIGNAL(linkShareCreated(const QSharedPointer<LinkShare>)), this, SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
+    connect(_manager.data(), SIGNAL(linkShareRequiresPassword()), this, SLOT(slotCreateShareRequiresPassword()));
 }
 
 void ShareDialog::done( int r ) {
@@ -178,25 +188,12 @@ void ShareDialog::done( int r ) {
 
 void ShareDialog::setExpireDate(const QDate &date)
 {
-    if( _public_share_id == 0 ) {
-        // no public share so far.
-        return;
-    }
     _pi_date->startAnimation();
-
-    OcsShareJob *job = new OcsShareJob(_account, this);
-    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotExpireSet(QVariantMap)));
-    job->setExpireDate(_public_share_id, date);
+    _share->setExpireDate(date);
 }
 
-void ShareDialog::slotExpireSet(const QVariantMap &reply)
+void ShareDialog::slotExpireSet()
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
-    if (code != 100) {
-        displayError(code);
-    } 
-
     _pi_date->stopAnimation();
 }
 
@@ -234,37 +231,21 @@ void ShareDialog::setPassword(const QString &password)
     _pi_password->startAnimation();
     QString path;
 
-    if( _public_share_id > 0 ) {
-        OcsShareJob *job = new OcsShareJob(_account, this);
-        connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPasswordSet(QVariantMap)));
-        job->setPassword(_public_share_id, password);
+    if( !_share.isNull() ) {
+        _share->setPassword(password);
     } else {
-        OcsShareJob *job = new OcsShareJob(_account, this);
-        connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPasswordSet(QVariantMap)));
-        connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotCreateShareFetched(QVariantMap)));
-
-        QDate date;
-        if( _ui->checkBox_expire->isChecked() ) {
-            date = _ui->calendar->date();
-        }
-
-        job->createShare(_sharePath, OcsShareJob::ShareType::Link, password, date);
+        _manager->createLinkShare(_sharePath, password);
     }
     _passwordJobRunning = true;
 }
 
-void ShareDialog::slotPasswordSet(const QVariantMap &reply)
+void ShareDialog::slotPasswordSet()
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
-    if (code != 100) {
-        displayError(code);
-    }
     /*
-         * When setting/deleting a password from a share the old share is
-         * deleted and a new one is created. So we need to refetch the shares
-         * at this point.
-         */
+     * When setting/deleting a password from a share the old share is
+     * deleted and a new one is created. So we need to refetch the shares
+     * at this point.
+     */
     getShares();
 
     _passwordJobRunning = false;
@@ -273,9 +254,7 @@ void ShareDialog::slotPasswordSet(const QVariantMap &reply)
 
 void ShareDialog::getShares()
 {
-    OcsShareJob *job = new OcsShareJob(_account, this);
-    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotSharesFetched(QVariantMap)));
-    job->getShares(_sharePath);
+    _manager->fetchShares(_sharePath);
 
     if (QFileInfo(_localPath).isFile()) {
         ThumbnailJob *job2 = new ThumbnailJob(_sharePath, _account, this);
@@ -284,34 +263,25 @@ void ShareDialog::getShares()
     }
 }
 
-void ShareDialog::slotSharesFetched(const QVariantMap &reply)
+void ShareDialog::slotSharesFetched(const QList<QSharedPointer<Share>> &shares)
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
-    if (code != 100 && code != 404) {
-        displayError(code);
-    }
-
-    ShareDialog::_shares = reply.value("ocs").toMap().value("data").toList();
     const QString versionString = _account->serverVersion();
-
-    qDebug() << Q_FUNC_INFO << versionString << "Fetched" << ShareDialog::_shares.count() << "shares";
+    qDebug() << Q_FUNC_INFO << versionString << "Fetched" << shares.count() << "shares";
 
     //Show link checkbox now
     _ui->checkBox_shareLink->setEnabled(true);
     _pi_link->stopAnimation();
 
-    Q_FOREACH(auto share, ShareDialog::_shares) {
-        QVariantMap data = share.toMap();
+    Q_FOREACH(auto share, shares) {
 
-        if (data.value("share_type").toInt() == static_cast<int>(OcsShareJob::ShareType::Link)) {
-            _public_share_id = data.value("id").toULongLong();
+        if (share->getShareType() == static_cast<int>(OcsShareJob::ShareType::Link)) {
+            _share = qSharedPointerDynamicCast<LinkShare>(share);
             _ui->pushButton_copy->show();
 
             _ui->widget_shareLink->show();
             _ui->checkBox_shareLink->setChecked(true);
 
-            if (data.value("share_with").isValid()) {
+            if (_share->isPasswordSet()) {
                 _ui->checkBox_password->setChecked(true);
                 _ui->lineEdit_password->setPlaceholderText("********");
                 _ui->lineEdit_password->show();
@@ -323,8 +293,8 @@ void ShareDialog::slotSharesFetched(const QVariantMap &reply)
                 _ui->pushButton_setPassword->hide();
             }
 
-            if (data.value("expiration").isValid()) {
-                _ui->calendar->setDate(QDate::fromString(data.value("expiration").toString(), "yyyy-MM-dd 00:00:00"));
+            if (_share->getExpireDate().isValid()) {
+                _ui->calendar->setDate(_share->getExpireDate());
                 _ui->calendar->setMinimumDate(QDate::currentDate().addDays(1));
                 _ui->calendar->setEnabled(true);
                 _ui->checkBox_expire->setChecked(true);
@@ -333,38 +303,29 @@ void ShareDialog::slotSharesFetched(const QVariantMap &reply)
                 _ui->checkBox_expire->setChecked(false);
             }
 
-            if (data.value("permissions").isValid()) {
-                int permissions = data.value("permissions").toInt();
-                /*
-                 * Only directories can have public upload set
-                 * For public links the server sets CREATE and UPDATE permissions.
-                 */
-                if (!_isFile && 
-                       (permissions & static_cast<int>(OcsShareJob::Permission::Update)) &&
-                       (permissions & static_cast<int>(OcsShareJob::Permission::Create))) {
+            /*
+             * Only directories can have public upload set
+             * For public links the server sets CREATE and UPDATE permissions.
+             */
+            if (!_isFile && 
+                (_share->getPermissions() & static_cast<int>(OcsShareJob::Permission::Update)) &&
+                (_share->getPermissions() & static_cast<int>(OcsShareJob::Permission::Create))) {
                     _ui->checkBox_editing->setChecked(true);
-                }
             }
 
-            QString url;
-            // From ownCloud server 8.2 the url field is always set for public shares
-            if (data.contains("url")) {
-                url = data.value("url").toString();
-            } else if (versionString.contains('.') && versionString.split('.')[0].toInt() >= 8) {
-                // From ownCloud server version 8 on, a different share link scheme is used.
-                url = Account::concatUrlPath(_account->url(), QString("index.php/s/%1").arg(data.value("token").toString())).toString();
-            } else {
-                QList<QPair<QString, QString>> queryArgs;
-                queryArgs.append(qMakePair(QString("service"), QString("files")));
-                queryArgs.append(qMakePair(QString("t"), data.value("token").toString()));
-                url = Account::concatUrlPath(_account->url(), QLatin1String("public.php"), queryArgs).toString();
-            }
-            setShareLink(url);
-
+            setShareLink(_share->getLink().toString());
             _ui->pushButton_copy->setEnabled(true);
+
+            // Connect all shares signals to gui slots
+            connect(_share.data(), SIGNAL(expireDateSet()), this, SLOT(slotExpireSet()));
+            connect(_share.data(), SIGNAL(publicUploadSet()), this, SLOT(slotPublicUploadSet()));
+            connect(_share.data(), SIGNAL(passwordSet()), this, SLOT(slotPasswordSet()));
+            connect(_share.data(), SIGNAL(shareDeleted()), this, SLOT(slotDeleteShareFetched()));
+
+            break;
         }
     }
-    if( _shares.count()>0 ) {
+    if( !_share.isNull() ) {
         setShareCheckBoxTitle(true);
     } else {
         // If there are no shares yet, check the checkbox to create a link automatically.
@@ -416,15 +377,9 @@ void ShareDialog::setShareLink( const QString& url )
 
 }
 
-void ShareDialog::slotDeleteShareFetched(const QVariantMap &reply)
+void ShareDialog::slotDeleteShareFetched()
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
-    if (code != 100) {
-        displayError(code);
-    }
-
-    _public_share_id = 0;
+    _share.clear();
     _pi_link->stopAnimation();
     _ui->lineEdit_password->clear();
     _ui->_labelShareLink->clear();
@@ -440,7 +395,6 @@ void ShareDialog::slotDeleteShareFetched(const QVariantMap &reply)
     _shareUrl.clear();
 
     setShareCheckBoxTitle(false);
-
 }
 
 void ShareDialog::slotCheckBoxShareLinkClicked()
@@ -466,42 +420,33 @@ void ShareDialog::slotCheckBoxShareLinkClicked()
             return;
         }
 
-        OcsShareJob *job = new OcsShareJob(_account, this);
-        connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotCreateShareFetched(QVariantMap)));
-        job->createShare(_sharePath, OcsShareJob::ShareType::Link);
+        _manager->createLinkShare(_sharePath);
     } else {
         _pi_link->startAnimation();
-        OcsShareJob *job = new OcsShareJob(_account, this);
-        connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotDeleteShareFetched(QVariantMap)));
-        job->deleteShare(_public_share_id);
+        _share->deleteShare();
     }
 }
 
-void ShareDialog::slotCreateShareFetched(const QVariantMap &reply)
+void ShareDialog::slotCreateShareFetched(const QSharedPointer<LinkShare> share)
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
     _pi_link->stopAnimation();
 
-    if (code == 403) {
-        // there needs to be a password
-        _ui->checkBox_password->setChecked(true);
-        _ui->checkBox_password->setEnabled(false);
-        _ui->checkBox_password->setText(tr("Public sh&aring requires a password"));
-        _ui->lineEdit_password->setFocus();
-        _ui->pushButton_copy->hide();
-        _ui->widget_shareLink->show();
-
-        slotCheckBoxPasswordClicked();
-        return;
-    } else if (code != 100) {
-        displayError(code);
-        return;
-    }
-
-    _public_share_id = reply.value("ocs").toMap().values("data")[0].toMap().value("id").toULongLong();
+    _share = share;
     _ui->pushButton_copy->show();
     getShares();
+}
+
+void ShareDialog::slotCreateShareRequiresPassword()
+{
+    // there needs to be a password
+    _ui->checkBox_password->setChecked(true);
+    _ui->checkBox_password->setEnabled(false);
+    _ui->checkBox_password->setText(tr("Public sh&aring requires a password"));
+    _ui->lineEdit_password->setFocus();
+    _ui->pushButton_copy->hide();
+    _ui->widget_shareLink->show();
+
+    slotCheckBoxPasswordClicked();
 }
 
 void ShareDialog::slotCheckBoxPasswordClicked()
@@ -532,7 +477,7 @@ void ShareDialog::slotCheckBoxExpireClicked()
     }
     else
     {
-        ShareDialog::setExpireDate(QDate());
+        setExpireDate(QDate());
         _ui->calendar->setEnabled(false);
     }
 }
@@ -561,23 +506,13 @@ void ShareDialog::setPublicUpload(bool publicUpload)
     _ui->checkBox_editing->setEnabled(false);
     _pi_editing->startAnimation();
 
-    OcsShareJob *job = new OcsShareJob(_account, this);
-    connect(job, SIGNAL(jobFinished(QVariantMap)), this, SLOT(slotPublicUploadSet(QVariantMap)));
-    job->setPublicUpload(_public_share_id, publicUpload);
+    _share->setPublicUpload(publicUpload);
 }
 
-void ShareDialog::slotPublicUploadSet(const QVariantMap &reply)
+void ShareDialog::slotPublicUploadSet()
 {
-    QString message;
-    int code = OcsShareJob::getJsonReturnCode(reply, message);
-    if (code == 100) {
-        _ui->checkBox_editing->setEnabled(true);
-    } else {
-        qDebug() << Q_FUNC_INFO << reply;
-        displayError(code);
-    }
-
     _pi_editing->stopAnimation();
+    _ui->checkBox_editing->setEnabled(true);
 }
 
 void ShareDialog::setShareCheckBoxTitle(bool haveShares)
@@ -604,120 +539,6 @@ void ShareDialog::displayError(int code)
     const QString errMsg = tr("OCS API error code: %1").arg(code);
     displayError(errMsg);
 }
-
-#if 0
-void ShareDialog::displayInfo( const QString& msg )
-{
-    _ui->label_sharePath->setText(msg);
-}
-
-/*
- * This code is disabled for now as we do not have answers for all the questions involved
- * here, see https://github.com/owncloud/client/issues/2732
- */
-bool ShareDialog::uploadExternalFile()
-{
-    bool re = false;
-    const QString folderName = QString("ownCloud"); // FIXME: get a proper folder name
-
-    Folder *folder = 0;
-    Folder::Map folders = FolderMan::instance()->map();
-    if( folders.isEmpty() ) {
-        displayInfo(tr("There is no sync folder configured."));
-        return false;
-    }
-    if( folders.contains( Theme::instance()->appNameGUI()) ) {
-        folder = folders.value(Theme::instance()->appNameGUI());
-    }
-    if( !folder ) {
-        folder = folders.value( folders.keys().at(0));
-    }
-    FolderMan::instance()->folder(folderName);
-    if( ! folder ) {
-        qDebug() << "Folder not defined: " << folderName;
-        displayInfo(tr("Cannot find a folder to upload to."));
-        return false;
-    }
-
-    QFileInfo fi(_localPath);
-    if( fi.isDir() ) {
-        // we can not do this for directories yet.
-        displayInfo(tr("Sharing of external directories is not yet working."));
-        return false;
-    }
-    _sharePath = folder->remotePath()+QLatin1Char('/')+fi.fileName();
-    _folderAlias = folderName;
-
-    // connect the finish signal of the folder before the file to upload
-    // is copied to the sync folder.
-    connect( folder, SIGNAL(syncFinished(SyncResult)), this, SLOT(slotNextSyncFinished(SyncResult)) );
-
-    // copy the file
-    _expectedSyncFile = folder->path()+fi.fileName();
-
-    QFileInfo target(_expectedSyncFile);
-    if( target.exists() ) {
-        _ui->label_sharePath->setText(tr("A sync file with the same name exists. "
-                                         "The file cannot be registered to sync."));
-        // TODO: Add a file comparison here. If the existing file is still the same
-        // as the file-to-copy we can share it.
-        _sharePath.clear();
-    } else {
-        _uploadFails = 0;
-        _ui->pi_share->startAnimation();
-        QFile file( _localPath);
-        if( file.copy(_expectedSyncFile) ) {
-            // copying succeeded.
-            re = true;
-            displayInfo(tr("Waiting to upload..."));
-        } else {
-            displayInfo(tr("Unable to register in sync space."));
-        }
-    }
-    return re;
-}
-
-void ShareDialog::slotNextSyncFinished( const SyncResult& result )
-{
-    // FIXME: Check for state!
-    SyncFileItemVector itemVector = result.syncFileItemVector();
-    SyncFileItem targetItem;
-    Folder *folder = FolderMan::instance()->folder(_folderAlias);
-    const QString folderPath = folder->path();
-
-    _ui->pi_share->stopAnimation();
-
-    foreach( SyncFileItem item, itemVector ) {
-        const QString fullSyncedFile = folderPath + item._file;
-        if( item._direction == SyncFileItem::Up &&
-                fullSyncedFile == _expectedSyncFile) {
-            // found the item!
-            targetItem = item;
-            continue;
-        }
-    }
-
-    if( targetItem.isEmpty() ) {
-        // The item was not in this sync run. Lets wait for the next one. FIXME
-        _uploadFails ++;
-        if( _uploadFails > 2 ) {
-            // stop the upload job
-            displayInfo(tr("The file cannot be synced."));
-        }
-    } else {
-        // it's there and the sync was successful.
-        // The server should be able to generate a share link now.
-        // Enable the sharing link
-        if( targetItem._status == SyncFileItem::Success ) {
-            _ui->checkBox_shareLink->setEnabled(true);
-            _ui->label_sharePath->setText(tr("%1 path: %2").arg(Theme::instance()->appNameGUI()).arg(_sharePath));
-        } else {
-            displayInfo(tr("Sync of registered file was not successful yet."));
-        }
-    }
-    _expectedSyncFile.clear();
-}
-#endif
 
 void ShareDialog::slotThumbnailFetched(const int &statusCode, const QByteArray &reply)
 {

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -23,7 +23,6 @@
 #include "configfile.h"
 #include "capabilities.h"
 
-#include "ocssharejob.h"
 #include "thumbnailjob.h"
 #include "share.h"
 
@@ -272,7 +271,7 @@ void ShareDialog::slotSharesFetched(const QList<QSharedPointer<Share>> &shares)
 
     Q_FOREACH(auto share, shares) {
 
-        if (share->getShareType() == static_cast<int>(OcsShareJob::ShareType::Link)) {
+        if (share->getShareType() == Share::TypeLink) {
             _share = qSharedPointerDynamicCast<LinkShare>(share);
             _ui->pushButton_copy->show();
 

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -307,10 +307,8 @@ void ShareDialog::slotSharesFetched(const QList<QSharedPointer<Share>> &shares)
              * Only directories can have public upload set
              * For public links the server sets CREATE and UPDATE permissions.
              */
-            if (!_isFile && 
-                (_share->getPermissions() & static_cast<int>(OcsShareJob::Permission::Update)) &&
-                (_share->getPermissions() & static_cast<int>(OcsShareJob::Permission::Create))) {
-                    _ui->checkBox_editing->setChecked(true);
+            if (!_isFile && _share->getPublicUpload()) {
+                _ui->checkBox_editing->setChecked(true);
             }
 
             setShareLink(_share->getLink().toString());

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -175,9 +175,10 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
      */
     _manager = new ShareManager(_account, this);
 
-    connect(_manager, SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), this, SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
-    connect(_manager, SIGNAL(linkShareCreated(const QSharedPointer<LinkShare>)), this, SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
-    connect(_manager, SIGNAL(linkShareRequiresPassword()), this, SLOT(slotCreateShareRequiresPassword()));
+    connect(_manager, SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
+    connect(_manager, SIGNAL(linkShareCreated(QSharedPointer<LinkShare>)), SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
+    connect(_manager, SIGNAL(linkShareRequiresPassword()), SLOT(slotCreateShareRequiresPassword()));
+    connect(_manager, SIGNAL(serverError(int, QString)), SLOT(displayError(int, QString)));
 }
 
 void ShareDialog::done( int r ) {
@@ -320,10 +321,11 @@ void ShareDialog::slotSharesFetched(const QList<QSharedPointer<Share>> &shares)
             _ui->pushButton_copy->setEnabled(true);
 
             // Connect all shares signals to gui slots
-            connect(_share.data(), SIGNAL(expireDateSet()), this, SLOT(slotExpireSet()));
-            connect(_share.data(), SIGNAL(publicUploadSet()), this, SLOT(slotPublicUploadSet()));
-            connect(_share.data(), SIGNAL(passwordSet()), this, SLOT(slotPasswordSet()));
-            connect(_share.data(), SIGNAL(shareDeleted()), this, SLOT(slotDeleteShareFetched()));
+            connect(_share.data(), SIGNAL(expireDateSet()), SLOT(slotExpireSet()));
+            connect(_share.data(), SIGNAL(publicUploadSet()), SLOT(slotPublicUploadSet()));
+            connect(_share.data(), SIGNAL(passwordSet()), SLOT(slotPasswordSet()));
+            connect(_share.data(), SIGNAL(shareDeleted()), SLOT(slotDeleteShareFetched()));
+            connect(_share.data(), SIGNAL(serverError(int, QString)), SLOT(displayError(int, QString)));
 
             break;
         }
@@ -543,6 +545,13 @@ void ShareDialog::setShareCheckBoxTitle(bool haveShares)
         _ui->checkBox_shareLink->setText( noSharesTitle );
     }
 
+}
+
+void ShareDialog::displayError(int code, const QString &message)
+{
+    const QString arg = QString("%1, %2").arg(code).arg(message);
+    const QString errMsg = tr("OCS API error code: %1").arg(arg);
+    displayError(errMsg);
 }
 
 void ShareDialog::displayError(const QString& errMsg)

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -173,11 +173,11 @@ ShareDialog::ShareDialog(AccountPtr account, const QString &sharePath, const QSt
     /*
      * Create the share manager and connect it properly
      */
-    _manager = QSharedPointer<ShareManager>(new ShareManager(_account, this));
+    _manager = new ShareManager(_account, this);
 
-    connect(_manager.data(), SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), this, SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
-    connect(_manager.data(), SIGNAL(linkShareCreated(const QSharedPointer<LinkShare>)), this, SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
-    connect(_manager.data(), SIGNAL(linkShareRequiresPassword()), this, SLOT(slotCreateShareRequiresPassword()));
+    connect(_manager, SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), this, SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
+    connect(_manager, SIGNAL(linkShareCreated(const QSharedPointer<LinkShare>)), this, SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
+    connect(_manager, SIGNAL(linkShareRequiresPassword()), this, SLOT(slotCreateShareRequiresPassword()));
 }
 
 void ShareDialog::done( int r ) {

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -22,8 +22,6 @@
 #include <QSharedPointer>
 #include <QList>
 
-#include "share.h"
-
 namespace OCC {
 
 namespace Ui {
@@ -33,6 +31,9 @@ class ShareDialog;
 class AbstractCredentials;
 class QuotaInfo;
 class SyncResult;
+class LinkShare;
+class Share;
+class ShareManager;
 
 /**
  * @brief The ShareDialog class

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -96,7 +96,7 @@ private:
     QProgressIndicator *_pi_date;
     QProgressIndicator *_pi_editing;
 
-    QSharedPointer<ShareManager> _manager;
+    ShareManager *_manager;
     QSharedPointer<LinkShare> _share;
 
     bool _resharingAllowed;

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -19,6 +19,10 @@
 #include "QProgressIndicator.h"
 #include <QDialog>
 #include <QVariantMap>
+#include <QSharedPointer>
+#include <QList>
+
+#include "share.h"
 
 namespace OCC {
 
@@ -45,11 +49,12 @@ public:
     void getShares();
 
 private slots:
-    void slotSharesFetched(const QVariantMap &reply);
-    void slotCreateShareFetched(const QVariantMap &reply);
-    void slotDeleteShareFetched(const QVariantMap &reply);
-    void slotPasswordSet(const QVariantMap &reply);
-    void slotExpireSet(const QVariantMap &reply);
+    void slotSharesFetched(const QList<QSharedPointer<Share>> &shares);
+    void slotCreateShareFetched(const QSharedPointer<LinkShare> share);
+    void slotCreateShareRequiresPassword();
+    void slotDeleteShareFetched();
+    void slotPasswordSet();
+    void slotExpireSet();
     void slotCalendarClicked(const QDate &date);
     void slotCheckBoxShareLinkClicked();
     void slotCheckBoxPasswordClicked();
@@ -59,7 +64,7 @@ private slots:
     void slotPushButtonCopyLinkPressed();
     void slotThumbnailFetched(const int &statusCode, const QByteArray &reply);
     void slotCheckBoxEditingClicked();
-    void slotPublicUploadSet(const QVariantMap &reply);
+    void slotPublicUploadSet();
 
     void done( int r );
 private:
@@ -83,8 +88,6 @@ private:
 #endif
 
     bool _passwordJobRunning;
-    QList<QVariant> _shares;
-    qulonglong _public_share_id;
     void setPassword(const QString &password);
     void setExpireDate(const QDate &date);
 
@@ -92,6 +95,9 @@ private:
     QProgressIndicator *_pi_password;
     QProgressIndicator *_pi_date;
     QProgressIndicator *_pi_editing;
+
+    QSharedPointer<ShareManager> _manager;
+    QSharedPointer<LinkShare> _share;
 
     bool _resharingAllowed;
     bool _isFile;

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -66,6 +66,8 @@ private slots:
     void slotCheckBoxEditingClicked();
     void slotPublicUploadSet();
 
+    void displayError(int code, const QString &message);
+
     void done( int r );
 private:
     void setShareCheckBoxTitle(bool haveShares);


### PR DESCRIPTION
Step closer to https://github.com/owncloud/client/issues/3737

Pretty big PR (I'm sorry... I'll promise to do better).

Basically this introduces the abstraction I want. And which should help significantly in making the user/group sharing easier to implement.

There is now a ShareManager, this is the entry point to do anything with shares. Be it creating, or fetching.

Then there is the Share class which represents a generic share and there is the LinkShare class. Since link shares are just like regular shares but slightly different :P. Share objects allow for interaction with the object. E.g. setting the password etc. 

The sharedialog code is converted to use the new code and still works for me so far. And is a lot simpler.

TODO:
- [ ] Triplle check share dialog functionality
- [x] Check share dialog functionality against older servers
- [ ] More comments
- [ ] Maybe some cleanup?
- [x] Connect error reporting from manager/share

@guruz @dragotin @ckamm please have a look. More commits will follow. But since it kind of works now