### PR TITLE
Make registry key a code block in autoupdate docs.

### DIFF
--- a/doc/autoupdate.rst
+++ b/doc/autoupdate.rst
@@ -89,7 +89,7 @@ To prevent automatic updates and disallow manual overrides:
 
 1. Edit this Registry key:
 
-	HKEY_LOCAL_MACHINE\Software\Policies\ownCloud\ownCloud
+    ``HKEY_LOCAL_MACHINE\Software\Policies\ownCloud\ownCloud``
 
 2. Add the key ``skipUpdateCheck`` (of type DWORD).
 


### PR DESCRIPTION
Currently only looks like this:

``HKEY_LOCAL_MACHINESoftwarePoliciesownCloudownCloud``

https://doc.owncloud.org/desktop/2.0/autoupdate.html#preventing-automatic-updates-in-windows-environments