### PR TITLE
New Activity View

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(client_UI
     ignorelisteditor.ui
     networksettings.ui
     protocolwidget.ui
+    synclogdialog.ui
     settingsdialog.ui
     sharedialog.ui
     sslerrordialog.ui
@@ -68,6 +69,7 @@ set(client_SRCS
     authenticationdialog.cpp
     proxyauthhandler.cpp
     proxyauthdialog.cpp
+    synclogdialog.cpp
     creds/credentialsfactory.cpp
     creds/httpcredentialsgui.cpp
     creds/shibbolethcredentials.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(client_UI
     ignorelisteditor.ui
     networksettings.ui
     protocolwidget.ui
+    activitywidget.ui
     synclogdialog.ui
     settingsdialog.ui
     sharedialog.ui
@@ -55,6 +56,7 @@ set(client_SRCS
     owncloudgui.cpp
     owncloudsetupwizard.cpp
     protocolwidget.cpp
+    activitywidget.cpp
     selectivesyncdialog.cpp
     settingsdialog.cpp
     sharedialog.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -57,6 +57,7 @@ set(client_SRCS
     owncloudsetupwizard.cpp
     protocolwidget.cpp
     activitywidget.cpp
+    activityitemdelegate.cpp
     selectivesyncdialog.cpp
     settingsdialog.cpp
     sharedialog.cpp

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -215,6 +215,16 @@ AccountPtr AccountManager::load(QSettings& settings)
     return acc;
 }
 
+AccountStatePtr AccountManager::account(const QString& name)
+{
+    foreach (const auto& acc, _accounts) {
+        if (acc->account()->displayName() == name) {
+            return acc;
+        }
+    }
+    return AccountStatePtr();
+}
+
 AccountState *AccountManager::addAccount(const AccountPtr& newAccount)
 {
     auto id = newAccount->id();

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -59,6 +59,11 @@ public:
     QList<AccountStatePtr> accounts() { return _accounts; }
 
     /**
+     * Return the account state pointer for an account identified by its display name
+     */
+    AccountStatePtr account(const QString& name);
+
+    /**
      * Delete the AccountState
      */
     void deleteAccount(AccountState *account);

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -75,11 +75,6 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QFontMetrics fm( font );
     int margin = fm.height()/4;
 
-    // awesome to detect the timeline entry
-    // if (index.data(Timeline).toBool()) {
-    //        return;
-    // }
-
     painter->save();
 
     QIcon actionIcon      = qvariant_cast<QIcon>(index.data(ActionIconRole));
@@ -137,7 +132,7 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QString timeStr = tr("%1 on %2").arg(timeText).arg(accountRole);
     if( !accountOnline ) {
         QPalette p = option.palette;
-        painter->setBrush(p.brush(QPalette::Inactive, QPalette::WindowText));
+        painter->setPen(p.color(QPalette::Disabled, QPalette::Text));
         timeStr.append(" ");
         timeStr.append(tr("(disconnected)"));
     }

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -28,23 +28,41 @@
 
 namespace OCC {
 
+int ActivityItemDelegate::_iconHeight = 0;
+int ActivityItemDelegate::_margin = 0;
+
+int ActivityItemDelegate::iconHeight()
+{
+    if( _iconHeight == 0 ) {
+        QStyleOptionViewItem option;
+        QFont font = option.font;
+
+        QFontMetrics fm(font);
+
+        _iconHeight = qRound(fm.height() / 5.0 * 8.0);
+    }
+    return _iconHeight;
+}
+
+int ActivityItemDelegate::rowHeight()
+{
+    if( _margin == 0 ) {
+    QStyleOptionViewItem opt;
+
+    QFont f = opt.font;
+    QFontMetrics fm(f);
+
+    _margin = fm.height()/4;
+    }
+    return iconHeight() + 2 * _margin;
+}
+
 QSize ActivityItemDelegate::sizeHint(const QStyleOptionViewItem & option ,
                                      const QModelIndex & /* index */) const
 {
     QFont font = option.font;
 
-    QFontMetrics fm(font);
-    int iconHeight = qRound(fm.height() / 5.0 * 8.0);
-    int margin = fm.height()/4;
-
-    // TODO: set a different height for the day-line
-
-    // calc height
-
-    int h = iconHeight;          // lets display the icon
-    h += 2*margin;               // two times margin
-
-    return QSize( 0, h);
+    return QSize( 0, rowHeight() );
 }
 
 void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -89,6 +89,7 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QString remoteLink    = qvariant_cast<QString>(index.data(LinkRole));
     QString timeText      = qvariant_cast<QString>(index.data(PointInTimeRole));
     QString accountRole   = qvariant_cast<QString>(index.data(AccountRole));
+    bool    accountOnline = qvariant_cast<bool>   (index.data(AccountConnectedRole));
 
     QRect actionIconRect = option.rect;
     QRect userIconRect   = option.rect;
@@ -132,8 +133,16 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     if( atPos > -1 )  {
         accountRole.remove(0, atPos+1);
     }
-    const QString timeStr = tr("%1 on %2").arg(timeText).arg(accountRole);
+
+    QString timeStr = tr("%1 on %2").arg(timeText).arg(accountRole);
+    if( !accountOnline ) {
+        QPalette p = option.palette;
+        painter->setBrush(p.brush(QPalette::Inactive, QPalette::WindowText));
+        timeStr.append(" ");
+        timeStr.append(tr("(disconnected)"));
+    }
     const QString elidedTime = fm.elidedText(timeStr, Qt::ElideRight, timeBox.width());
+
     painter->drawText(timeBox, elidedTime);
     painter->restore();
 

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -81,6 +81,7 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QIcon userIcon        = qvariant_cast<QIcon>(index.data(UserIconRole));
     QString actionText    = qvariant_cast<QString>(index.data(ActionTextRole));
     QString pathText      = qvariant_cast<QString>(index.data(PathRole));
+
     QString remoteLink    = qvariant_cast<QString>(index.data(LinkRole));
     QString timeText      = qvariant_cast<QString>(index.data(PointInTimeRole));
     QString accountRole   = qvariant_cast<QString>(index.data(AccountRole));

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -29,7 +29,7 @@
 namespace OCC {
 
 QSize ActivityItemDelegate::sizeHint(const QStyleOptionViewItem & option ,
-                                     const QModelIndex & index) const
+                                     const QModelIndex & /* index */) const
 {
     QFont font = option.font;
 
@@ -41,7 +41,7 @@ QSize ActivityItemDelegate::sizeHint(const QStyleOptionViewItem & option ,
 
     // calc height
 
-    int h = iconHeight;          // normal text height
+    int h = iconHeight;          // lets display the icon
     h += 2*margin;               // two times margin
 
     return QSize( 0, h);
@@ -81,17 +81,16 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     actionIconRect.setLeft( option.rect.left() + margin );
     actionIconRect.setWidth( iconWidth );
     actionIconRect.setHeight( iconHeight );
-    actionIconRect.setTop( actionIconRect.top() + margin ); // (iconRect.height()-iconsize.height())/2);
-
+    actionIconRect.setTop( actionIconRect.top() + margin );
     userIconRect.setLeft( actionIconRect.right() + margin );
     userIconRect.setWidth( iconWidth );
     userIconRect.setHeight( iconHeight );
-    userIconRect.setTop( actionIconRect.top() ); // (iconRect.height()-iconsize.height())/2);
+    userIconRect.setTop( actionIconRect.top() );
 
     int textTopOffset = qRound( (iconHeight - fm.height())/ 2.0 );
     // time rect
     QRect timeBox;
-    int timeBoxWidth = fm.boundingRect(QLatin1String("a few minutes ago")).width(); // FIXME.
+    int timeBoxWidth = fm.boundingRect(QLatin1String("4 hour(s) ago on longlongdomain.org")).width(); // FIXME.
     timeBox.setTop( actionIconRect.top()+textTopOffset);
     timeBox.setLeft( option.rect.right() - timeBoxWidth- margin );
     timeBox.setWidth( timeBoxWidth);
@@ -111,7 +110,12 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     const QString elidedAction = fm.elidedText(actionText, Qt::ElideRight, actionTextBox.width());
     painter->drawText(actionTextBox, elidedAction);
 
-    const QString elidedTime = fm.elidedText(timeText, Qt::ElideRight, timeBox.width());
+    int atPos = accountRole.indexOf(QLatin1Char('@'));
+    if( atPos > -1 )  {
+        accountRole.remove(0, atPos+1);
+    }
+    const QString timeStr = tr("%1 on %2").arg(timeText).arg(accountRole);
+    const QString elidedTime = fm.elidedText(timeStr, Qt::ElideRight, timeBox.width());
     painter->drawText(timeBox, elidedTime);
     painter->restore();
 

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "activityitemdelegate.h"
+#include "folderstatusmodel.h"
+#include "folderman.h"
+#include "accountstate.h"
+#include "utility.h"
+#include <theme.h>
+#include <account.h>
+
+#include <QFileIconProvider>
+#include <QPainter>
+#include <QApplication>
+
+namespace OCC {
+
+QSize ActivityItemDelegate::sizeHint(const QStyleOptionViewItem & option ,
+                                     const QModelIndex & index) const
+{
+    QFont font = option.font;
+
+    QFontMetrics fm(font);
+    int iconHeight = qRound(fm.height() / 5.0 * 8.0);
+    int margin = fm.height()/4;
+
+    // TODO: set a different height for the day-line
+
+    // calc height
+
+    int h = iconHeight;          // normal text height
+    h += 2*margin;               // two times margin
+
+    return QSize( 0, h);
+}
+
+void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+                                 const QModelIndex &index) const
+{
+    QStyledItemDelegate::paint(painter,option,index);
+
+    QFont font = option.font;
+
+    QFontMetrics fm( font );
+    int margin = fm.height()/4;
+
+    // awesome to detect the timeline entry
+    // if (index.data(Timeline).toBool()) {
+    //        return;
+    // }
+
+    painter->save();
+
+    QIcon actionIcon      = qvariant_cast<QIcon>(index.data(ActionIconRole));
+    QIcon userIcon        = qvariant_cast<QIcon>(index.data(UserIconRole));
+    QString actionText    = qvariant_cast<QString>(index.data(ActionTextRole));
+    QString pathText      = qvariant_cast<QString>(index.data(PathRole));
+    QString remoteLink    = qvariant_cast<QString>(index.data(LinkRole));
+    QString timeText      = qvariant_cast<QString>(index.data(PointInTimeRole));
+    QString accountRole   = qvariant_cast<QString>(index.data(AccountRole));
+
+    QRect actionIconRect = option.rect;
+    QRect userIconRect   = option.rect;
+
+    int iconHeight = qRound(fm.height() / 5.0 * 8.0);
+    int iconWidth = iconHeight;
+
+    actionIconRect.setLeft( option.rect.left() + margin );
+    actionIconRect.setWidth( iconWidth );
+    actionIconRect.setHeight( iconHeight );
+    actionIconRect.setTop( actionIconRect.top() + margin ); // (iconRect.height()-iconsize.height())/2);
+
+    userIconRect.setLeft( actionIconRect.right() + margin );
+    userIconRect.setWidth( iconWidth );
+    userIconRect.setHeight( iconHeight );
+    userIconRect.setTop( actionIconRect.top() ); // (iconRect.height()-iconsize.height())/2);
+
+    int textTopOffset = qRound( (iconHeight - fm.height())/ 2.0 );
+    // time rect
+    QRect timeBox;
+    int timeBoxWidth = fm.boundingRect(QLatin1String("a few minutes ago")).width(); // FIXME.
+    timeBox.setTop( actionIconRect.top()+textTopOffset);
+    timeBox.setLeft( option.rect.right() - timeBoxWidth- margin );
+    timeBox.setWidth( timeBoxWidth);
+    timeBox.setHeight( fm.height() );
+
+    QRect actionTextBox = timeBox;
+    actionTextBox.setLeft( userIconRect.right()+margin );
+    actionTextBox.setRight( timeBox.left()-margin );
+
+    /* === start drawing === */
+    QPixmap pm = actionIcon.pixmap(iconWidth, iconHeight, QIcon::Normal);
+    painter->drawPixmap(QPoint(actionIconRect.left(), actionIconRect.top()), pm);
+
+    pm = userIcon.pixmap(iconWidth, iconHeight, QIcon::Normal);
+    painter->drawPixmap(QPoint(userIconRect.left(), userIconRect.top()), pm);
+
+    const QString elidedAction = fm.elidedText(actionText, Qt::ElideRight, actionTextBox.width());
+    painter->drawText(actionTextBox, elidedAction);
+
+    const QString elidedTime = fm.elidedText(timeText, Qt::ElideRight, timeBox.width());
+    painter->drawText(timeBox, elidedTime);
+    painter->restore();
+
+}
+
+bool ActivityItemDelegate::editorEvent ( QEvent * event, QAbstractItemModel * model,
+                                         const QStyleOptionViewItem & option, const QModelIndex & index )
+{
+    return QStyledItemDelegate::editorEvent(event, model, option, index);
+}
+
+} // namespace OCC

--- a/src/gui/activityitemdelegate.h
+++ b/src/gui/activityitemdelegate.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@kde.org>
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+#include <QStyledItemDelegate>
+
+namespace OCC {
+
+/**
+ * @brief The ActivityItemDelegate class
+ * @ingroup gui
+ */
+class ActivityItemDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+
+    enum datarole { ActionIconRole = Qt::UserRole + 1,
+                    UserIconRole,
+                    AccountRole,
+                    ActionTextRole,
+                    PathRole,
+                    LinkRole,
+                    PointInTimeRole };
+    void paint( QPainter*, const QStyleOptionViewItem&, const QModelIndex& ) const Q_DECL_OVERRIDE;
+    QSize sizeHint( const QStyleOptionViewItem&, const QModelIndex& ) const Q_DECL_OVERRIDE;
+    bool editorEvent( QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
+                      const QModelIndex& index ) Q_DECL_OVERRIDE;
+
+};
+
+} // namespace OCC
+

--- a/src/gui/activityitemdelegate.h
+++ b/src/gui/activityitemdelegate.h
@@ -33,7 +33,9 @@ public:
                     ActionTextRole,
                     PathRole,
                     LinkRole,
-                    PointInTimeRole };
+                    PointInTimeRole,
+                    AccountConnectedRole };
+
     void paint( QPainter*, const QStyleOptionViewItem&, const QModelIndex& ) const Q_DECL_OVERRIDE;
     QSize sizeHint( const QStyleOptionViewItem&, const QModelIndex& ) const Q_DECL_OVERRIDE;
     bool editorEvent( QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
@@ -41,6 +43,7 @@ public:
 
     static int rowHeight();
     static int iconHeight();
+
 private:
     static int _margin;
     static int _iconHeight;

--- a/src/gui/activityitemdelegate.h
+++ b/src/gui/activityitemdelegate.h
@@ -39,6 +39,11 @@ public:
     bool editorEvent( QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
                       const QModelIndex& index ) Q_DECL_OVERRIDE;
 
+    static int rowHeight();
+    static int iconHeight();
+private:
+    static int _margin;
+    static int _iconHeight;
 };
 
 } // namespace OCC

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -73,13 +73,11 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
 
     switch (role) {
     case ActivityItemDelegate::PathRole:
-    case Qt::ToolTipRole:
         list = FolderMan::instance()->findFileInLocalFolders(a._file);
         if( list.count() > 0 ) {
             return QVariant(list.at(0));
         }
         return QVariant();
-
         break;
     case ActivityItemDelegate::ActionIconRole:
         return QVariant(); // FIXME once the action can be quantified, display on Icon
@@ -87,6 +85,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case ActivityItemDelegate::UserIconRole:
         return QIcon(QLatin1String(":/client/resources/account.png"));
         break;
+    case Qt::ToolTipRole:
     case ActivityItemDelegate::ActionTextRole:
         return a._subject;
         break;

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -260,6 +260,7 @@ ActivityWidget::ActivityWidget(QWidget *parent) :
     ActivityItemDelegate *delegate = new ActivityItemDelegate;
     delegate->setParent(this);
     _ui->_activityList->setItemDelegate(delegate);
+    _ui->_activityList->setAlternatingRowColors(true);
     _ui->_activityList->setModel(_model);
 
     _copyBtn = _ui->_dialogButtonBox->addButton(tr("Copy"), QDialogButtonBox::ActionRole);

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -109,10 +109,14 @@ void ActivityListModel::startFetchJob(AccountStatePtr s)
     JsonApiJob *job = new JsonApiJob(s->account(), QLatin1String("ocs/v1.php/cloud/activity"), this);
     QObject::connect(job, SIGNAL(jsonRecieved(QVariantMap)), this, SLOT(slotActivitiesReceived(QVariantMap)));
     job->setProperty("AccountStatePtr", QVariant::fromValue<AccountStatePtr>(s));
+
+    QList< QPair<QString,QString> > params;
+    params.append(qMakePair(QLatin1String("page"), QLatin1String("0")));
+    params.append(qMakePair(QLatin1String("pagesize"), QLatin1String("100")));
+    job->addQueryParams(params);
+
     _currentlyFetching.insert(s);
     job->start();
-
-
 }
 
 void ActivityListModel::slotActivitiesReceived(const QVariantMap& json)

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -92,8 +92,10 @@ bool ActivityListModel::canFetchMore(const QModelIndex& ) const
 
     QMap<AccountStatePtr, ActivityList>::const_iterator i = _activityLists.begin();
     while (i != _activityLists.end()) {
-        if( i.value().count() == 0 &&
-                ! _currentlyFetching.contains(i.key())) {
+        AccountStatePtr ast = i.key();
+        ActivityList activities = i.value();
+        if( ast->isConnected() && activities.count() == 0 &&
+                ! _currentlyFetching.contains(ast) ) {
             return true;
         }
         ++i;

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -50,7 +50,7 @@ QString ActivityList::accountName() const
     return _accountName;
 }
 
-// ========================================================================
+/* ==================================================================== */
 
 ActivityListModel::ActivityListModel(QWidget *parent)
     :QAbstractListModel(parent)
@@ -374,6 +374,7 @@ void ActivityWidget::slotOpenFile(QModelIndex indx)
     }
 }
 
+/* ==================================================================== */
 
 ActivitySettings::ActivitySettings(QWidget *parent)
     :QWidget(parent)

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -66,13 +66,19 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
 
     a = _finalList.at(index.row());
     AccountStatePtr ast = AccountManager::instance()->account(a._accName);
+    QStringList list;
 
     if (role == Qt::EditRole)
         return QVariant();
 
     switch (role) {
     case Qt::ToolTipRole:
+        list = FolderMan::instance()->findFileInLocalFolders(a._file);
+        if( list.count() > 0 ) {
+            return QVariant(list.at(0));
+        }
         return QVariant();
+
         break;
     case ActivityItemDelegate::ActionIconRole:
         return QVariant(); // FIXME once the action can be quantified, display on Icon

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -72,6 +72,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return QVariant();
 
     switch (role) {
+    case ActivityItemDelegate::PathRole:
     case Qt::ToolTipRole:
         list = FolderMan::instance()->findFileInLocalFolders(a._file);
         if( list.count() > 0 ) {
@@ -88,9 +89,6 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         break;
     case ActivityItemDelegate::ActionTextRole:
         return a._subject;
-        break;
-    case ActivityItemDelegate::PathRole:
-        return a._file;
         break;
     case ActivityItemDelegate::LinkRole:
         return a._link;
@@ -308,6 +306,9 @@ ActivityWidget::ActivityWidget(QWidget *parent) :
     connect(_copyBtn, SIGNAL(clicked()), SIGNAL(copyToClipboard()));
 
     connect(_model, SIGNAL(rowsInserted(QModelIndex,int,int)), SIGNAL(rowsInserted()));
+
+    connect( _ui->_activityList, SIGNAL(activated(QModelIndex)), this,
+             SLOT(slotOpenFile(QModelIndex)));
 }
 
 ActivityWidget::~ActivityWidget()
@@ -362,22 +363,15 @@ void ActivityWidget::storeActivityList( QTextStream& ts )
     }
 }
 
-void ActivityWidget::slotOpenFile( )
+void ActivityWidget::slotOpenFile(QModelIndex indx)
 {
-    // FIXME make work at all.
-#if 0
-    QString folderName = item->data(2, Qt::UserRole).toString();
-    QString fileName = item->text(1);
+    if( indx.isValid() ) {
+        QString fullPath = indx.data(ActivityItemDelegate::PathRole).toString();
 
-    Folder *folder = FolderMan::instance()->folder(folderName);
-    if (folder) {
-        // folder->path() always comes back with trailing path
-        QString fullPath = folder->path() + fileName;
-        if (QFile(fullPath).exists()) {
+        if (QFile::exists(fullPath)) {
             showInFileManager(fullPath);
         }
     }
-#endif
 }
 
 

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include <QtGui>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QtWidgets>
+#endif
+
+#include "activitywidget.h"
+#include "configfile.h"
+#include "syncresult.h"
+#include "logger.h"
+#include "utility.h"
+#include "theme.h"
+#include "folderman.h"
+#include "syncfileitem.h"
+#include "folder.h"
+#include "openfilemanager.h"
+#include "owncloudpropagator.h"
+
+#include "ui_activitywidget.h"
+
+#include <climits>
+
+namespace OCC {
+
+ActivityListModel::ActivityListModel(QWidget *parent)
+    :QAbstractListModel(parent)
+{
+
+}
+
+QVariant ActivityListModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    if (role == Qt::EditRole)
+        return QVariant();
+
+    switch (role) {
+    case Qt::ToolTipRole:
+    case Qt::DisplayRole:
+        return tr("%1 (%2)").arg("IM an item");
+    case Qt::DecorationRole:
+        return QFileIconProvider().icon(QFileIconProvider::Folder);
+        break;
+    }
+    return QVariant();
+
+}
+
+int ActivityListModel::rowCount(const QModelIndex&) const
+{
+    return 4;
+}
+
+/* ==================================================================== */
+
+ActivityWidget::ActivityWidget(QWidget *parent) :
+    QWidget(parent),
+    _ui(new Ui::ActivityWidget)
+{
+    _ui->setupUi(this);
+
+    // Adjust copyToClipboard() when making changes here!
+#if defined(Q_OS_MAC)
+    _ui->_activityList->setMinimumWidth(400);
+#endif
+
+    _ui->_activityList->setModel(new ActivityListModel(this));
+
+    connect(this, SIGNAL(guiLog(QString,QString)), Logger::instance(), SIGNAL(guiLog(QString,QString)));
+
+    _copyBtn = _ui->_dialogButtonBox->addButton(tr("Copy"), QDialogButtonBox::ActionRole);
+    _copyBtn->setToolTip( tr("Copy the activity list to the clipboard."));
+    _copyBtn->setEnabled(false);
+    connect(_copyBtn, SIGNAL(clicked()), SLOT(copyToClipboard()));
+}
+
+ActivityWidget::~ActivityWidget()
+{
+    delete _ui;
+}
+
+void ActivityWidget::copyToClipboard()
+{
+    QString text;
+    QTextStream ts(&text);
+#if 0
+    int topLevelItems = _ui->_activityList->topLevelItemCount();
+    for (int i = 0; i < topLevelItems; i++) {
+        QTreeWidgetItem *child = _ui->_activityList->topLevelItem(i);
+        ts << left
+                // time stamp
+            << qSetFieldWidth(10)
+            << child->data(0,Qt::DisplayRole).toString()
+                // file name
+            << qSetFieldWidth(64)
+            << child->data(1,Qt::DisplayRole).toString()
+                // folder
+            << qSetFieldWidth(30)
+            << child->data(2, Qt::DisplayRole).toString()
+                // action
+            << qSetFieldWidth(15)
+            << child->data(3, Qt::DisplayRole).toString()
+                // size
+            << qSetFieldWidth(10)
+            << child->data(4, Qt::DisplayRole).toString()
+            << qSetFieldWidth(0)
+            << endl;
+    }
+#endif
+    QApplication::clipboard()->setText(text);
+    emit guiLog(tr("Copied to clipboard"), tr("The sync status has been copied to the clipboard."));
+}
+
+// FIXME: Reused from protocol widget. Move over to utilities.
+QString ActivityWidget::timeString(QDateTime dt, QLocale::FormatType format) const
+{
+    const QLocale loc = QLocale::system();
+    QString dtFormat = loc.dateTimeFormat(format);
+    static const QRegExp re("(HH|H|hh|h):mm(?!:s)");
+    dtFormat.replace(re, "\\1:mm:ss");
+    return loc.toString(dt, dtFormat);
+}
+
+void ActivityWidget::slotOpenFile( )
+{
+    // FIXME make work at all.
+#if 0
+    QString folderName = item->data(2, Qt::UserRole).toString();
+    QString fileName = item->text(1);
+
+    Folder *folder = FolderMan::instance()->folder(folderName);
+    if (folder) {
+        // folder->path() always comes back with trailing path
+        QString fullPath = folder->path() + fileName;
+        if (QFile(fullPath).exists()) {
+            showInFileManager(fullPath);
+        }
+    }
+#endif
+}
+
+}

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -145,6 +145,7 @@ void ActivityListModel::slotActivitiesReceived(const QVariantMap& json)
     _activityLists[ai] = list;
 
     // if all activity lists were received, assemble the whole list
+    // otherwise wait until the others are finished
     bool allAreHere = true;
     foreach( ActivityList list, _activityLists.values() ) {
         if( list.count() == 0 ) {
@@ -152,6 +153,8 @@ void ActivityListModel::slotActivitiesReceived(const QVariantMap& json)
             break;
         }
     }
+
+    // FIXME: Be more efficient,
     if( allAreHere ) {
         combineActivityLists();
     }
@@ -188,6 +191,14 @@ void ActivityListModel::fetchMore(const QModelIndex &)
             startFetchJob(asp);
         }
     }
+}
+
+void ActivityListModel::slotRefreshActivity(AccountStatePtr ast)
+{
+    if(ast && _activityLists.contains(ast)) {
+        _activityLists[ast].clear();
+    }
+    startFetchJob(ast);
 }
 
 /* ==================================================================== */

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -30,6 +30,7 @@ class QPushButton;
 namespace OCC {
 
 class Account;
+class AccountStatusPtr;
 
 namespace Ui {
   class ActivityWidget;
@@ -89,19 +90,19 @@ public:
     void fetchMore(const QModelIndex&);
 
 public slots:
-    void slotRefreshActivity(AccountStatePtr ast);
+    void slotRefreshActivity(AccountState* ast);
 
 private slots:
     void slotActivitiesReceived(const QVariantMap& json);
 
 private:
-    void startFetchJob(AccountStatePtr s);
+    void startFetchJob(AccountState* s);
     void combineActivityLists();
     QString timeSpanFromNow(const QDateTime& dt) const;
 
-    QMap<AccountStatePtr, ActivityList> _activityLists;
+    QMap<AccountState*, ActivityList> _activityLists;
     ActivityList _finalList;
-    QSet<AccountStatePtr> _currentlyFetching;
+    QSet<AccountState*> _currentlyFetching;
 };
 
 /**
@@ -121,6 +122,7 @@ public:
 
 public slots:
     void slotOpenFile();
+    void slotRefresh(AccountState* ptr);
 
 protected slots:
     void copyToClipboard();

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -125,7 +125,7 @@ public:
     void storeActivityList(QTextStream &ts);
 
 public slots:
-    void slotOpenFile();
+    void slotOpenFile(QModelIndex indx);
     void slotRefresh(AccountState* ptr);
     void slotRemoveAccount( AccountState *ptr );
 

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -26,6 +26,7 @@
 #include "ui_activitywidget.h"
 
 class QPushButton;
+class QProgressIndicator;
 
 namespace OCC {
 
@@ -129,6 +130,7 @@ public slots:
 signals:
     void guiLog(const QString&, const QString&);
     void copyToClipboard();
+    void rowsInserted();
 
 private:
     QString timeString(QDateTime dt, QLocale::FormatType format) const;
@@ -158,6 +160,7 @@ private:
     QTabWidget *_tab;
     ActivityWidget *_activityWidget;
     ProtocolWidget *_protocolWidget;
+    QProgressIndicator *_progressIndicator;
 
 };
 

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -97,6 +97,7 @@ private slots:
 private:
     void startFetchJob(AccountStatePtr s);
     void combineActivityLists();
+    QString timeSpanFromNow(const QDateTime& dt) const;
 
     QMap<AccountStatePtr, ActivityList> _activityLists;
     ActivityList _finalList;

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef ACTIVITYWIDGET_H
+#define ACTIVITYWIDGET_H
+
+#include <QDialog>
+#include <QDateTime>
+#include <QLocale>
+#include <QAbstractListModel>
+
+#include "progressdispatcher.h"
+#include "owncloudgui.h"
+
+#include "ui_activitywidget.h"
+
+class QPushButton;
+
+namespace OCC {
+
+namespace Ui {
+  class ActivityWidget;
+}
+class Application;
+
+/**
+ * @brief The ActivityListModel
+ * @ingroup gui
+ */
+
+class ActivityListModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    explicit ActivityListModel(QWidget *parent=0);
+
+    QVariant data(const QModelIndex &index, int role) const Q_DECL_OVERRIDE;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
+
+};
+
+/**
+ * @brief The ActivityWidget class
+ * @ingroup gui
+ */
+class ActivityWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ActivityWidget(QWidget *parent = 0);
+    ~ActivityWidget();
+    QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
+
+public slots:
+    void slotOpenFile();
+
+protected slots:
+    void copyToClipboard();
+
+protected:
+
+signals:
+    void guiLog(const QString&, const QString&);
+
+private:
+    QString timeString(QDateTime dt, QLocale::FormatType format) const;
+    Ui::ActivityWidget *_ui;
+    QPushButton *_copyBtn;
+};
+
+}
+#endif // ActivityWIDGET_H

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -88,6 +88,9 @@ public:
     bool canFetchMore(const QModelIndex& ) const;
     void fetchMore(const QModelIndex&);
 
+public slots:
+    void slotRefreshActivity(AccountStatePtr ast);
+
 private slots:
     void slotActivitiesReceived(const QVariantMap& json);
 

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -40,8 +40,10 @@ namespace Ui {
 class Application;
 
 /**
- * @brief The ActivityListModel
+ * @brief Activity Structure
  * @ingroup gui
+ *
+ * contains all the information describing a single activity.
  */
 
 class Activity
@@ -66,6 +68,12 @@ public:
 
 };
 
+/**
+ * @brief The ActivityList
+ * @ingroup gui
+ *
+ * A QList based list of Activities
+ */
 class ActivityList:public QList<Activity>
 {
     // explicit ActivityList();
@@ -78,7 +86,12 @@ private:
 };
 
 
-
+/**
+ * @brief The ActivityListModel
+ * @ingroup gui
+ *
+ * Simple list model to provide the list view with data.
+ */
 class ActivityListModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -113,6 +126,9 @@ private:
 /**
  * @brief The ActivityWidget class
  * @ingroup gui
+ *
+ * The list widget to display the activities, contained in the
+ * subsequent ActivitySettings widget.
  */
 
 class ActivityWidget : public QWidget
@@ -143,6 +159,13 @@ private:
 };
 
 
+/**
+ * @brief The ActivitySettings class
+ * @ingroup gui
+ *
+ * Implements a tab for the settings dialog, displaying the three activity
+ * lists.
+ */
 class ActivitySettings : public QWidget
 {
     Q_OBJECT

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -21,12 +21,15 @@
 
 #include "progressdispatcher.h"
 #include "owncloudgui.h"
+#include "account.h"
 
 #include "ui_activitywidget.h"
 
 class QPushButton;
 
 namespace OCC {
+
+class Account;
 
 namespace Ui {
   class ActivityWidget;
@@ -38,6 +41,28 @@ class Application;
  * @ingroup gui
  */
 
+class Activity
+{
+public:
+    qlonglong _id;
+    QString   _subject;
+    QString   _message;
+    QString   _file;
+    QUrl      _link;
+    QDateTime _dateTime;
+};
+
+class ActivityList:public QList<Activity>
+{
+    // explicit ActivityList();
+public:
+    void setAccountName( const QString& name );
+    QString accountName() const;
+
+private:
+    QString _accountName;
+};
+
 class ActivityListModel : public QAbstractListModel
 {
     Q_OBJECT
@@ -47,6 +72,10 @@ public:
     QVariant data(const QModelIndex &index, int role) const Q_DECL_OVERRIDE;
     int rowCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
 
+    void addActivities( const ActivityList& activities );
+private:
+
+    QMap<QString, ActivityList> _activityLists;
 };
 
 /**
@@ -62,10 +91,15 @@ public:
     QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
 
 public slots:
+    void slotAddAccount( AccountStatePtr s );
     void slotOpenFile();
 
 protected slots:
     void copyToClipboard();
+    void slotRefresh();
+
+private slots:
+    void slotActivitiesReceived(const QVariantMap& json);
 
 protected:
 
@@ -76,6 +110,9 @@ private:
     QString timeString(QDateTime dt, QLocale::FormatType format) const;
     Ui::ActivityWidget *_ui;
     QPushButton *_copyBtn;
+    QTimer _timer;
+
+    ActivityListModel *_model;
 };
 
 }

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -31,6 +31,7 @@ namespace OCC {
 
 class Account;
 class AccountStatusPtr;
+class ProtocolWidget;
 
 namespace Ui {
   class ActivityWidget;
@@ -89,6 +90,8 @@ public:
     bool canFetchMore(const QModelIndex& ) const;
     void fetchMore(const QModelIndex&);
 
+    ActivityList activityList() { return _finalList; }
+
 public slots:
     void slotRefreshActivity(AccountState* ast);
 
@@ -109,6 +112,7 @@ private:
  * @brief The ActivityWidget class
  * @ingroup gui
  */
+
 class ActivityWidget : public QWidget
 {
     Q_OBJECT
@@ -116,21 +120,15 @@ public:
     explicit ActivityWidget(QWidget *parent = 0);
     ~ActivityWidget();
     QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
-
-    // FIXME: Move the tab widget to its own widget that is used in settingsdialog.
-    QTabWidget *tabWidget() { return _ui->_tabWidget; }
+    void storeActivityList(QTextStream &ts);
 
 public slots:
     void slotOpenFile();
     void slotRefresh(AccountState* ptr);
 
-protected slots:
-    void copyToClipboard();
-
-protected:
-
 signals:
     void guiLog(const QString&, const QString&);
+    void copyToClipboard();
 
 private:
     QString timeString(QDateTime dt, QLocale::FormatType format) const;
@@ -138,6 +136,29 @@ private:
     QPushButton *_copyBtn;
 
     ActivityListModel *_model;
+};
+
+
+class ActivitySettings : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ActivitySettings(QWidget *parent = 0);
+    ~ActivitySettings();
+    QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
+
+public slots:
+    void slotRefresh( AccountState* ptr );
+    void slotCopyToClipboard();
+
+signals:
+    void guiLog(const QString&, const QString&);
+
+private:
+    QTabWidget *_tab;
+    ActivityWidget *_activityWidget;
+    ProtocolWidget *_protocolWidget;
+
 };
 
 }

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -95,6 +95,7 @@ public:
 
 public slots:
     void slotRefreshActivity(AccountState* ast);
+    void slotRemoveAccount( AccountState *ast );
 
 private slots:
     void slotActivitiesReceived(const QVariantMap& json);
@@ -126,6 +127,7 @@ public:
 public slots:
     void slotOpenFile();
     void slotRefresh(AccountState* ptr);
+    void slotRemoveAccount( AccountState *ptr );
 
 signals:
     void guiLog(const QString&, const QString&);
@@ -151,6 +153,8 @@ public:
 
 public slots:
     void slotRefresh( AccountState* ptr );
+    void slotRemoveAccount( AccountState *ptr );
+
     void slotCopyToClipboard();
 
 signals:

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="1">
-    <widget class="QTabWidget" name="tabWidget">
+    <widget class="QTabWidget" name="_tabWidget">
      <property name="tabShape">
       <enum>QTabWidget::Rounded</enum>
      </property>
@@ -27,7 +27,7 @@
      </property>
      <widget class="QWidget" name="protocolTab">
       <attribute name="title">
-       <string>Sync Protocol</string>
+       <string>Server Activity</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
        <item row="0" column="0">
@@ -41,26 +41,6 @@
         </widget>
        </item>
       </layout>
-     </widget>
-     <widget class="QWidget" name="serverActivityTab">
-      <attribute name="title">
-       <string>Server Activity</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="ignoresTab">
-      <attribute name="title">
-       <string>Ignored Files</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="issuesTab">
-      <attribute name="title">
-       <string>Issues</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="tab">
-      <attribute name="title">
-       <string>Blacklist</string>
-      </attribute>
      </widget>
     </widget>
    </item>

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -6,31 +6,62 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>612</width>
-    <height>515</height>
+    <width>672</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Sync Activity</string>
+   <item row="0" column="1">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QDialogButtonBox" name="_dialogButtonBox">
-        <property name="standardButtons">
-         <set>QDialogButtonBox::NoButton</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QListView" name="_activityList"/>
-      </item>
-     </layout>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideMiddle</enum>
+     </property>
+     <widget class="QWidget" name="protocolTab">
+      <attribute name="title">
+       <string>Sync Protocol</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QListView" name="_activityList"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QDialogButtonBox" name="_dialogButtonBox">
+         <property name="standardButtons">
+          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="serverActivityTab">
+      <attribute name="title">
+       <string>Server Activity</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="ignoresTab">
+      <attribute name="title">
+       <string>Ignored Files</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="issuesTab">
+      <attribute name="title">
+       <string>Issues</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Blacklist</string>
+      </attribute>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -6,46 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>672</width>
-    <height>640</height>
+    <width>693</width>
+    <height>556</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="1">
-    <widget class="QTabWidget" name="_tabWidget">
-     <property name="tabShape">
-      <enum>QTabWidget::Rounded</enum>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="_headerLabel">
+     <property name="text">
+      <string>TextLabel</string>
      </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <property name="elideMode">
-      <enum>Qt::ElideMiddle</enum>
-     </property>
-     <widget class="QWidget" name="protocolTab">
-      <attribute name="title">
-       <string>Server Activity</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0">
-        <widget class="QListView" name="_activityList"/>
-       </item>
-       <item row="1" column="0">
-        <widget class="QDialogButtonBox" name="_dialogButtonBox">
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QListView" name="_activityList"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="_dialogButtonBox"/>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>_activityList</tabstop>
+  <tabstop>_dialogButtonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OCC::ActivityWidget</class>
+ <widget class="QWidget" name="OCC::ActivityWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>612</width>
+    <height>515</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Sync Activity</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="0">
+       <widget class="QDialogButtonBox" name="_dialogButtonBox">
+        <property name="standardButtons">
+         <set>QDialogButtonBox::NoButton</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QListView" name="_activityList"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -830,6 +830,23 @@ Folder *FolderMan::folderForPath(const QString &path)
     return 0;
 }
 
+QStringList FolderMan::findFileInLocalFolders( const QString& relPath )
+{
+    QStringList re;
+
+    foreach(Folder* folder, this->map().values()) {
+        QString path = folder->cleanPath();
+        QString remRelPath;
+        remRelPath = relPath.mid(folder->remotePath().length());
+        path += remRelPath;
+
+        if( QFile::exists(path) ) {
+            re.append( path );
+        }
+    }
+    return re;
+}
+
 void FolderMan::slotRemoveFolder( Folder *f )
 {
     if( !f ) {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -837,6 +837,7 @@ QStringList FolderMan::findFileInLocalFolders( const QString& relPath )
     foreach(Folder* folder, this->map().values()) {
         QString path = folder->cleanPath();
         QString remRelPath;
+        // cut off the remote path from the server path.
         remRelPath = relPath.mid(folder->remotePath().length());
         path += remRelPath;
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -57,6 +57,13 @@ public:
     /** Returns the folder which the file or directory stored in path is in */
     Folder* folderForPath(const QString& path);
 
+    /**
+      * returns a list of local files that exist on the local harddisk for an
+      * incoming relative server path. The method checks with all existing sync
+      * folders.
+      */
+    QStringList findFileInLocalFolders( const QString& relPath );
+
     /** Returns the folder by alias or NULL if no folder with the alias exists. */
     Folder *folder( const QString& );
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -100,6 +100,7 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
 GeneralSettings::~GeneralSettings()
 {
     delete _ui;
+    delete _syncLogDialog;
 }
 
 QSize GeneralSettings::sizeHint() const {
@@ -157,9 +158,12 @@ void GeneralSettings::slotToggleOptionalDesktopNotifications(bool enable)
 
 void GeneralSettings::slotOpenSyncLog()
 {
+    // the protocolwidget is connected to the ProgressDispatcher ot collect
+    // notifications also in case the logwindow is not visible. It is passed
+    // here to the LogDialog constructor which is not destroyed once created
+    // except in the destructor here.
     if (_syncLogDialog.isNull()) {
-        _syncLogDialog = new SyncLogDialog(this, _protocolWidget);
-        _syncLogDialog->setAttribute( Qt::WA_DeleteOnClose, true );
+        _syncLogDialog = new SyncLogDialog(0, _protocolWidget);
         _syncLogDialog->open();
     } else {
         ownCloudGui::raiseDialog(_syncLogDialog);

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -22,7 +22,6 @@
 #include "owncloudsetupwizard.h"
 #include "accountmanager.h"
 #include "synclogdialog.h"
-#include "protocolwidget.h"
 
 #include "updater/updater.h"
 #include "updater/ocupdater.h"
@@ -71,8 +70,6 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
     _ui->crashreporterCheckBox->setVisible(false);
 #endif
 
-    _protocolWidget = new ProtocolWidget;
-
     /* Set the left contents margin of the layout to zero to make the checkboxes
      * align properly vertically , fixes bug #3758
      */
@@ -88,7 +85,6 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
 
     connect(_ui->ignoredFilesButton, SIGNAL(clicked()), SLOT(slotIgnoreFilesEditor()));
     connect(_ui->addAccountButton, SIGNAL(clicked()), SLOT(slotOpenAccountWizard()));
-    connect(_ui->openSyncLog, SIGNAL(clicked()), SLOT(slotOpenSyncLog()));
 
     connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState*)),
             SLOT(slotAccountAddedOrRemoved()));
@@ -154,20 +150,6 @@ void GeneralSettings::slotToggleOptionalDesktopNotifications(bool enable)
 {
     ConfigFile cfgFile;
     cfgFile.setOptionalDesktopNotifications(enable);
-}
-
-void GeneralSettings::slotOpenSyncLog()
-{
-    // the protocolwidget is connected to the ProgressDispatcher ot collect
-    // notifications also in case the logwindow is not visible. It is passed
-    // here to the LogDialog constructor which is not destroyed once created
-    // except in the destructor here.
-    if (_syncLogDialog.isNull()) {
-        _syncLogDialog = new SyncLogDialog(0, _protocolWidget);
-        _syncLogDialog->open();
-    } else {
-        ownCloudGui::raiseDialog(_syncLogDialog);
-    }
 }
 
 void GeneralSettings::slotIgnoreFilesEditor()

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -21,6 +21,8 @@
 #include "configfile.h"
 #include "owncloudsetupwizard.h"
 #include "accountmanager.h"
+#include "synclogdialog.h"
+#include "protocolwidget.h"
 
 #include "updater/updater.h"
 #include "updater/ocupdater.h"
@@ -68,6 +70,8 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
 #ifndef WITH_CRASHREPORTER
     _ui->crashreporterCheckBox->setVisible(false);
 #endif
+
+    _protocolWidget = new ProtocolWidget;
 
     /* Set the left contents margin of the layout to zero to make the checkboxes
      * align properly vertically , fixes bug #3758
@@ -153,7 +157,13 @@ void GeneralSettings::slotToggleOptionalDesktopNotifications(bool enable)
 
 void GeneralSettings::slotOpenSyncLog()
 {
-
+    if (_syncLogDialog.isNull()) {
+        _syncLogDialog = new SyncLogDialog(this, _protocolWidget);
+        _syncLogDialog->setAttribute( Qt::WA_DeleteOnClose, true );
+        _syncLogDialog->open();
+    } else {
+        ownCloudGui::raiseDialog(_syncLogDialog);
+    }
 }
 
 void GeneralSettings::slotIgnoreFilesEditor()

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -84,6 +84,7 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
 
     connect(_ui->ignoredFilesButton, SIGNAL(clicked()), SLOT(slotIgnoreFilesEditor()));
     connect(_ui->addAccountButton, SIGNAL(clicked()), SLOT(slotOpenAccountWizard()));
+    connect(_ui->openSyncLog, SIGNAL(clicked()), SLOT(slotOpenSyncLog()));
 
     connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState*)),
             SLOT(slotAccountAddedOrRemoved()));
@@ -148,6 +149,11 @@ void GeneralSettings::slotToggleOptionalDesktopNotifications(bool enable)
 {
     ConfigFile cfgFile;
     cfgFile.setOptionalDesktopNotifications(enable);
+}
+
+void GeneralSettings::slotOpenSyncLog()
+{
+
 }
 
 void GeneralSettings::slotIgnoreFilesEditor()

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -45,7 +45,6 @@ private slots:
     void slotUpdateInfo();
     void slotIgnoreFilesEditor();
     void slotOpenAccountWizard();
-    void slotOpenSyncLog();
     void slotAccountAddedOrRemoved();
 
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -19,6 +19,8 @@
 
 namespace OCC {
 class IgnoreListEditor;
+class SyncLogDialog;
+class ProtocolWidget;
 
 namespace Ui {
 class GeneralSettings;
@@ -53,6 +55,8 @@ private:
 
     Ui::GeneralSettings *_ui;
     QPointer<IgnoreListEditor> _ignoreEditor;
+    QPointer<SyncLogDialog> _syncLogDialog;
+    ProtocolWidget *_protocolWidget;
 };
 
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -44,6 +44,7 @@ private slots:
     void slotUpdateInfo();
     void slotIgnoreFilesEditor();
     void slotOpenAccountWizard();
+    void slotOpenSyncLog();
     void slotAccountAddedOrRemoved();
 
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -20,7 +20,6 @@
 namespace OCC {
 class IgnoreListEditor;
 class SyncLogDialog;
-class ProtocolWidget;
 
 namespace Ui {
 class GeneralSettings;
@@ -56,7 +55,6 @@ private:
     Ui::GeneralSettings *_ui;
     QPointer<IgnoreListEditor> _ignoreEditor;
     QPointer<SyncLogDialog> _syncLogDialog;
-    ProtocolWidget *_protocolWidget;
 };
 
 

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -23,14 +23,14 @@
       <item row="0" column="0">
        <widget class="QCheckBox" name="autostartCheckBox">
         <property name="text">
-         <string>Launch on System Startup</string>
+         <string>&amp;Launch on System Startup</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QCheckBox" name="desktopNotificationsCheckBox">
         <property name="text">
-         <string>Show Desktop Notifications</string>
+         <string>Show &amp;Desktop Notifications</string>
         </property>
        </widget>
       </item>
@@ -40,7 +40,7 @@
          <string>For System Tray</string>
         </property>
         <property name="text">
-         <string>Use Monochrome Icons</string>
+         <string>Use &amp;Monochrome Icons</string>
         </property>
        </widget>
       </item>
@@ -53,12 +53,60 @@
       <string>Advanced</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QPushButton" name="ignoredFilesButton">
+          <property name="text">
+           <string>Edit &amp;Ignored Files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="addAccountButton">
+          <property name="text">
+           <string>&amp;Add an Account</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
       <item row="1" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QCheckBox" name="newFolderLimitCheckBox">
           <property name="text">
-           <string>Ask confirmation before downloading folders larger than</string>
+           <string>Ask &amp;confirmation before downloading folders larger than</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -97,7 +145,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="crashreporterCheckBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -106,45 +154,21 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Show crash reporter</string>
+         <string>S&amp;how crash reporter</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <widget class="QPushButton" name="ignoredFilesButton">
+         <widget class="QPushButton" name="openSyncLog">
           <property name="text">
-           <string>Edit Ignored Files</string>
+           <string>&amp;Open Synclog</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QPushButton" name="addAccountButton">
-          <property name="text">
-           <string>Add an Account</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -243,6 +267,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>autostartCheckBox</tabstop>
+  <tabstop>desktopNotificationsCheckBox</tabstop>
+  <tabstop>monoIconsCheckBox</tabstop>
+  <tabstop>ignoredFilesButton</tabstop>
+  <tabstop>addAccountButton</tabstop>
+  <tabstop>newFolderLimitCheckBox</tabstop>
+  <tabstop>newFolderLimitSpinBox</tabstop>
+  <tabstop>crashreporterCheckBox</tabstop>
+  <tabstop>openSyncLog</tabstop>
+  <tabstop>restartButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -161,13 +161,6 @@
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <widget class="QPushButton" name="openSyncLog">
-          <property name="text">
-           <string>&amp;Open Synclog</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -276,7 +269,6 @@
   <tabstop>newFolderLimitCheckBox</tabstop>
   <tabstop>newFolderLimitSpinBox</tabstop>
   <tabstop>crashreporterCheckBox</tabstop>
-  <tabstop>openSyncLog</tabstop>
   <tabstop>restartButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -204,6 +204,10 @@ void ownCloudGui::slotSyncStateChange( Folder* folder )
     if (result.status() == SyncResult::Success || result.status() == SyncResult::Error) {
         Logger::instance()->enterNextLogFile();
     }
+
+    if (result.status() == SyncResult::NotYetStarted) {
+        _settingsDialog->slotRefreshActivity( folder->accountState() );
+    }
 }
 
 void ownCloudGui::slotFoldersChanged()

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -192,15 +192,6 @@ void ProtocolWidget::slotOpenFile( QTreeWidgetItem *item, int )
     }
 }
 
-QString ProtocolWidget::fixupFilename( const QString& name )
-{
-    if( Utility::isMac() ) {
-        QString n(name);
-        return n.replace(QChar(':'), QChar('/'));
-    }
-    return name;
-}
-
 QTreeWidgetItem* ProtocolWidget::createCompletedTreewidgetItem(const QString& folder, const SyncFileItem& item)
 {
     auto f = FolderMan::instance()->folder(folder);
@@ -214,7 +205,7 @@ QTreeWidgetItem* ProtocolWidget::createCompletedTreewidgetItem(const QString& fo
     const QString longTimeStr = timeString(timestamp, QLocale::LongFormat);
 
     columns << timeStr;
-    columns << fixupFilename(item._originalFile);
+    columns << Utility::fileNameForGuiUse(item._originalFile);
     columns << f->shortGuiPath();
 
     // If the error string is set, it's prefered because it is a useful user message.

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -45,6 +45,8 @@ public:
     ~ProtocolWidget();
     QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
 
+    QTreeWidget *issueWidget() { return _issueItemView; }
+
 public slots:
     void slotProgressInfo( const QString& folder, const ProgressInfo& progress );
     void slotItemCompleted( const QString& folder, const SyncFileItem& item, const PropagatorJob& job);
@@ -72,6 +74,7 @@ private:
 
     const int IgnoredIndicatorRole;
     Ui::ProtocolWidget *_ui;
+    QTreeWidget *_issueItemView;
     QPushButton *_retrySyncBtn;
     QPushButton *_copyBtn;
 };

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -46,22 +46,20 @@ public:
     QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
 
     QTreeWidget *issueWidget() { return _issueItemView; }
+    void storeSyncActivity(QTextStream& ts);
+    void storeSyncIssues(QTextStream& ts);
 
 public slots:
     void slotProgressInfo( const QString& folder, const ProgressInfo& progress );
     void slotItemCompleted( const QString& folder, const SyncFileItem& item, const PropagatorJob& job);
     void slotOpenFile( QTreeWidgetItem* item, int );
 
-protected slots:
-    void copyToClipboard();
-    void slotRetrySync();
-
 protected:
     void showEvent(QShowEvent *);
     void hideEvent(QHideEvent *);
 
 signals:
-    void guiLog(const QString&, const QString&);
+    void copyToClipboard();
 
 private:
     void setSyncResultStatus(const SyncResult& result );
@@ -75,8 +73,6 @@ private:
     const int IgnoredIndicatorRole;
     Ui::ProtocolWidget *_ui;
     QTreeWidget *_issueItemView;
-    QPushButton *_retrySyncBtn;
-    QPushButton *_copyBtn;
 };
 
 }

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -65,8 +65,6 @@ private:
     void setSyncResultStatus(const SyncResult& result );
     void cleanIgnoreItems( const QString& folder );
     void computeResyncButtonEnabled();
-    QString fixupFilename( const QString& name );
-
 
     QTreeWidgetItem* createCompletedTreewidgetItem(const QString &folder, const SyncFileItem &item );
 

--- a/src/gui/protocolwidget.ui
+++ b/src/gui/protocolwidget.ui
@@ -13,58 +13,52 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
+  <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Sync Activity</string>
+    <widget class="QLabel" name="_headerLabel">
+     <property name="text">
+      <string>TextLabel</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QTreeWidget" name="_treeWidget">
-        <property name="alternatingRowColors">
-         <bool>true</bool>
-        </property>
-        <property name="rootIsDecorated">
-         <bool>false</bool>
-        </property>
-        <property name="uniformRowHeights">
-         <bool>true</bool>
-        </property>
-        <property name="columnCount">
-         <number>4</number>
-        </property>
-        <column>
-         <property name="text">
-          <string notr="true">1</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string notr="true">2</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string notr="true">3</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string notr="true">4</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QDialogButtonBox" name="_dialogButtonBox">
-        <property name="standardButtons">
-         <set>QDialogButtonBox::NoButton</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTreeWidget" name="_treeWidget">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+     <property name="uniformRowHeights">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>4</number>
+     </property>
+     <column>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">2</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">3</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">4</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="_dialogButtonBox"/>
    </item>
   </layout>
  </widget>

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -213,7 +213,7 @@ void SettingsDialog::accountAdded(AccountState *s)
     connect( accountSettings, SIGNAL(openFolderAlias(const QString&)),
              _gui, SLOT(slotFolderOpenAction(QString)));
 
-
+    slotRefreshActivity(s);
 }
 
 void SettingsDialog::accountRemoved(AccountState *s)
@@ -233,6 +233,8 @@ void SettingsDialog::accountRemoved(AccountState *s)
             break;
         }
     }
+
+    _activitySettings->slotRemoveAccount(s);
 }
 
 void SettingsDialog::customizeStyle()

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -24,6 +24,7 @@
 #include "owncloudgui.h"
 #include "activitywidget.h"
 #include "accountmanager.h"
+#include "protocolwidget.h"
 
 #include <QLabel>
 #include <QStandardItemModel>
@@ -80,8 +81,13 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     _activityAction = createColorAwareAction(QLatin1String(":/client/resources/activity.png"), tr("Activity"));
     _actionGroup->addAction(_activityAction);
     addActionToToolBar(_activityAction);
+
+    // FIXME: Put this QTabWidget into its own class to be used here.
+    QTabWidget *tabs = new QTabWidget(this);
+    tabs->addTab(new ProtocolWidget, tr("Sync Protocol"));
     ActivityWidget *activityWidget = new ActivityWidget;
-    _ui->stack->addWidget(activityWidget);
+    tabs->addTab(activityWidget, tr("Server Activity"));
+    _ui->stack->addWidget(tabs);
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
     _actionGroup->addAction(generalAction);
@@ -95,7 +101,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     NetworkSettings *networkSettings = new NetworkSettings;
     _ui->stack->addWidget(networkSettings);
 
-    _actionGroupWidgets.insert(_activityAction, activityWidget);
+    _actionGroupWidgets.insert(_activityAction, tabs);
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -83,11 +83,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     addActionToToolBar(_activityAction);
 
     // FIXME: Put this QTabWidget into its own class to be used here.
-    QTabWidget *tabs = new QTabWidget(this);
-    tabs->addTab(new ProtocolWidget, tr("Sync Protocol"));
     _activityWidget = new ActivityWidget;
-    tabs->addTab(_activityWidget, tr("Server Activity"));
-    _ui->stack->addWidget(tabs);
+    _activityWidget->setParent(this);
+    _ui->stack->addWidget(_activityWidget);
+    _activityWidget->tabWidget()->addTab(new ProtocolWidget(this), tr("Sync Protocol"));
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
     _actionGroup->addAction(generalAction);
@@ -101,7 +100,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     NetworkSettings *networkSettings = new NetworkSettings;
     _ui->stack->addWidget(networkSettings);
 
-    _actionGroupWidgets.insert(_activityAction, tabs);
+    _actionGroupWidgets.insert(_activityAction, _activityWidget);
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -237,7 +237,7 @@ void SettingsDialog::accountRemoved(AccountState *s)
 
 void SettingsDialog::customizeStyle()
 {
-    QString highlightColor(palette().highlight().color().name());
+    QString  highlightColor(palette().highlight().color().name());
     QString altBase(palette().alternateBase().color().name());
     QString dark(palette().dark().color().name());
     QString background(palette().base().color().name());
@@ -284,6 +284,14 @@ void SettingsDialog::addActionToToolBar(QAction *action) {
     btn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
     _toolBar->addWidget(btn);
     btn->setMinimumWidth(_toolBar->sizeHint().height() * 1.3);
+}
+
+void SettingsDialog::slotRefreshActivity( AccountState* accountState )
+{
+    if (accountState) {
+        qDebug() << "Refreshing Activity list for " << accountState->account()->displayName();
+        _activityWidget->slotRefresh(accountState);
+    }
 }
 
 } // namespace OCC

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -81,16 +81,12 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     _activityAction = createColorAwareAction(QLatin1String(":/client/resources/activity.png"), tr("Activity"));
     _actionGroup->addAction(_activityAction);
     addActionToToolBar(_activityAction);
+    _activitySettings = new ActivitySettings;
+    _ui->stack->addWidget(_activitySettings);
+    connect( _activitySettings, SIGNAL(guiLog(QString,QString)), _gui,
+             SLOT(slotShowOptionalTrayMessage(QString,QString)) );
 
-    // FIXME: Put this QTabWidget into its own class to be used here.
-    _activityWidget = new ActivityWidget;
-    _activityWidget->setParent(this);
-    _ui->stack->addWidget(_activityWidget);
-    _activityWidget->tabWidget()->setTabIcon(0, Theme::instance()->applicationIcon());
-
-    ProtocolWidget *pw = new ProtocolWidget(this);
-    _activityWidget->tabWidget()->addTab(pw, Theme::instance()->syncStateIcon(SyncResult::Success), tr("Sync Protocol"));
-    _activityWidget->tabWidget()->addTab(pw->issueWidget(), Theme::instance()->syncStateIcon(SyncResult::Problem), tr("Not Synced"));
+    // Add the protocol widget
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
     _actionGroup->addAction(generalAction);
@@ -104,7 +100,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     NetworkSettings *networkSettings = new NetworkSettings;
     _ui->stack->addWidget(networkSettings);
 
-    _actionGroupWidgets.insert(_activityAction, _activityWidget);
+    _actionGroupWidgets.insert(_activityAction, _activitySettings);
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 
@@ -294,7 +290,7 @@ void SettingsDialog::slotRefreshActivity( AccountState* accountState )
 {
     if (accountState) {
         qDebug() << "Refreshing Activity list for " << accountState->account()->displayName();
-        _activityWidget->slotRefresh(accountState);
+        _activitySettings->slotRefresh(accountState);
     }
 }
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -22,7 +22,7 @@
 #include "configfile.h"
 #include "progressdispatcher.h"
 #include "owncloudgui.h"
-#include "protocolwidget.h"
+#include "activitywidget.h"
 #include "accountmanager.h"
 
 #include <QLabel>
@@ -77,11 +77,11 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
 
     // Note: all the actions have a '\n' because the account name is in two lines and
     // all buttons must have the same size in order to keep a good layout
-    _protocolAction = createColorAwareAction(QLatin1String(":/client/resources/activity.png"), tr("Activity"));
-    _actionGroup->addAction(_protocolAction);
-    addActionToToolBar(_protocolAction);
-    ProtocolWidget *protocolWidget = new ProtocolWidget;
-    _ui->stack->addWidget(protocolWidget);
+    _activityAction = createColorAwareAction(QLatin1String(":/client/resources/activity.png"), tr("Activity"));
+    _actionGroup->addAction(_activityAction);
+    addActionToToolBar(_activityAction);
+    ActivityWidget *activityWidget = new ActivityWidget;
+    _ui->stack->addWidget(activityWidget);
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
     _actionGroup->addAction(generalAction);
@@ -95,7 +95,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     NetworkSettings *networkSettings = new NetworkSettings;
     _ui->stack->addWidget(networkSettings);
 
-    _actionGroupWidgets.insert(_protocolAction, protocolWidget);
+    _actionGroupWidgets.insert(_activityAction, activityWidget);
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 
@@ -178,8 +178,8 @@ void SettingsDialog::showFirstPage()
 
 void SettingsDialog::showActivityPage()
 {
-    if (_protocolAction) {
-        slotSwitchPage(_protocolAction);
+    if (_activityAction) {
+        slotSwitchPage(_activityAction);
     }
 }
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -85,8 +85,8 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     // FIXME: Put this QTabWidget into its own class to be used here.
     QTabWidget *tabs = new QTabWidget(this);
     tabs->addTab(new ProtocolWidget, tr("Sync Protocol"));
-    ActivityWidget *activityWidget = new ActivityWidget;
-    tabs->addTab(activityWidget, tr("Server Activity"));
+    _activityWidget = new ActivityWidget;
+    tabs->addTab(_activityWidget, tr("Server Activity"));
     _ui->stack->addWidget(tabs);
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
@@ -213,6 +213,8 @@ void SettingsDialog::accountAdded(AccountState *s)
     connect( accountSettings, SIGNAL(folderChanged()), _gui, SLOT(slotFoldersChanged()));
     connect( accountSettings, SIGNAL(openFolderAlias(const QString&)),
              _gui, SLOT(slotFolderOpenAction(QString)));
+
+
 }
 
 void SettingsDialog::accountRemoved(AccountState *s)

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -86,7 +86,11 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent) :
     _activityWidget = new ActivityWidget;
     _activityWidget->setParent(this);
     _ui->stack->addWidget(_activityWidget);
-    _activityWidget->tabWidget()->addTab(new ProtocolWidget(this), tr("Sync Protocol"));
+    _activityWidget->tabWidget()->setTabIcon(0, Theme::instance()->applicationIcon());
+
+    ProtocolWidget *pw = new ProtocolWidget(this);
+    _activityWidget->tabWidget()->addTab(pw, Theme::instance()->syncStateIcon(SyncResult::Success), tr("Sync Protocol"));
+    _activityWidget->tabWidget()->addTab(pw->issueWidget(), Theme::instance()->syncStateIcon(SyncResult::Problem), tr("Not Synced"));
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
     _actionGroup->addAction(generalAction);

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -36,7 +36,7 @@ class AccountSettings;
 class Application;
 class FolderMan;
 class ownCloudGui;
-class ActivityWidget;
+class ActivitySettings;
 
 /**
  * @brief The SettingsDialog class
@@ -82,7 +82,7 @@ private:
     // Maps the actions from the action group to the toolbar actions
     QHash<QAction*, QAction*> _toolbarAccountActions;
 
-    ActivityWidget *_activityWidget;
+    ActivitySettings *_activitySettings;
 
     QAction * _activityAction;
     ownCloudGui *_gui;

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -18,6 +18,7 @@
 #include <QStyledItemDelegate>
 
 #include "progressdispatcher.h"
+#include "owncloudgui.h"
 
 class QAction;
 class QActionGroup;
@@ -55,6 +56,7 @@ public slots:
     void showFirstPage();
     void showActivityPage();
     void slotSwitchPage(QAction *action);
+    void slotRefreshActivity(AccountState *accountState );
 
 protected:
     void reject() Q_DECL_OVERRIDE;

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -79,7 +79,7 @@ private:
     // Maps the actions from the action group to the toolbar actions
     QHash<QAction*, QAction*> _toolbarAccountActions;
 
-    QAction * _protocolAction;
+    QAction * _activityAction;
     ownCloudGui *_gui;
 };
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -35,6 +35,7 @@ class AccountSettings;
 class Application;
 class FolderMan;
 class ownCloudGui;
+class ActivityWidget;
 
 /**
  * @brief The SettingsDialog class
@@ -78,6 +79,8 @@ private:
     QToolBar* _toolBar;
     // Maps the actions from the action group to the toolbar actions
     QHash<QAction*, QAction*> _toolbarAccountActions;
+
+    ActivityWidget *_activityWidget;
 
     QAction * _activityAction;
     ownCloudGui *_gui;

--- a/src/gui/synclogdialog.cpp
+++ b/src/gui/synclogdialog.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ * Copyright (C) 2015 by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "synclogdialog.h"
+#include "ui_synclogdialog.h"
+#include "theme.h"
+#include "syncresult.h"
+#include "configfile.h"
+#include "capabilities.h"
+
+#include "QProgressIndicator.h"
+
+#include <QPushButton>
+
+
+namespace OCC {
+
+SyncLogDialog::SyncLogDialog(QWidget *parent, ProtocolWidget *protoWidget) :
+   QDialog(parent),
+    _ui(new Ui::SyncLogDialog)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setObjectName("SyncLogDialog"); // required as group for saveGeometry call
+
+    _ui->setupUi(this);
+
+    if( protoWidget) {
+        _ui->logWidgetLayout->addWidget(protoWidget);
+    }
+
+    QPushButton *closeButton = _ui->buttonBox->button(QDialogButtonBox::Close);
+    if( closeButton ) {
+        connect( closeButton, SIGNAL(clicked()), this, SLOT(close()) );
+    }
+}
+
+SyncLogDialog::~SyncLogDialog()
+{
+
+}
+
+}

--- a/src/gui/synclogdialog.cpp
+++ b/src/gui/synclogdialog.cpp
@@ -30,7 +30,6 @@ SyncLogDialog::SyncLogDialog(QWidget *parent, ProtocolWidget *protoWidget) :
    QDialog(parent),
     _ui(new Ui::SyncLogDialog)
 {
-    setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("SyncLogDialog"); // required as group for saveGeometry call
 
     _ui->setupUi(this);

--- a/src/gui/synclogdialog.h
+++ b/src/gui/synclogdialog.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <roeland@famdouma.nl>
+ * Copyright (C) 2015 by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef SyncLogDialog_H
+#define SyncLogDialog_H
+
+#include "protocolwidget.h"
+
+#include <QDialog>
+
+namespace OCC {
+
+
+namespace Ui {
+class SyncLogDialog;
+}
+
+
+/**
+ * @brief The SyncLogDialog class
+ * @ingroup gui
+ */
+class SyncLogDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SyncLogDialog(QWidget *parent = 0, ProtocolWidget *protoWidget = 0);
+    ~SyncLogDialog();
+
+private slots:
+
+private:
+
+    Ui::SyncLogDialog *_ui;
+};
+
+}
+
+#endif // SyncLogDialog_H

--- a/src/gui/synclogdialog.ui
+++ b/src/gui/synclogdialog.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OCC::SyncLogDialog</class>
+ <widget class="QDialog" name="OCC::SyncLogDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>372</width>
+    <height>247</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Synchronisation Log</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="logWidgetLayout"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -583,12 +583,19 @@ bool EntityExistsJob::finished()
 JsonApiJob::JsonApiJob(const AccountPtr &account, const QString& path, QObject* parent): AbstractNetworkJob(account, path, parent)
 { }
 
+void JsonApiJob::addQueryParams(QList< QPair<QString,QString> > params)
+{
+    _additionalParams = params;
+}
+
 void JsonApiJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader("OCS-APIREQUEST", "true");
     QUrl url = Account::concatUrlPath(account()->url(), path());
-    url.setQueryItems(QList<QPair<QString, QString> >() << qMakePair(QString::fromLatin1("format"), QString::fromLatin1("json")));
+    QList<QPair<QString, QString> > params = _additionalParams;
+    params << qMakePair(QString::fromLatin1("format"), QString::fromLatin1("json"));
+    url.setQueryItems(params);
     setReply(davRequest("GET", url, req));
     setupConnections(reply());
     AbstractNetworkJob::start();

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -209,12 +209,26 @@ class OWNCLOUDSYNC_EXPORT JsonApiJob : public AbstractNetworkJob {
     Q_OBJECT
 public:
     explicit JsonApiJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
+
+    /**
+     * @brief addQueryParams - add more parameters to the ocs call
+     * @param params: list pairs of strings containing the parameter name and the value.
+     *
+     * All parameters from the passed list are appended to the query. Note
+     * that the format=json parameter is added automatically and does not
+     * need to be set this way.
+     *
+     * This function needs to be called before start() obviously.
+     */
+    void addQueryParams(QList< QPair<QString,QString> > params);
 public slots:
     void start() Q_DECL_OVERRIDE;
 protected:
     bool finished() Q_DECL_OVERRIDE;
 signals:
     void jsonRecieved(const QVariantMap &json);
+private:
+    QList< QPair<QString,QString> > _additionalParams;
 };
 
 } // namespace OCC

--- a/src/libsync/utility.cpp
+++ b/src/libsync/utility.cpp
@@ -337,6 +337,15 @@ QString Utility::durationToDescriptiveString(quint64 msecs)
             QCoreApplication::translate("Utility", periods[p+1].name, 0, QCoreApplication::UnicodeUTF8, secondPartNum));
 }
 
+QString Utility::fileNameForGuiUse(const QString& fName)
+{
+    if( isMac() ) {
+        QString n(fName);
+        return n.replace(QChar(':'), QChar('/'));
+    }
+    return fName;
+}
+
 bool Utility::hasDarkSystray()
 {
     return hasDarkSystray_private();

--- a/src/libsync/utility.h
+++ b/src/libsync/utility.h
@@ -105,6 +105,8 @@ namespace Utility
     // For Mac and Windows, it returns QString()
     OWNCLOUDSYNC_EXPORT QByteArray versionOfInstalledBinary(const QString& command = QString() );
 
+    OWNCLOUDSYNC_EXPORT QString fileNameForGuiUse(const QString& fName);
+
     class OWNCLOUDSYNC_EXPORT StopWatch {
     private:
         QHash<QString, quint64> _lapTimes;


### PR DESCRIPTION
I'd like to create this pull request already to discuss the changes done here as early as possible.

This branch changes the way we display the sync activity in the former client releases and adds three new views to the Activity-tab in the client.

1. **Server Activiity**
This displays the server activity list. Currently it is pulled from the server and displayed if the server is reachable. 
2. **Sync Protocol**
Very similar to the former list of synced files, but without the ignored and error files in between. It's a plain positive list now.
3. **Not Synced**
A list of files that were not successfully synced because they were ignored (by user intention or because of other reasons) Later on we can also handle the blacklisting here more user friendly.

Some Screenshots:

![server_activity](https://cloud.githubusercontent.com/assets/1070214/10997983/e13afeba-8491-11e5-94b8-39157cb1052f.png)
 
![sync_proto](https://cloud.githubusercontent.com/assets/1070214/10997987/e7e5bec6-8491-11e5-85c7-6ab156738c99.png)

![not_synced](https://cloud.githubusercontent.com/assets/1070214/10997992/ec7fee16-8491-11e5-8a57-605a7472247a.png)

Please give me your feedback on this changes and if you think they help to improve user experience. Nothing is set in stone yet, please do not stumble above details. @MTRichards @moscicki @jancborchardt @DeepDiver1975 @karlitschek 

Thanks

