### PR TITLE
Populate account setup credentials from server URL

### DIFF
--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -78,6 +78,18 @@ void OwncloudHttpCredsPage::initializePage()
         if (!user.isEmpty()) {
             _ui.leUsername->setText(user);
         }
+    } else {
+        QUrl url = ocWizard->account()->url();
+
+        const QString user = url.userName();
+        const QString password = url.password();
+
+        if(!user.isEmpty()) {
+            _ui.leUsername->setText(user);
+        }
+        if(!password.isEmpty()) {
+            _ui.lePassword->setText(password);
+        }
     }
     _ui.leUsername->setFocus();
 }


### PR DESCRIPTION
If a user enters a server URL in the form of https://user:pass@example.com/, this will pre-populate the following credentials page with those values. This streamlines the setup process in the case where the URL already has the credentials.

To test:

1. Start the client and set up a new account. Use `https://user:pass@example.com` for the server URL. Click Next.
2. See `user` pre-populated for the username. See four dots pre-populated for the password.
3. Click Next and check that `user` and `pass` were used for authentication.