### PR TITLE
AccountSettings: Add a toolbox button for the account specific actions.

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -135,19 +135,19 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent) :
 void AccountSettings::createAccountToolbox()
 {
     QMenu *menu = new QMenu();
-    _toggleSignInOutAction = new QAction(tr("Sign Out"), this);
-    connect(_toggleSignInOutAction, SIGNAL(triggered(bool)), SLOT(slotToggleSignInState()));
-    menu->addAction(_toggleSignInOutAction);
-
-    QAction *action = new QAction(tr("Remove Account"), this);
-    menu->addAction(action);
-    connect( action, SIGNAL(triggered(bool)), SLOT(slotDeleteAccount()));
-
-    _addAccountAction = new QAction(tr("Add new Account..."), this);
+    _addAccountAction = new QAction(tr("Add new"), this);
     menu->addAction(_addAccountAction);
     connect(_addAccountAction, SIGNAL(triggered(bool)), SLOT(slotOpenAccountWizard()));
 
-    ui->_accountToolbox->setText(tr("Account"));
+    _toggleSignInOutAction = new QAction(tr("Sign out"), this);
+    connect(_toggleSignInOutAction, SIGNAL(triggered(bool)), SLOT(slotToggleSignInState()));
+    menu->addAction(_toggleSignInOutAction);
+
+    QAction *action = new QAction(tr("Remove"), this);
+    menu->addAction(action);
+    connect( action, SIGNAL(triggered(bool)), SLOT(slotDeleteAccount()));
+
+    ui->_accountToolbox->setText(tr("Account") + QLatin1Char(' '));
     ui->_accountToolbox->setMenu(menu);
     ui->_accountToolbox->setPopupMode(QToolButton::InstantPopup);
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -83,6 +83,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent) :
 #else
     ui->_folderList->setMinimumWidth( 300 );
 #endif
+    createAccountToolbox();
+    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState*)),
+            SLOT(slotAccountAdded(AccountState*)));
     connect(ui->_folderList, SIGNAL(customContextMenuRequested(QPoint)),
             this, SLOT(slotCustomContextMenuRequested(QPoint)));
 
@@ -126,8 +129,46 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent) :
     connect( &_quotaInfo, SIGNAL(quotaUpdated(qint64,qint64)),
             this, SLOT(slotUpdateQuota(qint64,qint64)));
 
-    connect(ui->signInButton, SIGNAL(clicked()) , this, SLOT(slotSignInAccount()));
-    connect(ui->deleteButton, SIGNAL(clicked()) , this, SLOT(slotDeleteAccount()));
+}
+
+
+void AccountSettings::createAccountToolbox()
+{
+    QMenu *menu = new QMenu();
+    _toggleSignInOutAction = new QAction(tr("Sign Out"), this);
+    connect(_toggleSignInOutAction, SIGNAL(triggered(bool)), SLOT(slotToggleSignInState()));
+    menu->addAction(_toggleSignInOutAction);
+
+    QAction *action = new QAction(tr("Remove Account"), this);
+    menu->addAction(action);
+    connect( action, SIGNAL(triggered(bool)), SLOT(slotDeleteAccount()));
+
+    _addAccountAction = new QAction(tr("Add new Account..."), this);
+    menu->addAction(_addAccountAction);
+    connect(_addAccountAction, SIGNAL(triggered(bool)), SLOT(slotOpenAccountWizard()));
+
+    ui->_accountToolbox->setText(tr("Account"));
+    ui->_accountToolbox->setMenu(menu);
+    ui->_accountToolbox->setPopupMode(QToolButton::InstantPopup);
+
+    // Expand already on single click
+    ui->_folderList->setExpandsOnDoubleClick(false);
+    QObject::connect(ui->_folderList, SIGNAL(clicked(const QModelIndex &)),
+                     this, SLOT(slotFolderListClicked(const QModelIndex&)));
+}
+
+void AccountSettings::slotOpenAccountWizard()
+{
+    if (QSystemTrayIcon::isSystemTrayAvailable()) {
+        topLevelWidget()->close();
+    }
+    OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)), 0);
+}
+
+void AccountSettings::slotToggleSignInState()
+{
+    bool signedInState = _accountState->isSignedOut();
+    _accountState->setSignedOut( !signedInState );
 }
 
 void AccountSettings::doExpand()
@@ -485,12 +526,6 @@ void AccountSettings::slotAccountStateChanged(int state)
            serverWithUser = tr("%1 as <i>%2</i>").arg(server, cred->user());
         }
 
-        if (state != AccountState::SignedOut && ui->signInButton->hasFocus()) {
-            // The button is about to be hidden, clear the focus so the focus don't go to the
-            // "remove account" button
-            ui->signInButton->clearFocus();
-        }
-        ui->signInButton->setVisible(state == AccountState::SignedOut);
         if (state == AccountState::Connected) {
             showConnectionLabel( tr("Connected to %1.").arg(serverWithUser) );
         } else if (state == AccountState::ServiceUnavailable) {
@@ -516,6 +551,15 @@ void AccountSettings::slotAccountStateChanged(int state)
         for (i = 0; i < _model->rowCount(); ++i) {
             if (ui->_folderList->isExpanded(_model->index(i)))
                 ui->_folderList->setExpanded(_model->index(i), false);
+        }
+    }
+    /* set the correct label for the Account toolbox button */
+    if( _accountState ) {
+        bool isConnected = _accountState->isConnected();
+        if( isConnected ) {
+            _toggleSignInOutAction->setText(tr("Sign out"));
+        } else {
+            _toggleSignInOutAction->setText(tr("Sign in"));
         }
     }
 }
@@ -624,9 +668,14 @@ void AccountSettings::refreshSelectiveSyncStatus()
     }
 }
 
-void AccountSettings::slotSignInAccount()
+void AccountSettings::slotAccountAdded(AccountState*)
 {
-    _accountState->setSignedOut(false);
+    // if the theme is limited to single account, the button must hide if
+    // there is already one account.
+    if( AccountManager::instance()->accounts().size() > 1 &&
+            !Theme::instance()->multiAccount() ) {
+        _addAccountAction->setVisible(false);
+    }
 }
 
 void AccountSettings::slotDeleteAccount()
@@ -657,6 +706,9 @@ void AccountSettings::slotDeleteAccount()
 
     // if there is no more account, show the wizard.
     if( manager->accounts().isEmpty() ) {
+        // allow to add a new account if there is non any more. Always think
+        // about single account theming!
+        _addAccountAction->setVisible(true);
         OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)));
     }
 

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -76,8 +76,10 @@ protected slots:
     void slotOpenCurrentFolder();
     void slotFolderWizardAccepted();
     void slotFolderWizardRejected();
-    void slotSignInAccount();
     void slotDeleteAccount();
+    void slotToggleSignInState();
+    void slotOpenAccountWizard();
+    void slotAccountAdded(AccountState *);
     void refreshSelectiveSyncStatus();
     void slotCustomContextMenuRequested(const QPoint&);
     void slotFolderListClicked( const QModelIndex& indx );
@@ -88,6 +90,7 @@ private:
     void showConnectionLabel(const QString& message,
                              QStringList errors = QStringList());
     bool event(QEvent*) Q_DECL_OVERRIDE;
+    void createAccountToolbox();
 
     Ui::AccountSettings *ui;
 
@@ -96,6 +99,8 @@ private:
     bool _wasDisabledBefore;
     AccountState *_accountState;
     QuotaInfo _quotaInfo;
+    QAction *_toggleSignInOutAction;
+    QAction *_addAccountAction;
 };
 
 } // namespace OCC

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -6,30 +6,18 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>469</width>
-    <height>652</height>
+    <width>575</width>
+    <height>557</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QWidget" name="accountStatus" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
        <widget class="SslButton" name="sslButton">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -42,7 +30,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QLabel" name="connectLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -61,42 +49,17 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QPushButton" name="signInButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Enter your credentials to connect to the server</string>
-        </property>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="_accountToolbox">
         <property name="text">
-         <string>Sign in</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="deleteButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Remove the account configuration from the client</string>
-        </property>
-        <property name="text">
-         <string>Remove Account</string>
+         <string>...</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <layout class="QHBoxLayout" name="storageGroupBox">
      <item>
       <widget class="QLabel" name="quotaInfoLabel">
@@ -147,7 +110,7 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QTreeView" name="_folderList">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -166,7 +129,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0">
     <widget class="QWidget" name="selectiveSyncStatus" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -83,13 +83,6 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
     _ui->monoIconsCheckBox->setVisible(QDir(themeDir).exists());
 
     connect(_ui->ignoredFilesButton, SIGNAL(clicked()), SLOT(slotIgnoreFilesEditor()));
-    connect(_ui->addAccountButton, SIGNAL(clicked()), SLOT(slotOpenAccountWizard()));
-
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState*)),
-            SLOT(slotAccountAddedOrRemoved()));
-    connect(AccountManager::instance(), SIGNAL(accountRemoved(AccountState*)),
-            SLOT(slotAccountAddedOrRemoved()));
-    slotAccountAddedOrRemoved();
 }
 
 GeneralSettings::~GeneralSettings()
@@ -168,13 +161,5 @@ void GeneralSettings::slotOpenAccountWizard()
     }
     OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)), 0);
 }
-
-void GeneralSettings::slotAccountAddedOrRemoved()
-{
-    _ui->addAccountButton->setVisible(
-        AccountManager::instance()->accounts().isEmpty()
-            || Theme::instance()->multiAccount());
-}
-
 
 } // namespace OCC

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -44,8 +44,6 @@ private slots:
     void slotUpdateInfo();
     void slotIgnoreFilesEditor();
     void slotOpenAccountWizard();
-    void slotAccountAddedOrRemoved();
-
 
 private:
     void loadMiscSettings();

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="generalGroupBox">
      <property name="title">
       <string>General Settings</string>
@@ -47,7 +47,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Advanced</string>
@@ -77,31 +77,7 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QPushButton" name="addAccountButton">
-          <property name="text">
-           <string>Add an Account</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QCheckBox" name="newFolderLimitCheckBox">
@@ -145,7 +121,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
          <widget class="QCheckBox" name="crashreporterCheckBox">
@@ -165,7 +141,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="aboutGroupBox">
      <property name="title">
       <string>About</string>
@@ -181,7 +157,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0">
     <widget class="QGroupBox" name="updatesGroupBox">
      <property name="title">
       <string>Updates</string>
@@ -232,7 +208,7 @@
      </layout>
     </widget>
    </item>
-   <item>
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -247,6 +223,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>autostartCheckBox</tabstop>
+  <tabstop>desktopNotificationsCheckBox</tabstop>
+  <tabstop>monoIconsCheckBox</tabstop>
+  <tabstop>ignoredFilesButton</tabstop>
+  <tabstop>newFolderLimitCheckBox</tabstop>
+  <tabstop>newFolderLimitSpinBox</tabstop>
+  <tabstop>crashreporterCheckBox</tabstop>
+  <tabstop>restartButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Also move the 'Add Account' button from the General Tab, where it
is not properly found, to the new account toolbox.

This results in a look like that:
![toolboxbutton](https://cloud.githubusercontent.com/assets/1070214/11147503/992fbe32-8a16-11e5-9a84-c45a13a08529.png)
Also note the Add-Account functionality, that moved from the General tab to here. 

@jancborchardt how is that? @phil-davis as we talked about in the other issue #4134