### PR TITLE
[Sharing] Permissions now in dropdown menu

### DIFF
--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -225,6 +225,9 @@ ShareWidget::ShareWidget(QSharedPointer<Share> share,
     _ui->permissionToolButton->setMenu(menu);
     _ui->permissionToolButton->setPopupMode(QToolButton::InstantPopup);
 
+    QIcon icon(QLatin1String(":/client/resources/more.png"));
+    _ui->permissionToolButton->setIcon(icon);
+
     // Set the permissions checkboxes
     displayPermissions();
 

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -37,6 +37,8 @@
 #include <qscrollarea.h>
 #include <qlayout.h>
 #include <QPropertyAnimation>
+#include <QMenu>
+#include <QAction>
 
 namespace OCC {
 
@@ -143,7 +145,7 @@ void ShareUserGroupWidget::slotSharesFetched(const QList<QSharedPointer<Share>> 
             continue;
         }
 
-        ShareWidget *s = new ShareWidget(share, _ui->scrollArea);
+        ShareWidget *s = new ShareWidget(share, _isFile, _ui->scrollArea);
         connect(s, SIGNAL(resizeRequested()), this, SLOT(slotAdjustScrollWidgetSize()));
         layout->addWidget(s);
 
@@ -196,27 +198,39 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex & index)
 }
 
 ShareWidget::ShareWidget(QSharedPointer<Share> share,
-                                   QWidget *parent) :
+                         bool isFile,
+                         QWidget *parent) :
   QWidget(parent),
   _ui(new Ui::ShareWidget),
   _share(share),
-  _showDetailedPermissions(false)
+  _isFile(isFile)
 {
     _ui->setupUi(this);
 
     _ui->sharedWith->setText(share->getShareWith()->format());
+ 
+    // Create detailed permissions menu
+    QMenu *menu = new QMenu(this);
+    _permissionCreate = new QAction(tr("create"), this);
+    _permissionCreate->setCheckable(true);
+    menu->addAction(_permissionCreate);
+    _permissionUpdate = new QAction(tr("change"), this);
+    _permissionUpdate->setCheckable(true);
+    menu->addAction(_permissionUpdate);
+    _permissionDelete = new QAction(tr("delete"), this);
+    _permissionDelete->setCheckable(true);
+    if (!_isFile) {
+        menu->addAction(_permissionDelete);
+    }
+    _ui->permissionToolButton->setMenu(menu);
+    _ui->permissionToolButton->setPopupMode(QToolButton::InstantPopup);
 
     // Set the permissions checkboxes
     displayPermissions();
 
-    // Hide "detailed permissions" by default
-    _ui->permissionDelete->setHidden(true);
-    _ui->permissionUpdate->setHidden(true);
-    _ui->permissionCreate->setHidden(true);
-
-    connect(_ui->permissionUpdate, SIGNAL(clicked(bool)), SLOT(slotPermissionsChanged()));
-    connect(_ui->permissionCreate, SIGNAL(clicked(bool)), SLOT(slotPermissionsChanged()));
-    connect(_ui->permissionDelete, SIGNAL(clicked(bool)), SLOT(slotPermissionsChanged()));
+    connect(_permissionUpdate, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
+    connect(_permissionCreate, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
+    connect(_permissionDelete, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
     connect(_ui->permissionShare,  SIGNAL(clicked(bool)), SLOT(slotPermissionsChanged()));
     connect(_ui->permissionsEdit,  SIGNAL(clicked(bool)), SLOT(slotEditPermissionsChanged()));
 
@@ -233,21 +247,6 @@ void ShareWidget::on_deleteShareButton_clicked()
     _share->deleteShare();
 }
 
-void ShareWidget::on_permissionToggleButton_clicked()
-{
-    _showDetailedPermissions = !_showDetailedPermissions;
-    _ui->permissionDelete->setVisible(_showDetailedPermissions);
-    _ui->permissionUpdate->setVisible(_showDetailedPermissions);
-    _ui->permissionCreate->setVisible(_showDetailedPermissions);
-
-    if (_showDetailedPermissions) {
-        _ui->permissionToggleButton->setText("Hide");
-    } else {
-        _ui->permissionToggleButton->setText("More");
-    }
-    emit resizeRequested();
-}
-
 ShareWidget::~ShareWidget()
 {
     delete _ui;
@@ -260,13 +259,16 @@ void ShareWidget::slotEditPermissionsChanged()
     Share::Permissions permissions = Share::PermissionRead;
 
     if (_ui->permissionShare->checkState() == Qt::Checked) {
-        permissions |= Share::PermissionUpdate;
+        permissions |= Share::PermissionShare;
     }
     
     if (_ui->permissionsEdit->checkState() == Qt::Checked) {
         permissions |= Share::PermissionCreate;
         permissions |= Share::PermissionUpdate;
-        permissions |= Share::PermissionDelete;
+
+        if (!_isFile) {
+            permissions |= Share::PermissionDelete;
+        }
     }
 
     _share->setPermissions(permissions);
@@ -278,15 +280,15 @@ void ShareWidget::slotPermissionsChanged()
     
     Share::Permissions permissions = Share::PermissionRead;
 
-    if (_ui->permissionUpdate->checkState() == Qt::Checked) {
+    if (_permissionUpdate->isChecked()) {
         permissions |= Share::PermissionUpdate;
     }
 
-    if (_ui->permissionCreate->checkState() == Qt::Checked) {
+    if (_permissionCreate->isChecked()) {
         permissions |= Share::PermissionCreate;
     }
 
-    if (_ui->permissionDelete->checkState() == Qt::Checked) {
+    if (_permissionDelete->isChecked()) {
         permissions |= Share::PermissionDelete;
     }
 
@@ -330,22 +332,22 @@ QSharedPointer<Share> ShareWidget::share() const
 
 void ShareWidget::displayPermissions()
 {
-    _ui->permissionCreate->setCheckState(Qt::Unchecked);
+    _permissionCreate->setChecked(false);
     _ui->permissionsEdit->setCheckState(Qt::Unchecked);
-    _ui->permissionDelete->setCheckState(Qt::Unchecked);
+    _permissionDelete->setChecked(false);
     _ui->permissionShare->setCheckState(Qt::Unchecked);
-    _ui->permissionUpdate->setCheckState(Qt::Unchecked);
+    _permissionUpdate->setChecked(false);
 
     if (_share->getPermissions() & Share::PermissionUpdate) {
-        _ui->permissionUpdate->setCheckState(Qt::Checked);
+        _permissionUpdate->setChecked(true);
         _ui->permissionsEdit->setCheckState(Qt::Checked);
     }
     if (_share->getPermissions() & Share::PermissionCreate) {
-        _ui->permissionCreate->setCheckState(Qt::Checked);
+        _permissionCreate->setChecked(true);
         _ui->permissionsEdit->setCheckState(Qt::Checked);
     }
-    if (_share->getPermissions() & Share::PermissionDelete) {
-        _ui->permissionDelete->setCheckState(Qt::Checked);
+    if (!_isFile && _share->getPermissions() & Share::PermissionDelete) {
+        _permissionDelete->setChecked(true);
         _ui->permissionsEdit->setCheckState(Qt::Checked);
     }
     if (_share->getPermissions() & Share::PermissionShare) {

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -24,6 +24,7 @@
 #include <QVector>
 #include <QTimer>
 
+class QAction;
 class QCompleter;
 class QModelIndex;
 
@@ -47,7 +48,7 @@ class ShareWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ShareWidget(QSharedPointer<Share> Share, QWidget *parent = 0);
+    explicit ShareWidget(QSharedPointer<Share> Share, bool isFile, QWidget *parent = 0);
     ~ShareWidget();
 
     QSharedPointer<Share> share() const;
@@ -60,18 +61,20 @@ private slots:
     void on_deleteShareButton_clicked();
     void slotPermissionsChanged();
     void slotEditPermissionsChanged();
-    void on_permissionToggleButton_clicked();
     void slotDeleteAnimationFinished();
 
     void slotShareDeleted();
     void slotPermissionsSet();
-
 private:
     void displayPermissions();
 
     Ui::ShareWidget *_ui;
     QSharedPointer<Share> _share;
-    bool _showDetailedPermissions;
+    bool _isFile;
+
+    QAction *_permissionCreate;
+    QAction *_permissionUpdate;
+    QAction *_permissionDelete;
 };
 
 

--- a/src/gui/sharewidget.ui
+++ b/src/gui/sharewidget.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>468</width>
-    <height>92</height>
+    <height>64</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,56 +46,38 @@
        <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
-         <height>20</height>
+         <height>15</height>
         </size>
        </property>
       </spacer>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string/>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QCheckBox" name="permissionShare">
-          <property name="text">
-           <string>Can Share</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QCheckBox" name="permissionsEdit">
           <property name="text">
-           <string>Can Edit</string>
+           <string>can edit</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QCheckBox" name="permissionCreate">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="permissionShare">
           <property name="text">
-           <string>Create</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="permissionUpdate">
-          <property name="text">
-           <string>Change</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QCheckBox" name="permissionDelete">
-          <property name="text">
-           <string>Delete</string>
+           <string>can share</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QPushButton" name="permissionToggleButton">
+         <widget class="QToolButton" name="permissionToolButton">
           <property name="text">
-           <string>More</string>
+           <string>...</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
As discusses with jan.

* Detailed permissions displayed in qtoolboxmenu
* Made share rows slightly smaller

Bug fix:

* Do not show delete permissions for file shares