### PR TITLE
improved linux build instructions.

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -206,7 +206,7 @@ To build the most up to date version of the client:
 
 3. Configure the client build::
 
-    cmake -DCMAKE_BUILD_TYPE="Debug" ..
+    cmake -DCMAKE_BUILD_TYPE="Debug" ../client
 
   ..note:: You must use absolute paths for the ``include`` and ``library``
            directories.

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -196,6 +196,7 @@ To build the most up to date version of the client:
 1. Clone the latest versions of the client from Git_ as follows::
 
     git clone git://github.com/owncloud/client.git
+    cd client
     git submodule init
     git submodule update
 
@@ -206,7 +207,7 @@ To build the most up to date version of the client:
 
 3. Configure the client build::
 
-    cmake -DCMAKE_BUILD_TYPE="Debug" ../client
+    cmake -DCMAKE_BUILD_TYPE="Debug" ..
 
   ..note:: You must use absolute paths for the ``include`` and ``library``
            directories.

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -193,20 +193,20 @@ You can download the desktop sync client from the ownCloud `Client Download Page
 
 To build the most up to date version of the client:
 
-1. Clone the latest versions of the client from Git_ as follows:
+1. Clone the latest versions of the client from Git_ as follows::
 
-  ``git clone git://github.com/owncloud/client.git``
-  ``git submodule init``
-  ``git submodule update``
+    git clone git://github.com/owncloud/client.git
+    git submodule init
+    git submodule update
 
-2. Create the build directory:
+2. Create the build directory::
 
-  ``mkdir client-build``
-  ``cd client-build``
+    mkdir client-build
+    cd client-build
 
-3. Configure the client build:
+3. Configure the client build::
 
-  ``cmake -DCMAKE_BUILD_TYPE="Debug" ../client``
+    cmake -DCMAKE_BUILD_TYPE="Debug" ..
 
   ..note:: You must use absolute paths for the ``include`` and ``library``
            directories.

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -209,10 +209,10 @@ To build the most up to date version of the client:
 
     cmake -DCMAKE_BUILD_TYPE="Debug" ..
 
-  ..note:: You must use absolute paths for the ``include`` and ``library``
+  .. note:: You must use absolute paths for the ``include`` and ``library``
            directories.
 
-  ..note:: On Mac OS X, you need to specify ``-DCMAKE_INSTALL_PREFIX=target``,
+  .. note:: On Mac OS X, you need to specify ``-DCMAKE_INSTALL_PREFIX=target``,
            where ``target`` is a private location, i.e. in parallel to your build
            dir by specifying ``../install``.
 


### PR DESCRIPTION
I am using :: lists, as the ``  versions mangle multi-line commands all in one long line.
The cmake command should just end in .., not in ../client

@Kawohl this should also work in your Dockerfile.