### PR TITLE
show displaynames of users in share dialog instead of userid

### DIFF
--- a/src/gui/sharee.cpp
+++ b/src/gui/sharee.cpp
@@ -137,7 +137,7 @@ QSharedPointer<Sharee> ShareeModel::parseSharee(const QVariantMap &data)
     const QString shareWith = data.value("value").toMap().value("shareWith").toString();
     Sharee::Type type = (Sharee::Type)data.value("value").toMap().value("shareType").toInt();
 
-    return QSharedPointer<Sharee>(new Sharee(shareWith, shareWith, type));
+    return QSharedPointer<Sharee>(new Sharee(shareWith, displayName, type));
 }
 
 /* Set the new sharee


### PR DESCRIPTION
Problem found by danimo and investigated by me: searching for LDAP users was buggy. They only appeared, when the search started with the userid.  

Server works correctly.

Turns out, displayname variable was not used. 

If we need this for 2.1 i can rebase and open a PR against that branch.

@danimo @rullzer 