### PR TITLE
Fixing bug in opening Activity log from tray icon menu 'Recent Changes/Details...'

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -183,7 +183,7 @@ void SettingsDialog::showFirstPage()
 void SettingsDialog::showActivityPage()
 {
     if (_activityAction) {
-        slotSwitchPage(_activityAction);
+        _activityAction->trigger();
     }
 }
 


### PR DESCRIPTION
Fixing bug in opening Activity log from tray icon menu 'Recent Changes/Details...'.
such that Settings dialog shows Activity tab, but highlighted tab could be different.
the problem fixed in settingsdialog.cpp.
settingsdialogmac.cpp checked, doesn't have the problem.

![owncloud-bug-screenshot](https://cloud.githubusercontent.com/assets/6030264/11560210/23a682e0-99d4-11e5-9e16-dd3523293c8b.png)
