### PR TITLE
Fix enum csync

### DIFF
--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -140,13 +140,6 @@ static bool _csync_filetype_different( const csync_file_stat_t *tmp, const csync
     if( tmp->type == CSYNC_FTW_TYPE_SLINK && fs->type != CSYNC_VIO_FILE_TYPE_SYMBOLIC_LINK )
         return true;
 
-    if( fs->type == CSYNC_VIO_FILE_TYPE_DIRECTORY && tmp->type != CSYNC_FTW_TYPE_DIR )
-        return true;
-    if( fs->type == CSYNC_VIO_FILE_TYPE_REGULAR && tmp->type != CSYNC_FTW_TYPE_FILE )
-        return true;
-    if( fs->type == CSYNC_VIO_FILE_TYPE_SYMBOLIC_LINK && tmp->type != CSYNC_FTW_TYPE_SLINK )
-        return true;
-
     return false; // both are NOT different.
 }
 

--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -353,10 +353,12 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
             }
 
             /* translate the file type between the two stat types csync has. */
-            if( tmp && tmp->type == 0 ) {
+            if( tmp && tmp->type == CSYNC_FTW_TYPE_FILE ) {
                 tmp_vio_type = CSYNC_VIO_FILE_TYPE_REGULAR;
-            } else if( tmp && tmp->type == 2 ) {
+            } else if( tmp && tmp->type == CSYNC_FTW_TYPE_DIR) {
                 tmp_vio_type = CSYNC_VIO_FILE_TYPE_DIRECTORY;
+            } else if( tmp && tmp->type == CSYNC_FTW_TYPE_SLINK ) {
+                tmp_vio_type = CSYNC_VIO_FILE_TYPE_SYMBOLIC_LINK;
             } else {
                 tmp_vio_type = CSYNC_VIO_FILE_TYPE_UNKNOWN;
             }


### PR DESCRIPTION
This fixes a  compatibility issue with the definitions of the type members within the two used structs.