### PR TITLE
Don't install tests and cmocka lib

### DIFF
--- a/cmake/modules/AddCMockaTest.cmake
+++ b/cmake/modules/AddCMockaTest.cmake
@@ -20,15 +20,4 @@ function (ADD_CMOCKA_TEST _testName _testSource)
     add_executable(${_testName} ${_testSource})
     target_link_libraries(${_testName} ${ARGN})
     add_test(${_testName} ${CMAKE_CURRENT_BINARY_DIR}/${_testName})
-
-  if(UNIT_TESTING)
-  INSTALL(
-  TARGETS
-    ${_testName}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-  endif(UNIT_TESTING)
-
 endfunction (ADD_CMOCKA_TEST)

--- a/csync/tests/CMakeLists.txt
+++ b/csync/tests/CMakeLists.txt
@@ -53,7 +53,3 @@ add_cmocka_test(check_csync_update csync_tests/check_csync_update.c ${TEST_TARGE
 # encoding
 add_cmocka_test(check_encoding_functions encoding_tests/check_encoding.c ${TEST_TARGET_LIBRARIES})
 
-if(UNIT_TESTING)
-    INSTALL( FILES "${CMOCKA_LIBRARIES}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif(UNIT_TESTING)
-


### PR DESCRIPTION
Neither tests nor the libcmocka needs to be installed globally.

ctest still works.