### PR TITLE
Add chunkSize config to documentation

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -22,3 +22,4 @@ You can change the following configuration settings (must be under the ``[ownClo
 
 - ``maxLogLines`` (default:  ``20000``) -- Specifies the maximum number of log lines displayed in the log window.
 
+- ``chunkSize`` (default:  ``5242880``) -- Specifies the chunk size of uploaded files in bytes.


### PR DESCRIPTION
Fixes https://github.com/owncloud/client/issues/4468

Ref: https://github.com/owncloud/client/issues/4354#issuecomment-171947435 and https://github.com/owncloud/client/blob/v2.1.1/src/libsync/configfile.cpp#L127