### PR TITLE
PropagatorDownload: fix possible crash

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -286,7 +286,9 @@ void GETFileJob::slotReadyRead()
 
 void GETFileJob::slotTimeout()
 {
-    qDebug() << "Timeout" << reply()->request().url();
+    qDebug() << "Timeout" << (reply() ? reply()->request().url() : path());
+    if (!reply())
+        return;
     _errorString =  tr("Connection Timeout");
     _errorStatus = SyncFileItem::FatalError;
     reply()->abort();


### PR DESCRIPTION
Backtrace seen from the crash reporter where reply() is null.