### PR TITLE
Checksums: keep the transfer checksum in the database as the content …

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -550,7 +550,7 @@ void PropagateDownloadFileQNAM::slotGetFinished()
     // as this is (still) also correct.
     ValidateChecksumHeader *validator = new ValidateChecksumHeader(this);
     connect(validator, SIGNAL(validated(QByteArray,QByteArray)),
-            SLOT(downloadFinished()));
+            SLOT(downloadFinished(QByteArray,QByteArray)));
     connect(validator, SIGNAL(validationFailed(QString)),
             SLOT(slotChecksumFail(QString)));
     auto checksumHeader = job->reply()->rawHeader(checkSumHeaderC);
@@ -638,8 +638,13 @@ static void handleRecallFile(const QString &fn)
 }
 } // end namespace
 
-void PropagateDownloadFileQNAM::downloadFinished()
+void PropagateDownloadFileQNAM::downloadFinished(const QByteArray& transportChecksumType,
+                                                 const QByteArray& transportChecksum)
 {
+    // by default, reuse the transport checksum as content checksum
+    _item->_contentChecksum = transportChecksum;
+    _item->_contentChecksumType = transportChecksumType;
+
     QString fn = _propagator->getFilePath(_item->_file);
 
     // In case of file name clash, report an error

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -128,7 +128,8 @@ public:
 private slots:
     void slotGetFinished();
     void abort() Q_DECL_OVERRIDE;
-    void downloadFinished();
+    void downloadFinished(const QByteArray& transportChecksumType = QByteArray(),
+                          const QByteArray &transportChecksum = QByteArray());
     void slotDownloadProgress(qint64,qint64);
     void slotChecksumFail( const QString& errMsg );
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -282,6 +282,12 @@ void PropagateUploadFileQNAM::slotStartUpload(const QByteArray& transmissionChec
     _transmissionChecksum = transmissionChecksum;
     _transmissionChecksumType = transmissionChecksumType;
 
+    if (_item->_contentChecksum.isEmpty() && _item->_contentChecksumType.isEmpty())  {
+        // If the _contentChecksum was not set, reuse the transmission checksum as the content checksum.
+        _item->_contentChecksum = transmissionChecksum;
+        _item->_contentChecksumType = transmissionChecksumType;
+    }
+
     const QString fullFilePath = _propagator->getFilePath(_item->_file);
 
     if (!FileSystem::fileExists(fullFilePath)) {


### PR DESCRIPTION
…checksum

Currently, we only use this for .eml files. But we can just store this checksum
in the database if it was computed anyway.

Issue #4487