### PR TITLE
factor out window raising method

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -60,6 +60,7 @@ set(client_SRCS
     ocsshareejob.cpp
     openfilemanager.cpp
     owncloudgui.cpp
+    windowraiser.cpp
     owncloudsetupwizard.cpp
     protocolwidget.cpp
     activitywidget.cpp

--- a/src/gui/creds/shibbolethcredentials.cpp
+++ b/src/gui/creds/shibbolethcredentials.cpp
@@ -30,6 +30,7 @@
 #include "cookiejar.h"
 #include "owncloudgui.h"
 #include "syncengine.h"
+#include "windowraiser.h"
 
 #include <keychain.h>
 
@@ -270,7 +271,7 @@ void ShibbolethCredentials::slotReadJobDone(QKeychain::Job *job)
 void ShibbolethCredentials::showLoginWindow()
 {
     if (!_browser.isNull()) {
-        ownCloudGui::raiseDialog(_browser);
+        WindowRaiser::raiseDialog(_browser);
         return;
     }
 
@@ -285,7 +286,7 @@ void ShibbolethCredentials::showLoginWindow()
             this, SLOT(onShibbolethCookieReceived(QNetworkCookie)), Qt::QueuedConnection);
     connect(_browser, SIGNAL(rejected()), this, SLOT(slotBrowserRejected()));
 
-    ownCloudGui::raiseDialog(_browser);
+    WindowRaiser::raiseDialog(_browser);
 }
 
 QList<QNetworkCookie> ShibbolethCredentials::accountCookies(Account* account)

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -22,6 +22,7 @@
 #include "owncloudsetupwizard.h"
 #include "accountmanager.h"
 #include "synclogdialog.h"
+#include "windowraiser.h"
 
 #include "updater/updater.h"
 #include "updater/ocupdater.h"
@@ -152,7 +153,7 @@ void GeneralSettings::slotIgnoreFilesEditor()
         _ignoreEditor->setAttribute( Qt::WA_DeleteOnClose, true );
         _ignoreEditor->open();
     } else {
-        ownCloudGui::raiseDialog(_ignoreEditor);
+        WindowRaiser::raiseDialog(_ignoreEditor);
     }
 }
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -33,6 +33,7 @@
 #include "openfilemanager.h"
 #include "accountmanager.h"
 #include "creds/abstractcredentials.h"
+#include "windowraiser.h"
 
 #include <QDesktopServices>
 #include <QMessageBox>
@@ -673,7 +674,7 @@ void ownCloudGui::slotShowSettings()
         _settingsDialog->setAttribute( Qt::WA_DeleteOnClose, true );
         _settingsDialog->show();
     }
-    raiseDialog(_settingsDialog.data());
+    WindowRaiser::raiseDialog(_settingsDialog.data());
 }
 
 void ownCloudGui::slotShowSyncProtocol()
@@ -704,7 +705,7 @@ void ownCloudGui::slotToggleLogBrowser()
     if (_logBrowser->isVisible() ) {
         _logBrowser->hide();
     } else {
-        raiseDialog(_logBrowser);
+        WindowRaiser::raiseDialog(_logBrowser);
     }
 }
 
@@ -719,44 +720,6 @@ void ownCloudGui::slotHelp()
 {
     QDesktopServices::openUrl(QUrl(Theme::instance()->helpUrl()));
 }
-
-void ownCloudGui::raiseDialog( QWidget *raiseWidget )
-{
-    if( raiseWidget && raiseWidget->parentWidget() == 0) {
-        // Qt has a bug which causes parent-less dialogs to pop-under.
-        raiseWidget->showNormal();
-        raiseWidget->raise();
-        raiseWidget->activateWindow();
-
-#if defined(Q_OS_MAC)
-        // viel hilft viel ;-)
-        MacWindow::bringToFront(raiseWidget);
-#endif
-#if defined(Q_OS_X11)
-        WId wid = widget->winId();
-        NETWM::init();
-
-        XEvent e;
-        e.xclient.type = ClientMessage;
-        e.xclient.message_type = NETWM::NET_ACTIVE_WINDOW;
-        e.xclient.display = QX11Info::display();
-        e.xclient.window = wid;
-        e.xclient.format = 32;
-        e.xclient.data.l[0] = 2;
-        e.xclient.data.l[1] = QX11Info::appTime();
-        e.xclient.data.l[2] = 0;
-        e.xclient.data.l[3] = 0l;
-        e.xclient.data.l[4] = 0l;
-        Display *display = QX11Info::display();
-        XSendEvent(display,
-                   RootWindow(display, DefaultScreen(display)),
-                   False, // propagate
-                   SubstructureRedirectMask|SubstructureNotifyMask,
-                   &e);
-#endif
-    }
-}
-
 
 void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &localPath, bool resharingAllowed)
 {
@@ -784,7 +747,7 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         _shareDialogs[localPath] = w;
         connect(w, SIGNAL(destroyed(QObject*)), SLOT(slotRemoveDestroyedShareDialogs()));
     }
-    raiseDialog(w);
+    WindowRaiser::raiseDialog(w);
 }
 
 void ownCloudGui::slotRemoveDestroyedShareDialogs()

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -49,7 +49,6 @@ public:
 
     bool checkAccountExists(bool openSettings);
 
-    static void raiseDialog(QWidget *raiseWidget);
     static QSize settingsDialogSize() { return QSize(800, 500); }
     void setupOverlayIcons();
 

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -32,6 +32,7 @@ ProxyAuthHandler* ProxyAuthHandler::instance()
 
 ProxyAuthHandler::ProxyAuthHandler()
     : _blocked(false)
+    , _dialog(0)
     , _waitingForDialog(0)
     , _waitingForKeychain(0)
     , _keychainJobRunning(false)

--- a/src/gui/windowraiser.cpp
+++ b/src/gui/windowraiser.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "windowraiser.h"
+#if defined(Q_OS_MAC)
+#    include "macwindow.h" // qtmacgoodies
+#endif
+
+#include <QWidget>
+
+#if defined(Q_OS_X11)
+#include <QX11Info>
+#endif
+
+namespace OCC {
+
+WindowRaiser::WindowRaiser()
+{
+}
+
+void WindowRaiser::raiseDialog( QWidget *raiseWidget )
+{
+    if( raiseWidget && raiseWidget->parentWidget() == 0) {
+        // Qt has a bug which causes parent-less dialogs to pop-under.
+        raiseWidget->showNormal();
+        raiseWidget->raise();
+        raiseWidget->activateWindow();
+
+#if defined(Q_OS_MAC)
+        // viel hilft viel ;-)
+        MacWindow::bringToFront(raiseWidget);
+#endif
+#if defined(Q_OS_X11)
+        WId wid = widget->winId();
+        NETWM::init();
+
+        XEvent e;
+        e.xclient.type = ClientMessage;
+        e.xclient.message_type = NETWM::NET_ACTIVE_WINDOW;
+        e.xclient.display = QX11Info::display();
+        e.xclient.window = wid;
+        e.xclient.format = 32;
+        e.xclient.data.l[0] = 2;
+        e.xclient.data.l[1] = QX11Info::appTime();
+        e.xclient.data.l[2] = 0;
+        e.xclient.data.l[3] = 0l;
+        e.xclient.data.l[4] = 0l;
+        Display *display = QX11Info::display();
+        XSendEvent(display,
+                   RootWindow(display, DefaultScreen(display)),
+                   False, // propagate
+                   SubstructureRedirectMask|SubstructureNotifyMask,
+                   &e);
+#endif
+    }
+}
+
+} // end namespace

--- a/src/gui/windowraiser.h
+++ b/src/gui/windowraiser.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef WINDOWRAISER_H
+#define WINDOWRAISER_H
+
+#include "systray.h"
+
+class QWidget;
+
+namespace OCC {
+
+
+/**
+ * @brief The WindowRaiser class
+ * @ingroup gui
+ */
+class WindowRaiser
+{
+public:
+
+    static void raiseDialog(QWidget *raiseWidget);
+
+private:
+    explicit WindowRaiser();
+};
+
+} // namespace OCC
+
+#endif // WINDOWRAISER_H


### PR DESCRIPTION
The interesting change is moving a static function that only raises the dialog into its own class. This improves separation between syncing client and window system. The reason why I'm separating this one out is because it's going to be needed from my clientlib shared bits, such as the credentialstore, but would drag in the whole gui application, which would be defeating the purpose entirely.

This pull request also initializes an otherwise empty pointer, in a separate commit.
