### PR TITLE
Propagator: Pump in more requests if we think current ones are quick

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -490,6 +490,10 @@ void PropfindJob::start()
         qWarning() << "Propfind with no properties!";
     }
     QNetworkRequest req;
+    // Always have a higher priority than the propagator because we use this from the UI
+    // and really want this to be done first (no matter what internal scheduling QNAM uses).
+    // Also possibly useful for avoiding false timeouts.
+    req.setPriority(QNetworkRequest::HighPriority);
     req.setRawHeader("Depth", "0");
     QByteArray propStr;
     foreach (const QByteArray &prop, properties) {

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -87,6 +87,16 @@ int OwncloudPropagator::maximumActiveJob()
     return max;
 }
 
+int OwncloudPropagator::hardMaximumActiveJob()
+{
+    int max = maximumActiveJob();
+    return max*2;
+    // FIXME: Wondering if we should hard-limit to 1 if maximumActiveJob() is 1
+    // to support our old use case of limiting concurrency (when "automatic" bandwidth
+    // limiting is set. But this causes https://github.com/owncloud/client/issues/4081
+}
+
+
 /** Updates, creates or removes a blacklist entry for the given item.
  *
  * Returns whether the file is in the blacklist now.
@@ -518,9 +528,31 @@ QString OwncloudPropagator::getFilePath(const QString& tmp_file_name) const
 
 void OwncloudPropagator::scheduleNextJob()
 {
-    if (this->_activeJobs < maximumActiveJob()) {
+    // TODO: If we see that the automatic up-scaling has a bad impact we
+    // need to check how to avoid this.
+    // Down-scaling on slow networks? https://github.com/owncloud/client/issues/3382
+    // Making sure we do up/down at same time? https://github.com/owncloud/client/issues/1633
+
+    if (_activeJobList.count() < maximumActiveJob()) {
         if (_rootJob->scheduleNextJob()) {
             QTimer::singleShot(0, this, SLOT(scheduleNextJob()));
+        }
+    } else if (_activeJobList.count() < hardMaximumActiveJob()) {
+        int likelyFinishedQuicklyCount = 0;
+        // NOTE: Only counts the first 3 jobs! Then for each
+        // one that is likely finished quickly, we can launch another one.
+        // When a job finishes another one will "move up" to be one of the first 3 and then
+        // be counted too.
+        for (int i = 0; i < maximumActiveJob() && i < _activeJobList.count(); i++) {
+            if (_activeJobList.at(i)->isLikelyFinishedQuickly()) {
+                likelyFinishedQuicklyCount++;
+            }
+        }
+        if (_activeJobList.count() < maximumActiveJob() + likelyFinishedQuicklyCount) {
+            qDebug() <<  "Can pump in another request!";
+            if (_rootJob->scheduleNextJob()) {
+                QTimer::singleShot(0, this, SLOT(scheduleNextJob()));
+            }
         }
     }
 }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -88,6 +88,11 @@ public:
 
     virtual JobParallelism parallelism() { return FullParallelism; }
 
+    /**
+     * For "small" jobs
+     */
+    virtual bool isLikelyFinishedQuickly() { return false; }
+
     /** The space that the running jobs need to complete but don't actually use yet.
      *
      * Note that this does *not* include the disk space that's already
@@ -278,7 +283,6 @@ public:
             , _journal(progressDb)
             , _finishedEmited(false)
             , _bandwidthManager(this)
-            , _activeJobs(0)
             , _anotherSyncNeeded(false)
             , _account(account)
     { }
@@ -293,14 +297,15 @@ public:
 
     QAtomicInt _abortRequested; // boolean set by the main thread to abort.
 
-    /* The number of currently active jobs */
-    int _activeJobs;
+    /* The list of currently active jobs */
+    QVector<PropagateItemJob*> _activeJobList;
 
     /** We detected that another sync is required after this one */
     bool _anotherSyncNeeded;
 
     /* The maximum number of active jobs in parallel  */
     int maximumActiveJob();
+    int hardMaximumActiveJob();
 
     bool isInSharedDirectory(const QString& file);
     bool localFileNameClash(const QString& relfile);

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -114,6 +114,9 @@ public:
     void start() Q_DECL_OVERRIDE;
     qint64 committedDiskSpace() const Q_DECL_OVERRIDE;
 
+    // We think it might finish quickly because it is a small file.
+    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < 100*1024; }
+
     /**
      * Whether an existing folder with the same name may be deleted before
      * the download.
@@ -140,6 +143,8 @@ private:
     QPointer<GETFileJob> _job;
     QFile _tmpFile;
     bool _deleteExisting;
+
+    QElapsedTimer _stopwatch;
 };
 
 }

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -64,7 +64,7 @@ void PropagateRemoteDelete::start()
                          _propagator->_remoteFolder + _item->_file,
                          this);
     connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotDeleteJobFinished()));
-    _propagator->_activeJobs ++;
+    _propagator->_activeJobList.append(this);
     _job->start();
 }
 
@@ -76,7 +76,7 @@ void PropagateRemoteDelete::abort()
 
 void PropagateRemoteDelete::slotDeleteJobFinished()
 {
-    _propagator->_activeJobs--;
+    _propagator->_activeJobList.removeOne(this);
 
     Q_ASSERT(_job);
 

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -49,6 +49,9 @@ public:
         : PropagateItemJob(propagator, item) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
+
+    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return !_item->_isDirectory; }
+
 private slots:
     void slotDeleteJobFinished();
 

--- a/src/libsync/propagateremotemkdir.h
+++ b/src/libsync/propagateremotemkdir.h
@@ -33,6 +33,9 @@ public:
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
 
+    // Creating a directory should be fast.
+    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return true; }
+
     /**
      * Whether an existing entity with the same name may be deleted before
      * creating the directory.

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -97,7 +97,7 @@ void PropagateRemoteMove::start()
                         _propagator->_remoteDir + _item->_renameTarget,
                         this);
     connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotMoveJobFinished()));
-    _propagator->_activeJobs++;
+    _propagator->_activeJobList.append(this);
     _job->start();
 
 }
@@ -110,7 +110,7 @@ void PropagateRemoteMove::abort()
 
 void PropagateRemoteMove::slotMoveJobFinished()
 {
-    _propagator->_activeJobs--;
+    _propagator->_activeJobList.removeOne(this);
 
     Q_ASSERT(_job);
 


### PR DESCRIPTION
Helps with small file sync #331
When I benchmarked this, it went up to 6 parallelism and
was about 1/3 faster than the previous fixed 3 parallelism.
Doing more than 6 is dangerous because QNAM limits to 6 TCP
connections and also the server might become a bottleneck.

Should also help for #4081