### PR TITLE
Activities: Hide if non of the accounts has the app enabled.

### DIFF
--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -113,7 +113,7 @@ private slots:
     void slotActivitiesReceived(const QVariantMap& json, int statusCode);
 
 signals:
-    void accountWithoutActivityApp(AccountState* ast);
+    void activityJobStatusCode(AccountState* ast, int statusCode);
 
 private:
     void startFetchJob(AccountState* s);
@@ -145,12 +145,13 @@ public slots:
     void slotOpenFile(QModelIndex indx);
     void slotRefresh(AccountState* ptr);
     void slotRemoveAccount( AccountState *ptr );
-    void slotAccountWithoutActivityApp(AccountState *ast);
+    void slotAccountActivityStatus(AccountState *ast, int statusCode);
 
 signals:
     void guiLog(const QString&, const QString&);
     void copyToClipboard();
     void rowsInserted();
+    void hideAcitivityTab(bool);
 
 private:
     void showLabels();
@@ -183,7 +184,9 @@ public slots:
     void slotRefresh( AccountState* ptr );
     void slotRemoveAccount( AccountState *ptr );
 
+private slots:
     void slotCopyToClipboard();
+    void setActivityTabHidden(bool hidden);
 
 signals:
     void guiLog(const QString&, const QString&);
@@ -192,6 +195,8 @@ private:
     bool event(QEvent* e) Q_DECL_OVERRIDE;
 
     QTabWidget *_tab;
+    int _activityTabId;
+
     ActivityWidget *_activityWidget;
     ProtocolWidget *_protocolWidget;
     QProgressIndicator *_progressIndicator;


### PR DESCRIPTION
If the ownCloud server does not have the activity app enabled,
it returns 999 as status code. If all the configured accounts
do that, this code hides the entire tab with the server
activities.

This is supposed to fix #4533