### PR TITLE
Fix crash due to destruction order

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -99,6 +99,7 @@ SyncEngine::SyncEngine(AccountPtr account, const QString& localPath,
 
 SyncEngine::~SyncEngine()
 {
+    _excludedFiles.reset();
     csync_destroy(_csync_ctx);
     _thread.quit();
     _thread.wait();


### PR DESCRIPTION
`ExcludedFiles::~ExcludedFiles` calls `c_strlist_destroy()`, so it must be run before `csync_destroy()`; field destructors are run after the destructor body, so we cannot use a smart pointer for `SyncEngine::_excludedFiles`.