### PR TITLE
AccountManager: take theURL from the Theme rather than from the confi…

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -216,6 +216,12 @@ QString Theme::overrideServerUrl() const
     return QString::null;
 }
 
+QString Theme::forceConfigAuthType() const
+{
+    return QString();
+}
+
+
 QString Theme::defaultClientFolder() const
 {
     return appName();

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -130,6 +130,13 @@ public:
     virtual QString overrideServerUrl() const;
 
     /**
+     * This is only usefull when previous version had a different overrideServerUrl
+     * with a different auth type in that case You should then specify "http" or "shibboleth".
+     * Normaly this should be left empty.
+     */
+    virtual QString forceConfigAuthType() const;
+
+    /**
      * The default folder name without path on the server at setup time.
      */
     virtual QString defaultServerFolder() const;


### PR DESCRIPTION
…g if the theme specify it

That way an upgrade of the client can actually change the URL
Issue https://github.com/owncloud/enterprise/issues/1113
https://github.com/owncloud/enterprise/issues/1126

In addition to restoring commit 7e5d89293d7bd52ac42d026d34a8154fbbdf33bb, this
add a way to override the auth type