### PR TITLE
Socket API refactor

### DIFF
--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -18,8 +18,6 @@
 
 namespace OCC {
 
-typedef QSharedPointer<AccountState> AccountStatePtr;
-
 /**
    @brief The AccountManager class
    @ingroup gui

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -34,6 +34,7 @@
 
 #include <QDebug>
 #include <QDesktopServices>
+#include <QDir>
 #include <QListWidgetItem>
 #include <QMessageBox>
 #include <QAction>

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -29,11 +29,13 @@ namespace OCC {
 class AccountState;
 class Account;
 
+typedef QExplicitlySharedDataPointer<AccountState> AccountStatePtr;
+
 /**
  * @brief Extra info about an ownCloud server account.
  * @ingroup gui
  */
-class AccountState : public QObject {
+class AccountState : public QObject, public QSharedData {
     Q_OBJECT
 public:
     enum State {
@@ -148,6 +150,6 @@ private:
 }
 
 Q_DECLARE_METATYPE(OCC::AccountState*)
-Q_DECLARE_METATYPE(QSharedPointer<OCC::AccountState>)
+Q_DECLARE_METATYPE(OCC::AccountStatePtr)
 
 #endif //ACCOUNTINFO_H

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -114,7 +114,6 @@ Folder::Folder(const FolderDefinition& definition,
     connect(_engine.data(), SIGNAL(transmissionProgress(ProgressInfo)), this, SLOT(slotTransmissionProgress(ProgressInfo)));
     connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
             this, SLOT(slotItemCompleted(const SyncFileItem &, const PropagatorJob &)));
-    connect(_engine.data(), SIGNAL(syncItemDiscovered(const SyncFileItem &)), this, SLOT(slotSyncItemDiscovered(const SyncFileItem &)));
     connect(_engine.data(), SIGNAL(newBigFolder(QString)), this, SLOT(slotNewBigFolderDiscovered(QString)));
 }
 
@@ -911,11 +910,6 @@ void Folder::slotItemCompleted(const SyncFileItem &item, const PropagatorJob& jo
         _syncResult.setWarnCount(_syncResult.warnCount()+1);
     }
     emit ProgressDispatcher::instance()->itemCompleted(alias(), item, job);
-}
-
-void Folder::slotSyncItemDiscovered(const SyncFileItem & item)
-{
-    emit ProgressDispatcher::instance()->syncItemDiscovered(alias(), item);
 }
 
 void Folder::slotNewBigFolderDiscovered(const QString &newF)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -441,32 +441,32 @@ void Folder::bubbleUpSyncResult()
     _syncResult.setWarnCount(ignoredItems);
 
     if( firstItemNew ) {
-        createGuiLog( firstItemNew->_file,     SyncFileStatus::STATUS_NEW, newItems );
+        createGuiLog( firstItemNew->_file, LogStatusNew, newItems );
     }
     if( firstItemDeleted ) {
-        createGuiLog( firstItemDeleted->_file, SyncFileStatus::STATUS_REMOVE, removedItems );
+        createGuiLog( firstItemDeleted->_file, LogStatusRemove, removedItems );
     }
     if( firstItemUpdated ) {
-        createGuiLog( firstItemUpdated->_file, SyncFileStatus::STATUS_UPDATED, updatedItems );
+        createGuiLog( firstItemUpdated->_file, LogStatusUpdated, updatedItems );
     }
 
     if( firstItemRenamed ) {
-        SyncFileStatus status(SyncFileStatus::STATUS_RENAME);
+        LogStatus status(LogStatusRename);
         // if the path changes it's rather a move
         QDir renTarget = QFileInfo(firstItemRenamed->_renameTarget).dir();
         QDir renSource = QFileInfo(firstItemRenamed->_file).dir();
         if(renTarget != renSource) {
-            status.set(SyncFileStatus::STATUS_MOVE);
+            status = LogStatusMove;
         }
         createGuiLog( firstItemRenamed->_originalFile, status, renamedItems, firstItemRenamed->_renameTarget );
     }
 
-    createGuiLog( firstItemError->_file,   SyncFileStatus::STATUS_ERROR, errorItems );
+    createGuiLog( firstItemError->_file, LogStatusError, errorItems );
 
     qDebug() << "OO folder slotSyncFinished: result: " << int(_syncResult.status());
 }
 
-void Folder::createGuiLog( const QString& filename, SyncFileStatus status, int count,
+void Folder::createGuiLog( const QString& filename, LogStatus status, int count,
                            const QString& renameTarget )
 {
     if(count > 0) {
@@ -475,52 +475,48 @@ void Folder::createGuiLog( const QString& filename, SyncFileStatus status, int c
         QString file = QDir::toNativeSeparators(filename);
         QString text;
 
-        // not all possible values of status are evaluated here because the others
-        // are not used in the calling function. Please check there.
-        switch (status.tag()) {
-        case SyncFileStatus::STATUS_REMOVE:
+        switch (status) {
+        case LogStatusRemove:
             if( count > 1 ) {
                 text = tr("%1 and %2 other files have been removed.", "%1 names a file.").arg(file).arg(count-1);
             } else {
                 text = tr("%1 has been removed.", "%1 names a file.").arg(file);
             }
             break;
-        case SyncFileStatus::STATUS_NEW:
+        case LogStatusNew:
             if( count > 1 ) {
                 text = tr("%1 and %2 other files have been downloaded.", "%1 names a file.").arg(file).arg(count-1);
             } else {
                 text = tr("%1 has been downloaded.", "%1 names a file.").arg(file);
             }
             break;
-        case SyncFileStatus::STATUS_UPDATED:
+        case LogStatusUpdated:
             if( count > 1 ) {
                 text = tr("%1 and %2 other files have been updated.").arg(file).arg(count-1);
             } else {
                 text = tr("%1 has been updated.", "%1 names a file.").arg(file);
             }
             break;
-        case SyncFileStatus::STATUS_RENAME:
+        case LogStatusRename:
             if( count > 1 ) {
                 text = tr("%1 has been renamed to %2 and %3 other files have been renamed.").arg(file).arg(renameTarget).arg(count-1);
             } else {
                 text = tr("%1 has been renamed to %2.", "%1 and %2 name files.").arg(file).arg(renameTarget);
             }
             break;
-        case SyncFileStatus::STATUS_MOVE:
+        case LogStatusMove:
             if( count > 1 ) {
                 text = tr("%1 has been moved to %2 and %3 other files have been moved.").arg(file).arg(renameTarget).arg(count-1);
             } else {
                 text = tr("%1 has been moved to %2.").arg(file).arg(renameTarget);
             }
             break;
-        case SyncFileStatus::STATUS_ERROR:
+        case LogStatusError:
             if( count > 1 ) {
                 text = tr("%1 and %2 other files could not be synced due to errors. See the log for details.", "%1 names a file.").arg(file).arg(count-1);
             } else {
                 text = tr("%1 could not be synced due to an error. See the log for details.").arg(file);
             }
-            break;
-        default:
             break;
         }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -21,7 +21,6 @@
 #include "progressdispatcher.h"
 #include "syncjournaldb.h"
 #include "clientproxy.h"
-#include "syncfilestatus.h"
 #include "networkjobs.h"
 
 #include <csync.h>
@@ -266,7 +265,16 @@ private:
 
     void checkLocalPath();
 
-    void createGuiLog(const QString& filename, SyncFileStatus status, int count,
+    enum LogStatus {
+        LogStatusRemove,
+        LogStatusRename,
+        LogStatusMove,
+        LogStatusNew,
+        LogStatusError,
+        LogStatusUpdated
+    };
+
+    void createGuiLog(const QString& filename, LogStatus status, int count,
                        const QString& renameTarget = QString::null );
 
     AccountStatePtr _accountState;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -267,7 +267,6 @@ private slots:
 
     void slotEmitFinishedDelayed();
 
-    void watcherSlot(QString);
     void slotNewBigFolderDiscovered(const QString &);
 
 private:

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -248,7 +248,6 @@ private slots:
     void slotFolderDiscovered(bool local, QString folderName);
     void slotTransmissionProgress(const ProgressInfo& pi);
     void slotItemCompleted(const SyncFileItem&, const PropagatorJob&);
-    void slotSyncItemDiscovered(const SyncFileItem & item);
 
     void slotRunEtagJob();
     void etagRetreived(const QString &);

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -87,7 +87,7 @@ class Folder : public QObject
     Q_OBJECT
 
 public:
-    Folder(const FolderDefinition& definition, QObject* parent = 0L);
+    Folder(const FolderDefinition& definition, AccountState* accountState, QObject* parent = 0L);
 
     ~Folder();
 
@@ -97,8 +97,7 @@ public:
     /**
      * The account the folder is configured on.
      */
-    void setAccountState( AccountState *account );
-    AccountState* accountState() const;
+    AccountState* accountState() const { return _accountState.data(); }
 
     /**
      * alias or nickname
@@ -281,7 +280,7 @@ private:
     void createGuiLog(const QString& filename, SyncFileStatus status, int count,
                        const QString& renameTarget = QString::null );
 
-    QPointer<AccountState> _accountState;
+    AccountStatePtr _accountState;
     FolderDefinition _definition;
 
     SyncResult _syncResult;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -26,15 +26,8 @@
 
 #include <csync.h>
 
-#include <QDir>
-#include <QHash>
-#include <QSet>
 #include <QObject>
 #include <QStringList>
-
-#include <QDebug>
-#include <QTimer>
-#include <qelapsedtimer.h>
 
 class QThread;
 class QSettings;
@@ -181,8 +174,7 @@ public:
 
      // Used by the Socket API
      SyncJournalDb *journalDb() { return &_journal; }
-
-     bool estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s);
+     SyncEngine &syncEngine() { return *_engine; }
 
      RequestEtagJob *etagJob() { return _requestEtagJob; }
      qint64 msecSinceLastSync() const { return _timeSinceLastSyncDone.elapsed(); }
@@ -262,7 +254,6 @@ private slots:
     void etagRetreived(const QString &);
     void etagRetreivedFromSyncEngine(const QString &);
 
-    void slotAboutToPropagate(SyncFileItemVector& );
     void slotThreadTreeWalkResult(const SyncFileItemVector& ); // after sync is done
 
     void slotEmitFinishedDelayed();
@@ -303,15 +294,6 @@ private:
     /// The number of requested follow-up syncs.
     /// Reset when no follow-up is requested.
     int           _consecutiveFollowUpSyncs;
-
-    // SocketAPI: Cache files and folders that had errors so that they can
-    // get a red ERROR icon.
-    QSet<QString>   _stateLastSyncItemsWithErrorNew; // gets moved to _stateLastSyncItemsWithError at end of sync
-    QSet<QString>   _stateLastSyncItemsWithError;
-
-    // SocketAPI: A folder is tained if we got a file watcher notification
-    // for it. It's displayed as EVAL.
-    QSet<QString>   _stateTaintedFolders;
 
     SyncJournalDb _journal;
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -147,9 +147,6 @@ void FolderMan::registerFolderMonitor( Folder *folder )
         // is lost this way, but we do not need it for the current implementation.
         connect(fw, SIGNAL(pathChanged(QString)), folder, SLOT(slotWatchedPathChanged(QString)));
         _folderWatchers.insert(folder->alias(), fw);
-
-        // This is at the moment only for the behaviour of the SocketApi.
-        connect(fw, SIGNAL(pathChanged(QString)), folder, SLOT(watcherSlot(QString)));
     }
 
     // register the folder with the socket API

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -105,6 +105,8 @@ void FolderMan::unloadFolder( Folder *f )
                this, SLOT(slotForwardFolderSyncStateChange()));
     disconnect(f, SIGNAL(syncPausedChanged(Folder*,bool)),
                this, SLOT(slotFolderSyncPaused(Folder*,bool)));
+    disconnect(&f->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
+               _socketApi.data(), SLOT(slotFileStatusChanged(const QString &, SyncFileStatus)));
 }
 
 int FolderMan::unloadAndDeleteAllFolders()
@@ -796,6 +798,8 @@ Folder* FolderMan::addFolderInternal(const FolderDefinition& folderDefinition, A
     connect(folder, SIGNAL(syncFinished(SyncResult)), SLOT(slotFolderSyncFinished(SyncResult)));
     connect(folder, SIGNAL(syncStateChange()), SLOT(slotForwardFolderSyncStateChange()));
     connect(folder, SIGNAL(syncPausedChanged(Folder*,bool)), SLOT(slotFolderSyncPaused(Folder*,bool)));
+    connect(&folder->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
+            _socketApi.data(), SLOT(slotFileStatusChanged(const QString &, SyncFileStatus)));
 
     registerFolderMonitor(folder);
     return folder;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -206,9 +206,8 @@ int FolderMan::setupFolders()
         foreach (const auto& folderAlias, settings->childGroups()) {
             FolderDefinition folderDefinition;
             if (FolderDefinition::load(*settings, folderAlias, &folderDefinition)) {
-                Folder* f = addFolderInternal(folderDefinition);
+                Folder* f = addFolderInternal(folderDefinition, account.data());
                 if (f) {
-                    f->setAccountState( account.data() );
                     slotScheduleSync(f);
                     emit folderSyncStateChange(f);
                 }
@@ -395,10 +394,8 @@ Folder* FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountStat
     folderDefinition.paused = paused;
     folderDefinition.ignoreHiddenFiles = ignoreHiddenFiles();
 
-    folder = addFolderInternal(folderDefinition);
+    folder = addFolderInternal(folderDefinition, accountState);
     if (folder) {
-        folder->setAccountState(accountState);
-
         QStringList blackList = settings.value( QLatin1String("blackList")).toStringList();
         if (!blackList.empty()) {
             //migrate settings
@@ -786,9 +783,8 @@ Folder* FolderMan::addFolder(AccountState* accountState, const FolderDefinition&
         return 0;
     }
 
-    auto folder = addFolderInternal(folderDefinition);
-    if(folder && accountState) {
-        folder->setAccountState(accountState);
+    auto folder = addFolderInternal(folderDefinition, accountState);
+    if(folder) {
         folder->saveToSettings();
         emit folderSyncStateChange(folder);
         emit folderListChanged(_folderMap);
@@ -796,9 +792,9 @@ Folder* FolderMan::addFolder(AccountState* accountState, const FolderDefinition&
     return folder;
 }
 
-Folder* FolderMan::addFolderInternal(const FolderDefinition& folderDefinition)
+Folder* FolderMan::addFolderInternal(const FolderDefinition& folderDefinition, AccountState* accountState)
 {
-    auto folder = new Folder(folderDefinition, this );
+    auto folder = new Folder(folderDefinition, accountState, this );
 
     qDebug() << "Adding folder to Folder Map " << folder;
     _folderMap[folder->alias()] = folder;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -19,7 +19,6 @@
 #include <QObject>
 #include <QQueue>
 #include <QList>
-#include <QPointer>
 
 #include "folder.h"
 #include "folderwatcher.h"
@@ -228,7 +227,7 @@ private:
     QPointer<RequestEtagJob>        _currentEtagJob; // alias of Folder running the current RequestEtagJob
 
     QMap<QString, FolderWatcher*> _folderWatchers;
-    QPointer<SocketApi> _socketApi;
+    QScopedPointer<SocketApi> _socketApi;
 
     /** The aliases of folders that shall be synced. */
     QQueue<Folder*> _scheduleQueue;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -202,7 +202,7 @@ private:
     /** Adds a new folder, does not add it to the account settings and
      *  does not set an account on the new folder.
       */
-    Folder* addFolderInternal(const FolderDefinition& folderDefinition);
+    Folder* addFolderInternal(const FolderDefinition& folderDefinition, AccountState* accountState);
 
     /* unloads a folder object, does not delete it */
     void unloadFolder( Folder * );

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -350,7 +350,7 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
     bool onePaused = false;
     bool allPaused = true;
     foreach (Folder* folder, folderMan->map()) {
-        if (folder->accountState() != accountState) {
+        if (folder->accountState() != accountState.data()) {
             continue;
         }
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -35,6 +35,7 @@
 #include "creds/abstractcredentials.h"
 
 #include <QDesktopServices>
+#include <QDir>
 #include <QMessageBox>
 #include <QSignalMapper>
 

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -35,7 +35,6 @@ class ShareDialog;
 class Application;
 class LogBrowser;
 class AccountState;
-typedef QSharedPointer<AccountState> AccountStatePtr;
 
 /**
  * @brief The ownCloudGui class

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -14,6 +14,7 @@
 #include "selectivesyncdialog.h"
 #include "folder.h"
 #include "account.h"
+#include "excludedfiles.h"
 #include "networkjobs.h"
 #include "theme.h"
 #include "folderman.h"
@@ -176,21 +177,11 @@ void SelectiveSyncTreeView::slotUpdateDirectories(QStringList list)
         pathToRemove.append('/');
 
     // Check for excludes.
-    //
-    // We would like to use Folder::isFileExcluded, but the folder doesn't
-    // exist yet. So we just create one temporarily...
-    FolderDefinition def;
-    def.localPath = pathToRemove;
-    def.ignoreHiddenFiles = FolderMan::instance()->ignoreHiddenFiles();
-    Folder f(def);
     QMutableListIterator<QString> it(list);
     while (it.hasNext()) {
         it.next();
-        QString path = it.value();
-        path.remove(pathToRemove);
-        if (f.isFileExcludedRelative(path)) {
+        if (ExcludedFiles::instance().isExcluded(it.value(), pathToRemove, FolderMan::instance()->ignoreHiddenFiles()))
             it.remove();
-        }
     }
 
     // Since / cannot be in the blacklist, expand it to the actual

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -330,8 +330,7 @@ void SocketApi::command_SHARE(const QString& localFile, QIODevice* socket)
         SyncFileStatus fileStatus = shareFolder->syncEngine().syncFileStatusTracker().fileStatus(file);
 
         // Verify the file is on the server (to our knowledge of course)
-        if (fileStatus.tag() != SyncFileStatus::STATUS_UPTODATE &&
-            fileStatus.tag() != SyncFileStatus::STATUS_UPDATED) {
+        if (fileStatus.tag() != SyncFileStatus::StatusUpToDate) {
             const QString message = QLatin1String("SHARE:NOTSYNCED:")+QDir::toNativeSeparators(localFile);
             sendMessage(socket, message);
             return;
@@ -386,8 +385,7 @@ void SocketApi::command_SHARE_STATUS(const QString &localFile, QIODevice *socket
         SyncFileStatus fileStatus = shareFolder->syncEngine().syncFileStatusTracker().fileStatus(file);
 
         // Verify the file is on the server (to our knowledge of course)
-        if (fileStatus.tag() != SyncFileStatus::STATUS_UPTODATE &&
-            fileStatus.tag() != SyncFileStatus::STATUS_UPDATED) {
+        if (fileStatus.tag() != SyncFileStatus::StatusUpToDate) {
             const QString message = QLatin1String("SHARE_STATUS:NOTSYNCED:")+QDir::toNativeSeparators(localFile);
             sendMessage(socket, message);
             return;

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -679,17 +679,9 @@ SyncFileStatus SocketApi::fileStatus(Folder *folder, const QString& systemFileNa
         }
     }
 
-    if (rec.isValid()) {
-        if (rec._remotePerm.isNull()) {
-            // probably owncloud 6, that does not have permissions flag yet.
-            QString url = folder->remoteUrl().toString() + fileName;
-            if (url.contains( folder->accountState()->account()->davPath() + QLatin1String("Shared/") )) {
-                status.setSharedWithMe(true);
-            }
-        } else if (rec._remotePerm.contains("S")) {
-            status.setSharedWithMe(true);
-        }
-    }
+    if (rec.isValid() && rec._remotePerm.contains("S"))
+        status.setSharedWithMe(true);
+
     if (status.tag() == SyncFileStatus::STATUS_NEW) {
         // check the parent folder if it is shared and if it is allowed to create a file/dir within
         QDir d( fi.path() );

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -45,7 +45,7 @@ class SocketApi : public QObject
 Q_OBJECT
 
 public:
-    SocketApi(QObject* parent = 0);
+    explicit SocketApi(QObject* parent = 0);
     virtual ~SocketApi();
 
 public slots:

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -60,12 +60,9 @@ private slots:
     void slotNewConnection();
     void onLostConnection();
     void slotReadSocket();
-    void slotItemCompleted(const QString &, const SyncFileItem &);
-    void slotSyncItemDiscovered(const QString &, const SyncFileItem &);
+    void slotFileStatusChanged(const QString& systemFileName, SyncFileStatus fileStatus);
 
 private:
-    SyncFileStatus fileStatus(Folder *folder, const QString& systemFileName);
-
     void sendMessage(QIODevice* socket, const QString& message, bool doWait = false);
     void broadcastMessage(const QString& verb, const QString &path, const QString &status = QString::null, bool doWait = false);
 

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -44,7 +44,7 @@ class SocketApi : public QObject
 Q_OBJECT
 
 public:
-    SocketApi(QObject* parent);
+    SocketApi(QObject* parent = 0);
     virtual ~SocketApi();
 
 public slots:

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -17,6 +17,7 @@
 #define SOCKETAPI_H
 
 #include "syncfileitem.h"
+#include "syncfilestatus.h"
 #include "ownsql.h"
 
 #if defined(Q_OS_MAC)

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -17,7 +17,6 @@
 #define SOCKETAPI_H
 
 #include "syncfileitem.h"
-#include "syncjournalfilerecord.h"
 #include "ownsql.h"
 
 #if defined(Q_OS_MAC)
@@ -66,8 +65,6 @@ private slots:
 
 private:
     SyncFileStatus fileStatus(Folder *folder, const QString& systemFileName);
-    SyncJournalFileRecord dbFileRecord_capi( Folder *folder, QString fileName );
-    SqlQuery *getSqlQuery( Folder *folder );
 
     void sendMessage(QIODevice* socket, const QString& message, bool doWait = false);
     void broadcastMessage(const QString& verb, const QString &path, const QString &status = QString::null, bool doWait = false);
@@ -84,8 +81,6 @@ private:
 
     QList<QIODevice*> _listeners;
     SocketApiServer _localServer;
-    QHash<Folder*, QSharedPointer<SqlQuery>> _dbQueries;
-    QHash<Folder*, QSharedPointer<SqlDatabase>> _openDbs;
 };
 
 }

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -56,6 +56,7 @@ set(libsync_SRCS
     propagateremotemkdir.cpp
     syncengine.cpp
     syncfilestatus.cpp
+    syncfilestatustracker.cpp
     syncjournaldb.cpp
     syncjournalfilerecord.cpp
     syncresult.cpp

--- a/src/libsync/accountfwd.h
+++ b/src/libsync/accountfwd.h
@@ -21,7 +21,7 @@ namespace OCC {
 class Account;
 typedef QSharedPointer<Account> AccountPtr;
 class AccountState;
-typedef QSharedPointer<AccountState> AccountStatePtr;
+typedef QExplicitlySharedDataPointer<AccountState> AccountStatePtr;
 
 } // namespace OCC
 

--- a/src/libsync/excludedfiles.cpp
+++ b/src/libsync/excludedfiles.cpp
@@ -14,8 +14,6 @@
 #include "excludedfiles.h"
 
 #include <QFileInfo>
-#include <QReadLocker>
-#include <QWriteLocker>
 
 extern "C" {
 #include "std/c_string.h"
@@ -44,13 +42,11 @@ ExcludedFiles& ExcludedFiles::instance()
 
 void ExcludedFiles::addExcludeFilePath(const QString& path)
 {
-    QWriteLocker locker(&_mutex);
     _excludeFiles.append(path);
 }
 
 bool ExcludedFiles::reloadExcludes()
 {
-    QWriteLocker locker(&_mutex);
     c_strlist_destroy(*_excludesPtr);
     *_excludesPtr = NULL;
 
@@ -89,6 +85,5 @@ bool ExcludedFiles::isExcluded(
         relativePath.chop(1);
     }
 
-    QReadLocker lock(&_mutex);
     return csync_excluded_no_ctx(*_excludesPtr, relativePath.toUtf8(), type) != CSYNC_NOT_EXCLUDED;
 }

--- a/src/libsync/excludedfiles.h
+++ b/src/libsync/excludedfiles.h
@@ -16,7 +16,6 @@
 #include "owncloudlib.h"
 
 #include <QObject>
-#include <QReadWriteLock>
 #include <QStringList>
 
 extern "C" {
@@ -68,7 +67,6 @@ private:
     // but the pointer can be in a csync_context so that it can itself also query the list.
     c_strlist_t** _excludesPtr;
     QStringList _excludeFiles;
-    mutable QReadWriteLock _mutex;
 };
 
 } // namespace OCC

--- a/src/libsync/excludedfiles.h
+++ b/src/libsync/excludedfiles.h
@@ -49,14 +49,12 @@ public:
     /**
      * Checks whether a file or directory should be excluded.
      *
-     * @param fullPath     the absolute path to the file
-     * @param relativePath path relative to the folder
-     *
-     * For directories, the paths must not contain a trailing /.
+     * @param filePath     the absolute path to the file
+     * @param basePath     folder path from which to apply exclude rules
      */
-    CSYNC_EXCLUDE_TYPE isExcluded(
-            const QString& fullPath,
-            const QString& relativePath,
+    bool isExcluded(
+            const QString& filePath,
+            const QString& basePath,
             bool excludeHidden) const;
 
 public slots:

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -239,8 +239,6 @@ signals:
                        const SyncFileItem & item,
                        const PropagatorJob & job);
 
-    void syncItemDiscovered(const QString &folder, const SyncFileItem & item);
-
 protected:
     void setProgressInfo(const QString& folder, const ProgressInfo& progress);
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -93,6 +93,7 @@ SyncEngine::SyncEngine(AccountPtr account, const QString& localPath,
     csync_create(&_csync_ctx, localPath.toUtf8().data(), url_string.toUtf8().data());
     csync_init(_csync_ctx);
     _excludedFiles.reset(new ExcludedFiles(&_csync_ctx->excludes));
+    _syncFileStatusTracker.reset(new SyncFileStatusTracker(this));
 
     _thread.setObjectName("SyncEngine_Thread");
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1306,33 +1306,14 @@ void SyncEngine::restoreOldFiles()
     }
 }
 
-bool SyncEngine::estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s)
+SyncFileItem* SyncEngine::findSyncItem(const QString &fileName) const
 {
-    Q_UNUSED(t);
-    QString pat(fn);
-    if( t == CSYNC_FTW_TYPE_DIR && ! fn.endsWith(QLatin1Char('/'))) {
-        pat.append(QLatin1Char('/'));
-    }
-
     Q_FOREACH(const SyncFileItemPtr &item, _syncedItems) {
-        //qDebug() << Q_FUNC_INFO << fn << item->_status << item->_file << fn.startsWith(item->_file) << item->_file.startsWith(fn);
-
-        if (item->_file.startsWith(pat) ||
-                item->_file == fn || item->_renameTarget == fn /* the same directory or file */) {
-            if (item->_status == SyncFileItem::NormalError
-                || item->_status == SyncFileItem::FatalError)
-                s->set(SyncFileStatus::StatusError);
-            else if (item->_status == SyncFileItem::FileIgnored)
-                s->set(SyncFileStatus::StatusIgnore);
-            else if (item->_status == SyncFileItem::Success)
-                s->set(SyncFileStatus::StatusUpToDate);
-            else
-                s->set(SyncFileStatus::StatusSync);
-            qDebug() << Q_FUNC_INFO << "Setting" << fn << "to" << s->toSocketAPIString();
-            return true;
-        }
+        // Directories will appear in this list as well, and will get their status set once all children have been propagated
+        if ((item->_file == fileName || item->_renameTarget == fileName))
+            return item.data();
     }
-    return false;
+    return 0;
 }
 
 qint64 SyncEngine::timeSinceFileTouched(const QString& fn) const

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1321,13 +1321,13 @@ bool SyncEngine::estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s
                 item->_file == fn || item->_renameTarget == fn /* the same directory or file */) {
             if (item->_status == SyncFileItem::NormalError
                 || item->_status == SyncFileItem::FatalError)
-                s->set(SyncFileStatus::STATUS_ERROR);
+                s->set(SyncFileStatus::StatusError);
             else if (item->_status == SyncFileItem::FileIgnored)
-                s->set(SyncFileStatus::STATUS_IGNORE);
+                s->set(SyncFileStatus::StatusIgnore);
             else if (item->_status == SyncFileItem::Success)
-                s->set(SyncFileStatus::STATUS_UPDATED);
+                s->set(SyncFileStatus::StatusUpToDate);
             else
-                s->set(SyncFileStatus::STATUS_EVAL);
+                s->set(SyncFileStatus::StatusSync);
             qDebug() << Q_FUNC_INFO << "Setting" << fn << "to" << s->toSocketAPIString();
             return true;
         }

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -69,6 +69,8 @@ public:
     /* Abort the sync.  Called from the main thread */
     void abort();
 
+    bool isSyncRunning() const { return _syncRunning; }
+
     /* Set the maximum size a folder can have without asking for confirmation
      * -1 means infinite
      */
@@ -168,7 +170,7 @@ private:
     // cleanup and emit the finished signal
     void finalize(bool success);
 
-    static bool _syncRunning; //true when one sync is running somewhere (for debugging)
+    static bool s_anySyncRunning; //true when one sync is running somewhere (for debugging)
 
     // Must only be acessed during update and reconcile
     QMap<QString, SyncFileItemPtr> _syncItemMap;
@@ -180,6 +182,7 @@ private:
     AccountPtr _account;
     CSYNC *_csync_ctx;
     bool _needsUpdate;
+    bool _syncRunning;
     QString _localPath;
     QUrl _remoteUrl;
     QString _remotePath;

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -85,7 +85,7 @@ public:
     /* Return true if we detected that another sync is needed to complete the sync */
     bool isAnotherSyncNeeded() { return _anotherSyncNeeded; }
 
-    bool estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s);
+    SyncFileItem* findSyncItem(const QString &fileName) const;
 
     /** Get the ms since a file was touched, or -1 if it wasn't.
      *

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -35,7 +35,7 @@
 #include "syncfileitem.h"
 #include "progressdispatcher.h"
 #include "utility.h"
-#include "syncfilestatus.h"
+#include "syncfilestatustracker.h"
 #include "accountfwd.h"
 #include "discoveryphase.h"
 #include "checksums.h"
@@ -75,10 +75,12 @@ public:
      * -1 means infinite
      */
     void setNewBigFolderSizeLimit(qint64 limit) { _newBigFolderSizeLimit = limit; }
+    bool ignoreHiddenFiles() const { return _csync_ctx->ignore_hidden_files; }
     void setIgnoreHiddenFiles(bool ignore) { _csync_ctx->ignore_hidden_files = ignore; }
 
     ExcludedFiles &excludedFiles() { return *_excludedFiles; }
     Utility::StopWatch &stopWatch() { return _stopWatch; }
+    SyncFileStatusTracker &syncFileStatusTracker() { return *_syncFileStatusTracker; }
 
     /* Return true if we detected that another sync is needed to complete the sync */
     bool isAnotherSyncNeeded() { return _anotherSyncNeeded; }
@@ -93,7 +95,7 @@ public:
 
     AccountPtr account() const;
     SyncJournalDb *journal() const { return _journal; }
-
+    QString localPath() const { return _localPath; }
     /**
      * Minimum age, in milisecond, of a file that can be uploaded.
      * Files more recent than that are not going to be uploaeded as they are considered
@@ -211,6 +213,7 @@ private:
     QScopedPointer<ProgressInfo> _progressInfo;
 
     QScopedPointer<ExcludedFiles> _excludedFiles;
+    QScopedPointer<SyncFileStatusTracker> _syncFileStatusTracker;
     Utility::StopWatch _stopWatch;
 
     // maps the origin and the target of the folders that have been renamed

--- a/src/libsync/syncfilestatus.cpp
+++ b/src/libsync/syncfilestatus.cpp
@@ -59,7 +59,8 @@ QString SyncFileStatus::toSocketAPIString() const
     case StatusSync:
         statusString = QLatin1String("SYNC");
         break;
-    case StatusIgnore:
+    case StatusWarning:
+        // The protocol says IGNORE, but all implementations show a yellow warning sign.
         statusString = QLatin1String("IGNORE");
         break;
     case StatusUpToDate:

--- a/src/libsync/syncfilestatus.cpp
+++ b/src/libsync/syncfilestatus.cpp
@@ -17,7 +17,7 @@
 
 namespace OCC {
 SyncFileStatus::SyncFileStatus()
-    :_tag(STATUS_NONE), _sharedWithMe(false)
+    :_tag(StatusNone), _sharedWithMe(false)
 {
 }
 
@@ -53,30 +53,21 @@ QString SyncFileStatus::toSocketAPIString() const
 
     switch(_tag)
     {
-    case STATUS_NONE:
+    case StatusNone:
         statusString = QLatin1String("NONE");
         break;
-    case STATUS_EVAL:
+    case StatusSync:
         statusString = QLatin1String("SYNC");
         break;
-    case STATUS_NEW:
-        statusString = QLatin1String("NEW");
-        break;
-    case STATUS_IGNORE:
+    case StatusIgnore:
         statusString = QLatin1String("IGNORE");
         break;
-    case STATUS_UPTODATE:
-    case STATUS_UPDATED:
+    case StatusUpToDate:
         statusString = QLatin1String("OK");
         break;
-    case STATUS_STAT_ERROR:
-    case STATUS_ERROR:
+    case StatusError:
         statusString = QLatin1String("ERROR");
         break;
-    default:
-        qWarning() << "This status should not be here:" << _tag;
-        Q_ASSERT(false);
-        statusString = QLatin1String("NONE");
     }
     if(_sharedWithMe) {
         statusString += QLatin1String("+SWM");

--- a/src/libsync/syncfilestatus.h
+++ b/src/libsync/syncfilestatus.h
@@ -28,18 +28,11 @@ class OWNCLOUDSYNC_EXPORT SyncFileStatus
 {
 public:
     enum SyncFileStatusTag {
-        STATUS_NONE,
-        STATUS_EVAL,
-        STATUS_REMOVE,
-        STATUS_RENAME,
-        STATUS_MOVE,
-        STATUS_NEW,
-        STATUS_CONFLICT,
-        STATUS_IGNORE,
-        STATUS_UPTODATE,
-        STATUS_STAT_ERROR,
-        STATUS_ERROR,
-        STATUS_UPDATED
+        StatusNone,
+        StatusSync,
+        StatusIgnore,
+        StatusUpToDate,
+        StatusError,
     };
 
     SyncFileStatus();

--- a/src/libsync/syncfilestatus.h
+++ b/src/libsync/syncfilestatus.h
@@ -30,7 +30,7 @@ public:
     enum SyncFileStatusTag {
         StatusNone,
         StatusSync,
-        StatusIgnore,
+        StatusWarning,
         StatusUpToDate,
         StatusError,
     };

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -26,11 +26,12 @@ static SyncFileStatus::SyncFileStatusTag lookupProblem(const QString &pathToMatc
         const QString &problemPath = it->first;
         SyncFileStatus::SyncFileStatusTag severity = it->second;
         // qDebug() << Q_FUNC_INFO << pathToMatch << severity << problemPath;
-        if (problemPath == pathToMatch)
+        if (problemPath == pathToMatch) {
             return severity;
-        else if (severity == SyncFileStatus::StatusError && problemPath.startsWith(pathToMatch))
+        } else if (severity == SyncFileStatus::StatusError && problemPath.startsWith(pathToMatch) && problemPath.at(pathToMatch.size()) == '/') {
+            Q_ASSERT(!pathToMatch.endsWith('/'));
             return SyncFileStatus::StatusWarning;
-        else if (!problemPath.startsWith(pathToMatch))
+        } else if (!problemPath.startsWith(pathToMatch)) {
             // Starting at lower_bound we get the first path that is not smaller,
             // since: "/a/" < "/a/aa" < "/a/aa/aaa" < "/a/ab/aba"
             // If problemMap keys are ["/a/aa/aaa", "/a/ab/aba"] and pathToMatch == "/a/aa",
@@ -38,6 +39,7 @@ static SyncFileStatus::SyncFileStatusTag lookupProblem(const QString &pathToMatc
             // problemPath.startsWith(pathToMatch) == false, we know that we've looked
             // at everything that interest us.
             break;
+        }
     }
     return SyncFileStatus::StatusNone;
 }

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -110,13 +110,7 @@ void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector& items)
         else if (showWarningInSocketApi(*item))
             _syncProblems[item->_file] = SyncFileStatus::StatusWarning;
 
-        QString systemFileName = _syncEngine->localPath() + item->destination();
-        // the trailing slash for directories must be appended as the filenames coming in
-        // from the plugins have that too. Otherwise the matching entry item is not found
-        // in the plugin.
-        if( item->_type == SyncFileItem::Type::Directory )
-            systemFileName += QLatin1Char('/');
-        emit fileStatusChanged(systemFileName, fileStatus(*item));
+        emit fileStatusChanged(getSystemDestination(*item), fileStatus(*item));
     }
 
     // Make sure to push any status that might have been resolved indirectly since the last sync
@@ -146,14 +140,7 @@ void SyncFileStatusTracker::slotItemCompleted(const SyncFileItem &item)
         Q_ASSERT(_syncProblems.find(item._file) == _syncProblems.end());
     }
 
-    QString systemFileName = _syncEngine->localPath() + item.destination();
-    // the trailing slash for directories must be appended as the filenames coming in
-    // from the plugins have that too. Otherwise the matching entry item is not found
-    // in the plugin.
-    if( item._type == SyncFileItem::Type::Directory ) {
-        systemFileName += QLatin1Char('/');
-    }
-    emit fileStatusChanged(systemFileName, fileStatus(item));
+    emit fileStatusChanged(getSystemDestination(item), fileStatus(item));
 }
 
 SyncFileStatus SyncFileStatusTracker::fileStatus(const SyncFileItem& item)
@@ -189,6 +176,18 @@ void SyncFileStatusTracker::invalidateParentPaths(const QString& path)
         QString parentPath = splitPath.mid(0, i).join('/');
         emit fileStatusChanged(_syncEngine->localPath() + parentPath, fileStatus(parentPath));
     }
+}
+
+QString SyncFileStatusTracker::getSystemDestination(const SyncFileItem& item)
+{
+    QString systemFileName = _syncEngine->localPath() + item.destination();
+    // the trailing slash for directories must be appended as the filenames coming in
+    // from the plugins have that too. Otherwise the matching entry item is not found
+    // in the plugin.
+    if( item._type == SyncFileItem::Type::Directory ) {
+        systemFileName += QLatin1Char('/');
+    }
+    return systemFileName;
 }
 
 }

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -86,6 +86,15 @@ SyncFileStatus SyncFileStatusTracker::fileStatus(const QString& systemFileName)
         qDebug() << "Removed trailing slash: " << fileName;
     }
 
+    // The SyncEngine won't notify us at all for CSYNC_FILE_SILENTLY_EXCLUDED
+    // and CSYNC_FILE_EXCLUDE_AND_REMOVE excludes. Even though it's possible
+    // that the status of CSYNC_FILE_EXCLUDE_LIST excludes will change if the user
+    // update the exclude list at runtime and doing it statically here removes
+    // our ability to notify changes through the fileStatusChanged signal,
+    // it's an acceptable compromize to treat all exclude types the same.
+    if( _syncEngine->excludedFiles().isExcluded(_syncEngine->localPath() + fileName, _syncEngine->localPath(), _syncEngine->ignoreHiddenFiles()) )
+        return SyncFileStatus(SyncFileStatus::StatusWarning);
+
     SyncFileItem* item = _syncEngine->findSyncItem(fileName);
     if (item)
         return fileStatus(*item);

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "syncfilestatustracker.h"
+#include "filesystem.h"
+#include "syncengine.h"
+#include "syncjournaldb.h"
+#include "syncjournalfilerecord.h"
+#include "utility.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+namespace OCC {
+
+/**
+ * Whether this item should get an ERROR icon through the Socket API.
+ *
+ * The Socket API should only present serious, permanent errors to the user.
+ * In particular SoftErrors should just retain their 'needs to be synced'
+ * icon as the problem is most likely going to resolve itself quickly and
+ * automatically.
+ */
+static bool showErrorInSocketApi(const SyncFileItem& item)
+{
+    const auto status = item._status;
+    return status == SyncFileItem::NormalError
+        || status == SyncFileItem::FatalError;
+}
+
+static void addErroredSyncItemPathsToList(const SyncFileItemVector& items, QSet<QString>* set) {
+    foreach (const SyncFileItemPtr &item, items) {
+        if (showErrorInSocketApi(*item)) {
+            set->insert(item->_file);
+        }
+    }
+}
+
+SyncFileStatusTracker::SyncFileStatusTracker(SyncEngine *syncEngine)
+    : _syncEngine(syncEngine)
+{
+    connect(syncEngine, SIGNAL(treeWalkResult(const SyncFileItemVector&)),
+              this, SLOT(slotThreadTreeWalkResult(const SyncFileItemVector&)));
+    connect(syncEngine, SIGNAL(aboutToPropagate(SyncFileItemVector&)),
+              this, SLOT(slotAboutToPropagate(SyncFileItemVector&)));
+    connect(syncEngine, SIGNAL(finished(bool)), SLOT(slotSyncFinished()));
+    connect(syncEngine, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
+            this, SLOT(slotItemCompleted(const SyncFileItem &)));
+}
+
+bool SyncFileStatusTracker::estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s)
+{
+    if (t == CSYNC_FTW_TYPE_DIR) {
+        if (Utility::doesSetContainPrefix(_stateLastSyncItemsWithError, fn)) {
+            qDebug() << Q_FUNC_INFO << "Folder has error" << fn;
+            s->set(SyncFileStatus::STATUS_ERROR);
+            return true;
+        }
+        // If sync is running, check _syncedItems, possibly give it STATUS_EVAL (=syncing down)
+        if (_syncEngine->isSyncRunning()) {
+            if (_syncEngine->estimateState(fn, t, s)) {
+                return true;
+            }
+        }
+        return false;
+    } else if ( t== CSYNC_FTW_TYPE_FILE) {
+        // check if errorList has the directory/file
+        if (Utility::doesSetContainPrefix(_stateLastSyncItemsWithError, fn)) {
+            s->set(SyncFileStatus::STATUS_ERROR);
+            return true;
+        }
+        // If sync running: _syncedItems -> SyncingState
+        if (_syncEngine->isSyncRunning()) {
+            if (_syncEngine->estimateState(fn, t, s)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+
+/**
+ * Get status about a single file.
+ */
+SyncFileStatus SyncFileStatusTracker::fileStatus(const QString& systemFileName)
+{
+    QString file = _syncEngine->localPath();
+    QString fileName = systemFileName.normalized(QString::NormalizationForm_C);
+    QString fileNameSlash = fileName;
+
+    if(fileName != QLatin1String("/") && !fileName.isEmpty()) {
+        file += fileName;
+    }
+
+    if( fileName.endsWith(QLatin1Char('/')) ) {
+        fileName.truncate(fileName.length()-1);
+        qDebug() << "Removed trailing slash: " << fileName;
+    } else {
+        fileNameSlash += QLatin1Char('/');
+    }
+
+    const QFileInfo fi(file);
+    if( !FileSystem::fileExists(file, fi) ) {
+        qDebug() << "OO File " << file << " is not existing";
+        return SyncFileStatus(SyncFileStatus::STATUS_STAT_ERROR);
+    }
+
+    // file is ignored?
+    // Qt considers .lnk files symlinks on Windows so we need to work
+    // around that here.
+    if( fi.isSymLink()
+#ifdef Q_OS_WIN
+            && fi.suffix() != "lnk"
+#endif
+            ) {
+        return SyncFileStatus(SyncFileStatus::STATUS_IGNORE);
+    }
+
+    csync_ftw_type_e type = CSYNC_FTW_TYPE_FILE;
+    if( fi.isDir() ) {
+        type = CSYNC_FTW_TYPE_DIR;
+    }
+
+    // Is it excluded?
+    if( _syncEngine->excludedFiles().isExcluded(file, _syncEngine->localPath(), _syncEngine->ignoreHiddenFiles()) ) {
+        return SyncFileStatus(SyncFileStatus::STATUS_IGNORE);
+    }
+
+    // Error if it is in the selective sync blacklist
+    foreach(const auto &s, _syncEngine->journal()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList)) {
+        if (fileNameSlash.startsWith(s)) {
+            return SyncFileStatus(SyncFileStatus::STATUS_ERROR);
+        }
+    }
+
+    SyncFileStatus status(SyncFileStatus::STATUS_NONE);
+    SyncJournalFileRecord rec = _syncEngine->journal()->getFileRecord(fileName );
+
+    if (estimateState(fileName, type, &status)) {
+        qDebug() << "Folder estimated status for" << fileName << "to" << status.toSocketAPIString();
+    } else if (fileName == "") {
+        // sync folder itself
+        // FIXME: The new parent folder logic should take over this, treating the root the same as any folder.
+    } else if (type == CSYNC_FTW_TYPE_DIR) {
+        if (rec.isValid()) {
+            status.set(SyncFileStatus::STATUS_UPTODATE);
+        } else {
+            qDebug() << "Could not determine state for folder" << fileName << "will set STATUS_NEW";
+            status.set(SyncFileStatus::STATUS_NEW);
+        }
+    } else if (type == CSYNC_FTW_TYPE_FILE) {
+        if (rec.isValid()) {
+            if( FileSystem::getModTime(fi.absoluteFilePath()) == Utility::qDateTimeToTime_t(rec._modtime) ) {
+                status.set(SyncFileStatus::STATUS_UPTODATE);
+            } else {
+                if (rec._remotePerm.isNull() || rec._remotePerm.contains("W") ) {
+                    status.set(SyncFileStatus::STATUS_EVAL);
+                } else {
+                    status.set(SyncFileStatus::STATUS_ERROR);
+                }
+            }
+        } else {
+            qDebug() << "Could not determine state for file" << fileName << "will set STATUS_NEW";
+            status.set(SyncFileStatus::STATUS_NEW);
+        }
+    }
+
+    if (rec.isValid() && rec._remotePerm.contains("S"))
+        status.setSharedWithMe(true);
+
+    if (status.tag() == SyncFileStatus::STATUS_NEW) {
+        // check the parent folder if it is shared and if it is allowed to create a file/dir within
+        QDir d( fi.path() );
+        auto parentPath = d.path();
+        auto dirRec = _syncEngine->journal()->getFileRecord(parentPath);
+        bool isDir = type == CSYNC_FTW_TYPE_DIR;
+        while( !d.isRoot() && !(d.exists() && dirRec.isValid()) ) {
+            d.cdUp(); // returns true if the dir exists.
+
+            parentPath = d.path();
+            // cut the folder path
+            dirRec = _syncEngine->journal()->getFileRecord(parentPath);
+
+            isDir = true;
+        }
+        if( dirRec.isValid() && !dirRec._remotePerm.isNull()) {
+            if( (isDir && !dirRec._remotePerm.contains("K"))
+                    || (!isDir && !dirRec._remotePerm.contains("C")) ) {
+                status.set(SyncFileStatus::STATUS_ERROR);
+            }
+        }
+    }
+    return status;
+}
+
+void SyncFileStatusTracker::slotThreadTreeWalkResult(const SyncFileItemVector& items)
+{
+    addErroredSyncItemPathsToList(items, &_stateLastSyncItemsWithErrorNew);
+}
+
+void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector& items)
+{
+    addErroredSyncItemPathsToList(items, &_stateLastSyncItemsWithErrorNew);
+}
+
+void SyncFileStatusTracker::slotSyncFinished()
+{
+    _stateLastSyncItemsWithError = _stateLastSyncItemsWithErrorNew;
+    _stateLastSyncItemsWithErrorNew.clear();
+}
+
+void SyncFileStatusTracker::slotItemCompleted(const SyncFileItem &item)
+{
+    if (showErrorInSocketApi(item)) {
+        _stateLastSyncItemsWithErrorNew.insert(item._file);
+    }
+}
+
+}

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -25,7 +25,7 @@ static SyncFileStatus::SyncFileStatusTag lookupProblem(const QString &pathToMatc
     for (auto it = lower; it != problemMap.cend(); ++it) {
         const QString &problemPath = it->first;
         SyncFileStatus::SyncFileStatusTag severity = it->second;
-        qDebug() << Q_FUNC_INFO << pathToMatch << severity << problemPath;
+        // qDebug() << Q_FUNC_INFO << pathToMatch << severity << problemPath;
         if (problemPath == pathToMatch)
             return severity;
         else if (severity == SyncFileStatus::StatusError && problemPath.startsWith(pathToMatch))
@@ -103,7 +103,7 @@ void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector& items)
     std::swap(_syncProblems, oldProblems);
 
     foreach (const SyncFileItemPtr &item, items) {
-        qDebug() << Q_FUNC_INFO << "Investigating" << item->destination() << item->_status;
+        // qDebug() << Q_FUNC_INFO << "Investigating" << item->destination() << item->_status;
 
         if (showErrorInSocketApi(*item))
             _syncProblems[item->_file] = SyncFileStatus::StatusError;
@@ -134,7 +134,7 @@ void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector& items)
 
 void SyncFileStatusTracker::slotItemCompleted(const SyncFileItem &item)
 {
-    qDebug() << Q_FUNC_INFO << item.destination() << item._status;
+    // qDebug() << Q_FUNC_INFO << item.destination() << item._status;
 
     if (showErrorInSocketApi(item)) {
         _syncProblems[item._file] = SyncFileStatus::StatusError;

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -18,23 +18,11 @@
 #include "ownsql.h"
 #include "syncfileitem.h"
 #include "syncfilestatus.h"
-#include <set>
+#include <map>
 
 namespace OCC {
 
 class SyncEngine;
-
-struct Problem {
-    QString path;
-    SyncFileStatus::SyncFileStatusTag severity = SyncFileStatus::StatusError;
-
-    Problem(const QString &path) : path(path) { }
-    Problem(const QString &path, SyncFileStatus::SyncFileStatusTag severity) : path(path), severity(severity) { }
-
-    // Assume that each path will only have one severity, don't care about it in sorting
-    bool operator<(const Problem &other) const { return path < other.path; }
-    bool operator==(const Problem &other) const { return path == other.path; }
-};
 
 class OWNCLOUDSYNC_EXPORT SyncFileStatusTracker : public QObject
 {
@@ -54,7 +42,7 @@ private:
     SyncFileStatus fileStatus(const SyncFileItem& item);
     void invalidateParentPaths(const QString& path);
     SyncEngine* _syncEngine;
-    std::set<Problem> _syncProblems;
+    std::map<QString, SyncFileStatus::SyncFileStatusTag> _syncProblems;
 };
 
 }

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef SYNCFILESTATUSTRACKER_H
+#define SYNCFILESTATUSTRACKER_H
+
+#include "ownsql.h"
+#include "syncfileitem.h"
+#include "syncfilestatus.h"
+#include <QSet>
+#include <csync.h>
+
+namespace OCC {
+
+class SyncEngine;
+
+class OWNCLOUDSYNC_EXPORT SyncFileStatusTracker : public QObject
+{
+public:
+    SyncFileStatusTracker(SyncEngine *syncEngine);
+    SyncFileStatus fileStatus(const QString& systemFileName);
+
+private slots:
+    void slotThreadTreeWalkResult(const SyncFileItemVector& items);
+    void slotAboutToPropagate(SyncFileItemVector& items);
+    void slotSyncFinished();
+    void slotItemCompleted(const SyncFileItem &item);
+
+private:
+    bool estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s);
+
+    SyncEngine *_syncEngine;
+    // SocketAPI: Cache files and folders that had errors so that they can
+    // get a red ERROR icon.
+    QSet<QString>   _stateLastSyncItemsWithErrorNew; // gets moved to _stateLastSyncItemsWithError at end of sync
+    QSet<QString>   _stateLastSyncItemsWithError;
+};
+
+}
+
+#endif

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -46,6 +46,8 @@ private slots:
 private:
     SyncFileStatus fileStatus(const SyncFileItem& item);
     void invalidateParentPaths(const QString& path);
+    QString getSystemDestination(const SyncFileItem& syncEnginePath);
+
     SyncEngine* _syncEngine;
     std::map<QString, SyncFileStatus::SyncFileStatusTag> _syncProblems;
 };

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -24,11 +24,16 @@ namespace OCC {
 
 class SyncEngine;
 
+/**
+ * @brief Takes care of tracking the status of individual files as they
+ *        go through the SyncEngine, to be reported as overlay icons in the shell.
+ * @ingroup libsync
+ */
 class OWNCLOUDSYNC_EXPORT SyncFileStatusTracker : public QObject
 {
     Q_OBJECT
 public:
-    SyncFileStatusTracker(SyncEngine* syncEngine);
+    explicit SyncFileStatusTracker(SyncEngine* syncEngine);
     SyncFileStatus fileStatus(const QString& systemFileName);
 
 signals:

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -26,15 +26,20 @@ class SyncEngine;
 
 class OWNCLOUDSYNC_EXPORT SyncFileStatusTracker : public QObject
 {
+    Q_OBJECT
 public:
     SyncFileStatusTracker(SyncEngine *syncEngine);
     SyncFileStatus fileStatus(const QString& systemFileName);
+
+signals:
+    void fileStatusChanged(const QString& systemFileName, SyncFileStatus fileStatus);
 
 private slots:
     void slotThreadTreeWalkResult(const SyncFileItemVector& items);
     void slotAboutToPropagate(SyncFileItemVector& items);
     void slotSyncFinished();
     void slotItemCompleted(const SyncFileItem &item);
+    void slotItemDiscovered(const SyncFileItem &item);
 
 private:
     bool estimateState(QString fn, csync_ftw_type_e t, SyncFileStatus* s);

--- a/src/libsync/utility.cpp
+++ b/src/libsync/utility.cpp
@@ -236,18 +236,6 @@ QString Utility::toCSyncScheme(const QString &urlStr)
     return url.toString();
 }
 
-bool Utility::doesSetContainPrefix(const QSet<QString> &l, const QString &p) {
-
-    Q_FOREACH (const QString &setPath, l) {
-        //qDebug() << Q_FUNC_INFO << p << setPath << setPath.startsWith(p);
-        if (setPath.startsWith(p)) {
-            return true;
-        }
-    }
-    //qDebug() << "-> NOOOOO!!!" << p << l.count();
-    return false;
-}
-
 QString Utility::escape(const QString &in)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/src/libsync/utility.h
+++ b/src/libsync/utility.h
@@ -40,11 +40,6 @@ namespace Utility
     OWNCLOUDSYNC_EXPORT void setLaunchOnStartup(const QString &appName, const QString& guiName, bool launch);
     OWNCLOUDSYNC_EXPORT qint64 freeDiskSpace(const QString &path);
     OWNCLOUDSYNC_EXPORT QString toCSyncScheme(const QString &urlStr);
-    /** Like QLocale::toString(double, 'f', prec), but drops trailing zeros after the decimal point */
-
-    OWNCLOUDSYNC_EXPORT bool doesSetContainPrefix(const QSet<QString> &l, const QString &p);
-
-
 
     /**
      * @brief compactFormatDouble - formats a double value human readable.

--- a/test/testfolderman.h
+++ b/test/testfolderman.h
@@ -15,6 +15,7 @@
 
 #include "utility.h"
 #include "folderman.h"
+#include "account.h"
 #include "accountstate.h"
 
 using namespace OCC;
@@ -52,10 +53,11 @@ private slots:
             f.write("hello");
         }
 
+        AccountStatePtr newAccountState(new AccountState(Account::create()));
         FolderMan *folderman = FolderMan::instance();
         QCOMPARE(folderman, &_fm);
-        QVERIFY(folderman->addFolder(0, folderDefinition(dir.path() + "/sub/ownCloud1")));
-        QVERIFY(folderman->addFolder(0, folderDefinition(dir.path() + "/ownCloud2")));
+        QVERIFY(folderman->addFolder(newAccountState.data(), folderDefinition(dir.path() + "/sub/ownCloud1")));
+        QVERIFY(folderman->addFolder(newAccountState.data(), folderDefinition(dir.path() + "/ownCloud2")));
 
 
         // those should be allowed


### PR DESCRIPTION
- Make the SyncEngine persistent in the Folder, in order to be able to move backed logic into libsync
- Move any backend logic from SocketApi into a new SyncFileStatusTracker in libsync
- Refactor SyncFileStatusTracker to simplify the logic, make it match 100% the status of files in the UI and support bubbling up error statuses to parent folders as a warning
- Blacklisted files are now kept marked as error in the overlay icons even though they are a simple information in the activity log

Next step is to try adding auto tests for this, but this branch was tested manually during development and can land without.