### PR TITLE
SelectiveSync: Verify if the list could be read from journal.

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -258,14 +258,18 @@ void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
         return;
     }
 
-    auto oldBlackListSet = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList).toSet();
-    auto blackListSet = newList.toSet();
-    auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
-    foreach(const auto &it, changes) {
-        journal->avoidReadFromDbOnNextSync(it);
-    }
+    bool ok;
 
-    journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, newList);
+    auto oldBlackListSet = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok).toSet();
+    if( ok ) {
+        auto blackListSet = newList.toSet();
+        auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
+        foreach(const auto &it, changes) {
+            journal->avoidReadFromDbOnNextSync(it);
+        }
+
+        journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, newList);
+    }
 }
 
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -606,7 +606,8 @@ void AccountSettings::refreshSelectiveSyncStatus()
             continue;
         }
 
-        auto undecidedList =  folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList);
+        bool ok;
+        auto undecidedList =  folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
         QString p;
         foreach(const auto &it, undecidedList) {
             // FIXME: add the folder alias in a hoover hint.

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -917,26 +917,29 @@ void Folder::slotNewBigFolderDiscovered(const QString &newF)
     auto journal = journalDb();
 
     // Add the entry to the blacklist if it is neither in the blacklist or whitelist already
-    auto blacklist = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList);
-    auto whitelist = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList);
-    if (!blacklist.contains(newFolder) && !whitelist.contains(newFolder)) {
+    bool ok1, ok2;
+    auto blacklist = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok1);
+    auto whitelist = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, &ok2);
+    if (ok1 && ok2 && !blacklist.contains(newFolder) && !whitelist.contains(newFolder)) {
         blacklist.append(newFolder);
         journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, blacklist);
     }
 
     // And add the entry to the undecided list and signal the UI
-    auto undecidedList = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList);
-    if (!undecidedList.contains(newFolder)) {
-        undecidedList.append(newFolder);
-        journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, undecidedList);
-        emit newBigFolderDiscovered(newFolder);
-    }
-    QString message = tr("A new folder larger than %1 MB has been added: %2.\n"
-                         "Please go in the settings to select it if you wish to download it.")
+    auto undecidedList = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok1);
+    if( ok1 ) {
+        if (!undecidedList.contains(newFolder)) {
+            undecidedList.append(newFolder);
+            journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, undecidedList);
+            emit newBigFolderDiscovered(newFolder);
+        }
+        QString message = tr("A new folder larger than %1 MB has been added: %2.\n"
+                             "Please go in the settings to select it if you wish to download it.")
                 .arg(ConfigFile().newBigFolderSizeLimit().second).arg(newF);
 
-    auto logger = Logger::instance();
-    logger->postOptionalGuiLog(Theme::instance()->appNameGUI(), message);
+        auto logger = Logger::instance();
+        logger->postOptionalGuiLog(Theme::instance()->appNameGUI(), message);
+    }
 }
 
 

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -90,6 +90,7 @@ private:
     SelectiveSyncTreeView *_treeView;
 
     Folder *_folder;
+    QPushButton *_okButton;
 };
 
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -740,6 +740,9 @@ void SyncEngine::startSync()
         qDebug() << Q_FUNC_INFO << (usingSelectiveSync ? "====Using Selective Sync" : "====NOT Using Selective Sync");
     } else {
         qDebug() << Q_FUNC_INFO << "Could not retrieve selective sync list from DB";
+        emit csyncError(tr("Unable to read the blacklist from the local database"));
+        finalize(false);
+        return;
     }
     csync_set_userdata(_csync_ctx, this);
 
@@ -770,6 +773,8 @@ void SyncEngine::startSync()
     if (!ok) {
         delete discoveryJob;
         qDebug() << Q_FUNC_INFO << "Unable to read selective sync list, aborting.";
+        emit csyncError(tr("Unable to read from the sync journal."));
+        finalize(false);
         return;
     }
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -733,10 +733,14 @@ void SyncEngine::startSync()
     // thereby speeding up the initial discovery significantly.
     _csync_ctx->db_is_empty = (fileRecordCount == 0);
 
-    auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList);
-    bool usingSelectiveSync = (!selectiveSyncBlackList.isEmpty());
-    qDebug() << (usingSelectiveSync ? "====Using Selective Sync" : "====NOT Using Selective Sync");
-
+    bool ok;
+    auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
+    if (ok) {
+        bool usingSelectiveSync = (!selectiveSyncBlackList.isEmpty());
+        qDebug() << Q_FUNC_INFO << (usingSelectiveSync ? "====Using Selective Sync" : "====NOT Using Selective Sync");
+    } else {
+        qDebug() << Q_FUNC_INFO << "Could not retrieve selective sync list from DB";
+    }
     csync_set_userdata(_csync_ctx, this);
 
     // Set up checksumming hook
@@ -762,7 +766,13 @@ void SyncEngine::startSync()
     DiscoveryJob *discoveryJob = new DiscoveryJob(_csync_ctx);
     discoveryJob->_selectiveSyncBlackList = selectiveSyncBlackList;
     discoveryJob->_selectiveSyncWhiteList =
-        _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList);
+        _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, &ok);
+    if (!ok) {
+        delete discoveryJob;
+        qDebug() << Q_FUNC_INFO << "Unable to read selective sync list, aborting.";
+        return;
+    }
+
     discoveryJob->_newBigFolderSizeLimit = _newBigFolderSizeLimit;
     discoveryJob->moveToThread(&_thread);
     connect(discoveryJob, SIGNAL(finished(int)), this, SLOT(slotDiscoveryJobFinished(int)));
@@ -1042,7 +1052,8 @@ QString SyncEngine::adjustRenamedPath(const QString& original)
  */
 void SyncEngine::checkForPermission()
 {
-    auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList);
+    bool selectiveListOk;
+    auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &selectiveListOk);
     std::sort(selectiveSyncBlackList.begin(), selectiveSyncBlackList.end());
 
     for (SyncFileItemVector::iterator it = _syncedItems.begin(); it != _syncedItems.end(); ++it) {
@@ -1053,7 +1064,9 @@ void SyncEngine::checkForPermission()
 
         // Do not propagate anything in the server if it is in the selective sync blacklist
         const QString path = (*it)->destination() + QLatin1Char('/');
-        if (std::binary_search(selectiveSyncBlackList.constBegin(), selectiveSyncBlackList.constEnd(),
+
+        // if reading the selective sync list from db failed, lets ignore all rather than nothing.
+        if (!selectiveListOk || std::binary_search(selectiveSyncBlackList.constBegin(), selectiveSyncBlackList.constEnd(),
                                 path)) {
             (*it)->_instruction = CSYNC_INSTRUCTION_IGNORE;
             (*it)->_status = SyncFileItem::FileIgnored;

--- a/src/libsync/syncjournaldb.cpp
+++ b/src/libsync/syncjournaldb.cpp
@@ -1393,12 +1393,14 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo& info)
     }
 }
 
-QStringList SyncJournalDb::getSelectiveSyncList(SyncJournalDb::SelectiveSyncListType type)
+QStringList SyncJournalDb::getSelectiveSyncList(SyncJournalDb::SelectiveSyncListType type, bool *ok )
 {
     QStringList result;
+    Q_ASSERT(ok);
 
     QMutexLocker locker(&_mutex);
     if( !checkConnect() ) {
+        *ok = false;
         return result;
     }
 
@@ -1406,6 +1408,7 @@ QStringList SyncJournalDb::getSelectiveSyncList(SyncJournalDb::SelectiveSyncList
     _getSelectiveSyncListQuery->bindValue(1, int(type));
     if (!_getSelectiveSyncListQuery->exec()) {
         qWarning() << "SQL query failed: "<< _getSelectiveSyncListQuery->error();
+        *ok = false;
         return result;
     }
     while( _getSelectiveSyncListQuery->next() ) {
@@ -1415,6 +1418,8 @@ QStringList SyncJournalDb::getSelectiveSyncList(SyncJournalDb::SelectiveSyncList
         }
         result.append(entry);
     }
+    *ok = true;
+
     return result;
 }
 

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -113,7 +113,7 @@ public:
         SelectiveSyncUndecidedList = 3
     };
     /* return the specified list from the database */
-    QStringList getSelectiveSyncList(SelectiveSyncListType type);
+    QStringList getSelectiveSyncList(SelectiveSyncListType type, bool *ok);
     /* Write the selective sync list (remove all other entries of that list */
     void setSelectiveSyncList(SelectiveSyncListType type, const QStringList &list);
 


### PR DESCRIPTION
If there is a read error from the database while trying to get
the list from database, make sure to not behave badly because
the list is empty.

Supposed to fix #4633