### PR TITLE
Fix hidden file handling #4655

### DIFF
--- a/csync/src/csync.c
+++ b/csync/src/csync.c
@@ -548,7 +548,6 @@ int csync_commit(CSYNC *ctx) {
   ctx->remote.read_from_db = 0;
   ctx->read_remote_from_db = true;
   ctx->db_is_empty = false;
-  ctx->ignore_hidden_files = true; // do NOT sync hidden files by default.
 
 
   /* Create new trees */

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -753,6 +753,8 @@ void Folder::startSync(const QStringList &pathList)
     quint64 limit = newFolderLimit.first ? newFolderLimit.second * 1000 * 1000 : -1; // convert from MB to B
     _engine->setNewBigFolderSizeLimit(limit);
 
+    _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
+
     QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
 
     // disable events until syncing is done

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -58,7 +58,7 @@ bool FolderWatcherPrivate::findFoldersBelow( const QDir& dir, QStringList& fullL
     } else {
         QStringList nameFilter;
         nameFilter << QLatin1String("*");
-        QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot|QDir::NoSymLinks;
+        QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Hidden;
         const QStringList pathes = dir.entryList(nameFilter, filter);
 
         QStringList::const_iterator constIterator;


### PR DESCRIPTION
There were two issues:

* With the refactoring of how Folder and SyncEngine relate, the
  ignore_hidden_files flag on the CSync context was reset after
  each sync run and not updated from the configuration again.

* The folder watcher failed to enumerate hidden folders and thus
  didn't watch for changes inside them. (linux only)