### PR TITLE
Disable unavailable sharing permissions #4383

### DIFF
--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -122,7 +122,7 @@ void OcsShareJob::createShare(const QString& path,
     addParam(QString::fromLatin1("path"), path);
     addParam(QString::fromLatin1("shareType"), QString::number(shareType));
     addParam(QString::fromLatin1("shareWith"), shareWith);
-    if (!(permissions & Share::PermissionDefault)) {
+    if (!(permissions & SharePermissionDefault)) {
         addParam(QString::fromLatin1("permissions"), QString::number(permissions));
     }
 

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -101,7 +101,7 @@ public:
     void createShare(const QString& path, 
                      const Share::ShareType shareType,
                      const QString& shareWith = "",
-                     const Share::Permissions permissions = Share::PermissionRead);
+                     const Share::Permissions permissions = SharePermissionRead);
 
     /**
      * Returns information on the items shared with the current user.

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -870,14 +870,27 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
 
     const auto accountState = folder->accountState();
 
+    // As a first approximation, set the set of permissions that can be granted
+    // either to everything (resharing allowed) or nothing (no resharing).
+    //
+    // The correct value will be found with a propfind from ShareDialog.
+    // (we want to show the dialog directly, not wait for the propfind first)
+    SharePermissions maxSharingPermissions =
+            SharePermissionRead
+            | SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete
+            | SharePermissionShare;
+    if (!resharingAllowed) {
+        maxSharingPermissions = 0;
+    }
+
+
     ShareDialog *w = 0;
     if (_shareDialogs.contains(localPath) && _shareDialogs[localPath]) {
         qDebug() << Q_FUNC_INFO << "Raising share dialog" << sharePath << localPath;
         w = _shareDialogs[localPath];
     } else {
-        qDebug() << Q_FUNC_INFO << "Opening share dialog" << sharePath << localPath;
-        w = new ShareDialog(accountState, sharePath, localPath, resharingAllowed);
-        w->getShares();
+        qDebug() << Q_FUNC_INFO << "Opening share dialog" << sharePath << localPath << maxSharingPermissions;
+        w = new ShareDialog(accountState, sharePath, localPath, maxSharingPermissions);
         w->setAttribute( Qt::WA_DeleteOnClose, true );
 
         _shareDialogs[localPath] = w;

--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -135,8 +135,8 @@ LinkShare::LinkShare(AccountPtr account,
 
 bool LinkShare::getPublicUpload()
 {
-    return ((_permissions & PermissionUpdate) &&
-            (_permissions & PermissionCreate));
+    return ((_permissions & SharePermissionUpdate) &&
+            (_permissions & SharePermissionCreate));
 }
 
 void LinkShare::setPublicUpload(bool publicUpload)
@@ -150,9 +150,9 @@ void LinkShare::setPublicUpload(bool publicUpload)
 void LinkShare::slotPublicUploadSet(const QVariantMap&, const QVariant &value)
 {
     if (value.toBool()) {
-        _permissions = PermissionRead | PermissionUpdate | PermissionCreate;
+        _permissions = SharePermissionRead | SharePermissionUpdate | SharePermissionCreate;
     } else {
-        _permissions = PermissionRead;
+        _permissions = SharePermissionRead;
     }
 
     emit publicUploadSet();
@@ -260,7 +260,7 @@ void ShareManager::slotCreateShare(const QVariantMap &reply)
     _jobContinuation.remove(sender());
 
     // Find existing share permissions (if this was shared with us)
-    Share::Permissions existingPermissions = Share::PermissionDefault;
+    Share::Permissions existingPermissions = SharePermissionDefault;
     foreach (const QVariant & element, reply["ocs"].toMap()["data"].toList()) {
         QVariantMap map = element.toMap();
         if (map["file_target"] == cont.path)
@@ -269,9 +269,9 @@ void ShareManager::slotCreateShare(const QVariantMap &reply)
 
     // Limit the permissions we request for a share to the ones the item
     // was shared with initially.
-    if (cont.permissions == Share::PermissionDefault) {
+    if (cont.permissions == SharePermissionDefault) {
         cont.permissions = existingPermissions;
-    } else if (existingPermissions != Share::PermissionDefault) {
+    } else if (existingPermissions != SharePermissionDefault) {
         cont.permissions &= existingPermissions;
     }
 

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -16,6 +16,7 @@
 
 #include "accountfwd.h"
 #include "sharee.h"
+#include "sharepermissions.h"
 
 #include <QObject>
 #include <QDate>
@@ -43,18 +44,7 @@ public:
         TypeRemote = Sharee::Federated
     };
 
-    /**
-     * Possible permissions
-     */
-    enum Permission {
-        PermissionRead   =  1,
-        PermissionUpdate =  2,
-        PermissionCreate =  4,
-        PermissionDelete =  8,
-        PermissionShare  = 16,
-        PermissionDefault = 1 << 30
-    };
-    Q_DECLARE_FLAGS(Permissions, Permission)
+    typedef SharePermissions Permissions;
 
     /*
      * Constructor for shares
@@ -63,7 +53,7 @@ public:
                    const QString& id,
                    const QString& path,
                    const ShareType shareType,
-                   const Permissions permissions = PermissionDefault,
+                   const Permissions permissions = SharePermissionDefault,
                    const QSharedPointer<Sharee> shareWith = QSharedPointer<Sharee>(NULL));
 
     /**
@@ -208,7 +198,6 @@ private:
     QDate _expireDate;
     QUrl _url;
 };
-Q_DECLARE_OPERATORS_FOR_FLAGS(Share::Permissions)
 
 /**
  * The share manager allows for creating, retrieving and deletion

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -15,11 +15,14 @@
 #define SHAREDIALOG_H
 
 #include "accountstate.h"
+#include "sharepermissions.h"
 
 #include <QPointer>
 #include <QString>
 #include <QDialog>
 #include <QWidget>
+
+class QProgressIndicator;
 
 namespace OCC {
 
@@ -38,27 +41,31 @@ public:
     explicit ShareDialog(QPointer<AccountState> accountState,
                          const QString &sharePath,
                          const QString &localPath,
-                         bool resharingAllowed,
+                         SharePermissions maxSharingPermissions,
                          QWidget *parent = 0);
     ~ShareDialog();
 
-    void getShares();
-
 private slots:
     void done( int r );
+    void slotMaxSharingPermissionsReceived(const QVariantMap &result);
+    void slotMaxSharingPermissionsError();
     void slotThumbnailFetched(const int &statusCode, const QByteArray &reply);
     void slotAccountStateChanged(int state);
 
 private:
+
+    void showSharingUi();
+
     Ui::ShareDialog *_ui;
     QPointer<AccountState> _accountState;
     QString _sharePath;
     QString _localPath;
 
-    bool _resharingAllowed;
+    SharePermissions _maxSharingPermissions;
 
     ShareLinkWidget *_linkWidget;
     ShareUserGroupWidget *_userGroupWidget;
+    QProgressIndicator *_progressIndicator;
 };
 
 }

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -29,7 +29,7 @@ namespace OCC {
 ShareLinkWidget::ShareLinkWidget(AccountPtr account,
                                  const QString &sharePath,
                                  const QString &localPath,
-                                 bool resharingAllowed,
+                                 SharePermissions maxSharingPermissions,
                                  bool autoShare,
                                  QWidget *parent) :
    QWidget(parent),
@@ -40,7 +40,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     _passwordJobRunning(false),
     _manager(NULL),
     _share(NULL),
-    _resharingAllowed(resharingAllowed),
+    _maxSharingPermissions(maxSharingPermissions),
     _autoShare(autoShare),
     _passwordRequired(false)
 {
@@ -292,7 +292,7 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         setShareCheckBoxTitle(true);
     } else {
         // If its clear that resharing is not allowed, display an error
-        if( !_resharingAllowed ) {
+        if( _maxSharingPermissions == 0 ) {
             displayError(tr("The file can not be shared because it was shared without sharing permission."));
             _ui->checkBox_shareLink->setEnabled(false);
         } else if (_autoShare && _ui->checkBox_shareLink->isEnabled()) {

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -16,6 +16,7 @@
 #define SHARELINKWIDGET_H
 
 #include "accountfwd.h"
+#include "sharepermissions.h"
 #include "QProgressIndicator.h"
 #include <QDialog>
 #include <QVariantMap>
@@ -47,7 +48,7 @@ public:
     explicit ShareLinkWidget(AccountPtr account,
                              const QString &sharePath,
                              const QString &localPath,
-                             bool resharingAllowed,
+                             SharePermissions maxSharingPermissions,
                              bool autoShare = false,
                              QWidget *parent = 0);
     ~ShareLinkWidget();
@@ -104,7 +105,7 @@ private:
     ShareManager *_manager;
     QSharedPointer<LinkShare> _share;
 
-    bool _resharingAllowed;
+    SharePermissions _maxSharingPermissions;
     bool _isFile;
     bool _autoShare;
     bool _passwordRequired;

--- a/src/gui/sharepermissions.h
+++ b/src/gui/sharepermissions.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) by Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef SHAREPERMISSIONS_H
+#define SHAREPERMISSIONS_H
+
+#include <qglobal.h>
+
+namespace OCC {
+
+/**
+ * Possible permissions, must match the server permission constants
+ */
+enum SharePermission {
+    SharePermissionRead   =  1,
+    SharePermissionUpdate =  2,
+    SharePermissionCreate =  4,
+    SharePermissionDelete =  8,
+    SharePermissionShare  = 16,
+    SharePermissionDefault = 1 << 30
+};
+Q_DECLARE_FLAGS(SharePermissions, SharePermission)
+Q_DECLARE_OPERATORS_FOR_FLAGS(SharePermissions)
+
+} // namespace OCC
+
+#endif

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -15,6 +15,7 @@
 #define SHAREUSERGROUPWIDGET_H
 
 #include "accountfwd.h"
+#include "sharepermissions.h"
 #include "QProgressIndicator.h"
 #include <QDialog>
 #include <QWidget>
@@ -48,7 +49,10 @@ class ShareWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ShareWidget(QSharedPointer<Share> Share, bool isFile, QWidget *parent = 0);
+    explicit ShareWidget(QSharedPointer<Share> Share,
+                         SharePermissions maxSharingPermissions,
+                         bool isFile,
+                         QWidget *parent = 0);
     ~ShareWidget();
 
     QSharedPointer<Share> share() const;
@@ -90,7 +94,7 @@ public:
     explicit ShareUserGroupWidget(AccountPtr account, 
                                   const QString &sharePath,
                                   const QString &localPath,
-                                  bool resharingAllowed,
+                                  SharePermissions maxSharingPermissions,
                                   QWidget *parent = 0);
     ~ShareUserGroupWidget();
 
@@ -121,7 +125,7 @@ private:
     ShareeModel *_completerModel;
     QTimer _completionTimer;
 
-    bool _resharingAllowed;
+    SharePermissions _maxSharingPermissions;
     bool _isFile;
     bool _disableCompleterActivated; // in order to avoid that we share the contents twice
     ShareManager *_manager;


### PR DESCRIPTION
Users can't reshare with more permissions than they have themselves.