### PR TITLE
SyncFileStatusTracker: Add a method to handle the root item.

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -229,7 +229,6 @@ class SyncStateExtension(GObject.GObject, Nautilus.ColumnProvider, Nautilus.Info
 
             for path1 in update_items:
                 socketConnect.nautilusVFSFile_table[path1]['item'].invalidate_extension_info()
-                print "Invalidated: "+path1
 
     # Handles a single line of server response and sets the emblem
     def handle_commands(self, action, args):

--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -249,7 +249,9 @@ class SyncStateExtension(GObject.GObject, Nautilus.ColumnProvider, Nautilus.Info
         # print("Action for " + file + ": " + args[0])  # For debug only
         if action == 'STATUS':
             newState = args[0]
-            emblem = Emblems[newState]
+            emblem = 'NOP' # Show nothing if no emblem si defined.
+            if newState in Emblems:
+                emblem = Emblems[newState]
             filename = ':'.join(args[1:])
 
             if emblem:

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -293,16 +293,8 @@ void SocketApi::command_RETRIEVE_FILE_STATUS(const QString& argument, QIODevice*
         const QString file = QDir::cleanPath(argument).mid(syncFolder->cleanPath().length()+1);
 
         // future: Send more specific states for paused, disconnected etc.
-        if( syncFolder->syncPaused() ){
+        if( syncFolder->syncPaused() || !syncFolder->accountState()->isConnected() ) {
             statusString = nopString;
-        } else if( !syncFolder->accountState()->isConnected() ) {
-            if( file.isEmpty() || file == QLatin1String("/") ) {
-                // only the root folder
-                statusString = nopString;
-            } else {
-                // all other files and dirs in unconnected sync
-                statusString = nopString;
-            }
         } else {
             SyncFileStatus fileStatus = syncFolder->syncEngine().syncFileStatusTracker().fileStatus(file);
 

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -274,6 +274,8 @@ void SocketApi::command_RETRIEVE_FOLDER_STATUS(const QString& argument, QIODevic
 
 void SocketApi::command_RETRIEVE_FILE_STATUS(const QString& argument, QIODevice* socket)
 {
+    const QString nopString("NOP");
+
     if( !socket ) {
         qDebug() << "No valid socket object.";
         return;
@@ -286,12 +288,26 @@ void SocketApi::command_RETRIEVE_FILE_STATUS(const QString& argument, QIODevice*
     Folder* syncFolder = FolderMan::instance()->folderForPath( argument );
     if (!syncFolder) {
         // this can happen in offline mode e.g.: nothing to worry about
-        statusString = QLatin1String("NOP");
+        statusString = nopString;
     } else {
         const QString file = QDir::cleanPath(argument).mid(syncFolder->cleanPath().length()+1);
-        SyncFileStatus fileStatus = syncFolder->syncEngine().syncFileStatusTracker().fileStatus(file);
 
-        statusString = fileStatus.toSocketAPIString();
+        // future: Send more specific states for paused, disconnected etc.
+        if( syncFolder->syncPaused() ){
+            statusString = nopString;
+        } else if( !syncFolder->accountState()->isConnected() ) {
+            if( file.isEmpty() || file == QLatin1String("/") ) {
+                // only the root folder
+                statusString = nopString;
+            } else {
+                // all other files and dirs in unconnected sync
+                statusString = nopString;
+            }
+        } else {
+            SyncFileStatus fileStatus = syncFolder->syncEngine().syncFileStatusTracker().fileStatus(file);
+
+            statusString = fileStatus.toSocketAPIString();
+        }
     }
 
     const QString message = QLatin1String("STATUS:") % statusString % QLatin1Char(':') %  QDir::toNativeSeparators(argument);

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -106,10 +106,9 @@ SyncFileStatus SyncFileStatusTracker::rootStatus()
             }
         }
         if( errs ) {
-            status = SyncFileStatus::StatusError;
-        } else if( warns ) {
-            status = SyncFileStatus::StatusWarning;
+            status = SyncFileStatus::StatusWarning; // some files underneath had errors
         }
+        // Only warnings do not change the root emblem away from ok.
     }
     return status;
 

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -102,13 +102,11 @@ SyncFileStatus SyncFileStatusTracker::rootStatus()
         status = SyncFileStatus::StatusSync;
     } else {
         // sync is not running. Check dirty list and _syncProblems
-        int errs = 0, warns = 0;
+        int errs = 0;
         for (auto it = _syncProblems.begin(); it != _syncProblems.end(); ++it) {
             if( it->second == SyncFileStatus::StatusError ) {
                 errs ++;
                 break; // stop if an error found at all.
-            } if( it->second == SyncFileStatus::StatusWarning ) {
-                warns ++;
             }
         }
         if( errs ) {

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -45,10 +45,13 @@ private slots:
 
 private:
     SyncFileStatus fileStatus(const SyncFileItem& item);
+    SyncFileStatus rootStatus();
+
     void invalidateParentPaths(const QString& path);
     QString getSystemDestination(const SyncFileItem& syncEnginePath);
 
     SyncEngine* _syncEngine;
+
     std::map<QString, SyncFileStatus::SyncFileStatusTag> _syncProblems;
 };
 


### PR DESCRIPTION
This uses some  heuristics to estimate the root status. Not complete as it completely neglects the database items, but maybe a start.

@jturcotte @ckamm please. 