### PR TITLE
Use expireDate if returned by the OCS Share API

### DIFF
--- a/src/gui/share.cpp
+++ b/src/gui/share.cpp
@@ -180,9 +180,19 @@ void LinkShare::setExpireDate(const QDate &date)
     job->setExpireDate(getId(), date);
 }
 
-void LinkShare::slotExpireDateSet(const QVariantMap&, const QVariant &value)
+void LinkShare::slotExpireDateSet(const QVariantMap& reply, const QVariant &value)
 {
-    _expireDate = value.toDate();
+    auto data = reply.value("ocs").toMap().value("data").toMap();
+
+    /*
+     * If the reply provides a data back (more REST style)
+     * they use this date.
+     */
+    if (data.value("expiration").isValid()) {
+       _expireDate = QDate::fromString(data.value("expiration").toString(), "yyyy-MM-dd 00:00:00");
+    } else {
+        _expireDate = value.toDate();
+    }
     emit expireDateSet();
 }
 

--- a/src/gui/share.h
+++ b/src/gui/share.h
@@ -190,7 +190,7 @@ signals:
 private slots:
     void slotPasswordSet(const QVariantMap&, const QVariant &value);
     void slotPublicUploadSet(const QVariantMap&, const QVariant &value);
-    void slotExpireDateSet(const QVariantMap&, const QVariant &value);
+    void slotExpireDateSet(const QVariantMap& reply, const QVariant &value);
     void slotSetPasswordError(int statusCode, const QString &message);
 
 private:

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -153,6 +153,10 @@ void ShareLinkWidget::setExpireDate(const QDate &date)
 
 void ShareLinkWidget::slotExpireSet()
 {
+    auto date = _share->getExpireDate();
+    if (date.isValid()) {
+        _ui->calendar->setDate(date);
+    }
     _pi_date->stopAnimation();
 }
 


### PR DESCRIPTION
If an app modifies the expiration date (for example the password policy
app) then on more recent versions of the server we will get the share
object back REST style. We should use that info!

Fixes #4409