### PR TITLE
Quota: Add branding option for the base folder

### DIFF
--- a/src/gui/quotainfo.cpp
+++ b/src/gui/quotainfo.cpp
@@ -17,6 +17,7 @@
 #include "networkjobs.h"
 #include "folderman.h"
 #include "creds/abstractcredentials.h"
+#include <theme.h>
 
 #include <QTimer>
 #include <QDebug>
@@ -82,20 +83,7 @@ bool QuotaInfo::canGetQuota() const
 
 QString QuotaInfo::quotaBaseFolder() const
 {
-    // If there's exactly one folder, use its remote path.
-    // Otherwise use /
-    bool foundOne = false;
-    QString path = "/";
-    for (const auto & folder : FolderMan::instance()->map()) {
-        if (folder->accountState() == _accountState) {
-            if (foundOne)
-                return "/";
-            foundOne = true;
-            path = folder->remotePath();
-        }
-    }
-
-    return path;
+    return Theme::instance()->quotaBaseFolder();
 }
 
 void QuotaInfo::slotCheckQuota()

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -459,7 +459,8 @@ QString Theme::wizardUrlHint() const
     return QString();
 }
 
-
-
+QString Theme::quotaBaseFolder() const
+{
+    return QLatin1String("/");
+}
 } // end namespace client
-

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -291,6 +291,16 @@ public:
      */
     virtual QString wizardUrlHint() const;
 
+    /**
+     * @brief the server folder that should be queried for the quota information
+     *
+     * This can be configured to show the quota infromation for a different
+     * folder than the root. This is the folder on which the client will do
+     * PROPFIND calls to get "quota-available-bytes" and "quota-used-bytes"
+     *
+     * Defaults: "/"
+     */
+    QString quotaBaseFolder() const;
 
 protected:
 #ifndef TOKEN_AUTH_ONLY


### PR DESCRIPTION
As discussed on issue #4460
Having the quote to be queried on subfolder is wrong in the generic case,
so add a branding option to configure it.

This partially reverts commit ff4cdc3161ddbb74a0fe10f969043ff898fbb93a