### PR TITLE
Overlay icons: Track touched files #4730

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -578,6 +578,7 @@ void Folder::slotWatchedPathChanged(const QString& path)
     // When no sync is running or it's in the prepare phase, we can
     // always schedule a new sync.
     if (! _engine->isSyncRunning() || _syncResult.status() == SyncResult::SyncPrepare) {
+        emit watchedFileChangedExternally(path);
         emit scheduleToSync(this);
         return;
     }
@@ -601,6 +602,7 @@ void Folder::slotWatchedPathChanged(const QString& path)
 #endif
 
     if (! ownChange) {
+        emit watchedFileChangedExternally(path);
         emit scheduleToSync(this);
     }
 }

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -204,6 +204,12 @@ signals:
     void newBigFolderDiscovered(const QString &); // A new folder bigger than the threshold was discovered
     void syncPausedChanged(Folder*, bool paused);
 
+    /**
+     * Fires for each change inside this folder that wasn't caused
+     * by sync activity.
+     */
+    void watchedFileChangedExternally(const QString& path);
+
 public slots:
 
      /**

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -107,6 +107,8 @@ void FolderMan::unloadFolder( Folder *f )
                this, SLOT(slotFolderSyncPaused(Folder*,bool)));
     disconnect(&f->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
                _socketApi.data(), SLOT(slotFileStatusChanged(const QString &, SyncFileStatus)));
+    disconnect(f, SIGNAL(watchedFileChangedExternally(QString)),
+               &f->syncEngine().syncFileStatusTracker(), SLOT(slotPathTouched(QString)));
 }
 
 int FolderMan::unloadAndDeleteAllFolders()
@@ -145,6 +147,7 @@ void FolderMan::registerFolderMonitor( Folder *folder )
         // to the signal mapper which maps to the folder alias. The changed path
         // is lost this way, but we do not need it for the current implementation.
         connect(fw, SIGNAL(pathChanged(QString)), folder, SLOT(slotWatchedPathChanged(QString)));
+
         _folderWatchers.insert(folder->alias(), fw);
     }
 
@@ -795,6 +798,8 @@ Folder* FolderMan::addFolderInternal(const FolderDefinition& folderDefinition, A
     connect(folder, SIGNAL(syncPausedChanged(Folder*,bool)), SLOT(slotFolderSyncPaused(Folder*,bool)));
     connect(&folder->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
             _socketApi.data(), SLOT(slotFileStatusChanged(const QString &, SyncFileStatus)));
+    connect(folder, SIGNAL(watchedFileChangedExternally(QString)),
+            &folder->syncEngine().syncFileStatusTracker(), SLOT(slotPathTouched(QString)));
 
     registerFolderMonitor(folder);
     return folder;

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -19,6 +19,7 @@
 #include "syncfileitem.h"
 #include "syncfilestatus.h"
 #include <map>
+#include <QSet>
 
 namespace OCC {
 
@@ -36,12 +37,16 @@ public:
     explicit SyncFileStatusTracker(SyncEngine* syncEngine);
     SyncFileStatus fileStatus(const QString& systemFileName);
 
+public slots:
+    void slotPathTouched(const QString& fileName);
+
 signals:
     void fileStatusChanged(const QString& systemFileName, SyncFileStatus fileStatus);
 
 private slots:
     void slotAboutToPropagate(SyncFileItemVector& items);
     void slotItemCompleted(const SyncFileItem& item);
+    void slotClearDirtyPaths();
 
 private:
     SyncFileStatus fileStatus(const SyncFileItem& item);
@@ -53,6 +58,7 @@ private:
     SyncEngine* _syncEngine;
 
     std::map<QString, SyncFileStatus::SyncFileStatusTag> _syncProblems;
+    QSet<QString> _dirtyPaths;
 };
 
 }


### PR DESCRIPTION
This uses the file watcher to keep track of files that were modified
in order to assign them the blue icon.

This is transient state that's not persisted across restarts.