### PR TITLE
Accountsettings: Generate an alias for new folders

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -277,7 +277,6 @@ void AccountSettings::slotFolderWizardAccepted()
     qDebug() << "* Folder wizard completed";
 
     FolderDefinition definition;
-    definition.alias        = folderWizard->field(QLatin1String("alias")).toString();
     definition.localPath    = FolderDefinition::prepareLocalPath(
             folderWizard->field(QLatin1String("sourceFolder")).toString());
     definition.targetPath   = folderWizard->property("targetPath").toString();

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -201,7 +201,7 @@ private:
     /** Adds a new folder, does not add it to the account settings and
      *  does not set an account on the new folder.
       */
-    Folder* addFolderInternal(const FolderDefinition& folderDefinition, AccountState* accountState);
+    Folder* addFolderInternal(FolderDefinition folderDefinition, AccountState* accountState);
 
     /* unloads a folder object, does not delete it */
     void unloadFolder( Folder * );

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -459,13 +459,6 @@ void OwncloudSetupWizard::slotAssistantFinished( int result )
         if (!startFromScratch || ensureStartFromScratch(localFolder)) {
             qDebug() << "Adding folder definition for" << localFolder << _remoteFolder;
             FolderDefinition folderDefinition;
-            auto alias = Theme::instance()->appName();
-            int count = 0;
-            folderDefinition.alias = alias;
-            while (folderMan->folder(folderDefinition.alias)) {
-                // There is already a folder configured with this name and folder names need to be unique
-                folderDefinition.alias = alias + QString::number(++count);
-            }
             folderDefinition.localPath = localFolder;
             folderDefinition.targetPath = _remoteFolder;
             folderDefinition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();


### PR DESCRIPTION
Before commit 1a51b6718a345f1e5f28dd1f4e0c04bdaeeb5357, the wizard was
making sure folder had an alias but this is no longer the case.
So generate still an unique alias.

Alias is not used in the UI any longer, it's just use for internal purposes.

For issue #4737