### PR TITLE
PropagateDownload: Throw an error if the file is empty while it shoul…

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -543,6 +543,14 @@ void PropagateDownloadFileQNAM::slotGetFinished()
         return;
     }
 
+    if (_tmpFile.size() == 0 && _item->_size > 0) {
+        FileSystem::remove(_tmpFile.fileName());
+        done(SyncFileItem::NormalError,
+             tr("The downloaded file is empty despite the server announced it should have been %1.")
+                .arg(Utility::octetsToString(_item->_size)));
+        return;
+    }
+
     // Do checksum validation for the download. If there is no checksum header, the validator
     // will also emit the validated() signal to continue the flow in slot downloadFinished()
     // as this is (still) also correct.


### PR DESCRIPTION
…d not have been

If the downloaded file is empty but the PROPFIND previously announced it
should not have been empty, this might mean the file was somehow corrupted
because of a bug on the server and that we should therefore not accept
the file.

Normaly we accept a change between the actual size of the file and what we
got during discovery because the file might have been updated to a new version
inbetween. But after this patch we won't accept the file if it was replaced
by an empty file.

Will help for issue #4583
Also requested by IL for issue 548