### PR TITLE
Adding CURL check in t6.pl

### DIFF
--- a/csync/tests/ownCloud/t6.pl
+++ b/csync/tests/ownCloud/t6.pl
@@ -31,6 +31,13 @@ use strict;
 
 print "Hello, this is t6, a tester for csync with ownCloud.\n";
 
+# Checking CURL is installed to avoid misleading errors later...
+system(("curl", "--help", ">", "/dev/null"));
+if ($? != 0) {
+   print "CURL is needed for this script, aborting with error\n";
+   exit 1;
+}
+
 initTesting();
 
 sub createPostUpdateScript($)


### PR DESCRIPTION
As t6 uses curl to run, and curl is not installed by default, it's better to check at the beginning and abort then, with a meaningful message, than later in the script, with an obscure one.