### PR TITLE
[shell/windows] Fix the windows status push not working

### DIFF
--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -35,7 +35,7 @@ class OWNCLOUDSYNC_EXPORT SyncFileStatusTracker : public QObject
     Q_OBJECT
 public:
     explicit SyncFileStatusTracker(SyncEngine* syncEngine);
-    SyncFileStatus fileStatus(const QString& systemFileName);
+    SyncFileStatus fileStatus(const QString& relativePath);
 
 public slots:
     void slotPathTouched(const QString& fileName);
@@ -54,7 +54,7 @@ private:
     SyncFileItem rootSyncFileItem();
 
     void invalidateParentPaths(const QString& path);
-    QString getSystemDestination(const SyncFileItem& syncEnginePath);
+    QString getSystemDestination(const QString& relativePath);
 
     SyncEngine* _syncEngine;
 


### PR DESCRIPTION
Since the windows implementation first does cache lookups using the
path string, directories need to be passed identically as through
RETRIEVE_FILE_STATUS.

Change the convention to never have a trailing slash for directories
in the protocol. This allows the convention to be applied without
having to access the disk (since we'd need to know if the path is
represented by a directory) and also matches the convention of the
rest of the sync engine. Individual file manager plugins are then
responsible of handling pushed paths as not ending with a trailing
slash.

This also:
- Moves the trailing slash removal logic from the SyncFileStatusTracker
  to the SocketApi class
- Remove the unneeded QString::normalized call in fileStatus, since
  this should already be done by the FolderWatcher and plugins