### PR TITLE
Adding network job factories

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -91,6 +91,7 @@ set(client_SRCS
     notificationwidget.cpp
     notificationconfirmjob.cpp
     servernotificationhandler.cpp
+    guinetworkjobfactory.cpp
     creds/credentialsfactory.cpp
     creds/httpcredentialsgui.cpp
     creds/shibbolethcredentials.cpp

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -25,12 +25,14 @@
 
 #include "activitydata.h"
 #include "activitylistmodel.h"
+#include "networkjobfactory.h"
 
 namespace OCC {
 
 ActivityListModel::ActivityListModel(QWidget *parent)
     :QAbstractListModel(parent)
 {
+    _factory = new NetworkJobFactory(this);
 }
 
 QVariant ActivityListModel::data(const QModelIndex &index, int role) const
@@ -118,7 +120,7 @@ void ActivityListModel::startFetchJob(AccountState* s)
     if( !s->isConnected() ) {
         return;
     }
-    JsonApiJob *job = new JsonApiJob(s->account(), QLatin1String("ocs/v1.php/cloud/activity"), this);
+    JsonApiJob *job = _factory->createJsonApiJob(s->account(), QLatin1String("ocs/v1.php/cloud/activity"), this);
     QObject::connect(job, SIGNAL(jsonReceived(QVariantMap, int)),
                      this, SLOT(slotActivitiesReceived(QVariantMap, int)));
     job->setProperty("AccountStatePtr", QVariant::fromValue<AccountState*>(s));

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -21,6 +21,7 @@
 namespace OCC {
 
 class AccountState;
+class NetworkJobFactory;
 
 /**
  * @brief The ActivityListModel
@@ -60,6 +61,9 @@ private:
     QMap<AccountState*, ActivityList> _activityLists;
     ActivityList _finalList;
     QSet<AccountState*> _currentlyFetching;
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 

--- a/src/gui/creds/shibbolethcredentials.cpp
+++ b/src/gui/creds/shibbolethcredentials.cpp
@@ -30,6 +30,7 @@
 #include "cookiejar.h"
 #include "owncloudgui.h"
 #include "syncengine.h"
+#include "networkjobfactory.h"
 
 #include <keychain.h>
 
@@ -53,7 +54,9 @@ ShibbolethCredentials::ShibbolethCredentials()
       _ready(false),
       _stillValid(false),
       _browser(0)
-{}
+{
+    _factory = new NetworkJobFactory(this);
+}
 
 ShibbolethCredentials::ShibbolethCredentials(const QNetworkCookie& cookie)
   : _ready(true),
@@ -61,6 +64,7 @@ ShibbolethCredentials::ShibbolethCredentials(const QNetworkCookie& cookie)
     _browser(0),
     _shibCookie(cookie)
 {
+    _factory = new NetworkJobFactory(this);
 }
 
 void ShibbolethCredentials::setAccount(Account* account)
@@ -210,7 +214,7 @@ void ShibbolethCredentials::slotFetchUser()
 {
     // We must first do a request to webdav so the session is enabled.
     // (because for some reason we can't access the API without that..  a bug in the server maybe?)
-    EntityExistsJob* job = new EntityExistsJob(_account->sharedFromThis(), _account->davPath(), this);
+    EntityExistsJob* job = _factory->createEntityExistsJob(_account->sharedFromThis(), _account->davPath(), this);
     connect(job, SIGNAL(exists(QNetworkReply*)), this, SLOT(slotFetchUserHelper()));
     job->setIgnoreCredentialFailure(true);
     job->start();

--- a/src/gui/creds/shibbolethcredentials.h
+++ b/src/gui/creds/shibbolethcredentials.h
@@ -32,6 +32,7 @@ namespace OCC
 {
 
 class ShibbolethWebView;
+class NetworkJobFactory;
 
 /**
  * @brief The ShibbolethCredentials class
@@ -90,6 +91,9 @@ private:
     QPointer<ShibbolethWebView> _browser;
     QNetworkCookie _shibCookie;
     QString _user;
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 } // namespace OCC

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -22,6 +22,7 @@
 #include "logger.h"
 #include "configfile.h"
 #include "networkjobs.h"
+#include "networkjobfactory.h"
 #include "syncjournalfilerecord.h"
 #include "syncresult.h"
 #include "utility.h"
@@ -119,6 +120,7 @@ Folder::Folder(const FolderDefinition& definition,
 
 Folder::~Folder()
 {
+    _factory = new NetworkJobFactory(this);
 }
 
 void Folder::checkLocalPath()
@@ -316,7 +318,7 @@ void Folder::slotRunEtagJob()
         // Do the ordinary etag check for the root folder and only schedule a real
         // sync if it's different.
 
-        _requestEtagJob = new RequestEtagJob(account, remotePath(), this);
+        _requestEtagJob = _factory->createRequestEtagJob(account, remotePath(), this);
         // check if the etag is different
         QObject::connect(_requestEtagJob, SIGNAL(etagRetreived(QString)), this, SLOT(etagRetreived(QString)));
         FolderMan::instance()->slotScheduleETagJob(alias(), _requestEtagJob);

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -35,6 +35,7 @@ namespace OCC {
 
 class SyncEngine;
 class AccountState;
+class NetworkJobFactory;
 
 /**
  * @brief The FolderDefinition class
@@ -312,6 +313,9 @@ private:
     SyncJournalDb _journal;
 
     ClientProxy   _clientProxy;
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -19,6 +19,8 @@
 #include <theme.h>
 #include <account.h>
 #include "folderstatusdelegate.h"
+#include "networkjobfactory.h"
+#include "networkjobs.h"
 
 #include <QFileIconProvider>
 #include <QVarLengthArray>
@@ -33,6 +35,7 @@ static const char propertyParentIndexC[] = "oc_parentIndex";
 FolderStatusModel::FolderStatusModel(QObject *parent)
     :QAbstractItemModel(parent), _accountState(0), _dirty(false)
 {
+    _factory = new NetworkJobFactory(this);
 }
 
 FolderStatusModel::~FolderStatusModel()
@@ -519,7 +522,7 @@ void FolderStatusModel::fetchMore(const QModelIndex& parent)
         }
         path += info->_path;
     }
-    LsColJob *job = new LsColJob(_accountState->account(), path, this);
+    LsColJob *job = _factory->createLsColJob(_accountState->account(), path, this);
     job->setProperties(QList<QByteArray>() << "resourcetype" << "http://owncloud.org/ns:size");
     job->setTimeout(60 * 1000);
     connect(job, SIGNAL(directoryListingSubfolders(QStringList)),

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -25,6 +25,7 @@ namespace OCC {
 
 class Folder;
 class ProgressInfo;
+class NetworkJobFactory;
 
 /**
  * @brief The FolderStatusModel class
@@ -139,6 +140,9 @@ private:
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>())
     { emit QAbstractItemModel::dataChanged(topLeft,bottomRight); }
 #endif
+
+    // Used to create the network jobs we need
+    NetworkJobFactory* _factory;
 
 signals:
     void dirtyChanged();

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -17,6 +17,7 @@
 #include "configfile.h"
 #include "theme.h"
 #include "networkjobs.h"
+#include "networkjobfactory.h"
 #include "account.h"
 #include "selectivesyncdialog.h"
 #include "accountstate.h"
@@ -175,6 +176,8 @@ FolderWizardRemotePath::FolderWizardRemotePath(AccountPtr account)
     // Make sure that there will be a scrollbar when the contents is too wide
     _ui.folderTreeWidget->header()->setStretchLastSection(false);
 #endif
+
+    _factory = new NetworkJobFactory(this);
 }
 
 void FolderWizardRemotePath::slotAddRemoteFolder()
@@ -206,7 +209,7 @@ void FolderWizardRemotePath::slotCreateRemoteFolder(const QString &folder)
     }
     fullPath += "/" + folder;
 
-    MkColJob *job = new MkColJob(_account, fullPath, this);
+    MkColJob *job = _factory->createMkColJob(_account, fullPath, this);
     /* check the owncloud configuration file and query the ownCloud */
     connect(job, SIGNAL(finished(QNetworkReply::NetworkError)),
                  SLOT(slotCreateRemoteFolderFinished(QNetworkReply::NetworkError)));
@@ -409,7 +412,7 @@ void FolderWizardRemotePath::slotTypedPathError(QNetworkReply* reply)
 
 LsColJob* FolderWizardRemotePath::runLsColJob(const QString& path)
 {
-    LsColJob *job = new LsColJob(_account, path, this);
+    LsColJob *job = _factory->createLsColJob(_account, path, this);
     job->setProperties(QList<QByteArray>() << "resourcetype");
     connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
             SLOT(slotUpdateDirectories(QStringList)));

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -30,6 +30,7 @@ namespace OCC {
 class SelectiveSyncTreeView;
 
 class ownCloudInfo;
+class NetworkJobFactory;
 
 /**
  * @brief The FormatWarningsWizardPage class
@@ -107,6 +108,9 @@ private:
     bool _warnWasVisible;
     AccountPtr _account;
     QTimer _lscolTimer;
+
+    // Used to create the network jobs we need
+    NetworkJobFactory* _factory;
 };
 
 /**

--- a/src/gui/guinetworkjobfactory.cpp
+++ b/src/gui/guinetworkjobfactory.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@owncloud.com>
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "guinetworkjobfactory.h"
+
+/** \file guinetworkjobfactory.cpp
+ *
+ * \brief Class that creates GUI network jobs on demand.
+ * Creates an normal or encrypted network job based on context.
+ *
+ * Overview
+ * --------
+ *
+ * TODO
+ *
+ */
+
+namespace OCC {
+
+/**
+ * @brief NetworkJobFactory::createThumbnailJob
+ * Creates either a normal or an encrypted ThumbnailJob network job, depending on path.
+ * @param path : Used to decide whether to create an encrypted or normal version of the network job,
+ * and passed as is to the relevant constructor
+ * @param account : passed as is to the relevant constructor
+ * @param parent : passed as is to the relevant constructor
+ * @return A pointer to the created network job. Will be either normal or encrypted.
+ */
+ThumbnailJob* GUINetworkJobFactory::createThumbnailJob(const QString& path, AccountPtr account, QObject* parent)
+{
+    if (! helper.isFileEncrypted(path))
+        return new ThumbnailJob(path, account, parent);
+    else
+        // for now isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+}

--- a/src/gui/guinetworkjobfactory.h
+++ b/src/gui/guinetworkjobfactory.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by orion1024 <orion1024+src@use.startmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef GUINETWORKJOBFACTORY_H
+#define GUINETWORKJOBFACTORY_H
+
+#include <QObject>
+
+#include "networkjobfactory.h"
+#include "thumbnailjob.h"
+
+namespace OCC {
+
+/**
+ * @brief Will handle reading from and writing to metadata information to permanent storage
+ * @ingroup libowncrypt
+ */
+class GUINetworkJobFactory : public QObject {
+
+public:
+
+    GUINetworkJobFactory(QObject *parent=0)
+        : QObject(parent) {}
+
+    ThumbnailJob* createThumbnailJob(const QString& path, AccountPtr account, QObject* parent = 0);
+
+    /*
+     * TODO orion : can't choose between normal and encrypted at creation time with current implementation.
+     * need to think about how to deal with these 2 jobs
+     *
+    OcsShareeJob* createOcsShareeJob(AccountPtr account);
+    OcsShareJob* createOcsShareJob(AccountPtr account);
+    */
+private:
+    NetworkJobFactoryHelper helper;
+};
+
+}
+
+#endif

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -32,6 +32,7 @@ namespace OCC {
 class AccountState;
 
 class OwncloudWizard;
+class NetworkJobFactory;
 
 /**
  * @brief The DetermineAuthTypeJob class
@@ -93,6 +94,9 @@ private:
     OwncloudWizard* _ocWizard;
     QString _initLocalFolder;
     QString _remoteFolder;
+
+    // Used to create the network jobs we need
+    NetworkJobFactory* _factory;
 
 };
 

--- a/src/gui/quotainfo.cpp
+++ b/src/gui/quotainfo.cpp
@@ -14,7 +14,7 @@
 #include "quotainfo.h"
 #include "account.h"
 #include "accountstate.h"
-#include "networkjobs.h"
+#include "networkjobfactory.h"
 #include "folderman.h"
 #include "creds/abstractcredentials.h"
 #include <theme.h>
@@ -40,6 +40,8 @@ QuotaInfo::QuotaInfo(AccountState *accountState, QObject *parent)
             SLOT(slotAccountStateChanged()));
     connect(&_jobRestartTimer, SIGNAL(timeout()), SLOT(slotCheckQuota()));
     _jobRestartTimer.setSingleShot(true);
+
+    _factory = new NetworkJobFactory(this);
 }
 
 void QuotaInfo::setActive(bool active)
@@ -98,7 +100,7 @@ void QuotaInfo::slotCheckQuota()
     }
 
     AccountPtr account = _accountState->account();
-    _job = new PropfindJob(account, quotaBaseFolder(), this);
+    _job = _factory->createPropfindJob(account, quotaBaseFolder(), this);
     _job->setProperties(QList<QByteArray>() << "quota-available-bytes" << "quota-used-bytes");
     connect(_job, SIGNAL(result(QVariantMap)), SLOT(slotUpdateLastQuota(QVariantMap)));
     connect(_job, SIGNAL(networkError(QNetworkReply*)), SLOT(slotRequestFailed()));

--- a/src/gui/quotainfo.h
+++ b/src/gui/quotainfo.h
@@ -23,6 +23,7 @@
 namespace OCC {
 class AccountState;
 class PropfindJob;
+class NetworkJobFactory;
 
 /**
  * @brief handles getting the quota to display in the UI
@@ -81,6 +82,9 @@ private:
     QDateTime _lastQuotaRecieved; // the time at which the quota was received last
     bool _active; // if we should check at regular interval (when the UI is visible)
     QPointer<PropfindJob> _job; // the currently running job
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -16,6 +16,7 @@
 #include "account.h"
 #include "excludedfiles.h"
 #include "networkjobs.h"
+#include "networkjobfactory.h"
 #include "theme.h"
 #include "folderman.h"
 #include <QDialogButtonBox>
@@ -72,6 +73,8 @@ SelectiveSyncTreeView::SelectiveSyncTreeView(AccountPtr account, QWidget* parent
     header()->setStretchLastSection(true);
     headerItem()->setText(0, tr("Name"));
     headerItem()->setText(1, tr("Size"));
+
+    _factory = new NetworkJobFactory(this);
 }
 
 QSize SelectiveSyncTreeView::sizeHint() const
@@ -81,7 +84,7 @@ QSize SelectiveSyncTreeView::sizeHint() const
 
 void SelectiveSyncTreeView::refreshFolders()
 {
-    LsColJob *job = new LsColJob(_account, _folderPath, this);
+    LsColJob *job = _factory->createLsColJob(_account, _folderPath, this);
     job->setProperties(QList<QByteArray>() << "resourcetype" << "http://owncloud.org/ns:size");
     connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
             this, SLOT(slotUpdateDirectories(QStringList)));
@@ -257,7 +260,7 @@ void SelectiveSyncTreeView::slotItemExpanded(QTreeWidgetItem *item)
     if (!_folderPath.isEmpty()) {
         prefix = _folderPath + QLatin1Char('/');
     }
-    LsColJob *job = new LsColJob(_account, prefix + dir, this);
+    LsColJob *job = _factory->createLsColJob(_account, prefix + dir, this);
     job->setProperties(QList<QByteArray>() << "resourcetype" << "http://owncloud.org/ns:size");
     connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
             SLOT(slotUpdateDirectories(QStringList)));

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -24,6 +24,7 @@ class QLabel;
 namespace OCC {
 
 class Folder;
+class NetworkJobFactory;
 
 /**
  * @brief The SelectiveSyncTreeView class
@@ -60,6 +61,10 @@ private:
     bool _inserting; // set to true when we are inserting new items on the list
     AccountPtr _account;
     QLabel *_loading;
+
+    // Used to create the network jobs we need
+    NetworkJobFactory* _factory;
+
 };
 
 /**

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -16,6 +16,7 @@
 #include "capabilities.h"
 #include "json.h"
 #include "networkjobs.h"
+#include "networkjobfactory.h"
 
 namespace OCC
 {
@@ -23,7 +24,7 @@ namespace OCC
 ServerNotificationHandler::ServerNotificationHandler(QObject *parent)
     : QObject(parent)
 {
-
+    _factory = new NetworkJobFactory(this);
 }
 
 void ServerNotificationHandler::slotFetchNotifications(AccountState *ptr)
@@ -46,7 +47,7 @@ void ServerNotificationHandler::slotFetchNotifications(AccountState *ptr)
     }
 
     // if the previous notification job has finished, start next.
-    _notificationJob = new JsonApiJob( ptr->account(), QLatin1String("ocs/v2.php/apps/notifications/api/v1/notifications"), this );
+    _notificationJob = _factory->createJsonApiJob(ptr->account(), QLatin1String("ocs/v2.php/apps/notifications/api/v1/notifications"), this );
     QObject::connect(_notificationJob.data(), SIGNAL(jsonReceived(QVariantMap, int)),
                      this, SLOT(slotNotificationsReceived(QVariantMap, int)));
     _notificationJob->setProperty("AccountStatePtr", QVariant::fromValue<AccountState*>(ptr));

--- a/src/gui/servernotificationhandler.h
+++ b/src/gui/servernotificationhandler.h
@@ -21,6 +21,8 @@
 namespace OCC
 {
 
+class NetworkJobFactory;
+
 class ServerNotificationHandler : public QObject
 {
     Q_OBJECT
@@ -39,7 +41,8 @@ private slots:
 private:
     QPointer<JsonApiJob> _notificationJob;
 
-
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 }

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -21,6 +21,7 @@
 #include "configfile.h"
 #include "theme.h"
 #include "thumbnailjob.h"
+#include "networkjobfactory.h"
 
 #include <QFileInfo>
 #include <QFileIconProvider>
@@ -113,9 +114,11 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     _progressIndicator->setToolTip(tr("Retrieving maximum possible sharing permissions from server..."));
     _ui->shareWidgetsLayout->addWidget(_progressIndicator);
 
+    _factory = new NetworkJobFactory(this);
+
     // Server versions >= 9.1 support the "share-permissions" property
     // older versions will just return share-permissions: ""
-    auto job = new PropfindJob(accountState->account(), _sharePath);
+    auto job = _factory->createPropfindJob(accountState->account(), _sharePath);
     job->setProperties(QList<QByteArray>() << "http://open-collaboration-services.org/ns:share-permissions");
     job->setTimeout(10 * 1000);
     connect(job, SIGNAL(result(QVariantMap)), SLOT(slotMaxSharingPermissionsReceived(QVariantMap)));

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -32,6 +32,7 @@ class ShareDialog;
 
 class ShareLinkWidget;
 class ShareUserGroupWidget;
+class NetworkJobFactory;
 
 class ShareDialog : public QDialog
 {
@@ -66,6 +67,9 @@ private:
     ShareLinkWidget *_linkWidget;
     ShareUserGroupWidget *_userGroupWidget;
     QProgressIndicator *_progressIndicator;
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 }

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -29,7 +29,7 @@
 #include "selectivesyncdialog.h"
 #include <folderman.h>
 #include "creds/abstractcredentials.h"
-#include "networkjobs.h"
+#include "networkjobfactory.h"
 
 namespace OCC
 {
@@ -68,6 +68,8 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage()
     _ui.lServerIcon->setPixmap(appIcon.pixmap(48));
     _ui.lLocalIcon->setText(QString());
     _ui.lLocalIcon->setPixmap(QPixmap(Theme::hidpiFileName(":/client/resources/folder-sync.png")));
+
+    _factory = new NetworkJobFactory(this);
 }
 
 void OwncloudAdvancedSetupPage::setupCustomization()
@@ -107,7 +109,7 @@ void OwncloudAdvancedSetupPage::initializePage()
     QTimer::singleShot(0, wizard()->button(QWizard::NextButton), SLOT(setFocus()));
 
     auto acc = static_cast<OwncloudWizard *>(wizard())->account();
-    auto quotaJob = new PropfindJob(acc, _remoteFolder, this);
+    auto quotaJob = _factory->createPropfindJob(acc, _remoteFolder, this);
     quotaJob->setProperties(QList<QByteArray>() << "http://owncloud.org/ns:size");
 
     connect(quotaJob, SIGNAL(result(QVariantMap)), SLOT(slotQuotaRetrieved(QVariantMap)));

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -25,6 +25,8 @@ class QProgressIndicator;
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * @brief The OwncloudAdvancedSetupPage class
  * @ingroup gui
@@ -72,6 +74,9 @@ private:
   QString _oldLocalFolder;
   QString _remoteFolder;
   QStringList _selectiveSyncBlacklist;
+
+  // Used to create the network jobs we need
+   NetworkJobFactory* _factory;
 };
 
 } // namespace OCC

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -65,6 +65,7 @@ set(libsync_SRCS
     ownsql.cpp
     checksums.cpp
     excludedfiles.cpp
+    networkjobfactory.cpp
     creds/dummycredentials.cpp
     creds/abstractcredentials.cpp
     creds/credentialscommon.cpp

--- a/src/libsync/connectionvalidator.h
+++ b/src/libsync/connectionvalidator.h
@@ -23,6 +23,8 @@
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * This is a job-like class to check that the server is up and that we are connected.
  * There are two entry points: checkServerAndAuth and checkAuthentication
@@ -117,6 +119,9 @@ private:
     QStringList _errors;
     AccountPtr   _account;
     bool _isCheckingServerAndAuth;
+
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 }

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -212,12 +212,13 @@ int get_errno_from_http_errcode( int err, const QString & reason ) {
 DiscoverySingleDirectoryJob::DiscoverySingleDirectoryJob(const AccountPtr &account, const QString &path, QObject *parent)
     : QObject(parent), _subPath(path), _account(account), _ignoredFirst(false)
 {
+    _factory = new NetworkJobFactory(this);
 }
 
 void DiscoverySingleDirectoryJob::start()
 {
     // Start the actual HTTP job
-    LsColJob *lsColJob = new LsColJob(_account, _subPath, this);
+    LsColJob *lsColJob = _factory->createLsColJob(_account, _subPath, this);
     lsColJob->setProperties(QList<QByteArray>() << "resourcetype" << "getlastmodified"
                         << "getcontentlength" << "getetag" << "http://owncloud.org/ns:id"
                         << "http://owncloud.org/ns:downloadURL" << "http://owncloud.org/ns:dDC"
@@ -488,7 +489,7 @@ void DiscoveryMainThread::doGetSizeSlot(const QString& path, qint64* result)
     _currentGetSizeResult = result;
 
     // Schedule the DiscoverySingleDirectoryJob
-    auto propfindJob = new PropfindJob(_account, fullPath, this);
+    auto propfindJob = _factory->createPropfindJob(_account, fullPath, this);
     propfindJob->setProperties(QList<QByteArray>() << "resourcetype" << "http://owncloud.org/ns:size");
     QObject::connect(propfindJob, SIGNAL(finishedWithError()),
                      this, SLOT(slotGetSizeFinishedWithError()));

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -19,10 +19,11 @@
 #include <QStringList>
 #include <csync.h>
 #include <QMap>
-#include "networkjobs.h"
 #include <QMutex>
 #include <QWaitCondition>
 #include <QLinkedList>
+#include "networkjobs.h"
+#include "networkjobfactory.h"
 
 namespace OCC {
 
@@ -102,6 +103,10 @@ private:
     AccountPtr _account;
     bool _ignoredFirst;
     QPointer<LsColJob> _lsColJob;
+
+    // Used to create the network jobs we need
+    NetworkJobFactory* _factory;
+
 };
 
 // Lives in main thread. Deleted by the SyncEngine
@@ -119,7 +124,8 @@ class DiscoveryMainThread : public QObject {
 public:
     DiscoveryMainThread(AccountPtr account) : QObject(), _account(account),
         _currentDiscoveryDirectoryResult(0), _currentGetSizeResult(0)
-    { }
+    { _factory = new NetworkJobFactory(this); }
+
     void abort();
 
 
@@ -140,6 +146,9 @@ signals:
     void etagConcatenation(const QString &);
 public:
     void setupHooks(DiscoveryJob* discoveryJob, const QString &pathPrefix);
+private:
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 /**

--- a/src/libsync/networkjobfactory.cpp
+++ b/src/libsync/networkjobfactory.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@owncloud.com>
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "networkjobfactory.h"
+
+/** \file networkjobfactory.cpp
+ *
+ * \brief Class that creates network jobs on demand.
+ * Creates an normal or encrypted network job based on context.
+ *
+ * Overview
+ * --------
+ *
+ * TODO
+ *
+ */
+
+namespace OCC {
+
+MkColJob* NetworkJobFactory::createMkColJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new MkColJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+LsColJob* NetworkJobFactory::createLsColJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new LsColJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+RequestEtagJob* NetworkJobFactory::createRequestEtagJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new RequestEtagJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+PropfindJob* NetworkJobFactory::createPropfindJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new PropfindJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+ProppatchJob* NetworkJobFactory::createProppatchJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new ProppatchJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+EntityExistsJob* NetworkJobFactory::createEntityExistsJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new EntityExistsJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+JsonApiJob* NetworkJobFactory::createJsonApiJob(AccountPtr account, const QString &path, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new JsonApiJob(account, path, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+GETFileJob* NetworkJobFactory::createGETFileJob(AccountPtr account, const QString& path, QFile *device,
+                             const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                             quint64 resumeStart, QObject* parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new GETFileJob(account, path, device, headers, expectedEtagForResume, resumeStart, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+GETFileJob* NetworkJobFactory::createGETFileJob(AccountPtr account, const QUrl& url, QFile *device,
+                             const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                             quint64 resumeStart, QObject* parent)
+{
+    if (! _helper.isFileEncrypted(url))
+        return new GETFileJob(account, url, device, headers, expectedEtagForResume, resumeStart, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+PUTFileJob* NetworkJobFactory::createPUTFileJob(AccountPtr account, const QString& path, QIODevice *device,
+                             const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new PUTFileJob(account, path, device, headers, chunk, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+/**
+ * @brief NetworkJobFactory::createPollJob
+ * Creates either a normal or an encrypted ThumbnailJob network job, depending on path.
+ * @param account : passed as is to the relevant constructor
+ * @param path : Used to decide whether to create an encrypted or normal version of the network job,
+ * and passed as is to the relevant constructor
+ * @param item : passed as is to the relevant constructor
+ * @param journal : passed as is to the relevant constructor
+ * @param localPath : passed as is to the relevant constructor
+ * @param parent : passed as is to the relevant constructor
+ * @return A pointer to the created network job. Will be either normal or encrypted.
+ */
+PollJob* NetworkJobFactory::createPollJob(AccountPtr account, const QString &path, const SyncFileItemPtr &item,
+                       SyncJournalDb *journal, const QString &localPath, QObject *parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new PollJob(account, path, item, journal, localPath, parent);
+    else
+        // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+/**
+ * \brief Used by the factory to determine whether a job should be created in
+ * its normal version or an encrypted version.
+ *
+ * Overview
+ * --------
+ *
+ * TODO
+ *
+ */
+bool OWNCLOUDSYNC_EXPORT NetworkJobFactoryHelper::isFileEncrypted(SyncFileItem *item)
+{
+    // TODO orion : for now always return false, we only want to create normal networkjob.
+    Q_UNUSED(item)
+    return false;
+}
+
+bool OWNCLOUDSYNC_EXPORT NetworkJobFactoryHelper::isFileEncrypted(const QString &path)
+{
+    // TODO orion : for now always return false, we only want to create normal networkjob.
+    Q_UNUSED(path)
+    return false;
+}
+
+bool OWNCLOUDSYNC_EXPORT NetworkJobFactoryHelper::isFileEncrypted(const QUrl &url)
+{
+    // TODO orion : for now always return false, we only want to create normal networkjob.
+    Q_UNUSED(url)
+    return false;
+}
+
+}

--- a/src/libsync/networkjobfactory.cpp
+++ b/src/libsync/networkjobfactory.cpp
@@ -15,6 +15,12 @@
 
 #include "networkjobfactory.h"
 
+#include "networkjobs.h"
+#include "propagatedownload.h"
+#include "propagateupload.h"
+#include "propagateremotedelete.h"
+#include "propagateremotemove.h"
+
 /** \file networkjobfactory.cpp
  *
  * \brief Class that creates network jobs on demand.
@@ -136,7 +142,7 @@ PUTFileJob* NetworkJobFactory::createPUTFileJob(AccountPtr account, const QStrin
 
 /**
  * @brief NetworkJobFactory::createPollJob
- * Creates either a normal or an encrypted ThumbnailJob network job, depending on path.
+ * Creates either a normal or an encrypted PollJob network job, depending on path.
  * @param account : passed as is to the relevant constructor
  * @param path : Used to decide whether to create an encrypted or normal version of the network job,
  * and passed as is to the relevant constructor
@@ -153,6 +159,26 @@ PollJob* NetworkJobFactory::createPollJob(AccountPtr account, const QString &pat
         return new PollJob(account, path, item, journal, localPath, parent);
     else
         // for now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+DeleteJob* NetworkJobFactory::createDeleteJob(AccountPtr account, const QString& path, QObject* parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new DeleteJob(account, path, parent);
+    else
+        // For now helper.isFileEncrypted returns always false so this is never executed.
+        // TODO orion : update once the encrypted class is created.
+        return 0;
+}
+
+MoveJob* NetworkJobFactory::createMoveJob(AccountPtr account, const QString& path, const QString &destination, QObject* parent)
+{
+    if (! _helper.isFileEncrypted(path))
+        return new MoveJob(account, path, destination, parent);
+    else
+        // For now helper.isFileEncrypted returns always false so this is never executed.
         // TODO orion : update once the encrypted class is created.
         return 0;
 }

--- a/src/libsync/networkjobfactory.h
+++ b/src/libsync/networkjobfactory.h
@@ -16,20 +16,27 @@
 #define NETWORKJOBFACTORY_H
 
 #include <QObject>
+#include <QFile>
 
 #include "networkjobs.h"
 #include "syncfileitem.h"
-#include "propagatedownload.h"
-#include "propagateupload.h"
+#include "owncloudlib.h"
 
 namespace OCC {
+
+class GETFileJob;
+class PUTFileJob;
+class PollJob;
+class SyncJournalDb;
+class DeleteJob;
+class MoveJob;
 
 /**
  * @brief The NetworkJobFactoryHelper class
  * Provides helper methods to factory classes.
  */
-class NetworkJobFactoryHelper : public QObject {
-
+class OWNCLOUDSYNC_EXPORT NetworkJobFactoryHelper : public QObject {
+    Q_OBJECT
 public:
     NetworkJobFactoryHelper(QObject *parent=0)
         : QObject(parent) {}
@@ -44,8 +51,8 @@ public:
  * @brief Will handle reading from and writing to metadata information to permanent storage
  * @ingroup libowncrypt
  */
-class NetworkJobFactory : public QObject {
-
+class OWNCLOUDSYNC_EXPORT NetworkJobFactory : public QObject {
+    Q_OBJECT
 public:
 
     NetworkJobFactory(QObject *parent=0)
@@ -71,6 +78,10 @@ public:
 
     PollJob* createPollJob(AccountPtr account, const QString &path, const SyncFileItemPtr &item,
                            SyncJournalDb *journal, const QString &localPath, QObject *parent);
+
+    DeleteJob* createDeleteJob(AccountPtr account, const QString& path, QObject* parent = 0);
+
+    MoveJob* createMoveJob(AccountPtr account, const QString& path, const QString &destination, QObject* parent = 0);
 
 private:
     NetworkJobFactoryHelper _helper;

--- a/src/libsync/networkjobfactory.h
+++ b/src/libsync/networkjobfactory.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) by orion1024 <orion1024+src@use.startmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef NETWORKJOBFACTORY_H
+#define NETWORKJOBFACTORY_H
+
+#include <QObject>
+
+#include "networkjobs.h"
+#include "syncfileitem.h"
+#include "propagatedownload.h"
+#include "propagateupload.h"
+
+namespace OCC {
+
+/**
+ * @brief The NetworkJobFactoryHelper class
+ * Provides helper methods to factory classes.
+ */
+class NetworkJobFactoryHelper : public QObject {
+
+public:
+    NetworkJobFactoryHelper(QObject *parent=0)
+        : QObject(parent) {}
+
+    bool isFileEncrypted(SyncFileItem *item);
+    bool isFileEncrypted(const QString &path);
+    bool isFileEncrypted(const QUrl &url);
+
+};
+
+/**
+ * @brief Will handle reading from and writing to metadata information to permanent storage
+ * @ingroup libowncrypt
+ */
+class NetworkJobFactory : public QObject {
+
+public:
+
+    NetworkJobFactory(QObject *parent=0)
+        : QObject(parent) {}
+
+    MkColJob* createMkColJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    LsColJob* createLsColJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    RequestEtagJob* createRequestEtagJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    PropfindJob* createPropfindJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    ProppatchJob* createProppatchJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    EntityExistsJob* createEntityExistsJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    JsonApiJob* createJsonApiJob(AccountPtr account, const QString &path, QObject *parent = 0);
+
+    GETFileJob* createGETFileJob(AccountPtr account, const QString& path, QFile *device,
+                                 const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                                 quint64 resumeStart, QObject* parent = 0);
+    GETFileJob* createGETFileJob(AccountPtr account, const QUrl& url, QFile *device,
+                                 const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                                 quint64 resumeStart, QObject* parent = 0);
+
+    PUTFileJob* createPUTFileJob(AccountPtr account, const QString& path, QIODevice *device,
+                                 const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent = 0);
+
+    PollJob* createPollJob(AccountPtr account, const QString &path, const SyncFileItemPtr &item,
+                           SyncJournalDb *journal, const QString &localPath, QObject *parent);
+
+private:
+    NetworkJobFactoryHelper _helper;
+
+};
+
+}
+
+#endif

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -22,15 +22,20 @@ class QUrl;
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * @brief The EntityExistsJob class
  * @ingroup libsync
  */
 class OWNCLOUDSYNC_EXPORT EntityExistsJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit EntityExistsJob(AccountPtr account, const QString &path, QObject* parent = 0);
     void start() Q_DECL_OVERRIDE;
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit EntityExistsJob(AccountPtr account, const QString &path, QObject* parent = 0);
 
 signals:
     void exists(QNetworkReply*);
@@ -60,8 +65,8 @@ signals:
 
 class OWNCLOUDSYNC_EXPORT LsColJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit LsColJob(AccountPtr account, const QString &path, QObject *parent = 0);
     void start() Q_DECL_OVERRIDE;
     QHash<QString, qint64> _sizes;
 
@@ -84,6 +89,9 @@ signals:
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit LsColJob(AccountPtr account, const QString &path, QObject *parent = 0);
 
 private:
     QList<QByteArray> _properties;
@@ -101,8 +109,8 @@ private:
  */
 class OWNCLOUDSYNC_EXPORT PropfindJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit PropfindJob(AccountPtr account, const QString &path, QObject *parent = 0);
     void start() Q_DECL_OVERRIDE;
 
     /**
@@ -119,6 +127,10 @@ public:
 signals:
     void result(const QVariantMap &values);
     void finishedWithError(QNetworkReply *reply = 0);
+
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit PropfindJob(AccountPtr account, const QString &path, QObject *parent = 0);
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
@@ -138,8 +150,8 @@ private:
  */
 class OWNCLOUDSYNC_EXPORT ProppatchJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit ProppatchJob(AccountPtr account, const QString &path, QObject *parent = 0);
     void start() Q_DECL_OVERRIDE;
 
     /**
@@ -156,6 +168,9 @@ public:
 signals:
     void success();
     void finishedWithError();
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit ProppatchJob(AccountPtr account, const QString &path, QObject *parent = 0);
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
@@ -170,12 +185,15 @@ private:
  */
 class OWNCLOUDSYNC_EXPORT MkColJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit MkColJob(AccountPtr account, const QString &path, QObject *parent = 0);
     void start() Q_DECL_OVERRIDE;
 
 signals:
     void finished(QNetworkReply::NetworkError);
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit MkColJob(AccountPtr account, const QString &path, QObject *parent = 0);
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
@@ -216,12 +234,16 @@ private:
  */
 class OWNCLOUDSYNC_EXPORT RequestEtagJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit RequestEtagJob(AccountPtr account, const QString &path, QObject *parent = 0);
     void start() Q_DECL_OVERRIDE;
 
 signals:
     void etagRetreived(const QString &etag);
+
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit RequestEtagJob(AccountPtr account, const QString &path, QObject *parent = 0);
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
@@ -244,8 +266,8 @@ private slots:
  */
 class OWNCLOUDSYNC_EXPORT JsonApiJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 public:
-    explicit JsonApiJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
 
     /**
      * @brief addQueryParams - add more parameters to the ocs call
@@ -263,6 +285,9 @@ public slots:
     void start() Q_DECL_OVERRIDE;
 protected:
     bool finished() Q_DECL_OVERRIDE;
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit JsonApiJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
+
 signals:
 
     /**

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -235,7 +235,7 @@ private slots:
  *
  * To be used like this:
  * \code
- * _job = new JsonApiJob(account, QLatin1String("ocs/v1.php/foo/bar"), this);
+ * _job = _factory->createJsonApiJob(account, QLatin1String("ocs/v1.php/foo/bar"), this);
  * connect(job, SIGNAL(jsonReceived(QVariantMap)), ...)
  * The received QVariantMap is empty in case of error or otherwise is a map as parsed by QtJson
  * \encode

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -45,6 +45,7 @@ qint64 freeSpaceLimit();
 
 class SyncJournalDb;
 class OwncloudPropagator;
+class NetworkJobFactory;
 
 /**
  * @brief the base class of propagator jobs
@@ -151,6 +152,9 @@ protected:
         _item->_errorString = msg;
     }
 
+   // Used by child classes to create the network jobs we need
+    NetworkJobFactory* _factory;
+
 protected slots:
     void slotRestoreJobCompleted(const SyncFileItem& );
 
@@ -158,8 +162,7 @@ private:
     QScopedPointer<PropagateItemJob> _restoreJob;
 
 public:
-    PropagateItemJob(OwncloudPropagator* propagator, const SyncFileItemPtr &item)
-        : PropagatorJob(propagator), _item(item) {}
+    PropagateItemJob(OwncloudPropagator* propagator, const SyncFileItemPtr &item);
 
     bool scheduleNextJob() Q_DECL_OVERRIDE {
         if (_state != NotYetStarted) {
@@ -391,8 +394,7 @@ class CleanupPollsJob : public QObject {
     QString _localPath;
 public:
     explicit CleanupPollsJob(const QVector< SyncJournalDb::PollInfo > &pollInfos, AccountPtr account,
-                             SyncJournalDb *journal, const QString &localPath, QObject* parent = 0)
-        : QObject(parent), _pollInfos(pollInfos), _account(account), _journal(journal), _localPath(localPath) {}
+                             SyncJournalDb *journal, const QString &localPath, QObject* parent = 0);
 
     ~CleanupPollsJob();
 
@@ -402,6 +404,9 @@ signals:
     void aborted(const QString &error);
 private slots:
     void slotPollFinished();
+private:
+    // Used to create the network jobs we need
+     NetworkJobFactory* _factory;
 };
 
 }

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -23,6 +23,7 @@
 #include "filesystem.h"
 #include "propagatorjobs.h"
 #include "checksums.h"
+#include "networkjobfactory.h"
 
 #include <json.h>
 #include <QNetworkAccessManager>
@@ -396,7 +397,7 @@ void PropagateDownloadFileQNAM::start()
 
     if (_item->_directDownloadUrl.isEmpty()) {
         // Normal job, download from oC instance
-        _job = new GETFileJob(_propagator->account(),
+        _job = _factory->createGETFileJob(_propagator->account(),
                             _propagator->_remoteFolder + _item->_file,
                             &_tmpFile, headers, expectedEtagForResume, _resumeStart);
     } else {
@@ -408,7 +409,7 @@ void PropagateDownloadFileQNAM::start()
         }
 
         QUrl url = QUrl::fromUserInput(_item->_directDownloadUrl);
-        _job = new GETFileJob(_propagator->account(),
+        _job = _factory->createGETFileJob(_propagator->account(),
                               url,
                               &_tmpFile, headers, expectedEtagForResume, _resumeStart);
     }

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -21,12 +21,16 @@
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * @brief The GETFileJob class
  * @ingroup libsync
  */
 class GETFileJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
+
     QFile* _device;
     QMap<QByteArray, QByteArray> _headers;
     QString _errorString;
@@ -43,14 +47,6 @@ class GETFileJob : public AbstractNetworkJob {
     time_t _lastModified;
 public:
 
-    // DOES NOT take ownership of the device.
-    explicit GETFileJob(AccountPtr account, const QString& path, QFile *device,
-                        const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-                        quint64 resumeStart, QObject* parent = 0);
-    // For directDownloadUrl:
-    explicit GETFileJob(AccountPtr account, const QUrl& url, QFile *device,
-                        const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-                        quint64 resumeStart, QObject* parent = 0);
     virtual ~GETFileJob() {
         if (_bandwidthManager) {
             _bandwidthManager->unregisterDownloadJob(this);
@@ -97,6 +93,17 @@ public:
 signals:
     void finishedSignal();
     void downloadProgress(qint64,qint64);
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    // DOES NOT take ownership of the device.
+    explicit GETFileJob(AccountPtr account, const QString& path, QFile *device,
+                        const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                        quint64 resumeStart, QObject* parent = 0);
+    // For directDownloadUrl:
+    explicit GETFileJob(AccountPtr account, const QUrl& url, QFile *device,
+                        const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
+                        quint64 resumeStart, QObject* parent = 0);
+
 private slots:
     void slotReadyRead();
     void slotMetaDataChanged();

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -15,6 +15,7 @@
 #include "propagateremotedelete.h"
 #include "owncloudpropagator_p.h"
 #include "account.h"
+#include "networkjobfactory.h"
 
 namespace OCC {
 
@@ -60,7 +61,7 @@ void PropagateRemoteDelete::start()
 
     qDebug() << Q_FUNC_INFO << _item->_file;
 
-    _job = new DeleteJob(_propagator->account(),
+    _job = _factory->createDeleteJob(_propagator->account(),
                          _propagator->_remoteFolder + _item->_file,
                          this);
     connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotDeleteJobFinished()));

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -18,14 +18,17 @@
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * @brief The DeleteJob class
  * @ingroup libsync
  */
 class DeleteJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
+
 public:
-    explicit DeleteJob(AccountPtr account, const QString& path, QObject* parent = 0);
 
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
@@ -35,6 +38,11 @@ public:
 
 signals:
     void finishedSignal();
+
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit DeleteJob(AccountPtr account, const QString& path, QObject* parent = 0);
+
 };
 
 /**

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -19,6 +19,7 @@
 #include "filesystem.h"
 #include <QFile>
 #include <QStringList>
+#include "networkjobfactory.h"
 
 namespace OCC {
 
@@ -92,7 +93,7 @@ void PropagateRemoteMove::start()
         }
     }
 
-    _job = new MoveJob(_propagator->account(),
+    _job = _factory->createMoveJob(_propagator->account(),
                         _propagator->_remoteFolder + _item->_file,
                         _propagator->_remoteDir + _item->_renameTarget,
                         this);

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -18,15 +18,18 @@
 
 namespace OCC {
 
+class NetworkJobFactory;
+
 /**
  * @brief The MoveJob class
  * @ingroup libsync
  */
 class MoveJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
+
     const QString _destination;
 public:
-    explicit MoveJob(AccountPtr account, const QString& path, const QString &destination, QObject* parent = 0);
 
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
@@ -36,6 +39,11 @@ public:
 
 signals:
     void finishedSignal();
+
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    explicit MoveJob(AccountPtr account, const QString& path, const QString &destination, QObject* parent = 0);
+
 };
 
 /**

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -194,7 +194,7 @@ void PropagateUploadFileQNAM::start()
         return slotComputeContentChecksum();
     }
 
-    auto job = new DeleteJob(_propagator->account(),
+    auto job = _factory->createDeleteJob(_propagator->account(),
                              _propagator->_remoteFolder + _item->_file,
                              this);
     _jobs.append(job);
@@ -553,7 +553,7 @@ void PropagateUploadFileQNAM::startNextChunk()
     }
 
     // job takes ownership of device via a QScopedPointer. Job deletes itself when finishing
-    PUTFileJob* job = new PUTFileJob(_propagator->account(), _propagator->_remoteFolder + path, device, headers, _currentChunk);
+    PUTFileJob* job = _factory->createPUTFileJob(_propagator->account(), _propagator->_remoteFolder + path, device, headers, _currentChunk);
     _jobs.append(job);
     connect(job, SIGNAL(finishedSignal()), this, SLOT(slotPutFinished()));
     connect(job, SIGNAL(uploadProgress(qint64,qint64)), this, SLOT(slotUploadProgress(qint64,qint64)));
@@ -824,7 +824,7 @@ void PropagateUploadFileQNAM::slotUploadProgress(qint64 sent, qint64 total)
 
 void PropagateUploadFileQNAM::startPollJob(const QString& path)
 {
-    PollJob* job = new PollJob(_propagator->account(), path, _item,
+    PollJob* job = _factory->createPollJob(_propagator->account(), path, _item,
                                _propagator->_journal, _propagator->_localDir, this);
     connect(job, SIGNAL(finishedSignal()), SLOT(slotPollFinished()));
     SyncJournalDb::PollInfo info;

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -23,6 +23,7 @@
 
 namespace OCC {
 class BandwidthManager;
+class NetworkJobFactory;
 
 /**
  * @brief The UploadDevice class
@@ -84,6 +85,7 @@ protected slots:
  */
 class PUTFileJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
 
 private:
     QScopedPointer<QIODevice> _device;
@@ -91,10 +93,6 @@ private:
     QString _errorString;
 
 public:
-    // Takes ownership of the device
-    explicit PUTFileJob(AccountPtr account, const QString& path, QIODevice *device,
-                        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent = 0)
-        : AbstractNetworkJob(account, path, parent), _device(device), _headers(headers), _chunk(chunk) {}
     ~PUTFileJob();
 
     int _chunk;
@@ -117,6 +115,13 @@ signals:
     void finishedSignal();
     void uploadProgress(qint64,qint64);
 
+protected:
+    // Can only be created through the friend class, NetworkJobFactory
+    // Takes ownership of the device
+    explicit PUTFileJob(AccountPtr account, const QString& path, QIODevice *device,
+                        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent = 0)
+        : AbstractNetworkJob(account, path, parent), _device(device), _headers(headers), _chunk(chunk) {}
+
 private slots:
 #if QT_VERSION < 0x050402
     void slotSoftAbort();
@@ -132,14 +137,12 @@ private slots:
  */
 class PollJob : public AbstractNetworkJob {
     Q_OBJECT
+    friend class NetworkJobFactory;
+
     SyncJournalDb *_journal;
     QString _localPath;
 public:
     SyncFileItemPtr _item;
-    // Takes ownership of the device
-    explicit PollJob(AccountPtr account, const QString &path, const SyncFileItemPtr &item,
-                     SyncJournalDb *journal, const QString &localPath, QObject *parent)
-        : AbstractNetworkJob(account, path, parent), _journal(journal), _localPath(localPath), _item(item) {}
 
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
@@ -152,6 +155,13 @@ public:
 
 signals:
     void finishedSignal();
+
+protected:
+    // Takes ownership of the device
+    explicit PollJob(AccountPtr account, const QString &path, const SyncFileItemPtr &item,
+                     SyncJournalDb *journal, const QString &localPath, QObject *parent)
+        : AbstractNetworkJob(account, path, parent), _journal(journal), _localPath(localPath), _item(item) {}
+
 };
 
 /**


### PR DESCRIPTION
Hello,

This is a new PR that lays down more groundwork towards adding ownCrypt.

The goal is to provide 2 factory classes that will handle the construction of NetworkJob objects (one for libsync jobs, one for gui jobs).

A quick example :
Before :
`MkColJob *job = new MkColJob( [args] )`
After :
`MkColJob *job = _factory->createMkColJob([args])`

For now, the factories always creates normal network jobs. But later on, they will enable the creation of either normal or ownCrypt network jobs, depending on whether the node is protected with ownCrypt. The idea is that the class requesting the creation **won't (and won't need to) know whether they are using a normal or ownCrypt version of the job**.
Polymorphism will be needed to achieve that but that's for another PR.

After this PR is merged, direct construction of network job should no longer be possible for most of the jobs : the network jobs constructors are made `protected` instead of `public`, and only the `friend` factory classes can call them. The goal is to enforce all job creations through factories.

Some jobs are spared from the factory requirement when they won't need an ownCrypt version, such as `CheckServerJob`.
But I suppose that for consistency sake I could include them in the factory too, what do you think ?

Note : I still need to finish the GUI factory, the PR is not yet finished.
But since there might be some discussion on my approach, the sooner it starts the better.
