### PR TITLE
Fix assert on restore after propagation

### DIFF
--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -180,8 +180,7 @@ void SyncFileStatusTracker::slotItemCompleted(const SyncFileItem &item)
     } else if (showWarningInSocketApi(item)) {
         _syncProblems[item._file] = SyncFileStatus::StatusWarning;
     } else {
-        // There is currently no situation where an error status set during discovery/update is fixed by propagation.
-        Q_ASSERT(_syncProblems.find(item._file) == _syncProblems.end());
+        _syncProblems.erase(item._file);
     }
 
     emit fileStatusChanged(getSystemDestination(item.destination()), syncFileItemStatus(item));


### PR DESCRIPTION
The assert was there to make sure that this case wasn't happening
to eventually be properly tested. Remove the assert for now but this
codepath should eventually be unit tested using this specific situation.