### PR TITLE
A final release version number breaks regex

### DIFF
--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -127,7 +127,7 @@ private slots:
 	    qDebug() << "Version of installed ownCloud Binary: " << ver;
 	    QVERIFY( !ver.isEmpty());
 
-	    QRegExp rx( "ownCloud version \\d+\\.\\d+\\.\\d+.+" );
+	    QRegExp rx( "ownCloud version \\d+\\.\\d+\\.\\d+.*" );
             QVERIFY( rx.exactMatch(ver));
 	} else {
 	    QVERIFY( versionOfInstalledBinary().isEmpty());


### PR DESCRIPTION
f.ex. a valid verson nr: 2.2.0
-> fist \d+ = 2
-> second \d+ = 2
-> the last \d+ = 0
-> .+ in not matching, because there is nothing to match