### PR TITLE
Upload: put the job in the active list while doing the checksum compu…

### DIFF
--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -297,7 +297,12 @@ public:
 
     QAtomicInt _abortRequested; // boolean set by the main thread to abort.
 
-    /* The list of currently active jobs */
+    /** The list of currently active jobs.
+        This list contains the jobs that are currently using ressources and is used purely to
+        know how many jobs there is currently running for the scheduler.
+        Jobs add themself to the list when they do an assynchronous operation.
+        Jobs can be several time on the list (example, when several chunks are uploaded in parallel)
+     */
     QList<PropagateItemJob*> _activeJobList;
 
     /** We detected that another sync is required after this one */

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -209,8 +209,6 @@ void PropagateUploadFileQNAM::slotComputeContentChecksum()
         return;
     }
 
-    _propagator->_activeJobList.removeOne(this);
-
     const QString filePath = _propagator->getFilePath(_item->_file);
 
     // remember the modtime before checksumming to be able to detect a file
@@ -274,6 +272,10 @@ void PropagateUploadFileQNAM::slotComputeTransmissionChecksum(const QByteArray& 
 
 void PropagateUploadFileQNAM::slotStartUpload(const QByteArray& transmissionChecksumType, const QByteArray& transmissionChecksum)
 {
+    // Remove ourselfs from the list of active job, before any posible call to done()
+    // When we start chunks, we will add it again, once for every chunks.
+    _propagator->_activeJobList.removeOne(this);
+
     _transmissionChecksum = transmissionChecksum;
     _transmissionChecksumType = transmissionChecksumType;
 


### PR DESCRIPTION
…tation.

This fixes an issue in which too many jobs are started un parallel
while uploading many files, which could cause too much memory usage as the
chunks are stored in memory.