### PR TITLE
Always follow redirects in network jobs

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -43,7 +43,7 @@ namespace OCC {
 AbstractNetworkJob::AbstractNetworkJob(AccountPtr account, const QString &path, QObject *parent)
     : QObject(parent)
     , _timedout(false)
-    , _followRedirects(false)
+    , _followRedirects(true)
     , _account(account)
     , _ignoreCredentialFailure(false)
     , _reply(0)

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -359,7 +359,6 @@ CheckServerJob::CheckServerJob(AccountPtr account, QObject *parent)
     : AbstractNetworkJob(account, QLatin1String(statusphpC) , parent)
     , _subdirFallback(false)
 {
-	_followRedirects = true;
     setIgnoreCredentialFailure(true);
 }
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -99,7 +99,6 @@ void GETFileJob::start() {
     } else {
         // Use direct URL
         setReply(davRequest("GET", _directDownloadUrl, req));
-        _followRedirects = true;  // (follow redirections for the direct download)
     }
     setupConnections(reply());
 


### PR DESCRIPTION
This is a move away from the original policy where jobs would only follow
redirects in special cases.

Two restrictions are in place:

1. We do not allow protocol downgrades (https -> http) 
2. We stop redirects after we find them looping (e.g. old = new url, or indirectly when looping 10
times).

This is closer to RFC conforming behavior, although currently we will treat
301 replies like they were 302. This is for a separate commit.