### PR TITLE
Don't try to determine pixel ratio with Qt < 5.6.0

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -53,9 +53,7 @@ int main(int argc, char **argv)
     // want to use sizes relative to the font size everywhere.
     // This is automatic on OS X, but opt-in on Windows and Linux
     // https://doc-snapshots.qt.io/qt5-5.6/highdpi.html#qt-support
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-    qputenv("QT_DEVICE_PIXEL_RATIO", "auto");
-#else
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
 #endif
 #endif // !Q_OS_MAC


### PR DESCRIPTION
This seems to be broken. Worst case users can still set it manually

Addresses #4840