### PR TITLE
Fix Qt4 build

### DIFF
--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -388,6 +388,7 @@ private:
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     // access to signals which are protected in Qt4
     friend class PropagateDownloadFileQNAM;
+    friend class PropagateUploadFileQNAM;
 #endif
 };
 


### PR DESCRIPTION
Since a signal is protected in Qt4 and we are triggering a signal from upload as well now this is required to unbreak Qt4 builds.