### PR TITLE
GUI: don't force the environment variable for high DPI on linux.

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -47,16 +47,19 @@ int main(int argc, char **argv)
 {
     Q_INIT_RESOURCE(client);
 
-#ifndef Q_OS_MAC
+#ifdef Q_OS_WIN
     // If the font size ratio is set on Windows, we need to
     // enable the auto pixelRatio in Qt since we don't
     // want to use sizes relative to the font size everywhere.
     // This is automatic on OS X, but opt-in on Windows and Linux
     // https://doc-snapshots.qt.io/qt5-5.6/highdpi.html#qt-support
+    // We do not define it on linux so the behaviour is kept the same
+    // as other Qt apps in the desktop environment. (which may or may
+    // not set this envoronment variable)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
 #endif
-#endif // !Q_OS_MAC
+#endif // !Q_OS_WIN
 
 #ifdef Q_OS_MAC
     Mac::CocoaInitializer cocoaInit; // RIIA


### PR DESCRIPTION
Setting the Environment variable only for owncloud makes in inconsistant with
other Qt application running at the same time.

The users can still set it themself for the whole desktop if they wish.

Addresses #4840