### PR TITLE
Folder: fix removing folder with escaped characters

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -631,7 +631,7 @@ void Folder::removeFromSettings() const
 {
     auto  settings = _accountState->settings();
     settings->beginGroup(QLatin1String("Folders"));
-    settings->remove(_definition.alias);
+    settings->remove(FolderMan::escapeAlias(_definition.alias));
 }
 
 bool Folder::isFileExcludedAbsolute(const QString& fullPath) const


### PR DESCRIPTION
FolderDefinition::save and load escapes the alias. We also need to escape
it when we remove it.
New folder can't be created with alias that needs escaping, but old folder
from old config may still exist, and we must allow user to delete them.