### PR TITLE
GUI: Show link to the page that allow to add a new token

### DIFF
--- a/src/gui/creds/httpcredentialsgui.h
+++ b/src/gui/creds/httpcredentialsgui.h
@@ -30,6 +30,8 @@ public:
     HttpCredentialsGui(const QString& user, const QString& password, const QString& certificatePath, const QString& certificatePasswd) : HttpCredentials(user, password, certificatePath, certificatePasswd) {}
     void askFromUser() Q_DECL_OVERRIDE;
     Q_INVOKABLE void askFromUserAsync();
+
+    static QString requestAppPasswordText(const Account *account);
 };
 
 } // namespace OCC

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -142,11 +142,15 @@ void OwncloudSetupWizard::slotDetermineAuthType(const QString &urlString)
 
 void OwncloudSetupWizard::slotOwnCloudFoundAuth(const QUrl& url, const QVariantMap &info)
 {
+    auto serverVersion = CheckServerJob::version(info);
+
     _ocWizard->appendToConfigurationLog(tr("<font color=\"green\">Successfully connected to %1: %2 version %3 (%4)</font><br/><br/>")
                                         .arg(url.toString())
                                         .arg(Theme::instance()->appNameGUI())
                                         .arg(CheckServerJob::versionString(info))
-                                        .arg(CheckServerJob::version(info)));
+                                        .arg(serverVersion));
+
+    _ocWizard->account()->setServerVersion(serverVersion);
 
     QString p = url.path();
     if (p.endsWith("/status.php")) {

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -93,7 +93,6 @@ private:
     OwncloudWizard* _ocWizard;
     QString _initLocalFolder;
     QString _remoteFolder;
-
 };
 
 }

--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -114,6 +114,8 @@ void OwncloudHttpCredsPage::initializePage()
             _ui.lePassword->setText(password);
         }
     }
+    _ui.tokenLabel->setText(HttpCredentialsGui::requestAppPasswordText(ocWizard->account().data()));
+    _ui.tokenLabel->setVisible(!_ui.tokenLabel->text().isEmpty());
     _ui.leUsername->setFocus();
 }
 

--- a/src/gui/wizard/owncloudhttpcredspage.ui
+++ b/src/gui/wizard/owncloudhttpcredspage.ui
@@ -7,14 +7,30 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>196</height>
+    <height>248</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+   <item row="5" column="1">
+    <layout class="QHBoxLayout" name="resultLayout"/>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="topLabel">
+     <property name="text">
+      <string notr="true">TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -30,7 +46,23 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1">
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>48</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
     <layout class="QFormLayout" name="formLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="usernameLabel">
@@ -43,7 +75,7 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="passwordLabel">
        <property name="text">
         <string>&amp;Password</string>
        </property>
@@ -55,7 +87,7 @@
      <item row="2" column="0" colspan="2">
       <widget class="QLabel" name="errorLabel">
        <property name="text">
-        <string>Error Label</string>
+        <string notr="true">Error Label</string>
        </property>
        <property name="openExternalLinks">
         <bool>true</bool>
@@ -74,7 +106,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="1">
+   <item row="4" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -87,42 +119,23 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="2">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>48</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="resultLayout"/>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QLabel" name="topLabel">
+   <item row="6" column="0" colspan="3">
+    <widget class="QLabel" name="bottomLabel">
      <property name="text">
-      <string>TextLabel</string>
+      <string notr="true">TextLabel</string>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="tokenLabel">
+     <property name="text">
+      <string notr="true">TextLabel</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="QLabel" name="bottomLabel">
-     <property name="text">
-      <string>TextLabel</string>
+     <property name="openExternalLinks">
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
If owncloud >= 9.1 is detexted:
instead of "Password:" ask for "Password or Token"
and add a link to the ownCloud page that allow to add device token

Issue #4877