### PR TITLE
SocketAPI: Push new status of dirty files regardless when not synced

### DIFF
--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -47,7 +47,6 @@ private slots:
     void slotAboutToPropagate(SyncFileItemVector& items);
     void slotItemCompleted(const SyncFileItem& item);
     void slotSyncEngineRunningChanged();
-    void slotClearDirtyPaths();
 
 private:
     SyncFileStatus syncFileItemStatus(const SyncFileItem& item);


### PR DESCRIPTION
The FolderWatcher inserts files to be marked as SYNC and we
currently assume that all file statuses will be updated by the
following sync. It's however possible that the FolderWatcher
notify us of a change that csync won't consider necessary to
propagate, in which case a new status wouldn't be pushed and
the file manager would continue showing this file as syncing.

Re-push the file status when emptying the dirty files list
before propagating to avoid this issue, most likely the OK
status.