### PR TITLE
excludes: Only log if the pattern was really logged.

### DIFF
--- a/csync/src/csync_exclude.c
+++ b/csync/src/csync_exclude.c
@@ -52,7 +52,7 @@ int _csync_exclude_add(c_strlist_t **inList, const char *string) {
         for (i = 0; i < (*inList)->count; ++i) {
             char *pattern = (*inList)->vector[i];
             if (c_streq(pattern, string)) {
-                return 0;
+                return 1;
             }
         }
     }
@@ -151,8 +151,10 @@ int csync_exclude_load(const char *fname, c_strlist_t **list) {
         buf[i] = '\0';
         if (*entry != '#') {
           const char *unescaped = csync_exclude_expand_escapes(entry);
-          CSYNC_LOG(CSYNC_LOG_PRIORITY_TRACE, "Adding entry: %s", unescaped);
           rc = _csync_exclude_add(list, unescaped);
+          if( rc == 0 ) {
+              CSYNC_LOG(CSYNC_LOG_PRIORITY_TRACE, "Adding entry: %s", unescaped);
+          }
           SAFE_FREE(unescaped);
           if (rc < 0) {
               goto out;


### PR DESCRIPTION
Otherwise we have the log line even though the pattern was not logged.