### PR TITLE
Setup csync logging earlier

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -139,6 +139,7 @@ Application::Application(int &argc, char **argv) :
     setupTranslations();
 
     // Setup global excludes
+    qDebug() << "Loading global exclude list";
     ConfigFile cfg;
     ExcludedFiles& excludes = ExcludedFiles::instance();
     excludes.addExcludeFilePath( cfg.excludeFile(ConfigFile::SystemScope) );
@@ -335,6 +336,14 @@ void Application::slotownCloudWizardDone( int res )
     }
 }
 
+static void csyncLogCatcher(int /*verbosity*/,
+                        const char */*function*/,
+                        const char *buffer,
+                        void */*userdata*/)
+{
+    Logger::instance()->csyncLog( QString::fromUtf8(buffer) );
+}
+
 void Application::setupLogging()
 {
     // might be called from second instance
@@ -350,6 +359,9 @@ void Application::setupLogging()
                 .arg(property("ui_lang").toString())
                 .arg(_theme->version());
 
+    // Setup CSYNC logging to forward to our own logger
+    csync_set_log_callback( csyncLogCatcher );
+    csync_set_log_level( Logger::instance()->isNoop() ? 0 : 11 );
 }
 
 void Application::slotUseMonoIconsChanged(bool)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -46,14 +46,6 @@
 
 namespace OCC {
 
-static void csyncLogCatcher(int /*verbosity*/,
-                        const char */*function*/,
-                        const char *buffer,
-                        void */*userdata*/)
-{
-    Logger::instance()->csyncLog( QString::fromUtf8(buffer) );
-}
-
 
 Folder::Folder(const FolderDefinition& definition,
                AccountState* accountState,
@@ -730,8 +722,6 @@ void Folder::startSync(const QStringList &pathList)
     if (proxyDirty()) {
         setProxyDirty(false);
     }
-    csync_set_log_callback( csyncLogCatcher );
-    csync_set_log_level( Logger::instance()->isNoop() ? 0 : 11 );
 
     if (isBusy()) {
         qCritical() << "* ERROR csync is still running and new sync requested.";


### PR DESCRIPTION
We were missing some csync related log output during startup.

Discovered in #4967