### PR TITLE
csync: Use the full file stat destructors

### DIFF
--- a/csync/src/csync_statedb.c
+++ b/csync/src/csync_statedb.c
@@ -472,7 +472,7 @@ int csync_statedb_get_below_path( CSYNC *ctx, const char *path ) {
 
                 if (excluded == CSYNC_FILE_EXCLUDE_AND_REMOVE
                         || excluded == CSYNC_FILE_SILENTLY_EXCLUDED) {
-                    SAFE_FREE(st);
+                    csync_file_stat_free(st);
                     continue;
                 }
 
@@ -481,7 +481,7 @@ int csync_statedb_get_below_path( CSYNC *ctx, const char *path ) {
 
             /* store into result list. */
             if (c_rbtree_insert(ctx->remote.tree, (void *) st) < 0) {
-                SAFE_FREE(st);
+                csync_file_stat_free(st);
                 ctx->status_code = CSYNC_STATUS_TREE_ERROR;
                 break;
             }

--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -269,8 +269,8 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
     tmp = csync_statedb_get_stat_by_hash(ctx, h);
 
     if(_last_db_return_error(ctx)) {
-        SAFE_FREE(st);
-        SAFE_FREE(tmp);
+        csync_file_stat_free(st);
+        csync_file_stat_free(tmp);
         ctx->status_code = CSYNC_STATUS_UNSUCCESSFUL;
         return -1;
     }
@@ -357,7 +357,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
         enum csync_vio_file_type_e tmp_vio_type = CSYNC_VIO_FILE_TYPE_UNKNOWN;
 
         /* tmp might point to malloc mem, so free it here before reusing tmp  */
-        SAFE_FREE(tmp);
+        csync_file_stat_free(tmp);
 
         /* check if it's a file and has been renamed */
         if (ctx->current == LOCAL_REPLICA) {
@@ -366,7 +366,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
             tmp = csync_statedb_get_stat_by_inode(ctx, fs->inode);
 
             if(_last_db_return_error(ctx)) {
-                SAFE_FREE(st);
+                csync_file_stat_free(st);
                 ctx->status_code = CSYNC_STATUS_UNSUCCESSFUL;
                 return -1;
             }
@@ -422,7 +422,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
             tmp = csync_statedb_get_stat_by_file_id(ctx, fs->file_id);
 
             if(_last_db_return_error(ctx)) {
-                SAFE_FREE(st);
+                csync_file_stat_free(st);
                 ctx->status_code = CSYNC_STATUS_UNSUCCESSFUL;
                 return -1;
             }
@@ -451,7 +451,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
 
                 if (fs->type == CSYNC_VIO_FILE_TYPE_DIRECTORY && ctx->current == REMOTE_REPLICA && ctx->callbacks.checkSelectiveSyncNewFolderHook) {
                     if (ctx->callbacks.checkSelectiveSyncNewFolderHook(ctx->callbacks.update_callback_userdata, path)) {
-                        SAFE_FREE(st);
+                        csync_file_stat_free(st);
                         return 1;
                     }
                 }
@@ -461,7 +461,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
     }
   } else  {
       CSYNC_LOG(CSYNC_LOG_PRIORITY_DEBUG, "Unable to open statedb" );
-      SAFE_FREE(st);
+      csync_file_stat_free(st);
       ctx->status_code = CSYNC_STATUS_UNSUCCESSFUL;
       return -1;
   }
@@ -523,14 +523,14 @@ out:
   switch (ctx->current) {
     case LOCAL_REPLICA:
       if (c_rbtree_insert(ctx->local.tree, (void *) st) < 0) {
-        SAFE_FREE(st);
+        csync_file_stat_free(st);
         ctx->status_code = CSYNC_STATUS_TREE_ERROR;
         return -1;
       }
       break;
     case REMOTE_REPLICA:
       if (c_rbtree_insert(ctx->remote.tree, (void *) st) < 0) {
-        SAFE_FREE(st);
+        csync_file_stat_free(st);
         ctx->status_code = CSYNC_STATUS_TREE_ERROR;
         return -1;
       }

--- a/csync/src/vio/csync_vio_file_stat.c
+++ b/csync/src/vio/csync_vio_file_stat.c
@@ -56,6 +56,7 @@ void csync_vio_file_stat_destroy(csync_vio_file_stat_t *file_stat) {
   SAFE_FREE(file_stat->directDownloadUrl);
   SAFE_FREE(file_stat->directDownloadCookies);
   SAFE_FREE(file_stat->name);
+  SAFE_FREE(file_stat->original_name);
   SAFE_FREE(file_stat);
 }
 

--- a/csync/src/vio/csync_vio_local_unix.c
+++ b/csync/src/vio/csync_vio_local_unix.c
@@ -141,7 +141,7 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
   return file_stat;
 
 err:
-  SAFE_FREE(file_stat);
+  csync_vio_file_stat_destroy(file_stat);
 
   return NULL;
 }


### PR DESCRIPTION
* For csync_file_stat_t and csync_vio_file_stat_t
* Add original_name to the vio file stat destructor