### PR TITLE
Fix a deadlock when shutting down during discovery

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -564,7 +564,7 @@ csync_vio_handle_t* DiscoveryJob::remote_vio_opendir_hook (const char *url,
         discoveryJob->_vioMutex.lock();
         const QString qurl = QString::fromUtf8(url);
         emit discoveryJob->doOpendirSignal(qurl, directoryResult.data());
-        discoveryJob->_vioWaitCondition.wait(&discoveryJob->_vioMutex, ULONG_MAX); // FIXME timeout?
+        discoveryJob->_vioWaitCondition.wait(&discoveryJob->_vioMutex, 30000);
         discoveryJob->_vioMutex.unlock();
 
         qDebug() << discoveryJob << url << "...Returned from main thread";


### PR DESCRIPTION
Since the SyncEngine now quits and waits for the discovery thread,
the main thread can enter a deadlock where the discovery thread waits
for its directory result.

Add a 2 seconds timer to the discovery thread wait condition
to limit the deadlock time.