### PR TITLE
SocketAPI: Use different pipe name #4977

### DIFF
--- a/shell_integration/windows/OCUtil/CommunicationSocket.cpp
+++ b/shell_integration/windows/OCUtil/CommunicationSocket.cpp
@@ -45,7 +45,7 @@ std::wstring getUserName() {
 std::wstring CommunicationSocket::DefaultPipePath()
 {
 	auto pipename = std::wstring(L"\\\\.\\pipe\\");
-	pipename += L"ownCloud\\";
+	pipename += L"ownCloud-";
 	pipename += getUserName();
 	return pipename;
 }

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -74,7 +74,7 @@ SocketApi::SocketApi(QObject* parent)
 
     if (Utility::isWindows()) {
         socketPath = QLatin1String("\\\\.\\pipe\\")
-                + QLatin1String("ownCloud") + '\\'
+                + QLatin1String("ownCloud-")
                 + QString::fromLocal8Bit(qgetenv("USERNAME"));
         // TODO: once the windows extension supports multiple
         // client connections, switch back to the theme name


### PR DESCRIPTION
Named pipe names that contain backslashes sometimes lead to problems.

