### PR TITLE
Fix windows HiDPI #4994

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -58,6 +58,8 @@ int main(int argc, char **argv)
     // not set this envoronment variable)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "1");
+#else
+    qputenv("QT_DEVICE_PIXEL_RATIO", "auto"); // See #4840, #4994
 #endif
 #endif // !Q_OS_WIN
 


### PR DESCRIPTION
This was removed in 0194ebb2229adc33f5b9790231a3384b46474bde
because it breaks on Linux. However, it looks like it is correct
for Windows. In the meantime the surrounding ifdef has changed
from !Q_OS_MAC to Q_OS_WIN, so reverting it makes sense.