### PR TITLE
Excludes: Use QRegularExpression for speedup WiP

### DIFF
--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -39,6 +39,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <config_csync.h>
+#include "csync_exclude.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/csync/src/csync_exclude.h
+++ b/csync/src/csync_exclude.h
@@ -21,6 +21,8 @@
 #ifndef _CSYNC_EXCLUDE_H
 #define _CSYNC_EXCLUDE_H
 
+#include "std/c_string.h"
+
 enum csync_exclude_type_e {
   CSYNC_NOT_EXCLUDED   = 0,
   CSYNC_FILE_SILENTLY_EXCLUDED,
@@ -36,6 +38,10 @@ typedef enum csync_exclude_type_e CSYNC_EXCLUDE_TYPE;
 #ifdef NDEBUG
 int _csync_exclude_add(c_strlist_t **inList, const char *string);
 #endif
+
+// Hook from mirall
+typedef CSYNC_EXCLUDE_TYPE (*csync_exclude_traversal_hook) (
+        const char *path, int filetype, void *userData);
 
 /**
  * @brief Load exclude list
@@ -62,7 +68,7 @@ int csync_exclude_load(const char *fname, c_strlist_t **list);
  *
  * @return  2 if excluded and needs cleanup, 1 if excluded, 0 if not.
  */
-CSYNC_EXCLUDE_TYPE csync_excluded_traversal(c_strlist_t *excludes, const char *path, int filetype);
+CSYNC_EXCLUDE_TYPE csync_excluded_traversal(c_strlist_t *excludes, const char *path, int filetype, csync_exclude_traversal_hook hook, void *hookUserData);
 
 /**
  * @brief csync_excluded_no_ctx
@@ -72,7 +78,6 @@ CSYNC_EXCLUDE_TYPE csync_excluded_traversal(c_strlist_t *excludes, const char *p
  * @return
  */
 CSYNC_EXCLUDE_TYPE csync_excluded_no_ctx(c_strlist_t *excludes, const char *path, int filetype);
-#endif /* _CSYNC_EXCLUDE_H */
 
 /**
  * @brief Checks if filename is considered reserved by Windows
@@ -81,5 +86,5 @@ CSYNC_EXCLUDE_TYPE csync_excluded_no_ctx(c_strlist_t *excludes, const char *path
  */
 bool csync_is_windows_reserved_word(const char *file_name);
 
-
+#endif /* _CSYNC_EXCLUDE_H */
 /* vim: set ft=c.doxygen ts=8 sw=2 et cindent: */

--- a/csync/src/csync_private.h
+++ b/csync/src/csync_private.h
@@ -101,6 +101,10 @@ struct csync_s {
       csync_checksum_hook checksum_hook;
       void *checksum_userdata;
 
+      /* Hook for the QRegExp based exclude checker */
+      csync_exclude_traversal_hook excluded_traversal_hook;
+      void *excluded_traversal_userdata;
+
   } callbacks;
   c_strlist_t *excludes;
 

--- a/csync/src/csync_statedb.c
+++ b/csync/src/csync_statedb.c
@@ -466,7 +466,7 @@ int csync_statedb_get_below_path( CSYNC *ctx, const char *path ) {
             /* Check for exclusion from the tree.
              * Note that this is only a safety net in case the ignore list changes
              * without a full remote discovery being triggered. */
-            CSYNC_EXCLUDE_TYPE excluded = csync_excluded_traversal(ctx->excludes, st->path, st->type);
+            CSYNC_EXCLUDE_TYPE excluded = csync_excluded_traversal(ctx->excludes, st->path, st->type, ctx->callbacks.excluded_traversal_hook, ctx->callbacks.excluded_traversal_userdata);
             if (excluded != CSYNC_NOT_EXCLUDED) {
                 CSYNC_LOG(CSYNC_LOG_PRIORITY_TRACE, "%s excluded (%d)", st->path, excluded);
 

--- a/csync/src/csync_update.c
+++ b/csync/src/csync_update.c
@@ -203,7 +203,7 @@ static int _csync_detect_update(CSYNC *ctx, const char *file,
       excluded =CSYNC_FILE_EXCLUDE_STAT_FAILED;
   } else {
     /* Check if file is excluded */
-    excluded = csync_excluded_traversal(ctx->excludes, path, type);
+    excluded = csync_excluded_traversal(ctx->excludes, path, type, ctx->callbacks.excluded_traversal_hook, ctx->callbacks.excluded_traversal_userdata);
   }
 
   if( excluded == CSYNC_NOT_EXCLUDED ) {

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -23,6 +23,7 @@
 #include <QMutex>
 #include <QWaitCondition>
 #include <QLinkedList>
+#include <QRegularExpression>
 
 namespace OCC {
 
@@ -181,6 +182,10 @@ class DiscoveryJob : public QObject {
                                                                   void *userdata);
     QMutex _vioMutex;
     QWaitCondition _vioWaitCondition;
+
+    QRegularExpression _exclude_traversel_regexp_exclude;
+    QRegularExpression _exclude_traversel_regexp_exclude_and_remove;
+    static CSYNC_EXCLUDE_TYPE excluded_traversal_hook (const char *path, int filetype, void *userdata);
 
 
 public:


### PR DESCRIPTION
Unfortunately this does not speed up thins significantly yet, i only see csync_exclude_traversal going from 14.5% of time to 14.0% of time or so

But maybe I need to check if the JIT is really used and also add some of the other patterns that hardcodedly use fnmatch to the hook.

FYI @ckamm 

It changes our exclude list to those two lists:

```
".*~|~\\$.*|\\.~lock\\..*|~.*\\.tmp|\\._.*|desktop\\.ini|\\..*\\.sw.|\\..*\\..*sw.|\\.fseventd|\\.apdisk|\\.htaccess|\\.directory|.*\\.part|.*\\.filepart|.*\\.crdownload|.*\\.kate-swp|.*\\.gnucash\\.tmp-.*|\\.synkron\\..*|\\.sync\\.ffs_db|\\.symform|\\.symform-store|\\.fuse_hidden.*|.*\\.unison|\\.nfs.*|My Saved Places\\."
".*\\.~.*|Icon\r.*|\\.DS_Store|\\.ds_store|Thumbs\\.db|\\.TemporaryItems|\\.Trashes|\\.DocumentRevisions-V100|\\.Trash-.*"
```

Maybe I can avoid having two regexp objects by using capture groups or something like that?
