### PR TITLE
Share: Permissions for federated shares on servers >=9.1 #4996

### DIFF
--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -248,10 +248,12 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex & index)
     layout->addWidget(indicator);
 
     /*
-     * Don't send the reshare permissions for federataed shares
+     * Don't send the reshare permissions for federated shares for servers <9.1
      * https://github.com/owncloud/core/issues/22122#issuecomment-185637344
+     * https://github.com/owncloud/client/issues/4996
      */
-    if (sharee->type() == Sharee::Federated) {
+    if (sharee->type() == Sharee::Federated
+            && _account->serverVersionInt() < 0x090100) {
         int permissions = SharePermissionRead | SharePermissionUpdate;
         if (!_isFile) {
             permissions |= SharePermissionCreate | SharePermissionDelete;
@@ -335,10 +337,12 @@ ShareWidget::ShareWidget(QSharedPointer<Share> share,
     connect(_ui->permissionsEdit,  SIGNAL(clicked(bool)), SLOT(slotEditPermissionsChanged()));
 
     /*
-     * We don't show permssion share for federated shares
+     * We don't show permssion share for federated shares with server <9.1
      * https://github.com/owncloud/core/issues/22122#issuecomment-185637344
+     * https://github.com/owncloud/client/issues/4996
      */
-    if (share->getShareType() == Share::TypeRemote) {
+    if (share->getShareType() == Share::TypeRemote
+            && share->account()->serverVersionInt() < 0x090100) {
         _ui->permissionShare->setVisible(false);
         _ui->permissionToolButton->setVisible(false);
     }


### PR DESCRIPTION
This disables the workaround 487e1fdca5ee04fc98c1ed77898df70d740967c8
for servers that are new enough to support fine grained permissions
on federated shares.

The consequence is that the 'reshare' permission is now granted by
default and that users can edit permissions on the usual fine-grained
level again.

The way the client deals with servers <9.1 is unchanged.