### PR TITLE
AccountManager: Don't force the server URL while loading the config.

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -213,14 +213,12 @@ AccountPtr AccountManager::loadAccountHelper(QSettings& settings)
 
     QString authType = settings.value(QLatin1String(authTypeC)).toString();
     QString overrideUrl = Theme::instance()->overrideServerUrl();
-    if( !overrideUrl.isEmpty() ) {
-        // if there is a overrideUrl, don't even bother reading from the config as all the accounts
-        // must use the overrideUrl
+    QString forceAuth = Theme::instance()->forceConfigAuthType();
+    if(!forceAuth.isEmpty() && !overrideUrl.isEmpty() ) {
+        // If forceAuth is set, this might also mean the overrideURL has changed.
+        // See enterprise issues #1126
         acc->setUrl(overrideUrl);
-        auto forceAuth = Theme::instance()->forceConfigAuthType();
-        if (!forceAuth.isEmpty()) {
-            authType = forceAuth;
-        }
+        authType = forceAuth;
     } else {
         acc->setUrl(settings.value(QLatin1String(urlC)).toUrl());
     }


### PR DESCRIPTION
While loading the account, only override the server url if Theme::forceConfigAuthType
is set. This restore the behavior from the client 2.2.0 for theme that did not
use Theme::forceConfigAuthType.