### PR TITLE
Windows: Skip symlinks and junctions again #5019

### DIFF
--- a/csync/src/vio/csync_vio_local_win.c
+++ b/csync/src/vio/csync_vio_local_win.c
@@ -167,16 +167,20 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
   }
   file_stat->name = c_utf8_from_locale(handle->ffd.cFileName);
 
+    file_stat->flags = CSYNC_VIO_FILE_FLAGS_NONE;
     file_stat->fields |= CSYNC_VIO_FILE_STAT_FIELDS_TYPE;
-    if ( (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
-         && (handle->ffd.dwReserved0 & IO_REPARSE_TAG_SYMLINK)
-         // The SIS or DEDUP flag points to a MS deduplication feature of
-         // certain file storage products. It is not a normal symlink
-         // that should be ignored.
-         && (! (handle->ffd.dwReserved0 & IO_REPARSE_TAG_SIS))
-         && (! (handle->ffd.dwReserved0 & IO_REPARSE_TAG_DEDUP)) ) {
-        file_stat->flags = CSYNC_VIO_FILE_FLAGS_SYMLINK;
-        file_stat->type = CSYNC_VIO_FILE_TYPE_SYMBOLIC_LINK;
+    if (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        // Detect symlinks, and treat junctions as symlinks too.
+        if (handle->ffd.dwReserved0 == IO_REPARSE_TAG_SYMLINK
+                || handle->ffd.dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT) {
+            file_stat->flags |= CSYNC_VIO_FILE_FLAGS_SYMLINK;
+            file_stat->type = CSYNC_VIO_FILE_TYPE_SYMBOLIC_LINK;
+        } else {
+            // The SIS and DEDUP reparse points should be treated as
+            // regular files. We don't know about the other ones yet,
+            // but will also treat them normally for now.
+            file_stat->type = CSYNC_VIO_FILE_TYPE_REGULAR;
+        }
     } else if (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_DEVICE
                 || handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_OFFLINE
                 || handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_TEMPORARY) {
@@ -187,7 +191,6 @@ csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle) {
         file_stat->type = CSYNC_VIO_FILE_TYPE_REGULAR;
     }
 
-    file_stat->flags = CSYNC_VIO_FILE_FLAGS_NONE;
     /* Check for the hidden flag */
     if( handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN ) {
         file_stat->flags |= CSYNC_VIO_FILE_FLAGS_HIDDEN;


### PR DESCRIPTION
Fixes an accidental behavior change introduced in
055c2ef73f84b68ebfbe0296fadef438981cba37

Affects #4056 and owncloud/enterprise#1225.