### PR TITLE
SyncEngine: Reads the data-fingerprint property

### DIFF
--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -81,6 +81,8 @@ class DiscoverySingleDirectoryJob : public QObject {
     Q_OBJECT
 public:
     explicit DiscoverySingleDirectoryJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
+    // Specify thgat this is the root and we need to check the data-fingerprint
+    void setIsRootPath() { _isRootPath = true; }
     void start();
     void abort();
     // This is not actually a network job, it is just a job
@@ -100,8 +102,15 @@ private:
     QString _etagConcatenation;
     QString _firstEtag;
     AccountPtr _account;
+    // The first result is for the directory itself and need to be ignored.
+    // This flag is true if it was already ignored.
     bool _ignoredFirst;
+    // Set to true if this is the root path and we need to check the data-fingerprint
+    bool _isRootPath;
     QPointer<LsColJob> _lsColJob;
+
+public:
+    QByteArray _dataFingerprint;
 };
 
 // Lives in main thread. Deleted by the SyncEngine
@@ -115,12 +124,15 @@ class DiscoveryMainThread : public QObject {
     AccountPtr _account;
     DiscoveryDirectoryResult *_currentDiscoveryDirectoryResult;
     qint64 *_currentGetSizeResult;
+    bool _firstFolderProcessed;
 
 public:
     DiscoveryMainThread(AccountPtr account) : QObject(), _account(account),
-        _currentDiscoveryDirectoryResult(0), _currentGetSizeResult(0)
+        _currentDiscoveryDirectoryResult(0), _currentGetSizeResult(0), _firstFolderProcessed(false)
     { }
     void abort();
+
+    QByteArray _dataFingerprint;
 
 
 public slots:

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -402,7 +402,7 @@ void OwncloudPropagator::start(const SyncFileItemVector& items)
     connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
             this, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
     connect(_rootJob.data(), SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
-    connect(_rootJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(emitFinished()));
+    connect(_rootJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(emitFinished(SyncFileItem::Status)));
     connect(_rootJob.data(), SIGNAL(ready()), this, SLOT(scheduleNextJob()), Qt::QueuedConnection);
 
     qDebug() << "Using QNAM/HTTP parallel code path";

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -321,7 +321,7 @@ public:
         if (_rootJob) {
             _rootJob->abort();
         }
-        emitFinished();
+        emitFinished(SyncFileItem::NormalError);
     }
 
     // timeout in seconds
@@ -349,9 +349,9 @@ public:
 private slots:
 
     /** Emit the finished signal and make sure it is only emitted once */
-    void emitFinished() {
+    void emitFinished(SyncFileItem::Status status) {
         if (!_finishedEmited)
-            emit finished();
+            emit finished(status == SyncFileItem::Success);
         _finishedEmited = true;
     }
 
@@ -360,7 +360,7 @@ private slots:
 signals:
     void itemCompleted(const SyncFileItem &, const PropagatorJob &);
     void progress(const SyncFileItem&, quint64 bytes);
-    void finished();
+    void finished(bool success);
 
     /** Emitted when propagation has problems with a locked file. */
     void seenLockedFile(const QString &fileName);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -152,7 +152,7 @@ signals:
 private slots:
     void slotRootEtagReceived(const QString &);
     void slotItemCompleted(const SyncFileItem& item, const PropagatorJob & job);
-    void slotFinished();
+    void slotFinished(bool success);
     void slotProgress(const SyncFileItem& item, quint64 curent);
     void slotDiscoveryJobFinished(int updateResult);
     void slotCleanPollsJobAborted(const QString &error);

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -154,6 +154,12 @@ public:
      */
     QByteArray getChecksumType(int checksumTypeId);
 
+    /**
+     * The data-fingerprint used to detect backup
+     */
+    void setDataFingerprint(const QByteArray &dataFingerprint);
+    QByteArray dataFingerprint();
+
 private:
     bool updateDatabaseStructure();
     bool updateMetadataTableStructure();
@@ -196,6 +202,9 @@ private:
     QScopedPointer<SqlQuery> _getChecksumTypeIdQuery;
     QScopedPointer<SqlQuery> _getChecksumTypeQuery;
     QScopedPointer<SqlQuery> _insertChecksumTypeQuery;
+    QScopedPointer<SqlQuery> _getDataFingerprintQuery;
+    QScopedPointer<SqlQuery> _setDataFingerprintQuery1;
+    QScopedPointer<SqlQuery> _setDataFingerprintQuery2;
 
     /* This is the list of paths we called avoidReadFromDbOnNextSync on.
      * It means that they should not be written to the DB in any case since doing


### PR DESCRIPTION
When it changes, assume a backup was recovered, and keep conflict files.

Issues: #2325 and https://github.com/owncloud/enterprise/issues/966