### PR TITLE
ShibbolethView: Open a debug windows that shows cipher info.

### DIFF
--- a/src/gui/creds/shibboleth/shibbolethwebview.cpp
+++ b/src/gui/creds/shibboleth/shibbolethwebview.cpp
@@ -20,6 +20,7 @@
 #include <QMessageBox>
 #include <QNetworkReply>
 #include <QSettings>
+#include <QMainWindow>
 
 #include "creds/shibboleth/shibbolethwebview.h"
 #include "creds/shibbolethcredentials.h"
@@ -74,10 +75,23 @@ ShibbolethWebView::ShibbolethWebView(AccountPtr account, QWidget* parent)
     connect(page->networkAccessManager()->cookieJar(),
             SIGNAL(newCookiesForUrl (QList<QNetworkCookie>, QUrl)),
             this, SLOT(onNewCookiesForUrl (QList<QNetworkCookie>, QUrl)));
+
     page->mainFrame()->load(account->url());
     this->setPage(page);
     setWindowTitle(tr("%1 - Authenticate").arg(Theme::instance()->appNameGUI()));
 
+    // Debug view to display the cipher suite
+    if( !qgetenv("OWNCLOUD_SHIBBOLETH_DEBUG").isEmpty() ) {
+        // open an additional window to display some cipher debug info
+        QWebPage *debugPage = new UserAgentWebPage(this);
+        debugPage->mainFrame()->load( QUrl("https://cc.dcsec.uni-hannover.de/"));
+        QWebView *debugView = new QWebView(this);
+        debugView->setPage(debugPage);
+        QMainWindow *window = new QMainWindow(this);
+        window->setWindowTitle(tr("SSL Chipher Debug View"));
+        window->setCentralWidget(debugView);
+        window->show();
+    }
     // If we have a valid cookie, it's most likely expired. We can use this as
     // as a criteria to tell the user why the browser window pops up
     QNetworkCookie shibCookie = ShibbolethCredentials::findShibCookie(_account.data(), ShibbolethCredentials::accountCookies(_account.data()));
@@ -142,7 +156,6 @@ void ShibbolethWebView::slotLoadFinished(bool success)
 
     if (!success) {
         qDebug() << Q_FUNC_INFO << "Could not load Shibboleth login page to log you in.";
-
     }
 }
 


### PR DESCRIPTION
It opens a window and connects to a cipher test
page, showing the output from there, that helps for debugging.

The window is enabled by setting the environment variable
OWNCLOUD_SHIBBOLETH_DEBUG

I wonder if we want that in 2.2 branch to be released with 2.2.3?