### PR TITLE
Revert "Fix a deadlock when shutting down during discovery"

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -564,7 +564,7 @@ csync_vio_handle_t* DiscoveryJob::remote_vio_opendir_hook (const char *url,
         discoveryJob->_vioMutex.lock();
         const QString qurl = QString::fromUtf8(url);
         emit discoveryJob->doOpendirSignal(qurl, directoryResult.data());
-        discoveryJob->_vioWaitCondition.wait(&discoveryJob->_vioMutex, 30000);
+        discoveryJob->_vioWaitCondition.wait(&discoveryJob->_vioMutex, ULONG_MAX); // FIXME timeout?
         discoveryJob->_vioMutex.unlock();
 
         qDebug() << discoveryJob << url << "...Returned from main thread";


### PR DESCRIPTION
Reverts owncloud/client#4993, could be the cause of #5092 and the cost is higher than the benefit if this is the case. A network request taking more than 30 seconds isn't something unlikely in this world and shouldn't be a good reason to abort. We should try to untangle the threads dependencies to properly fix this if possible instead.