### PR TITLE
SyncEngine: Fix detection of backup or full resync

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -847,6 +847,8 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
 
     _hasNoneFiles = false;
     _hasRemoveFile = false;
+    _hasForwardInTimeFiles = false;
+    _backInTimeFiles = 0;
     bool walkOk = true;
     _seenFiles.clear();
     _temporarilyUnavailablePaths.clear();


### PR DESCRIPTION
Once upon a time, the SyncEngine was instantiated once per sync. But now that the SyncEngine is kept between sync, we need to reset all these variable between syncs.