### PR TITLE
Show the rename target in the client log file.

### DIFF
--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -145,7 +145,11 @@ void SyncRunFileLog::logItem( const SyncFileItem& item )
     const QChar L = QLatin1Char('|');
     _out << ts << L;
     _out << QString::number(item._requestDuration) << L;
-    _out << item._file << L;
+    if( item.log._instruction != CSYNC_INSTRUCTION_RENAME ) {
+        _out << item._file << L;
+    } else {
+        _out << item._file << QLatin1String(" -> ") << item._renameTarget << L;
+    }
     _out << instructionToStr( item.log._instruction ) << L;
     _out << directionToStr( item._direction ) << L;
     _out << QString::number(item.log._modtime) << L;


### PR DESCRIPTION
Adds the rename target to the the sync log that lies around in the sync dir. Helpful to understand nifty problems.