### PR TITLE
Selective Sync: Fix request loop and show error in view

### DIFF
--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -63,6 +63,7 @@ public:
         bool _fetched; // If we did the LSCOL for this folder already
         bool _fetching; // Whether a LSCOL job is currently running
         bool _hasError; // If the last fetching job ended in an error
+        QString _lastErrorString;
         bool _fetchingLabel; // Whether a 'fetching in progress' label is shown.
 
         bool _isUndecided; // undecided folders are the big folders that the user has not accepted yet


### PR DESCRIPTION
I got into a situation where the model would endlessly request the directory
contents from the server because we did not notice yet that the server
is actually in maintenance mode while we were expanding the tree view when
changing the tab to the account or when just expanding it by clicking.