### PR TITLE
Wizard: Do the system proxy lookup in a thread

### DIFF
--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -66,6 +66,8 @@ signals:
 
 private slots:
     void slotDetermineAuthType(const QString&);
+    void slotSystemProxyLookupDone(const QNetworkProxy &proxy);
+    void slotContinueDetermineAuth();
     void slotOwnCloudFoundAuth(const QUrl&, const QVariantMap&);
     void slotNoOwnCloudFoundAuth(QNetworkReply *reply);
     void slotNoOwnCloudFoundAuthTimeout(const QUrl&url);

--- a/src/libsync/clientproxy.cpp
+++ b/src/libsync/clientproxy.cpp
@@ -129,7 +129,6 @@ SystemProxyRunnable::SystemProxyRunnable(const QUrl &url) : QObject(), QRunnable
 
 void SystemProxyRunnable::run()
 {
-    qDebug() << Q_FUNC_INFO << "Starting system proxy lookup";
     qRegisterMetaType<QNetworkProxy>("QNetworkProxy");
     QList<QNetworkProxy> proxies = QNetworkProxyFactory::systemProxyForQuery(QNetworkProxyQuery(_url));
 

--- a/src/libsync/clientproxy.h
+++ b/src/libsync/clientproxy.h
@@ -57,7 +57,7 @@ private:
     QUrl _url;
 };
 
-QString printQNetworkProxy(const QNetworkProxy &proxy);
+OWNCLOUDSYNC_EXPORT QString printQNetworkProxy(const QNetworkProxy &proxy);
 
 
 }


### PR DESCRIPTION
This is analogous to the code in ConnectionValidator. Otherwise Qt did it internally and blocked the UI.

I had this pending in a branch for another issue.

@danimo Sorry that this might collide with your new wizard code.