### PR TITLE
Excludes: Consider files in hidden folders excluded #5163

### DIFF
--- a/src/libsync/excludedfiles.cpp
+++ b/src/libsync/excludedfiles.cpp
@@ -76,13 +76,22 @@ bool ExcludedFiles::isExcluded(
         return true;
     }
 
-    QFileInfo fi(filePath);
     if( excludeHidden ) {
-        if( fi.isHidden() || fi.fileName().startsWith(QLatin1Char('.')) ) {
-            return true;
+        QString path = filePath;
+        // Check all path subcomponents, but to *not* check the base path:
+        // We do want to be able to sync with a hidden folder as the target.
+        while (path.size() > basePath.size()) {
+            QFileInfo fi(path);
+            if( fi.isHidden() || fi.fileName().startsWith(QLatin1Char('.')) ) {
+                return true;
+            }
+
+            // Get the parent path
+            path = fi.absolutePath();
         }
     }
 
+    QFileInfo fi(filePath);
     csync_ftw_type_e type = CSYNC_FTW_TYPE_FILE;
     if (fi.isDir()) {
         type = CSYNC_FTW_TYPE_DIR;


### PR DESCRIPTION
Previously, we only checked the hiddenness of the target file and
ignored the hiddenness of the containing folders. This lead to
undesired behavior when people synced their home folders and there
was a folder watcher notification for a non-hidden file in one of
the hidden folders.

I'm not fully sure why, but sometimes notifications for .foo/bar were
already ignored, but notifications for .foo/bar/car were not. This may
be because of how we set up the FolderWatchers on Linux.

The new behavior is to check all path components for hiddenness, up
until the base path (but excluding the base path, so using a hidden
folder as a sync folder will work).