### PR TITLE
Fix the MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 cmake_minimum_required(VERSION 2.6)
 cmake_policy(VERSION 2.8.0)
+if(POLICY CMP0020)
+  cmake_policy(SET CMP0020 NEW)
+endif()
 
 project(client)
 
@@ -57,7 +60,7 @@ endif()
 
 include(GNUInstallDirs)
 include(DefineInstallationPaths)
-
+include(GenerateExportHeader)
 
 include(GetGitRevisionDescription)
 
@@ -166,6 +169,9 @@ find_package(SQLite3 3.8.0 REQUIRED)
 # On some OS, we want to use our own, not the system sqlite
 if (USE_OUR_OWN_SQLITE3)
     include_directories(BEFORE ${SQLITE3_INCLUDE_DIR})
+    if (WIN32)
+        add_definitions(-DSQLITE_API=__declspec\(dllimport\))
+    endif()
 endif()
 
 find_package(ZLIB)
@@ -180,6 +186,7 @@ add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 if( WIN32 )
 add_definitions( -D__USE_MINGW_ANSI_STDIO=1 )
+add_definitions( -DNOMINMAX )
 endif( WIN32 )
 
 # Handle Translations, pick all client_* files from trans directory.

--- a/cmake/modules/Warnings.cmake
+++ b/cmake/modules/Warnings.cmake
@@ -2,21 +2,23 @@
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING* file.
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                    OUTPUT_VARIABLE GCC_VERSION)
-    if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")
-    else(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+                        OUTPUT_VARIABLE GCC_VERSION)
+        if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")
+        else(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+        endif(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
+    else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-    endif(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-endif(CMAKE_COMPILER_IS_GNUCXX)
+    endif()
 
-if(DEFINED MIRALL_FATAL_WARNINGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-endif(DEFINED MIRALL_FATAL_WARNINGS)
+    if(DEFINED MIRALL_FATAL_WARNINGS)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    endif(DEFINED MIRALL_FATAL_WARNINGS)
+endif()

--- a/csync/src/CMakeLists.txt
+++ b/csync/src/CMakeLists.txt
@@ -81,6 +81,13 @@ set(csync_HDRS
 # Statically include sqlite
 if (USE_OUR_OWN_SQLITE3)
     list(APPEND csync_SRCS ${SQLITE3_SOURCE})
+    if (WIN32)
+        # We want to export sqlite symbols from the ocsync DLL without
+        # having to patch both sqlite3.h and the amalgation sqlite3.c,
+        # so do the import/export magic manually through the build system.
+        remove_definitions(-DSQLITE_API=__declspec\(dllimport\))
+        add_definitions(-DSQLITE_API=__declspec\(dllexport\))
+    endif()
 endif()
 
 include_directories(
@@ -90,6 +97,12 @@ include_directories(
 
 add_library(${CSYNC_LIBRARY} SHARED ${csync_SRCS})
 #add_library(${CSYNC_LIBRARY}_static STATIC ${csync_SRCS})
+
+generate_export_header( ${CSYNC_LIBRARY}
+  BASE_NAME ${CSYNC_LIBRARY}
+  EXPORT_MACRO_NAME OCSYNC_EXPORT
+  EXPORT_FILE_NAME ocsynclib.h
+)
 
 target_link_libraries(${CSYNC_LIBRARY} ${CSYNC_LINK_LIBRARIES})
 #target_link_libraries(${CSYNC_LIBRARY}_static ${CSYNC_LINK_LIBRARIES})

--- a/csync/src/csync.c
+++ b/csync/src/csync.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <stdbool.h>
 

--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -33,10 +33,10 @@
 #define _CSYNC_H
 
 #include "std/c_private.h"
+#include "ocsynclib.h"
 #include <sys/stat.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <config_csync.h>
 
@@ -229,14 +229,14 @@ struct csync_vio_file_stat_s {
   char *original_name; // only set if locale conversion fails
 };
 
-csync_vio_file_stat_t *csync_vio_file_stat_new(void);
-csync_vio_file_stat_t *csync_vio_file_stat_copy(csync_vio_file_stat_t *file_stat);
+csync_vio_file_stat_t OCSYNC_EXPORT *csync_vio_file_stat_new(void);
+csync_vio_file_stat_t OCSYNC_EXPORT *csync_vio_file_stat_copy(csync_vio_file_stat_t *file_stat);
 
-void csync_vio_file_stat_destroy(csync_vio_file_stat_t *fstat);
+void OCSYNC_EXPORT csync_vio_file_stat_destroy(csync_vio_file_stat_t *fstat);
 
-void csync_vio_file_stat_set_file_id( csync_vio_file_stat_t* dst, const char* src );
+void OCSYNC_EXPORT csync_vio_file_stat_set_file_id( csync_vio_file_stat_t* dst, const char* src );
 
-void csync_vio_set_file_id(char* dst, const char *src );
+void OCSYNC_EXPORT csync_vio_set_file_id(char* dst, const char *src );
 
 
 /**
@@ -317,7 +317,7 @@ typedef const char* (*csync_checksum_hook) (
  *
  * @param csync  The context variable to allocate.
  */
-void csync_create(CSYNC **csync, const char *local, const char *remote);
+void OCSYNC_EXPORT csync_create(CSYNC **csync, const char *local, const char *remote);
 
 /**
  * @brief Initialize the file synchronizer.
@@ -326,7 +326,7 @@ void csync_create(CSYNC **csync, const char *local, const char *remote);
  *
  * @param ctx  The context to initialize.
  */
-void csync_init(CSYNC *ctx);
+void OCSYNC_EXPORT csync_init(CSYNC *ctx);
 
 /**
  * @brief Update detection
@@ -335,7 +335,7 @@ void csync_init(CSYNC *ctx);
  *
  * @return  0 on success, less than 0 if an error occurred.
  */
-int csync_update(CSYNC *ctx);
+int OCSYNC_EXPORT csync_update(CSYNC *ctx);
 
 /**
  * @brief Reconciliation
@@ -344,7 +344,7 @@ int csync_update(CSYNC *ctx);
  *
  * @return  0 on success, less than 0 if an error occurred.
  */
-int csync_reconcile(CSYNC *ctx);
+int OCSYNC_EXPORT csync_reconcile(CSYNC *ctx);
 
 /**
  * @brief Re-initializes the csync context
@@ -353,7 +353,7 @@ int csync_reconcile(CSYNC *ctx);
  *
  * @return  0 on success, less than 0 if an error occurred.
  */
-int csync_commit(CSYNC *ctx);
+int OCSYNC_EXPORT csync_commit(CSYNC *ctx);
 
 /**
  * @brief Destroy the csync context
@@ -364,7 +364,7 @@ int csync_commit(CSYNC *ctx);
  *
  * @return  0 on success, less than 0 if an error occurred.
  */
-int csync_destroy(CSYNC *ctx);
+int OCSYNC_EXPORT csync_destroy(CSYNC *ctx);
 
 /**
  * @brief Get the userdata saved in the context.
@@ -386,7 +386,7 @@ void *csync_get_userdata(CSYNC *ctx);
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_set_userdata(CSYNC *ctx, void *userdata);
+int OCSYNC_EXPORT csync_set_userdata(CSYNC *ctx, void *userdata);
 
 /**
  * @brief Get the authentication callback set.
@@ -396,7 +396,7 @@ int csync_set_userdata(CSYNC *ctx, void *userdata);
  * @return              The authentication callback set or NULL if an error
  *                      occurred.
  */
-csync_auth_callback csync_get_auth_callback(CSYNC *ctx);
+csync_auth_callback OCSYNC_EXPORT csync_get_auth_callback(CSYNC *ctx);
 
 /**
  * @brief Set the authentication callback.
@@ -407,7 +407,7 @@ csync_auth_callback csync_get_auth_callback(CSYNC *ctx);
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_set_auth_callback(CSYNC *ctx, csync_auth_callback cb);
+int OCSYNC_EXPORT csync_set_auth_callback(CSYNC *ctx, csync_auth_callback cb);
 
 /**
  * @brief Set the log level.
@@ -416,14 +416,14 @@ int csync_set_auth_callback(CSYNC *ctx, csync_auth_callback cb);
  *
  * @return 0 on success, < 0 if an error occurred.
  */
-int csync_set_log_level(int level);
+int OCSYNC_EXPORT csync_set_log_level(int level);
 
 /**
  * @brief Get the log verbosity
  *
  * @return            The log verbosity, -1 on error.
  */
-int csync_get_log_level(void);
+int OCSYNC_EXPORT csync_get_log_level(void);
 
 /**
  * @brief Get the logging callback set.
@@ -431,7 +431,7 @@ int csync_get_log_level(void);
  * @return              The logging callback set or NULL if an error
  *                      occurred.
  */
-csync_log_callback csync_get_log_callback(void);
+csync_log_callback OCSYNC_EXPORT csync_get_log_callback(void);
 
 /**
  * @brief Set the logging callback.
@@ -440,14 +440,14 @@ csync_log_callback csync_get_log_callback(void);
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_set_log_callback(csync_log_callback cb);
+int OCSYNC_EXPORT csync_set_log_callback(csync_log_callback cb);
 
 /**
  * @brief get the userdata set for the logging callback.
  *
  * @return              The userdata or NULL.
  */
-void *csync_get_log_userdata(void);
+void OCSYNC_EXPORT *csync_get_log_userdata(void);
 
 /**
  * @brief Set the userdata passed to the logging callback.
@@ -456,13 +456,13 @@ void *csync_get_log_userdata(void);
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_set_log_userdata(void *data);
+int OCSYNC_EXPORT csync_set_log_userdata(void *data);
 
 /* Used for special modes or debugging */
-CSYNC_STATUS csync_get_status(CSYNC *ctx);
+CSYNC_STATUS OCSYNC_EXPORT csync_get_status(CSYNC *ctx);
 
 /* Used for special modes or debugging */
-int csync_set_status(CSYNC *ctx, int status);
+int OCSYNC_EXPORT csync_set_status(CSYNC *ctx, int status);
 
 typedef int csync_treewalk_visit_func(TREE_WALK_FILE* ,void*);
 
@@ -475,7 +475,7 @@ typedef int csync_treewalk_visit_func(TREE_WALK_FILE* ,void*);
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_walk_local_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int filter);
+int OCSYNC_EXPORT csync_walk_local_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int filter);
 
 /**
  * @brief Walk the remote file tree and call a visitor function for each file.
@@ -486,7 +486,7 @@ int csync_walk_local_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int fi
  *
  * @return              0 on success, less than 0 if an error occurred.
  */
-int csync_walk_remote_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int filter);
+int OCSYNC_EXPORT csync_walk_remote_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int filter);
 
 /**
  * @brief Get the csync status string.
@@ -495,7 +495,7 @@ int csync_walk_remote_tree(CSYNC *ctx, csync_treewalk_visit_func *visitor, int f
  *
  * @return               A const pointer to a string with more precise status info.
  */
-const char *csync_get_status_string(CSYNC *ctx);
+const char OCSYNC_EXPORT *csync_get_status_string(CSYNC *ctx);
 
 #ifdef WITH_ICONV
 /**
@@ -505,7 +505,7 @@ const char *csync_get_status_string(CSYNC *ctx);
  *
  * @return              0 on success, or an iconv error number.
  */
-int csync_set_iconv_codec(const char *from);
+int OCSYNC_EXPORT csync_set_iconv_codec(const char *from);
 #endif
 
 /**
@@ -513,24 +513,24 @@ int csync_set_iconv_codec(const char *from);
  *
  * @param ctx           The csync context.
  */
-void csync_request_abort(CSYNC *ctx);
+void OCSYNC_EXPORT csync_request_abort(CSYNC *ctx);
 
 /**
  * @brief Clears the abort flag. Can be called from another thread.
  *
  * @param ctx           The csync context.
  */
-void csync_resume(CSYNC *ctx);
+void OCSYNC_EXPORT csync_resume(CSYNC *ctx);
 
 /**
  * @brief Checks for the abort flag, to be used from the modules.
  *
  * @param ctx           The csync context.
  */
-int  csync_abort_requested(CSYNC *ctx);
+int  OCSYNC_EXPORT csync_abort_requested(CSYNC *ctx);
 
-char *csync_normalize_etag(const char *);
-time_t oc_httpdate_parse( const char *date );
+char OCSYNC_EXPORT *csync_normalize_etag(const char *);
+time_t OCSYNC_EXPORT oc_httpdate_parse( const char *date );
 
 #ifdef __cplusplus
 }

--- a/csync/src/csync_exclude.c
+++ b/csync/src/csync_exclude.c
@@ -28,7 +28,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include "c_lib.h"
 #include "c_private.h"
@@ -36,6 +35,12 @@
 #include "csync_private.h"
 #include "csync_exclude.h"
 #include "csync_misc.h"
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #define CSYNC_LOG_CATEGORY_NAME "csync.exclude"
 #include "csync_log.h"

--- a/csync/src/csync_exclude.h
+++ b/csync/src/csync_exclude.h
@@ -21,6 +21,8 @@
 #ifndef _CSYNC_EXCLUDE_H
 #define _CSYNC_EXCLUDE_H
 
+#include "ocsynclib.h"
+
 enum csync_exclude_type_e {
   CSYNC_NOT_EXCLUDED   = 0,
   CSYNC_FILE_SILENTLY_EXCLUDED,
@@ -46,7 +48,7 @@ int _csync_exclude_add(c_strlist_t **inList, const char *string);
  *
  * @return  0 on success, -1 if an error occurred with errno set.
  */
-int csync_exclude_load(const char *fname, c_strlist_t **list);
+int OCSYNC_EXPORT csync_exclude_load(const char *fname, c_strlist_t **list);
 
 /**
  * @brief Check if the given path should be excluded in a traversal situation.
@@ -72,7 +74,7 @@ CSYNC_EXCLUDE_TYPE csync_excluded_traversal(c_strlist_t *excludes, const char *p
  * @param filetype
  * @return
  */
-CSYNC_EXCLUDE_TYPE csync_excluded_no_ctx(c_strlist_t *excludes, const char *path, int filetype);
+CSYNC_EXCLUDE_TYPE OCSYNC_EXPORT csync_excluded_no_ctx(c_strlist_t *excludes, const char *path, int filetype);
 #endif /* _CSYNC_EXCLUDE_H */
 
 /**

--- a/csync/src/csync_log.c
+++ b/csync/src/csync_log.c
@@ -23,12 +23,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#else
-#include <sys/utime.h>
-#endif
-#include <time.h>
 
 #include "csync_private.h"
 #include "csync_log.h"
@@ -37,46 +31,11 @@ CSYNC_THREAD int csync_log_level;
 CSYNC_THREAD csync_log_callback csync_log_cb;
 CSYNC_THREAD void *csync_log_userdata;
 
-static int current_timestring(int hires, char *buf, size_t len)
-{
-    char tbuf[64];
-    struct timeval tv;
-    struct tm *tm;
-    time_t t;
-
-    gettimeofday(&tv, NULL);
-    t = (time_t) tv.tv_sec;
-
-    tm = localtime(&t);
-    if (tm == NULL) {
-        return -1;
-    }
-
-    if (hires) {
-        strftime(tbuf, sizeof(tbuf) - 1, "%Y/%m/%d %H:%M:%S", tm);
-        snprintf(buf, len, "%s.%06ld", tbuf, (long) tv.tv_usec);
-    } else {
-        strftime(tbuf, sizeof(tbuf) - 1, "%Y/%m/%d %H:%M:%S", tm);
-        snprintf(buf, len, "%s", tbuf);
-    }
-
-    return 0;
-}
-
 static void csync_log_stderr(int verbosity,
                              const char *function,
                              const char *buffer)
 {
-    char date[64] = {0};
-    int rc;
-
-    rc = current_timestring(1, date, sizeof(date));
-    if (rc == 0) {
-        fprintf(stderr, "[%s, %d] %s:", date+5, verbosity, function);
-    } else {
-        fprintf(stderr, "[%d] %s", verbosity, function);
-    }
-
+    fprintf(stderr, "[%d] %s", verbosity, function);
     fprintf(stderr, "  %s\n", buffer);
 }
 static void csync_log_function(int verbosity,

--- a/csync/src/csync_misc.c
+++ b/csync/src/csync_misc.c
@@ -39,7 +39,6 @@
 # include <shlobj.h>
 #else /* _WIN32 */
 # include <pwd.h>
-# include <unistd.h>
 #endif /* _WIN32 */
 
 #include "c_lib.h"

--- a/csync/src/csync_misc.h
+++ b/csync/src/csync_misc.h
@@ -36,7 +36,7 @@
 #define FNM_CASEFOLD    (1 << 4) /* Compare without regard to case.  */
 #endif
 
-int csync_fnmatch(__const char *__pattern, __const char *__name, int __flags);
+int csync_fnmatch(const char *pattern, const char *name, int flags);
 
 /**
  * @brief csync_errno_to_status - errno to csync status code

--- a/csync/src/csync_private.h
+++ b/csync/src/csync_private.h
@@ -224,9 +224,6 @@ struct _csync_treewalk_context_s
 };
 typedef struct _csync_treewalk_context_s _csync_treewalk_context;
 
-
-time_t oc_httpdate_parse( const char *date );
-
 void set_errno_from_http_errcode( int err );
 
 /**

--- a/csync/src/csync_reconcile.h
+++ b/csync/src/csync_reconcile.h
@@ -50,7 +50,7 @@
  *
  * @todo Add an argument to set the algorithm to use.
  */
-int csync_reconcile_updates(CSYNC *ctx);
+int OCSYNC_EXPORT csync_reconcile_updates(CSYNC *ctx);
 
 /**
  * }@

--- a/csync/src/csync_rename.h
+++ b/csync/src/csync_rename.h
@@ -27,11 +27,11 @@ extern "C" {
 #endif
 
 /* Return the final destination path of a given patch in case of renames */
-char *csync_rename_adjust_path(CSYNC *ctx, const char *path);
+char OCSYNC_EXPORT *csync_rename_adjust_path(CSYNC *ctx, const char *path);
 /* Return the source of a given path in case of renames */
-char *csync_rename_adjust_path_source(CSYNC *ctx, const char *path);
-void csync_rename_destroy(CSYNC *ctx);
-void csync_rename_record(CSYNC *ctx, const char *from, const char *to);
+char OCSYNC_EXPORT *csync_rename_adjust_path_source(CSYNC *ctx, const char *path);
+void OCSYNC_EXPORT csync_rename_destroy(CSYNC *ctx);
+void OCSYNC_EXPORT csync_rename_record(CSYNC *ctx, const char *from, const char *to);
 
 #ifdef __cplusplus
 }

--- a/csync/src/csync_statedb.c
+++ b/csync/src/csync_statedb.c
@@ -27,7 +27,6 @@
 
 #include <sqlite3.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -53,7 +52,7 @@
 
 #define sqlite_open(A, B) sqlite3_open_v2(A,B, SQLITE_OPEN_READONLY+SQLITE_OPEN_NOMUTEX, NULL)
 
-#define SQLTM_TIME 150000
+#define SQLTM_TIME 150
 #define SQLTM_COUNT 10
 
 #define SQLITE_BUSY_HANDLED(F) if(1) { \
@@ -61,7 +60,7 @@
     do { rc = F ; \
       if( (rc == SQLITE_BUSY) || (rc == SQLITE_LOCKED) ) { \
          n++; \
-         usleep(SQLTM_TIME); \
+         csync_sleep(SQLTM_TIME); \
       } \
     }while( (n < SQLTM_COUNT) && ((rc == SQLITE_BUSY) || (rc == SQLITE_LOCKED))); \
   }
@@ -519,8 +518,7 @@ c_strlist_t *csync_statedb_query(sqlite3 *db,
     /* compile SQL program into a virtual machine, reattempteing if busy */
     do {
       if (busy_count) {
-        /* sleep 100 msec */
-        usleep(100000);
+        csync_sleep(100);
         CSYNC_LOG(CSYNC_LOG_PRIORITY_DEBUG, "sqlite3_prepare: BUSY counter: %zu", busy_count);
       }
       err = sqlite3_prepare(db, statement, -1, &stmt, &tail);
@@ -547,8 +545,7 @@ c_strlist_t *csync_statedb_query(sqlite3 *db,
             CSYNC_LOG(CSYNC_LOG_PRIORITY_ERROR, "Busy counter has reached its maximum. Aborting this sql statement");
             break;
           }
-          /* sleep 100 msec */
-          usleep(100000);
+          csync_sleep(100);
           CSYNC_LOG(CSYNC_LOG_PRIORITY_TRACE, "sqlite3_step: BUSY counter: %zu", busy_count);
           continue;
         }

--- a/csync/src/csync_time.h
+++ b/csync/src/csync_time.h
@@ -26,5 +26,6 @@
 #include "csync_private.h"
 
 int csync_gettime(struct timespec *tp);
+void csync_sleep(unsigned int msecs);
 
 #endif /* _CSYNC_TIME_H */

--- a/csync/src/csync_util.h
+++ b/csync/src/csync_util.h
@@ -26,9 +26,9 @@
 
 #include "csync_private.h"
 
-const char *csync_instruction_str(enum csync_instructions_e instr);
+const char OCSYNC_EXPORT *csync_instruction_str(enum csync_instructions_e instr);
 
-void csync_memstat_check(void);
+void OCSYNC_EXPORT csync_memstat_check(void);
 
-bool csync_file_locked_or_open( const char *dir, const char *fname);
+bool OCSYNC_EXPORT csync_file_locked_or_open( const char *dir, const char *fname);
 #endif /* _CSYNC_UTIL_H */

--- a/csync/src/std/CMakeLists.txt
+++ b/csync/src/std/CMakeLists.txt
@@ -26,6 +26,12 @@ set(cstdlib_SRCS
   c_time.c
 )
 
+if(NOT HAVE_ASPRINTF AND NOT HAVE___MINGW_ASPRINTF)
+    list(APPEND cstdlib_SRCS
+        asprintf.c
+    )
+endif()
+
 include_directories(
   ${CSTDLIB_PUBLIC_INCLUDE_DIRS}
   ${CSTDLIB_PRIVATE_INCLUDE_DIRS}

--- a/csync/src/std/asprintf.c
+++ b/csync/src/std/asprintf.c
@@ -1,0 +1,90 @@
+/*
+  https://raw.githubusercontent.com/littlstar/asprintf.c/20ce5207a4ecb24017b5a17e6cd7d006e3047146/asprintf.c
+
+  The MIT License (MIT)
+
+  Copyright (c) 2014 Little Star Media, Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * `asprintf.c' - asprintf
+ *
+ * copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
+ */
+
+#ifndef HAVE_ASPRINTF
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "asprintf.h"
+
+int
+asprintf (char **str, const char *fmt, ...) {
+  int size = 0;
+  va_list args;
+
+  // init variadic argumens
+  va_start(args, fmt);
+
+  // format and get size
+  size = vasprintf(str, fmt, args);
+
+  // toss args
+  va_end(args);
+
+  return size;
+}
+
+int
+vasprintf (char **str, const char *fmt, va_list args) {
+  int size = 0;
+  va_list tmpa;
+
+  // copy
+  va_copy(tmpa, args);
+
+  // apply variadic arguments to
+  // sprintf with format to get size
+  size = vsnprintf(NULL, size, fmt, tmpa);
+
+  // toss args
+  va_end(tmpa);
+
+  // return -1 to be compliant if
+  // size is less than 0
+  if (size < 0) { return -1; }
+
+  // alloc with size plus 1 for `\0'
+  *str = (char *) malloc(size + 1);
+
+  // return -1 to be compliant
+  // if pointer is `NULL'
+  if (NULL == *str) { return -1; }
+
+  // format string with original
+  // variadic arguments and set new size
+  size = vsprintf(*str, fmt, args);
+  return size;
+}
+
+#endif

--- a/csync/src/std/asprintf.h
+++ b/csync/src/std/asprintf.h
@@ -1,0 +1,60 @@
+/*
+  https://raw.githubusercontent.com/littlstar/asprintf.c/20ce5207a4ecb24017b5a17e6cd7d006e3047146/asprintf.h
+
+  The MIT License (MIT)
+
+  Copyright (c) 2014 Little Star Media, Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+/**
+ * `asprintf.h' - asprintf.c
+ *
+ * copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
+ */
+
+#ifndef HAVE_ASPRINTF
+#ifndef ASPRINTF_H
+#define ASPRINTF_H 1
+
+#include <stdarg.h>
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted string
+ * accepting a `va_list' args of variadic
+ * arguments.
+ */
+
+int
+vasprintf (char **, const char *, va_list);
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted
+ * string accepting `n' arguments of
+ * variadic arguments.
+ */
+
+int
+asprintf (char **, const char *, ...);
+
+#endif
+#endif

--- a/csync/src/std/c_private.h
+++ b/csync/src/std/c_private.h
@@ -31,14 +31,17 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+#include <windows.h>
 #include <windef.h>
 #include <winbase.h>
 #include <wchar.h>
+#else
+#include <unistd.h>
 #endif
 
 #include <errno.h>
 
-#ifdef _WIN32
+#ifdef __MINGW32__
 #define EDQUOT 0
 #define ENODATA 0
 #ifndef S_IRGRP
@@ -65,6 +68,8 @@
 #define nlink_t int
 #define getuid() 0
 #define geteuid() 0
+#elif defined(_WIN32)
+#define mode_t int
 #else
 #include <fcntl.h>
 #endif
@@ -89,8 +94,12 @@ typedef struct stat csync_stat_t;
 #define ENODATA EBADF
 #endif
 
-#if !defined(HAVE_ASPRINTF) && defined(HAVE___MINGW_ASPRINTF)
+#if !defined(HAVE_ASPRINTF)
+#if defined(HAVE___MINGW_ASPRINTF)
 #define asprintf __mingw_asprintf
+#else
+#include "asprintf.h"
+#endif
 #endif
 
 #ifndef HAVE_STRERROR_R

--- a/csync/src/std/c_time.c
+++ b/csync/src/std/c_time.c
@@ -25,6 +25,10 @@
 #include "c_path.h"
 #include "c_time.h"
 
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+
 struct timespec c_tspecdiff(struct timespec time1, struct timespec time0) {
   struct timespec ret;
   int xsec = 0;

--- a/csync/src/std/c_time.h
+++ b/csync/src/std/c_time.h
@@ -22,7 +22,6 @@
 #define _C_TIME_H
 
 #include <time.h>
-#include <sys/time.h>
 
 /**
  * @brief Calculate time difference

--- a/csync/src/vio/csync_vio_local.h
+++ b/csync/src/vio/csync_vio_local.h
@@ -21,12 +21,10 @@
 #ifndef _CSYNC_VIO_LOCAL_H
 #define _CSYNC_VIO_LOCAL_H
 
-#include <sys/time.h>
+csync_vio_handle_t OCSYNC_EXPORT *csync_vio_local_opendir(const char *name);
+int OCSYNC_EXPORT csync_vio_local_closedir(csync_vio_handle_t *dhandle);
+csync_vio_file_stat_t OCSYNC_EXPORT *csync_vio_local_readdir(csync_vio_handle_t *dhandle);
 
-csync_vio_handle_t *csync_vio_local_opendir(const char *name);
-int csync_vio_local_closedir(csync_vio_handle_t *dhandle);
-csync_vio_file_stat_t *csync_vio_local_readdir(csync_vio_handle_t *dhandle);
-
-int csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf);
+int OCSYNC_EXPORT csync_vio_local_stat(const char *uri, csync_vio_file_stat_t *buf);
 
 #endif /* _CSYNC_VIO_LOCAL_H */

--- a/csync/src/vio/csync_vio_local_win.c
+++ b/csync/src/vio/csync_vio_local_win.c
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <dirent.h>
 #include <stdio.h>
 
 #include "windows.h"

--- a/csync/tests/csync_tests/check_csync_exclude.c
+++ b/csync/tests/csync_tests/check_csync_exclude.c
@@ -20,6 +20,7 @@
 #include "config_csync.h"
 #include <string.h>
 #include <time.h>
+#include <sys/time.h>
 
 #include "torture.h"
 

--- a/csync/tests/csync_tests/check_csync_log.c
+++ b/csync/tests/csync_tests/check_csync_log.c
@@ -19,7 +19,6 @@
  */
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "torture.h"
 

--- a/csync/tests/csync_tests/check_csync_statedb_load.c
+++ b/csync/tests/csync_tests/check_csync_statedb_load.c
@@ -18,7 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <string.h>
-#include <unistd.h>
 
 #include "torture.h"
 

--- a/csync/tests/std_tests/check_std_c_time.c
+++ b/csync/tests/std_tests/check_std_c_time.c
@@ -18,7 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <string.h>
-#include <unistd.h>
 
 #include "torture.h"
 

--- a/csync/tests/vio_tests/check_vio.c
+++ b/csync/tests/vio_tests/check_vio.c
@@ -22,7 +22,6 @@
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
-#include <unistd.h>
 
 #include "torture.h"
 

--- a/csync/tests/vio_tests/check_vio_ext.c
+++ b/csync/tests/vio_tests/check_vio_ext.c
@@ -22,7 +22,6 @@
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
-#include <unistd.h>
 #include <stdio.h>
 
 #include "torture.h"

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -41,6 +41,7 @@
 #include <windows.h>
 #else
 #include <termios.h>
+#include <unistd.h>
 #endif
 
 using namespace OCC;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -70,9 +70,9 @@ set(client_SRCS
     activityitemdelegate.cpp
     selectivesyncdialog.cpp
     settingsdialog.cpp
-    share.cpp
     sharedialog.cpp
     sharelinkwidget.cpp
+    sharemanager.cpp
     shareusergroupwidget.cpp
     sharee.cpp
     socketapi.cpp

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -15,7 +15,7 @@
 #define OCSSHAREJOB_H
 
 #include "ocsjob.h"
-#include "share.h"
+#include "sharemanager.h"
 #include <QVector>
 #include <QList>
 #include <QPair>

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -17,7 +17,7 @@
 #include "account.h"
 #include "capabilities.h"
 
-#include "share.h"
+#include "sharemanager.h"
 
 #include "QProgressIndicator.h"
 #include <QBuffer>

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -11,7 +11,7 @@
  * for more details.
  */
 
-#include "share.h"
+#include "sharemanager.h"
 #include "ocssharejob.h"
 #include "account.h"
 
@@ -30,9 +30,9 @@ Q_DECLARE_METATYPE(CreateShare)
 
 namespace OCC {
 
-Share::Share(AccountPtr account, 
-             const QString& id, 
-             const QString& path, 
+Share::Share(AccountPtr account,
+             const QString& id,
+             const QString& path,
              const ShareType shareType,
              const Permissions permissions,
              const QSharedPointer<Sharee> shareWith)
@@ -100,7 +100,7 @@ void Share::slotDeleted()
 
 void Share::slotOcsError(int statusCode, const QString &message)
 {
-    emit serverError(statusCode, message);   
+    emit serverError(statusCode, message);
 }
 
 QUrl LinkShare::getLink() const
@@ -229,7 +229,7 @@ void ShareManager::slotLinkShareCreated(const QVariantMap &reply)
     if (code == 403) {
         emit linkShareRequiresPassword(message);
         return;
-    } 
+    }
 
     //Parse share
     auto data = reply.value("ocs").toMap().value("data").toMap();
@@ -329,7 +329,7 @@ void ShareManager::slotSharesFetched(const QVariantMap &reply)
             newShare = parseShare(data);
         }
 
-        shares.append(QSharedPointer<Share>(newShare));    
+        shares.append(QSharedPointer<Share>(newShare));
     }
 
     qDebug() << Q_FUNC_INFO << "Sending " << shares.count() << "shares";
@@ -371,7 +371,7 @@ QSharedPointer<Share> ShareManager::parseShare(const QVariantMap &data)
     QSharedPointer<Sharee> sharee(new Sharee(data.value("share_with").toString(),
                                              data.value("share_with_displayname").toString(),
                                              (Sharee::Type)data.value("share_type").toInt()));
-    
+
     return QSharedPointer<Share>(new Share(_account,
                                            data.value("id").toString(),
                                            data.value("path").toString(),

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -11,8 +11,8 @@
  * for more details.
  */
 
-#ifndef SHARE_H
-#define SHARE_H
+#ifndef SHAREMANAGER_H
+#define SHAREMANAGER_H
 
 #include "accountfwd.h"
 #include "sharee.h"
@@ -127,7 +127,7 @@ private slots:
 class LinkShare : public Share {
     Q_OBJECT
 public:
- 
+
     explicit LinkShare(AccountPtr account,
                        const QString& id,
                        const QString& path,
@@ -154,7 +154,7 @@ public:
      * In case of a server error the serverError signal is emitted.
      */
     void setPublicUpload(bool publicUpload);
-    
+
     /*
      * Set the password
      *
@@ -276,7 +276,6 @@ private:
     AccountPtr _account;
 };
 
-
 }
 
-#endif // SHARE_H
+#endif // SHAREMANAGER_H

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -24,8 +24,8 @@
 #include "capabilities.h"
 
 #include "thumbnailjob.h"
-#include "share.h"
 #include "sharee.h"
+#include "sharemanager.h"
 
 #include "QProgressIndicator.h"
 #include <QBuffer>

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -1,6 +1,5 @@
 project(libsync)
 set(CMAKE_AUTOMOC TRUE)
-include(GenerateExportHeader)
 
 configure_file( version.h.in "${CMAKE_CURRENT_BINARY_DIR}/version.h" )
 

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -29,10 +29,11 @@
 #endif
 
 #ifdef Q_OS_WIN
+#include <windows.h>
 #include <windef.h>
 #include <winbase.h>
 #include <fcntl.h>
-
+#include <io.h>
 #endif
 
 // We use some internals of csync:

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -31,6 +31,10 @@
 #include <QDebug>
 #include <cmath>
 
+#ifdef Q_OS_UNIX
+#include <unistd.h>
+#endif
+
 namespace OCC {
 
 // Always coming in with forward slashes.

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -18,8 +18,7 @@
 
 static const QUrl sRootUrl("owncloud://somehost/owncloud/remote.php/webdav/");
 
-namespace {
-QString generateEtag() {
+static QString generateEtag() {
     return QString::number(QDateTime::currentDateTime().toMSecsSinceEpoch(), 16);
 }
 
@@ -35,7 +34,6 @@ public:
     QString pathRoot() const { return first(); }
     QString fileName() const { return last(); }
 };
-}
 
 class FileModifier
 {


### PR DESCRIPTION
- Replace functions that are provided by MinGW with a Win32-based
  implementation
- Explicitly export needed symbols from ocsync.dll
- Rename share.h to sharemanager.h since the name clashes with one
  of the Windows headers and get included from there
- Remove the timestamp from the fallback csync stderr logging, it's
  not used since we always provide a log callback