### PR TITLE
Folder/Watcher: Fix up #5174 #5153

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -123,9 +123,11 @@ Folder::~Folder()
 void Folder::checkLocalPath()
 {
     const QFileInfo fi(_definition.localPath);
-
     _canonicalLocalPath = fi.canonicalFilePath();
-    if( !_canonicalLocalPath.endsWith('/') ) {
+    if (_canonicalLocalPath.isEmpty()) {
+        qDebug() << "Broken symlink:" << _definition.localPath;
+        _canonicalLocalPath = _definition.localPath;
+    } else if( !_canonicalLocalPath.endsWith('/') ) {
         _canonicalLocalPath.append('/');
     }
 


### PR DESCRIPTION
It was surprising to have a broken symlink return empty for
canonical path.
