### PR TITLE
OwnSQL: avoid crashing in SqlQuery::reset_and_clear_bindings

### DIFF
--- a/src/libsync/ownsql.cpp
+++ b/src/libsync/ownsql.cpp
@@ -230,8 +230,12 @@ bool SqlQuery::isPragma()
 
 bool SqlQuery::exec()
 {
+    if (!_stmt) {
+        return false;
+    }
+
     // Don't do anything for selects, that is how we use the lib :-|
-    if(_stmt && !isSelect() && !isPragma() ) {
+    if( !isSelect() && !isPragma() ) {
         int rc, n = 0;
         do {
             rc = sqlite3_step(_stmt);
@@ -376,8 +380,10 @@ void SqlQuery::finish()
 
 void SqlQuery::reset_and_clear_bindings()
 {
-    SQLITE_DO(sqlite3_reset(_stmt));
-    SQLITE_DO(sqlite3_clear_bindings(_stmt));
+    if (_stmt) {
+        SQLITE_DO(sqlite3_reset(_stmt));
+        SQLITE_DO(sqlite3_clear_bindings(_stmt));
+    }
 }
 
 } // namespace OCC


### PR DESCRIPTION
The crash reporter shows a lot of crashes in sqlite3_clear_bindings
which seems to indicate that _stmt is null. We should guard against
a null value in order to avoid crashing.

This should only happen if the prepare call fails. We don't usually
check the return value of the prepare call, but if _stmt is null, the
exec call should return false, not true. We check the result of the
exec call, so this should then abort the sync with an error, rather
than crashing.