### PR TITLE
csync: Do not wipe the db file name when cleaning csync_ctx.

### DIFF
--- a/csync/src/csync.c
+++ b/csync/src/csync.c
@@ -521,7 +521,6 @@ static void _csync_clean_ctx(CSYNC *ctx)
     c_rbtree_free(ctx->local.tree);
     c_rbtree_free(ctx->remote.tree);
 
-    SAFE_FREE(ctx->statedb.file);
     SAFE_FREE(ctx->remote.root_perms);
 }
 


### PR DESCRIPTION
The name of the db is only set in the constructor of the SyncEngine
and never again. If we wipe it, subsequent operations can not open
the database through csync. For example csync_update does that.

This problem was found after the client reported a csync error
after changing the selective sync list.