### PR TITLE
Improve macOS SysTray/StatusBar monochrome icon

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -67,7 +67,7 @@ ownCloudGui::ownCloudGui(Application *parent) :
     _tray->setParent(this);
 
     // for the beginning, set the offline icon until the account was verified
-    _tray->setIcon( Theme::instance()->folderOfflineIcon(true));
+    _tray->setIcon( Theme::instance()->folderOfflineIcon(true, contextMenuVisible()));
 
     connect(_tray.data(), SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             SLOT(slotTrayClicked(QSystemTrayIcon::ActivationReason)));
@@ -262,7 +262,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     }
 
     if (!problemAccounts.empty()) {
-        _tray->setIcon(Theme::instance()->folderOfflineIcon(true));
+        _tray->setIcon(Theme::instance()->folderOfflineIcon(true, contextMenuVisible()));
 #ifdef Q_OS_WIN
         // Windows has a 128-char tray tooltip length limit.
         QStringList accountNames;
@@ -289,11 +289,11 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     }
 
     if (allSignedOut) {
-        _tray->setIcon(Theme::instance()->folderOfflineIcon(true));
+        _tray->setIcon(Theme::instance()->folderOfflineIcon(true, contextMenuVisible()));
         _tray->setToolTip(tr("Please sign in"));
         return;
     } else if (allPaused) {
-        _tray->setIcon(Theme::instance()->syncStateIcon(SyncResult::Paused, true));
+        _tray->setIcon(Theme::instance()->syncStateIcon(SyncResult::Paused, true, contextMenuVisible()));
         _tray->setToolTip(tr("Account synchronization is disabled"));
         return;
     }
@@ -323,12 +323,12 @@ void ownCloudGui::slotComputeOverallSyncStatus()
             trayMessage = tr("No sync folders configured.");
         }
 
-        QIcon statusIcon = Theme::instance()->syncStateIcon( overallResult.status(), true);
+        QIcon statusIcon = Theme::instance()->syncStateIcon( overallResult.status(), true, contextMenuVisible());
         _tray->setIcon( statusIcon );
         _tray->setToolTip(trayMessage);
     } else {
         // undefined because there are no folders.
-        QIcon icon = Theme::instance()->syncStateIcon(SyncResult::Problem, true);
+        QIcon icon = Theme::instance()->syncStateIcon(SyncResult::Problem, true, contextMenuVisible());
         _tray->setIcon( icon );
         _tray->setToolTip(tr("There are no sync folders configured."));
     }
@@ -405,6 +405,9 @@ void ownCloudGui::slotContextMenuAboutToShow()
     // For some reason on OS X _contextMenu->isVisible returns always false
     qDebug() << "";
     _contextMenuVisibleOsx = true;
+
+    // Update icon in sys tray, as it might change depending on the context menu state
+    slotComputeOverallSyncStatus();
 }
 
 void ownCloudGui::slotContextMenuAboutToHide()
@@ -412,6 +415,9 @@ void ownCloudGui::slotContextMenuAboutToHide()
     // For some reason on OS X _contextMenu->isVisible returns always false
     qDebug() << "";
     _contextMenuVisibleOsx = false;
+
+    // Update icon in sys tray, as it might change depending on the context menu state
+    slotComputeOverallSyncStatus();
 }
 
 bool ownCloudGui::contextMenuVisible() const

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -115,11 +115,11 @@ QIcon Theme::trayFolderIcon( const QString& backend ) const
  * helper to load a icon from either the icon theme the desktop provides or from
  * the apps Qt resources.
  */
-QIcon Theme::themeIcon( const QString& name, bool sysTray ) const
+QIcon Theme::themeIcon( const QString& name, bool sysTray, bool sysTrayMenuVisible ) const
 {
     QString flavor;
     if (sysTray) {
-        flavor = systrayIconFlavor(_mono);
+        flavor = systrayIconFlavor(_mono, sysTrayMenuVisible);
     } else {
         flavor = QLatin1String("colored");
     }
@@ -157,6 +157,14 @@ QIcon Theme::themeIcon( const QString& name, bool sysTray ) const
             }
         }
     }
+
+    #ifdef Q_OS_MAC
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+    // This defines the icon as a template and enables automatic macOS color handling
+    // See https://bugreports.qt.io/browse/QTBUG-42109
+    cached.setIsMask(_mono && sysTray && !sysTrayMenuVisible);
+    #endif
+    #endif
 
     return cached;
 }
@@ -227,11 +235,17 @@ QString Theme::defaultClientFolder() const
     return appName();
 }
 
-QString Theme::systrayIconFlavor(bool mono) const
+QString Theme::systrayIconFlavor(bool mono, bool sysTrayMenuVisible ) const
 {
     QString flavor;
     if (mono) {
         flavor = Utility::hasDarkSystray() ? QLatin1String("white") : QLatin1String("black");
+
+        #ifdef Q_OS_MAC
+        if (sysTrayMenuVisible) {
+            flavor = QLatin1String("white");
+        }
+        #endif
     } else {
         flavor = QLatin1String("colored");
     }
@@ -331,7 +345,7 @@ QVariant Theme::customMedia( CustomMediaType type )
     return re;
 }
 
-QIcon Theme::syncStateIcon( SyncResult::Status status, bool sysTray ) const
+QIcon Theme::syncStateIcon( SyncResult::Status status, bool sysTray, bool sysTrayMenuVisible ) const
 {
     // FIXME: Mind the size!
     QString statusIcon;
@@ -363,7 +377,7 @@ QIcon Theme::syncStateIcon( SyncResult::Status status, bool sysTray ) const
         statusIcon = QLatin1String("state-error");
     }
 
-    return themeIcon( statusIcon, sysTray );
+    return themeIcon( statusIcon, sysTray, sysTrayMenuVisible );
 }
 
 QIcon Theme::folderDisabledIcon( ) const
@@ -371,9 +385,9 @@ QIcon Theme::folderDisabledIcon( ) const
     return themeIcon( QLatin1String("state-pause") );
 }
 
-QIcon Theme::folderOfflineIcon(bool systray) const
+QIcon Theme::folderOfflineIcon(bool sysTray, bool sysTrayMenuVisible ) const
 {
-    return themeIcon( QLatin1String("state-offline"), systray );
+    return themeIcon( QLatin1String("state-offline"), sysTray, sysTrayMenuVisible );
 }
 
 QColor Theme::wizardHeaderTitleColor() const

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -97,10 +97,10 @@ public:
     /**
       * get an sync state icon
       */
-    virtual QIcon   syncStateIcon( SyncResult::Status, bool sysTray = false ) const;
+    virtual QIcon   syncStateIcon( SyncResult::Status, bool sysTray = false, bool sysTrayMenuVisible = false) const;
 
     virtual QIcon   folderDisabledIcon() const;
-    virtual QIcon   folderOfflineIcon(bool systray = false) const;
+    virtual QIcon   folderOfflineIcon(bool sysTray = false, bool sysTrayMenuVisible = false) const;
     virtual QIcon   applicationIcon() const = 0;
 #endif
 
@@ -152,7 +152,7 @@ public:
     virtual QString enforcedLocale() const { return QString::null; }
 
     /** colored, white or black */
-    QString systrayIconFlavor(bool mono) const;
+    QString systrayIconFlavor(bool mono, bool sysTrayMenuVisible = false) const;
 
 #ifndef TOKEN_AUTH_ONLY
     /**
@@ -304,7 +304,7 @@ public:
 
 protected:
 #ifndef TOKEN_AUTH_ONLY
-    QIcon themeIcon(const QString& name, bool sysTray = false) const;
+    QIcon themeIcon(const QString& name, bool sysTray = false, bool sysTrayMenuVisible = false) const;
 #endif
     Theme();
 


### PR DESCRIPTION
- Use a white icon if the context menu is visible.
This is enables the same behaviour as every other App.
Before:
<img width="324" alt="screenshot 2016-10-05 20 57 59" src="https://cloud.githubusercontent.com/assets/1390036/19128141/49dd6c52-8b42-11e6-9929-25a2fdccffe7.png">
After:
<img width="345" alt="screenshot 2016-10-05 20 58 08" src="https://cloud.githubusercontent.com/assets/1390036/19128146/508e6114-8b42-11e6-94b1-cd5a1f0f8423.png">

- Enable `QIcon::setIsMask` if compiled on Qt >= 5.6 to allow automatic macOS color handling
(See [QTBUG-42109](https://bugreports.qt.io/browse/QTBUG-42109))
The monochrome icon now better matches the black tone of all other icons (blending with the background) if used with a white menu bar.
<img width="631" alt="screenshot 2016-10-05 21 29 18" src="https://cloud.githubusercontent.com/assets/1390036/19128233/cbab8eda-8b42-11e6-8175-69f131c3fc1d.png">
The icon now nicely blends with the other icons even if multiple monitors are connected and this is not the active monitor/desktop.
<img width="471" alt="screenshot 2016-10-05 21 09 40" src="https://cloud.githubusercontent.com/assets/1390036/19128205/a2e79ca0-8b42-11e6-9734-2813d305ce94.png">
<img width="398" alt="screenshot 2016-10-05 21 10 43" src="https://cloud.githubusercontent.com/assets/1390036/19128206/a33dfe06-8b42-11e6-9b5d-ca29f7a306e8.png">

- No changes if the colored icons are used.

As this is my first contribution, I'm not sure if it is ok to add `#ifdef Q_OS_MAC` or should I create methods in the `Utility` class?