### PR TITLE
Move check for mono icons into separate function

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -79,9 +79,7 @@ GeneralSettings::GeneralSettings(QWidget *parent) :
 
     // OEM themes are not obliged to ship mono icons, so there
     // is no point in offering an option
-    QString themeDir = QString::fromLatin1(":/client/theme/%1/")
-            .arg(Theme::instance()->systrayIconFlavor(true));
-    _ui->monoIconsCheckBox->setVisible(QDir(themeDir).exists());
+    _ui->monoIconsCheckBox->setVisible(Theme::instance()->monoIconsAvailable());
 
     connect(_ui->ignoredFilesButton, SIGNAL(clicked()), SLOT(slotIgnoreFilesEditor()));
 }

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -263,6 +263,12 @@ bool Theme::systrayUseMonoIcons() const
     return _mono;
 }
 
+bool Theme::monoIconsAvailable() const
+{
+    QString themeDir = QString::fromLatin1(":/client/theme/%1/").arg(Theme::instance()->systrayIconFlavor(true));
+    return QDir(themeDir).exists();
+}
+
 QString Theme::updateCheckUrl() const
 {
     return QLatin1String("https://updates.owncloud.com/client/");

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -202,6 +202,11 @@ public:
     bool systrayUseMonoIcons() const;
 
     /**
+     * Check if mono icons are available
+     */
+    bool monoIconsAvailable() const;
+
+    /**
      * @brief Where to check for new Updates.
      */
     virtual QString updateCheckUrl() const;


### PR DESCRIPTION
Refactor the code to use a separate function to check if mono icons are available.
This could be used in #5229.

Open questions:
- This only checks for a single color (black or white). Should this be changed to check for both?
  (macOS currently requires black&white icons, this could also be changed to white only if build on >= Qt 5.6.0).
