### PR TITLE
FolderWatcher (linux): optimize slotAddFolderRecursive

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -188,7 +188,7 @@ QString Folder::shortGuiLocalPath() const
 }
 
 
-bool Folder::ignoreHiddenFiles()
+bool Folder::ignoreHiddenFiles() const
 {
     bool re(_definition.ignoreHiddenFiles);
     return re;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -167,7 +167,7 @@ public:
       * Ignore syncing of hidden files or not. This is defined in the
       * folder definition
       */
-     bool ignoreHiddenFiles();
+     bool ignoreHiddenFiles() const;
      void setIgnoreHiddenFiles(bool ignore);
 
      // Used by the Socket API

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -23,6 +23,7 @@
 #include <QStringList>
 #include <QObject>
 #include <QVarLengthArray>
+#include <syncengine.h>
 
 namespace OCC {
 
@@ -48,31 +49,6 @@ FolderWatcherPrivate::~FolderWatcherPrivate()
 
 }
 
-// attention: result list passed by reference!
-bool FolderWatcherPrivate::findFoldersBelow( const QDir& dir, QStringList& fullList )
-{
-    bool ok = true;
-    if( !(dir.exists() && dir.isReadable()) ) {
-        qDebug() << "Non existing path coming in: " << dir.absolutePath();
-        ok = false;
-    } else {
-        QStringList nameFilter;
-        nameFilter << QLatin1String("*");
-        QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Hidden;
-        const QStringList pathes = dir.entryList(nameFilter, filter);
-
-        QStringList::const_iterator constIterator;
-        for (constIterator = pathes.constBegin(); constIterator != pathes.constEnd();
-               ++constIterator) {
-            const QString fullPath(dir.path()+QLatin1String("/")+(*constIterator));
-            fullList.append(fullPath);
-            ok = findFoldersBelow(QDir(fullPath), fullList);
-        }
-    }
-
-    return ok;
-}
-
 void FolderWatcherPrivate::inotifyRegisterPath(const QString& path)
 {
     if( !path.isEmpty()) {
@@ -88,40 +64,46 @@ void FolderWatcherPrivate::inotifyRegisterPath(const QString& path)
 
 void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
 {
-    int subdirs = 0;
     qDebug() << "(+) Watcher:" << path;
-
-    QDir inPath(path);
-    inotifyRegisterPath(inPath.absolutePath());
-
     const QStringList watchedFolders = _watches.values();
-
-    QStringList allSubfolders;
-    if( !findFoldersBelow(QDir(path), allSubfolders)) {
-        qDebug() << "Could not traverse all sub folders";
-    }
-    // qDebug() << "currently watching " << watchedFolders;
-    QStringListIterator subfoldersIt(allSubfolders);
-    while (subfoldersIt.hasNext()) {
-        QString subfolder = subfoldersIt.next();
-        // qDebug() << "  (**) subfolder: " << subfolder;
-        QDir folder (subfolder);
-        if (folder.exists() && !watchedFolders.contains(folder.absolutePath())) {
-            subdirs++;
-            if( _parent->pathIsIgnored(subfolder) ) {
-                qDebug() << "* Not adding" << folder.path();
-                continue;
-            }
-            inotifyRegisterPath(folder.absolutePath());
-        } else {
-            qDebug() << "    `-> discarded:" << folder.path();
-        }
-    }
-
+    int subdirs = addFolderRecursiveHelper(path, watchedFolders.toSet());
     if (subdirs >0) {
         qDebug() << "    `-> and" << subdirs << "subdirectories";
     }
 }
+
+int FolderWatcherPrivate::addFolderRecursiveHelper(const QString &path, const QSet<QString> &watchedFolders)
+{
+    QDir dir(path);
+    if( !(dir.exists() && dir.isReadable()) ) {
+        qDebug() << "Non existing path coming in: " << dir.absolutePath();
+        return 0;
+    }
+    int subdirs = 1;
+
+    inotifyRegisterPath(dir.absolutePath());
+
+    QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Hidden;
+    const QStringList pathes = dir.entryList(filter);
+    for (auto constIterator = pathes.constBegin(); constIterator != pathes.constEnd(); ++constIterator) {
+        const QString subfolder = path + QLatin1String("/") + (*constIterator);
+        QDir folder(subfolder);
+        if (folder.exists() && !watchedFolders.contains(subfolder)) {
+#ifndef OWNCLOUD_TEST // InotifyWatcherTest is not interested in ignored files and does not link against the folder
+            if( _parent->_folder->syncEngine().excludedFiles().isExcluded(
+                    subfolder, path, _parent->_folder->ignoreHiddenFiles())) {
+                qDebug() << "* Not adding" << folder.path();
+                continue;
+            }
+#endif
+            subdirs += addFolderRecursiveHelper(subfolder, watchedFolders);
+        } else {
+            qDebug() << "    `-> discarded:" << folder.path();
+        }
+    }
+    return subdirs;
+}
+
 
 void FolderWatcherPrivate::slotReceivedNotification(int fd)
 {

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -33,7 +33,6 @@ class FolderWatcherPrivate : public QObject
 {
     Q_OBJECT
 public:
-    FolderWatcherPrivate() { }
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
     ~FolderWatcherPrivate();
 
@@ -45,10 +44,9 @@ protected slots:
     void slotAddFolderRecursive(const QString &path);
 
 protected:
-    bool findFoldersBelow( const QDir& dir, QStringList& fullList );
+    int addFolderRecursiveHelper(const QString &path, const QSet<QString> &watchedFolders);
     void inotifyRegisterPath(const QString& path);
 
-private:
     FolderWatcher *_parent;
 
     QString _folder;


### PR DESCRIPTION
- Instead of putting all the pathes in a big QStringList and then process them,
  do the processing as we iterate with QDirIterator
- Since we know that the parent directory is not ignored, we can simplify the
  ignore check by not checking the part before (i.e: we call
  ExcludedFiles::isExcluded with the parent 'path' as base path) This is what
  speeds up considerably the function.

Note that the OWNCLOUD_TEST check is already there in FolderWatcher::pathIsIgnored
so the behavior is not changed
