### PR TITLE
SyncEngine: Permission error in subfolder of a folder that cannnot be…

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1163,7 +1163,7 @@ void SyncEngine::checkForPermission()
                             qDebug() << "Moving of " << (*it)->_file << " canceled because no permission to add parent folder";
                         }
                         (*it)->_instruction = CSYNC_INSTRUCTION_ERROR;
-                        (*it)->_status = SyncFileItem::NormalError;
+                        (*it)->_status = SyncFileItem::SoftError;
                         (*it)->_errorString = tr("Not allowed because you don't have permission to add parent folder");
                     }
 


### PR DESCRIPTION
… added is a SoftError

Issue #5059