### PR TITLE
Add script to create a caja plugin.

### DIFF
--- a/shell_integration/nautilus/CMakeLists.txt
+++ b/shell_integration/nautilus/CMakeLists.txt
@@ -4,6 +4,7 @@ if( UNIX AND NOT APPLE )
 
     configure_file(syncstate.py syncstate.py COPYONLY)
     configure_file(syncstate.py syncstate_nemo.py COPYONLY)
+    configure_file(syncstate.py syncstate_caja.py COPYONLY)
 
     # Call the setupappname.sh script to set the custom app name.
     set (cmd "${CMAKE_CURRENT_SOURCE_DIR}/setappname.sh")
@@ -18,9 +19,17 @@ if( UNIX AND NOT APPLE )
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                     ERROR_VARIABLE errors OUTPUT_VARIABLE out)
 
+    # Create a caja plugin script from the nautilus one. 
+    # cajacmd copies the syncstate.py and performs string replacement.
+    set (cajacmd "${CMAKE_CURRENT_SOURCE_DIR}/createcajaplugin.sh")
+    execute_process(COMMAND ${cajacmd}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                    ERROR_VARIABLE errors OUTPUT_VARIABLE out)
+
                                         
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/syncstate.py DESTINATION ${DATADIR}/nautilus-python/extensions RENAME syncstate-${APPLICATION_SHORTNAME}.py)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/syncstate_nemo.py DESTINATION ${DATADIR}/nemo-python/extensions RENAME syncstate-${APPLICATION_SHORTNAME}.py)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/syncstate_caja.py DESTINATION ${DATADIR}/caja-python/extensions RENAME syncstate-${APPLICATION_SHORTNAME}.py)
     
     
 

--- a/shell_integration/nautilus/createcajaplugin.sh
+++ b/shell_integration/nautilus/createcajaplugin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# this script creates a plugin for nemo, just be replacing
-# all occurences of Nautilus with Nemo.
+# this script creates a plugin for caja, just by replacing
+# all occurences of Nautilus with Caja (case sensitive).
 
 sed -i.org -e 's/Nautilus/Caja/g' syncstate_caja.py
 sed -i.org -e 's/nautilus/caja/g' syncstate_caja.py

--- a/shell_integration/nautilus/createcajaplugin.sh
+++ b/shell_integration/nautilus/createcajaplugin.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# this script creates a plugin for nemo, just be replacing
+# all occurences of Nautilus with Nemo.
+
+sed -i.org -e 's/Nautilus/Caja/g' syncstate_caja.py
+sed -i.org -e 's/nautilus/caja/g' syncstate_caja.py


### PR DESCRIPTION
Caja is a fork of nautilus maintained by the Mate project.
This adds a script to create a caja plugin from the nautilus plugin.
It replaces all occurences of nautilus with caja (case sensitive).
This is done in the same way the nemo plugin is generated from the nautilus one.