### PR TITLE
SyncEngine: disable heuristics for backup restoration for server >= 9.1

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -589,11 +589,15 @@ int SyncEngine::treewalkFile( TREE_WALK_FILE *file, bool remote )
             // This counts as a NONE for detecting if all the files on the server were changed
             _hasNoneFiles = true;
         } else if (!isDirectory) {
-            if (std::difftime(file->modtime, file->other.modtime) < 0) {
+            auto difftime = std::difftime(file->modtime, file->other.modtime);
+            if (difftime < -3600*2) {
                 // We are going back on time
+                // We only increment if the difference is more than two hours to avoid clock skew
+                // issues or DST changes. (We simply ignore files that goes in the past less than
+                // two hours for the backup detection heuristics.)
                 _backInTimeFiles++;
                 qDebug() << file->path << "has a timestamp earlier than the local file";
-            } else {
+            } else if (difftime > 0) {
                 _hasForwardInTimeFiles = true;
             }
         }
@@ -928,7 +932,10 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
             && _discoveryMainThread->_dataFingerprint != databaseFingerprint) {
         qDebug() << "data fingerprint changed, assume restore from backup" << databaseFingerprint << _discoveryMainThread->_dataFingerprint;
         restoreOldFiles();
-    } else if (!_hasForwardInTimeFiles && _backInTimeFiles >= 2) {
+    } else if (!_hasForwardInTimeFiles && _backInTimeFiles >= 2 && _account->serverVersionInt() < 0x090100) {
+        // The server before ownCloud 9.1 did not have the data-fingerprint property. So in that
+        // case we use heuristics to detect restored backup.  This is disabled with newer version
+        // because this causes troubles to the user and is not as reliable as the data-fingerprint.
         qDebug() << "All the changes are bringing files in the past, asking the user";
         // this typically happen when a backup is restored on the server
         bool restore = false;


### PR DESCRIPTION
The ownCloud 9.1 server has a data-fingerprint property that the admin must
change in case of backup restoration. When this change, the client understands
that a backup was restored, and will generate conflict files and re-upload
new files.

The heuristics based system checks that there is at least two files wose mtime
is put back in the past and no files that goes forward. In that case we ask the
user before creating the conflicts.

This commit disable the heuristics for newer server that have the data-fingerpint.
And change the heuristics to two hours because we want to avoid false positive due
to some clock error, and that 2 hours of lost due to backup restoration is probably
not so bad.

We only ask the user in the heuristics based aproach so in practice this mean that
the "backup-detected" dialog will no longer appear with newer server.

Relates issues #5260, #5109
