### PR TITLE
nautilus integration: "share" extension for syncing folders

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -87,22 +87,17 @@ class SocketConnect(GObject.GObject):
     def _connectToSocketServer(self):
         try:
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            postfix = os.path.join(appname, "socket")
-            sock_file = os.path.join(get_runtime_dir(), postfix)
-            print ("Socket: " + sock_file + " <=> /" + postfix)
-            if sock_file != postfix:
-                try:
-                    print("Socket File: " + sock_file)
-                    self._sock.connect(sock_file)
-                    self.connected = True
-                    print("Setting connected to %r." % self.connected )
-                    self._watch_id = GObject.io_add_watch(self._sock, GObject.IO_IN, self._handle_notify)
-                    print("Socket watch id: " + str(self._watch_id))
-                    return False  # Don't run again
-                except Exception as e:
-                    print("Could not connect to unix socket. " + str(e))
-            else:
-                print("Sock-File not valid: " + sock_file)
+            sock_file = os.path.join(get_runtime_dir(), appname, "socket")
+            try:
+                print("Socket File: " + sock_file)
+                self._sock.connect(sock_file) # fails if sock_file doesn't exist
+                self.connected = True
+                print("Setting connected to %r." % self.connected )
+                self._watch_id = GObject.io_add_watch(self._sock, GObject.IO_IN, self._handle_notify)
+                print("Socket watch id: " + str(self._watch_id))
+                return False  # Don't run again
+            except Exception as e:
+                print("Could not connect to unix socket. " + str(e))
         except Exception as e:  # Bad habbit
             print("Connect could not be established, try again later.")
             self._sock.close()


### PR DESCRIPTION
Issue #4608
- folder state is either OK or SYNC usually
- this extension does not know about if a folder is shareable
- a OK folder is shareable
- a SYNC folder could be uploaded or not uploaded
- this commit looks into file entries below this folder
- if one exists with state OK or SYNC
  this folder must have been uploaded
- better would be if the server (gui) tells us
  if the folder is uploaded
