### PR TITLE
Cache the value of last unfinished job in the PropagateDerectory scheduleNextJob 

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -606,9 +606,15 @@ bool PropagateDirectory::scheduleNextJob()
         return false;
     }
 
+    // cache the value of first unfinished subjob
     bool stopAtDirectory = false;
-    // FIXME: use the cached value of finished job
-    for (int i = 0; i < _subJobs.count(); ++i) {
+    int i = _firstUnfinishedSubJob;
+    int subJobsCount = _subJobs.count();
+    while (i < subJobsCount && _subJobs.at(i)->_state == Finished) {
+      _firstUnfinishedSubJob = ++i;
+    }
+
+    for (int i = _firstUnfinishedSubJob; i < subJobsCount; ++i) {
         if (_subJobs.at(i)->_state == Finished) {
             continue;
         }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -195,10 +195,11 @@ public:
     int _jobsFinished; // number of jobs that have completed
     int _runningNow; // number of subJobs running right now
     SyncFileItem::Status _hasError;  // NoStatus,  or NormalError / SoftError if there was an error
+    int _firstUnfinishedSubJob;
 
     explicit PropagateDirectory(OwncloudPropagator *propagator, const SyncFileItemPtr &item = SyncFileItemPtr(new SyncFileItem))
         : PropagatorJob(propagator)
-        , _firstJob(0), _item(item),  _jobsFinished(0), _runningNow(0), _hasError(SyncFileItem::NoStatus)
+        , _firstJob(0), _item(item),  _jobsFinished(0), _runningNow(0), _hasError(SyncFileItem::NoStatus), _firstUnfinishedSubJob(0)
     { }
 
     virtual ~PropagateDirectory() {


### PR DESCRIPTION
This PR solves the problem discussed in this PR https://github.com/owncloud/client/pull/5269, implementing the solution of @ckamm which appears to work :

I did not run in any race condition and manualy tested most of the cases. Hope this will work out

@guruz @ogoffart 
