### PR TITLE
Conflicts: Use the local mtime for the conflict file name #5273

### DIFF
--- a/csync/tests/ownCloud/t7.pl
+++ b/csync/tests/ownCloud/t7.pl
@@ -232,6 +232,37 @@ assertLocalAndRemoteDir( '', 0);
 system("sqlite3 " . localDir().'.csync_journal.db .dump');
 
 
+#######################################################################
+printInfo( "multiple restores of a file create different conflict files" );
+
+system("sleep 1"); #make sure changes have different mtime
+
+system("echo 'modified_1' > ". localDir() . "readonlyDirectory_PERM_M_/canotBeModified_PERM_DVN_.data");
+
+#do the sync
+csync();
+assertCsyncJournalOk(localDir());
+
+system("sleep 1"); #make sure changes have different mtime
+
+system("echo 'modified_2' > ". localDir() . "readonlyDirectory_PERM_M_/canotBeModified_PERM_DVN_.data");
+
+#do the sync
+csync();
+assertCsyncJournalOk(localDir());
+
+# there should be two conflict files
+# TODO check that the conflict file has the right content
+my @conflicts = glob(localDir().'readonlyDirectory_PERM_M_/canotBeModified_PERM_DVN__conflict-*.data' );
+assert( scalar @conflicts == 2 );
+# remove the conflicts for the next assertLocalAndRemoteDir
+system("rm " . localDir().'readonlyDirectory_PERM_M_/canotBeModified_PERM_DVN__conflict-*.data' );
+
+### Both side should still be the same
+assertLocalAndRemoteDir( '', 0);
+
+
+
 cleanup();
 
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -593,7 +593,7 @@ void PropagateDownloadFile::deleteExistingFolder()
     }
 
     QString conflictDir = FileSystem::makeConflictFileName(
-            existingDir, Utility::qDateTimeFromTime_t(_item->_modtime));
+            existingDir, Utility::qDateTimeFromTime_t(FileSystem::getModTime(existingDir)));
 
     emit _propagator->touchedFile(existingDir);
     emit _propagator->touchedFile(conflictDir);
@@ -722,7 +722,8 @@ void PropagateDownloadFile::downloadFinished()
             && !FileSystem::fileEquals(fn, _tmpFile.fileName());
     if (isConflict) {
         QString renameError;
-        QString conflictFileName = FileSystem::makeConflictFileName(fn, Utility::qDateTimeFromTime_t(_item->_modtime));
+        QString conflictFileName = FileSystem::makeConflictFileName(
+                fn, Utility::qDateTimeFromTime_t(FileSystem::getModTime(fn)));
         if (!FileSystem::rename(fn, conflictFileName, &renameError)) {
             // If the rename fails, don't replace it.
 


### PR DESCRIPTION
Otherwise local conflict files may be overridden in a restore
situation. See ticket for details.