### PR TITLE
Discovery: consider also the "shared by me" as shared

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -20,6 +20,7 @@
 #include <QUrl>
 #include "account.h"
 #include <QFileInfo>
+#include <cstring>
 
 namespace OCC {
 
@@ -236,7 +237,8 @@ void DiscoverySingleDirectoryJob::start()
     QList<QByteArray> props;
     props << "resourcetype" << "getlastmodified" << "getcontentlength" << "getetag"
           << "http://owncloud.org/ns:id" << "http://owncloud.org/ns:downloadURL"
-          << "http://owncloud.org/ns:dDC" << "http://owncloud.org/ns:permissions";
+          << "http://owncloud.org/ns:dDC" << "http://owncloud.org/ns:permissions"
+          << "http://owncloud.org/ns:share-types";
     if (_isRootPath)
         props << "http://owncloud.org/ns:data-fingerprint";
 
@@ -308,9 +310,25 @@ static csync_vio_file_stat_t* propertyMapToFileStat(const QMap<QString,QString> 
             } else {
                 qWarning() << "permissions too large" << v;
             }
+        } else if (property == "share-types" && !value.isEmpty()) {
+            // Since QMap is sorted, "share-types" is always "permissions".
+            if (file_stat->remotePerm[0] == '\0' || !(file_stat->fields & CSYNC_VIO_FILE_STAT_FIELDS_PERM)) {
+                qWarning() << "Server returned a share type, but no permissions?";
+            } else {
+                // S means shared with me.
+                // But for our purpose, we want to know if the file is shared. It does not matter
+                // if we are the owner or not.
+                // Piggy back on the persmission field 'S'
+                if (!std::strchr(file_stat->remotePerm, 'S')) {
+                    if (std::strlen(file_stat->remotePerm) < sizeof(file_stat->remotePerm)-1) {
+                        std::strcat(file_stat->remotePerm, "S");
+                    } else {
+                        qWarning() << "permissions too large" << file_stat->remotePerm;
+                    }
+                }
+            }
         }
     }
-
     return file_stat;
 }
 

--- a/src/libsync/syncfilestatus.cpp
+++ b/src/libsync/syncfilestatus.cpp
@@ -17,12 +17,12 @@
 
 namespace OCC {
 SyncFileStatus::SyncFileStatus()
-    :_tag(StatusNone), _sharedWithMe(false)
+    :_tag(StatusNone), _shared(false)
 {
 }
 
 SyncFileStatus::SyncFileStatus(SyncFileStatusTag tag)
-    :_tag(tag), _sharedWithMe(false)
+    :_tag(tag), _shared(false)
 {
 
 }
@@ -37,14 +37,14 @@ SyncFileStatus::SyncFileStatusTag SyncFileStatus::tag() const
     return _tag;
 }
 
-void SyncFileStatus::setSharedWithMe(bool isShared)
+void SyncFileStatus::setShared(bool isShared)
 {
-    _sharedWithMe = isShared;
+    _shared = isShared;
 }
 
-bool SyncFileStatus::sharedWithMe() const
+bool SyncFileStatus::shared() const
 {
-    return _sharedWithMe;
+    return _shared;
 }
 
 QString SyncFileStatus::toSocketAPIString() const
@@ -72,7 +72,7 @@ QString SyncFileStatus::toSocketAPIString() const
         statusString = QLatin1String("ERROR");
         break;
     }
-    if(canBeShared && _sharedWithMe) {
+    if(canBeShared && _shared) {
         statusString += QLatin1String("+SWM");
     }
 

--- a/src/libsync/syncfilestatus.h
+++ b/src/libsync/syncfilestatus.h
@@ -43,18 +43,18 @@ public:
     void set(SyncFileStatusTag tag);
     SyncFileStatusTag tag() const;
 
-    void setSharedWithMe( bool isShared );
-    bool sharedWithMe() const;
+    void setShared( bool isShared );
+    bool shared() const;
 
     QString toSocketAPIString() const;
 private:
     SyncFileStatusTag _tag;
-    bool _sharedWithMe;
+    bool _shared;
 
 };
 
 inline bool operator==(const SyncFileStatus &a, const SyncFileStatus &b) {
-    return a.tag() == b.tag() && a.sharedWithMe() == b.sharedWithMe();
+    return a.tag() == b.tag() && a.shared() == b.shared();
 }
 
 inline bool operator!=(const SyncFileStatus &a, const SyncFileStatus &b) {

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -272,7 +272,7 @@ SyncFileStatus SyncFileStatusTracker::resolveSyncAndErrorStatus(const QString &r
     }
 
     if (isShared)
-        status.setSharedWithMe(true);
+        status.setShared(true);
 
     return status;
 }

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -244,6 +244,7 @@ public:
     QDateTime lastModified = QDateTime::currentDateTime().addDays(-7);
     QString etag = generateEtag();
     QByteArray fileId = generateFileId();
+    QByteArray extraDavProperties;
     qint64 size = 0;
     char contentChar = 'W';
 
@@ -314,6 +315,7 @@ public:
             xml.writeTextElement(davUri, QStringLiteral("getetag"), fileInfo.etag);
             xml.writeTextElement(ocUri, QStringLiteral("permissions"), fileInfo.isShared ? QStringLiteral("SRDNVCKW") : QStringLiteral("RDNVCKW"));
             xml.writeTextElement(ocUri, QStringLiteral("id"), fileInfo.fileId);
+            buffer.write(fileInfo.extraDavProperties);
             xml.writeEndElement(); // prop
             xml.writeTextElement(davUri, QStringLiteral("status"), "HTTP/1.1 200 OK");
             xml.writeEndElement(); // propstat
@@ -648,7 +650,7 @@ public:
     OCC::SyncEngine &syncEngine() const { return *_syncEngine; }
 
     FileModifier &localModifier() { return _localModifier; }
-    FileModifier &remoteModifier() { return _fakeQnam->currentRemoteState(); }
+    FileInfo &remoteModifier() { return _fakeQnam->currentRemoteState(); }
     FileInfo currentLocalState() {
         QDir rootDir{_tempDir.path()};
         FileInfo rootTemplate;

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -376,6 +376,10 @@ private slots:
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         fakeFolder.remoteModifier().insert("S/s0");
         fakeFolder.remoteModifier().appendByte("S/s1");
+        fakeFolder.remoteModifier().insert("B/b3");
+        fakeFolder.remoteModifier().find("B/b3")->extraDavProperties
+            = "<oc:share-types><oc:share-type>0</oc:share-type></oc:share-types>";
+
         StatusPushSpy statusSpy(fakeFolder.syncEngine());
 
         fakeFolder.scheduleSync();
@@ -395,6 +399,8 @@ private slots:
         QEXPECT_FAIL("", "We currently only know if a new file is shared on the second sync, after a PROPFIND.", Continue);
         QCOMPARE(statusSpy.statusOf("S/s0"), sharedUpToDateStatus);
         QCOMPARE(statusSpy.statusOf("S/s1"), sharedUpToDateStatus);
+        QCOMPARE(statusSpy.statusOf("B/b1").sharedWithMe(), false);
+        QCOMPARE(statusSpy.statusOf("B/b3"), sharedUpToDateStatus);
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -371,7 +371,7 @@ private slots:
 
     void sharedStatus() {
         SyncFileStatus sharedUpToDateStatus(SyncFileStatus::StatusUpToDate);
-        sharedUpToDateStatus.setSharedWithMe(true);
+        sharedUpToDateStatus.setShared(true);
 
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         fakeFolder.remoteModifier().insert("S/s0");
@@ -399,7 +399,7 @@ private slots:
         QEXPECT_FAIL("", "We currently only know if a new file is shared on the second sync, after a PROPFIND.", Continue);
         QCOMPARE(statusSpy.statusOf("S/s0"), sharedUpToDateStatus);
         QCOMPARE(statusSpy.statusOf("S/s1"), sharedUpToDateStatus);
-        QCOMPARE(statusSpy.statusOf("B/b1").sharedWithMe(), false);
+        QCOMPARE(statusSpy.statusOf("B/b1").shared(), false);
         QCOMPARE(statusSpy.statusOf("B/b3"), sharedUpToDateStatus);
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());


### PR DESCRIPTION
The "S" in the permission is only for the "Shared with me" files.
It is only used to show the shared status in the overlay icons.
But we also wish to show the shared status for files that are shared
"by" the users. We can find that out using the 'share-types' webdav
property. If set, then we are sharing the object.
We fake a 'S' in the permission as for our purpose, they mean the same.

Issue #4788