### PR TITLE
Folder: Make folder only accessible by user #5282

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -30,6 +30,7 @@
 #include "owncloudsetupwizard.h"
 #include "creds/abstractcredentials.h"
 #include "tooltipupdater.h"
+#include "filesystem.h"
 
 #include <math.h>
 
@@ -299,8 +300,9 @@ void AccountSettings::slotFolderWizardAccepted()
                                      tr("<p>Could not create local folder <i>%1</i>.")
                                         .arg(QDir::toNativeSeparators(definition.localPath)));
                 return;
+            } else {
+                FileSystem::setFolderMinimumPermissions(definition.localPath);
             }
-
         }
     }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -31,6 +31,7 @@
 #include "sslerrordialog.h"
 #include "accountmanager.h"
 #include "clientproxy.h"
+#include "filesystem.h"
 
 #include "creds/credentialsfactory.h"
 #include "creds/abstractcredentials.h"
@@ -340,8 +341,8 @@ void OwncloudSetupWizard::slotCreateLocalAndRemoteFolders(const QString& localFo
     } else {
         QString res = tr("Creating local sync folder %1...").arg(localFolder);
         if( fi.mkpath( localFolder ) ) {
+            FileSystem::setFolderMinimumPermissions(localFolder);
             Utility::setupFavLink( localFolder );
-            // FIXME: Create a local sync folder.
             res += tr("ok");
         } else {
             res += tr("failed.");

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -145,6 +145,17 @@ void FileSystem::setFileReadOnly(const QString& filename, bool readonly)
     file.setPermissions(permissions);
 }
 
+void FileSystem::setFolderMinimumPermissions(const QString& filename)
+{
+#ifdef Q_OS_MAC
+    QFile::Permissions perm = QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner;
+    QFile file(filename);
+    file.setPermissions(perm);
+#else
+    Q_UNUSED(filename);
+#endif
+}
+
 
 void FileSystem::setFileReadOnlyWeak(const QString& filename, bool readonly)
 {

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -66,6 +66,12 @@ void OWNCLOUDSYNC_EXPORT setFileReadOnly(const QString& filename, bool readonly)
  */
 void OWNCLOUDSYNC_EXPORT setFileReadOnlyWeak(const QString& filename, bool readonly);
 
+/**
+ * @brief Try to set permissions so that other users on the local machine can not
+ * go into the folder.
+ */
+void OWNCLOUDSYNC_EXPORT setFolderMinimumPermissions(const QString& filename);
+
 /** convert a "normal" windows path into a path that can be 32k chars long. */
 QString OWNCLOUDSYNC_EXPORT longWinPath( const QString& inpath );
 


### PR DESCRIPTION
Because on OS X the parent folder might not protect
against access.