### PR TITLE
libsync: Don't store the remote URI in the csync or in the SyncEngine

### DIFF
--- a/csync/src/csync.c
+++ b/csync/src/csync.c
@@ -89,7 +89,7 @@ static int _data_cmp(const void *key, const void *data) {
   return 0;
 }
 
-void csync_create(CSYNC **csync, const char *local, const char *remote) {
+void csync_create(CSYNC **csync, const char *local) {
   CSYNC *ctx;
   size_t len = 0;
 
@@ -102,12 +102,6 @@ void csync_create(CSYNC **csync, const char *local, const char *remote) {
   while(len > 0 && local[len - 1] == '/') --len;
 
   ctx->local.uri = c_strndup(local, len);
-
-  /* remove trailing slashes */
-  len = strlen(remote);
-  while(len > 0 && remote[len - 1] == '/') --len;
-
-  ctx->remote.uri = c_strndup(remote, len);
 
   ctx->status_code = CSYNC_STATUS_OK;
 
@@ -199,7 +193,7 @@ int csync_update(CSYNC *ctx) {
   ctx->current = REMOTE_REPLICA;
   ctx->replica = ctx->remote.type;
 
-  rc = csync_ftw(ctx, ctx->remote.uri, csync_walker, MAX_DEPTH);
+  rc = csync_ftw(ctx, "", csync_walker, MAX_DEPTH);
   if (rc < 0) {
       if(ctx->status_code == CSYNC_STATUS_OK) {
           ctx->status_code = csync_errno_to_status(errno, CSYNC_STATUS_UPDATE_ERROR);
@@ -579,7 +573,6 @@ int csync_destroy(CSYNC *ctx) {
   _csync_clean_ctx(ctx);
 
   SAFE_FREE(ctx->local.uri);
-  SAFE_FREE(ctx->remote.uri);
   SAFE_FREE(ctx->error_string);
 
 #ifdef WITH_ICONV

--- a/csync/src/csync.h
+++ b/csync/src/csync.h
@@ -317,7 +317,7 @@ typedef const char* (*csync_checksum_hook) (
  *
  * @param csync  The context variable to allocate.
  */
-void OCSYNC_EXPORT csync_create(CSYNC **csync, const char *local, const char *remote);
+void OCSYNC_EXPORT csync_create(CSYNC **csync, const char *local);
 
 /**
  * @brief Initialize the file synchronizer.

--- a/csync/src/csync_private.h
+++ b/csync/src/csync_private.h
@@ -126,7 +126,6 @@ struct csync_s {
   } local;
 
   struct {
-    char *uri;
     c_rbtree_t *tree;
     enum csync_replica_e type;
     int  read_from_db;

--- a/csync/tests/csync_tests/check_csync_commit.c
+++ b/csync/tests/csync_tests/check_csync_commit.c
@@ -30,10 +30,7 @@ static void setup(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     *state = csync;
 }
@@ -45,10 +42,7 @@ static void setup_module(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-
-    csync_create(&csync, "/tmp/check_csync1", "dummy://foo/bar");
+    csync_create(&csync, "/tmp/check_csync1");
 
     csync_init(csync);
     *state = csync;
@@ -64,9 +58,6 @@ static void teardown(void **state) {
     assert_int_equal(rc, 0);
 
     rc = system("rm -rf /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-
-    rc = system("rm -rf /tmp/check_csync2");
     assert_int_equal(rc, 0);
 
     *state = NULL;

--- a/csync/tests/csync_tests/check_csync_create.c
+++ b/csync/tests/csync_tests/check_csync_create.c
@@ -42,7 +42,7 @@ static void check_csync_create(void **state)
 
     (void) state; /* unused */
 
-    csync_create(&csync, "/tmp/csync1", "/tmp/csync2");
+    csync_create(&csync, "/tmp/csync1");
 
     rc = csync_destroy(csync);
     assert_int_equal(rc, 0);

--- a/csync/tests/csync_tests/check_csync_exclude.c
+++ b/csync/tests/csync_tests/check_csync_exclude.c
@@ -32,7 +32,7 @@
 static void setup(void **state) {
     CSYNC *csync;
 
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     *state = csync;
 }
@@ -41,7 +41,7 @@ static void setup_init(void **state) {
     CSYNC *csync;
     int rc;
 
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     rc = csync_exclude_load(EXCLUDE_LIST_FILE, &(csync->excludes));
     assert_int_equal(rc, 0);

--- a/csync/tests/csync_tests/check_csync_init.c
+++ b/csync/tests/csync_tests/check_csync_init.c
@@ -30,10 +30,7 @@ static void setup(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     *state = csync;
 }
@@ -45,10 +42,7 @@ static void setup_module(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-
-    csync_create(&csync, "/tmp/check_csync1", "dummy://foo/bar");
+    csync_create(&csync, "/tmp/check_csync1");
 
     *state = csync;
 }
@@ -63,9 +57,6 @@ static void teardown(void **state) {
     assert_int_equal(rc, 0);
 
     rc = system("rm -rf /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-
-    rc = system("rm -rf /tmp/check_csync2");
     assert_int_equal(rc, 0);
 
     *state = NULL;

--- a/csync/tests/csync_tests/check_csync_log.c
+++ b/csync/tests/csync_tests/check_csync_log.c
@@ -33,10 +33,7 @@ static void setup(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     *state = csync;
 }
@@ -51,9 +48,6 @@ static void teardown(void **state) {
     assert_int_equal(rc, 0);
 
     rc = system("rm -rf /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-
-    rc = system("rm -rf /tmp/check_csync2");
     assert_int_equal(rc, 0);
 
     *state = NULL;

--- a/csync/tests/csync_tests/check_csync_statedb_load.c
+++ b/csync/tests/csync_tests/check_csync_statedb_load.c
@@ -36,7 +36,7 @@ static void setup(void **state) {
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
 
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
 
     csync->statedb.file = c_strdup( TESTDB );
     *state = csync;

--- a/csync/tests/csync_tests/check_csync_statedb_query.c
+++ b/csync/tests/csync_tests/check_csync_statedb_query.c
@@ -34,15 +34,11 @@ static void setup(void **state)
 
     rc = system("rm -rf /tmp/check_csync1");
     assert_int_equal(rc, 0);
-    rc = system("rm -rf /tmp/check_csync2");
-    assert_int_equal(rc, 0);
     rc = system("mkdir -p /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-    rc = system("mkdir -p /tmp/check_csync2");
     assert_int_equal(rc, 0);
     rc = system("mkdir -p /tmp/check_csync");
     assert_int_equal(rc, 0);
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
     csync_init(csync);
 
     sqlite3 *db = NULL;
@@ -105,8 +101,6 @@ static void teardown(void **state) {
     rc = system("rm -rf /tmp/check_csync");
     assert_int_equal(rc, 0);
     rc = system("rm -rf /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-    rc = system("rm -rf /tmp/check_csync2");
     assert_int_equal(rc, 0);
 
     *state = NULL;

--- a/csync/tests/csync_tests/check_csync_update.c
+++ b/csync/tests/csync_tests/check_csync_update.c
@@ -91,9 +91,7 @@ static void setup(void **state)
     assert_int_equal(rc, 0);
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-    csync_create(&csync, "/tmp/check_csync1", "/tmp/check_csync2");
+    csync_create(&csync, "/tmp/check_csync1");
     csync_init(csync);
 
     /* Create a new db with metadata */
@@ -122,9 +120,7 @@ static void setup_ftw(void **state)
     assert_int_equal(rc, 0);
     rc = system("mkdir -p /tmp/check_csync1");
     assert_int_equal(rc, 0);
-    rc = system("mkdir -p /tmp/check_csync2");
-    assert_int_equal(rc, 0);
-    csync_create(&csync, "/tmp", "/tmp");
+    csync_create(&csync, "/tmp");
     csync_init(csync);
 
     sqlite3 *db = NULL;
@@ -161,8 +157,6 @@ static void teardown_rm(void **state) {
     rc = system("rm -rf /tmp/check_csync");
     assert_int_equal(rc, 0);
     rc = system("rm -rf /tmp/check_csync1");
-    assert_int_equal(rc, 0);
-    rc = system("rm -rf /tmp/check_csync2");
     assert_int_equal(rc, 0);
 }
 

--- a/csync/tests/vio_tests/check_vio.c
+++ b/csync/tests/vio_tests/check_vio.c
@@ -48,7 +48,7 @@ static void setup(void **state)
     rc = system("rm -rf /tmp/csync_test");
     assert_int_equal(rc, 0);
 
-    csync_create(&csync, "/tmp/csync1", "/tmp/csync2");
+    csync_create(&csync, "/tmp/csync1");
 
     csync->replica = LOCAL_REPLICA;
 

--- a/csync/tests/vio_tests/check_vio_ext.c
+++ b/csync/tests/vio_tests/check_vio_ext.c
@@ -96,7 +96,7 @@ static void setup_testenv(void **state) {
     statevar *mystate = malloc( sizeof(statevar) );
     mystate->result = NULL;
 
-    csync_create(&(mystate->csync), "/tmp/csync1", "/tmp/csync2");
+    csync_create(&(mystate->csync), "/tmp/csync1");
 
     mystate->csync->replica = LOCAL_REPLICA;
 

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -475,7 +475,7 @@ restart_sync:
         selectiveSyncFixup(&db, selectiveSyncList);
     }
 
-    SyncEngine engine(account, options.source_dir, QUrl(options.target_url), folder, &db);
+    SyncEngine engine(account, options.source_dir, folder, &db);
     engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
     QObject::connect(&engine, SIGNAL(finished(bool)), &app, SLOT(quit()));
     QObject::connect(&engine, SIGNAL(transmissionProgress(ProgressInfo)), &cmd, SLOT(transmissionProgressSlot()));

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -81,7 +81,7 @@ Folder::Folder(const FolderDefinition& definition,
 
     _syncResult.setFolder(_definition.alias);
 
-    _engine.reset(new SyncEngine(_accountState->account(), path(), remoteUrl(), remotePath(), &_journal));
+    _engine.reset(new SyncEngine(_accountState->account(), path(), remotePath(), &_journal));
     // pass the setting if hidden files are to be ignored, will be read in csync_update
     _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -806,25 +806,6 @@ void FolderStatusModel::slotApplySelectiveSync()
     resetFolders();
 }
 
-static QString shortenFilename( Folder *f, const QString& file )
-{
-    // strip off the server prefix from the file name
-    QString shortFile(file);
-    if( shortFile.isEmpty() ) {
-        return QString::null;
-    }
-
-    if(shortFile.startsWith(QLatin1String("ownclouds://")) ||
-            shortFile.startsWith(QLatin1String("owncloud://")) ) {
-        // rip off the whole ownCloud URL.
-        if( f ) {
-            QString remotePathUrl = f->remoteUrl().toString();
-            shortFile.remove(Utility::toCSyncScheme(remotePathUrl));
-        }
-    }
-    return shortFile;
-}
-
 void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
 {
     auto par = qobject_cast<QWidget*>(QObject::parent());
@@ -898,7 +879,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
         curItemProgress = curItem._size;
     }
 
-    QString itemFileName = shortenFilename(f, curItem._file);
+    QString itemFileName = curItem._file;
     QString kindString = Progress::asActionString(curItem);
 
     QString fileProgressString;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -412,10 +412,12 @@ void OwncloudPropagator::start(const SyncFileItemVector& items)
     QTimer::singleShot(0, this, SLOT(scheduleNextJob()));
 }
 
+// ownCloud server  < 7.0 did not had permissions so we need some other euristics
+// to detect wrong doing in a Shared directory
 bool OwncloudPropagator::isInSharedDirectory(const QString& file)
 {
     bool re = false;
-    if( _remoteDir.contains( _account->davPath() + QLatin1String("Shared") ) ) {
+    if( _remoteFolder.startsWith( QLatin1String("Shared") ) ) {
         // The Shared directory is synced as its own sync connection
         re = true;
     } else {

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -267,8 +267,7 @@ class OwncloudPropagator : public QObject {
 
 public:
     const QString _localDir; // absolute path to the local directory. ends with '/'
-    const QString _remoteDir; // path to the root of the remote. ends with '/'  (include WebDAV path)
-    const QString _remoteFolder; // folder. (same as remoteDir but without the WebDAV path)
+    const QString _remoteFolder; // remote folder, ends with '/'
 
     SyncJournalDb * const _journal;
     bool _finishedEmited; // used to ensure that finished is only emitted once
@@ -276,10 +275,8 @@ public:
 
 public:
     OwncloudPropagator(AccountPtr account, const QString &localDir,
-                       const QString &remoteDir, const QString &remoteFolder,
-                       SyncJournalDb *progressDb)
+                       const QString &remoteFolder, SyncJournalDb *progressDb)
             : _localDir((localDir.endsWith(QChar('/'))) ? localDir : localDir+'/' )
-            , _remoteDir((remoteDir.endsWith(QChar('/'))) ? remoteDir : remoteDir+'/' )
             , _remoteFolder((remoteFolder.endsWith(QChar('/'))) ? remoteFolder : remoteFolder+'/' )
             , _journal(progressDb)
             , _finishedEmited(false)

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -20,6 +20,7 @@
 #include "filesystem.h"
 #include <QFile>
 #include <QStringList>
+#include <QDir>
 
 namespace OCC {
 
@@ -101,10 +102,11 @@ void PropagateRemoteMove::start()
         }
     }
 
+    QString destination = QDir::cleanPath(_propagator->account()->url().path() + QLatin1Char('/')
+            + _propagator->account()->davPath() + _propagator->_remoteFolder + _item->_renameTarget);
     _job = new MoveJob(_propagator->account(),
                         _propagator->_remoteFolder + _item->_file,
-                        _propagator->_remoteDir + _item->_renameTarget,
-                        this);
+                        destination, this);
     connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotMoveJobFinished()));
     _propagator->_activeJobList.append(this);
     _job->start();

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -271,6 +271,7 @@ void PropagateUploadFileNG::startNextChunk()
         QString destination = _propagator->account()->url().path()
             + QLatin1String("/remote.php/dav/files/") + _propagator->account()->user()
             + _propagator->_remoteFolder + _item->_file;
+
         auto headers = PropagateUploadFileCommon::headers();
 
         // "If-Match applies to the source, but we are interested in comparing the etag of the destination

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -58,7 +58,7 @@ class OWNCLOUDSYNC_EXPORT SyncEngine : public QObject
     Q_OBJECT
 public:
     SyncEngine(AccountPtr account, const QString &localPath,
-               const QUrl &remoteURL, const QString &remotePath, SyncJournalDb *journal);
+               const QString &remotePath, SyncJournalDb *journal);
     ~SyncEngine();
 
     static QString csyncErrorToString( CSYNC_STATUS);
@@ -196,7 +196,6 @@ private:
     bool _needsUpdate;
     bool _syncRunning;
     QString _localPath;
-    QUrl _remoteUrl;
     QString _remotePath;
     QString _remoteRootEtag;
     SyncJournalDb *_journal;

--- a/src/libsync/utility.cpp
+++ b/src/libsync/utility.cpp
@@ -242,19 +242,6 @@ QString Utility::compactFormatDouble(double value, int prec, const QString& unit
     return str;
 }
 
-QString Utility::toCSyncScheme(const QString &urlStr)
-{
-
-    QUrl url( urlStr );
-    if( url.scheme() == QLatin1String("http") ) {
-        url.setScheme( QLatin1String("owncloud") );
-    } else {
-        // connect SSL!
-        url.setScheme( QLatin1String("ownclouds") );
-    }
-    return url.toString();
-}
-
 QString Utility::escape(const QString &in)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/src/libsync/utility.h
+++ b/src/libsync/utility.h
@@ -43,7 +43,6 @@ namespace Utility
     OWNCLOUDSYNC_EXPORT bool hasLaunchOnStartup(const QString &appName);
     OWNCLOUDSYNC_EXPORT void setLaunchOnStartup(const QString &appName, const QString& guiName, bool launch);
     OWNCLOUDSYNC_EXPORT qint64 freeDiskSpace(const QString &path);
-    OWNCLOUDSYNC_EXPORT QString toCSyncScheme(const QString &urlStr);
 
     /**
      * @brief compactFormatDouble - formats a double value human readable.

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -740,7 +740,7 @@ public:
         _account->setCredentials(new FakeCredentials{_fakeQnam});
 
         _journalDb.reset(new OCC::SyncJournalDb(localPath()));
-        _syncEngine.reset(new OCC::SyncEngine(_account, localPath(), sRootUrl, "", _journalDb.get()));
+        _syncEngine.reset(new OCC::SyncEngine(_account, localPath(), "", _journalDb.get()));
 
         // A new folder will update the local file state database on first sync.
         // To have a state matching what users will encounter, we have to a sync

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -64,14 +64,6 @@ private slots:
         QVERIFY(hasLaunchOnStartup(appName) == false);
     }
 
-    void testToCSyncScheme()
-    {
-        QVERIFY(toCSyncScheme("http://example.com/owncloud/") ==
-                              "owncloud://example.com/owncloud/");
-        QVERIFY(toCSyncScheme("https://example.com/owncloud/") ==
-                              "ownclouds://example.com/owncloud/");
-    }
-
     void testDurationToDescriptiveString()
     {
         QLocale::setDefault(QLocale("C"));


### PR DESCRIPTION
We are going to change the webdav path depending on the capabilities.
But the SyncEngine and csync might have been created before the capabilities
are retrieved.

The main raison why we gave the path to the sync engine was to pass it to csync.
But the thing is that csync don't need anymore this url as everything is done by the
discovery classes in libsync that use the network jobs that use the account for the urls.
So csync do not need the remote URI.

shortenFilename in folderstatusmodel.cpp was useless because the string is the
_file of a SyncFileItem which is the relative file name, that name never
starts with owncloud://.

All the csync test creates the folder because csync use to check if the folder
exists. But we don't need to do that anymore