### PR TITLE
Use OWNCLOUD_BIN_DIR directly in C++ code.

### DIFF
--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -22,7 +22,7 @@ macro(owncloud_add_test test_class additional_cpp)
     )
 
     add_definitions(-DOWNCLOUD_TEST)
-    add_definitions(-DOWNCLOUD_BIN_PATH=${CMAKE_BINARY_DIR}/bin)
+    add_definitions(-DOWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
     add_test(NAME ${OWNCLOUD_TEST_CLASS}Test COMMAND ${OWNCLOUD_TEST_CLASS}Test)
 endmacro()
 
@@ -51,5 +51,5 @@ macro(owncloud_add_benchmark test_class additional_cpp)
     )
 
     add_definitions(-DOWNCLOUD_TEST)
-    add_definitions(-DOWNCLOUD_BIN_PATH=${CMAKE_BINARY_DIR}/bin)
+    add_definitions(-DOWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
 endmacro()

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -11,10 +11,6 @@
 
 #include "utility.h"
 
-#define STR_(X) #X
-#define STR(X) STR_(X)
-#define BIN_PATH STR(OWNCLOUD_BIN_PATH)
-
 using namespace OCC::Utility;
 
 class TestUtility : public QObject
@@ -118,7 +114,7 @@ private slots:
             }
             // pass the binary name owncloud to the next call. This brakes branding,
             // but branding is not supposed to work with this.
-            QString ver = versionOfInstalledBinary(BIN_PATH+QLatin1String("/owncloud"));
+            QString ver = versionOfInstalledBinary(OWNCLOUD_BIN_PATH+QLatin1String("/owncloud"));
 	    qDebug() << "Version of installed ownCloud Binary: " << ver;
 	    QVERIFY( !ver.isEmpty());
 


### PR DESCRIPTION
No need to do a STR replacement. It actually broke test execution for
Debian.

See https://bugs.debian.org/844937