### PR TITLE
libsync: use the new webdav url if the server reports it

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -57,6 +57,11 @@ Account::~Account()
 
 QString Account::davPath() const
 {
+    if (capabilities().chunkingNg()) {
+        // The chunking-ng means the server prefer to use the new webdav URL
+        return QLatin1String("/remote.php/dav/files/") + davUser() + QLatin1Char('/');
+    }
+
     // make sure to have a trailing slash
     if( !_davPath.endsWith('/') ) {
         QString dp(_davPath);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -110,6 +110,9 @@ QByteArray Capabilities::uploadChecksumType() const
 
 bool Capabilities::chunkingNg() const
 {
+    static const auto chunkng = qgetenv("OWNCLOUD_CHUNKING_NG");
+    if (chunkng == "0") return false;
+    if (chunkng == "1") return true;
     return _capabilities["dav"].toMap()["chunking"].toByteArray() >= "1.0";
 }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -271,9 +271,7 @@ PropagateItemJob* OwncloudPropagator::createJob(const SyncFileItemPtr &item) {
                 return job;
             } else {
                 PropagateUploadFileCommon *job = 0;
-                static const auto chunkng = qgetenv("OWNCLOUD_CHUNKING_NG");
-                if (item->_size > chunkSize()
-                        && (account()->capabilities().chunkingNg() || chunkng == "1") && chunkng != "0") {
+                if (item->_size > chunkSize() && account()->capabilities().chunkingNg()) {
                     job = new PropagateUploadFileNG(this, item);
                 } else {
                     job = new PropagateUploadFileV1(this, item);

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -268,10 +268,8 @@ void PropagateUploadFileNG::startNextChunk()
         Q_ASSERT(_jobs.isEmpty()); // There should be no running job anymore
         _finished = true;
         // Finish with a MOVE
-        QString destination = _propagator->account()->url().path()
-            + QLatin1String("/remote.php/dav/files/") + _propagator->account()->davUser()
-            + _propagator->_remoteFolder + _item->_file;
-
+        QString destination = QDir::cleanPath(_propagator->account()->url().path() + QLatin1Char('/')
+            + _propagator->account()->davPath() + _propagator->_remoteFolder + _item->_file);
         auto headers = PropagateUploadFileCommon::headers();
 
         // "If-Match applies to the source, but we are interested in comparing the etag of the destination


### PR DESCRIPTION
The rules to select the webdav url are now:

 - If the server reports that the new chunking algorithm is working,
   always use remote.php/dav/files/<username>
   This capability can be overriden with an environment variable

 - Otherwise, use the dav path provided by the theme, which defaults to
   remote.php/webdav

This means that with the newer server, the branding can no longer override
the webdav URL. If there is still an usecase for the branding to do so, we
need to find another way to override it. But it is now more complicated to
configure as might need include the username and need different endpoint
depending on the operations (chunks or not)