### PR TITLE
owncloudcmd: Don't put the password in the URL

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -329,8 +329,7 @@ int main(int argc, char **argv) {
     if( !options.target_url.contains( account->davPath() )) {
         options.target_url.append(account->davPath());
     }
-    if (options.target_url.startsWith("http"))
-        options.target_url.replace(0, 4, "owncloud");
+
     QUrl url = QUrl::fromUserInput(options.target_url);
 
     // Order of retrieval attempt (later attempts override earlier ones):
@@ -370,14 +369,6 @@ int main(int argc, char **argv) {
              password = queryPassword(user);
          }
      }
-
-    // ### ensure URL is free of credentials
-    if (url.userName().isEmpty()) {
-        url.setUserName(user);
-    }
-    if (url.password().isEmpty()) {
-        url.setPassword(password);
-    }
 
     // take the unmodified url to pass to csync_create()
     QByteArray remUrl = options.target_url.toUtf8();


### PR DESCRIPTION
As the URL might be print on the logs.
Also don't change the scheme from http to owncloud.

This was required before when we were using neon through csync, but now that
we use QNAM for everything we don't need it. The credentials from the account
are used.