### PR TITLE
Prototype: Folder items scheduler - evaluation attribute sorted tree

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -401,8 +401,11 @@ void OwncloudPropagator::start(const SyncFileItemVector& items)
     }
 
     foreach(PropagatorJob* it, directoriesToRemove) {
+        it->setHighJobPriority();
         _rootJob->append(it);
     }
+
+    _rootJob->updateJobPredicateValues();
 
     connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
             this, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
@@ -574,20 +577,29 @@ OwncloudPropagator::DiskSpaceResult OwncloudPropagator::diskSpaceCheck() const
 
 // ================================================================================
 
+void PropagateDirectory::updateJobPredicateValues()
+{
+    QMutableVectorIterator<PropagatorJob *> containerJobsIterator(_containerJobs);
+    while (containerJobsIterator.hasNext()) {
+        PropagatorJob * job = containerJobsIterator.next();
+        job->updateJobPredicateValues();
+         _subJobs.insertMulti(job->getJobPredicateValue(), job);
+         containerJobsIterator.remove();
+    }
+}
+
 PropagatorJob::JobParallelism PropagateDirectory::parallelism()
 {
     // If any of the non-finished sub jobs is not parallel, we have to wait
-
-    // FIXME!  we should probably cache this result
-
     if (_firstJob && _firstJob->_state != Finished) {
         if (_firstJob->parallelism() != FullParallelism)
             return WaitForFinished;
     }
 
-    // FIXME: use the cached value of finished job
-    for (int i = 0; i < _subJobs.count(); ++i) {
-        if (_subJobs.at(i)->_state != Finished && _subJobs.at(i)->parallelism() != FullParallelism) {
+    QMapIterator<quint64, PropagatorJob *> subJobsIterator(_subJobs);
+    while (subJobsIterator.hasNext()) {
+        subJobsIterator.next();
+        if (subJobsIterator.value()->_state != Finished && subJobsIterator.value()->parallelism() != FullParallelism) {
             return WaitForFinished;
         }
     }
@@ -604,6 +616,11 @@ bool PropagateDirectory::scheduleNextJob()
     if (_state == NotYetStarted) {
         _state = Running;
 
+        // at the begining of the Directory Job, update expected number of Jobs to be synced
+        _totalJobs = _subJobs.count();
+        if (_firstJob)
+            _totalJobs++;
+
         if (!_firstJob && _subJobs.isEmpty()) {
             finalize();
             return true;
@@ -618,30 +635,27 @@ bool PropagateDirectory::scheduleNextJob()
         return false;
     }
 
-    // cache the value of first unfinished subjob
     bool stopAtDirectory = false;
-    int i = _firstUnfinishedSubJob;
-    int subJobsCount = _subJobs.count();
-    while (i < subJobsCount && _subJobs.at(i)->_state == Finished) {
-      _firstUnfinishedSubJob = ++i;
-    }
 
-    for (int i = _firstUnfinishedSubJob; i < subJobsCount; ++i) {
-        if (_subJobs.at(i)->_state == Finished) {
+    QMutableMapIterator<quint64, PropagatorJob *> subJobsIterator(_subJobs);
+    while (subJobsIterator.hasNext()) {
+        subJobsIterator.next();
+        if (subJobsIterator.value()->_state == Finished) {
+            subJobsIterator.remove();
             continue;
         }
 
-        if (stopAtDirectory && qobject_cast<PropagateDirectory*>(_subJobs.at(i))) {
+        if (stopAtDirectory && qobject_cast<PropagateDirectory*>(subJobsIterator.value())) {
             return false;
         }
 
-        if (possiblyRunNextJob(_subJobs.at(i))) {
+        if (possiblyRunNextJob(subJobsIterator.value())) {
             return true;
         }
 
-        Q_ASSERT(_subJobs.at(i)->_state == Running);
+        Q_ASSERT(subJobsIterator.value()->_state == Running);
 
-        auto paral = _subJobs.at(i)->parallelism();
+        auto paral = subJobsIterator.value()->parallelism();
         if (paral == WaitForFinished) {
             return false;
         }
@@ -666,14 +680,9 @@ void PropagateDirectory::slotSubJobFinished(SyncFileItem::Status status)
     _runningNow--;
     _jobsFinished++;
 
-    int totalJobs = _subJobs.count();
-    if (_firstJob) {
-        totalJobs++;
-    }
-
     // We finished processing all the jobs
     // check if we finished
-    if (_jobsFinished >= totalJobs) {
+    if (_jobsFinished >= _totalJobs) {
         Q_ASSERT(!_runningNow); // how can we be finished if there are still jobs running now
         finalize();
     } else {

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -60,7 +60,24 @@ protected:
     OwncloudPropagator *_propagator;
 
 public:
-    explicit PropagatorJob(OwncloudPropagator* propagator) : _propagator(propagator), _state(NotYetStarted) {}
+    enum JobPriority {
+
+        /** Jobs can prioritized, so that they will be executed first, according to insertion order */
+        InsertionOrderHighPriority,
+
+        /** Jobs are normaly prioritized, so that they will be executed according to some predicate represented by integer*/
+        NormalPriority,\
+
+        /** To contruct predicate for this Priority, all subitem has to be classified and contenerised  */
+        ContainerItemsPriority,
+    };
+
+    explicit PropagatorJob(OwncloudPropagator* propagator, JobPriority priority) : _propagator(propagator), _priority(priority), _state(NotYetStarted) {}
+
+    /*
+    * Keeps track of the priority of the object
+    */
+    JobPriority _priority;
 
     enum JobState {
         NotYetStarted,
@@ -99,6 +116,23 @@ public:
      * in use by running jobs for things like a download-in-progress.
      */
     virtual qint64 committedDiskSpace() const { return 0; }
+
+    /**
+     * Returns job priority predicate value
+     * 0 if InsertionOrderHighPriority
+     * Priority if other type of priority
+     */
+    virtual quint64 getJobPredicateValue() const { return 0; }
+
+    /**
+     * Updates job priorities for the given job
+     */
+    virtual void updateJobPredicateValues() {}
+
+    /**
+     * Enforces job priority
+     */
+    virtual void setHighJobPriority() { _priority = JobPriority::InsertionOrderHighPriority; }
 
 public slots:
     virtual void abort() {}
@@ -158,8 +192,8 @@ private:
     QScopedPointer<PropagateItemJob> _restoreJob;
 
 public:
-    PropagateItemJob(OwncloudPropagator* propagator, const SyncFileItemPtr &item)
-        : PropagatorJob(propagator), _item(item) {}
+    PropagateItemJob(OwncloudPropagator* propagator, const SyncFileItemPtr &item, JobPriority priority)
+        : PropagatorJob(propagator, priority), _item(item) {}
 
     bool scheduleNextJob() Q_DECL_OVERRIDE {
         if (_state != NotYetStarted) {
@@ -187,27 +221,49 @@ public:
     // e.g: create the directory
     QScopedPointer<PropagateItemJob>_firstJob;
 
-    // all the sub files or sub directories.
-    QVector<PropagatorJob *> _subJobs;
+    /*
+     * All the sub files or sub directories. This map has to be updated with _containerJobs
+     * QMultiMap is ordered by the key value, or in case of equal keys (e.g 0) by insertion order.
+     * <quint64 predicate, PropagatorJob * job>, where predicate is obtained by call to getJobPredicateValue()
+     */
+    QMultiMap<quint64, PropagatorJob *> _subJobs;
+
+    /*
+     * This vector is just temporary structure used to keep the "container" jobs like directory job.
+     * After the updateJobPredicateValues() is called on this directories, these container jobs will be inserted
+     * to _subJobs queue. Note: This has to be called after all items are added to the _subJobs for whole the sync!
+     */
+    QVector<PropagatorJob *> _containerJobs;
 
     SyncFileItemPtr _item;
 
     int _jobsFinished; // number of jobs that have completed
+    int _totalJobs; // number of jobs that will be defined to be synced
     int _runningNow; // number of subJobs running right now
     SyncFileItem::Status _hasError;  // NoStatus,  or NormalError / SoftError if there was an error
-    int _firstUnfinishedSubJob;
+
+    /*
+     * Keeps track of the all the sub files or sub directories priority.
+    */
+    qint64 _subJobsPriority;
 
     explicit PropagateDirectory(OwncloudPropagator *propagator, const SyncFileItemPtr &item = SyncFileItemPtr(new SyncFileItem))
-        : PropagatorJob(propagator)
-        , _firstJob(0), _item(item),  _jobsFinished(0), _runningNow(0), _hasError(SyncFileItem::NoStatus), _firstUnfinishedSubJob(0)
+        : PropagatorJob(propagator, JobPriority::ContainerItemsPriority)
+        , _firstJob(0), _item(item),  _jobsFinished(0),  _totalJobs(0), _runningNow(0), _hasError(SyncFileItem::NoStatus), _subJobsPriority(0)
     { }
 
     virtual ~PropagateDirectory() {
         qDeleteAll(_subJobs);
+        qDeleteAll(_containerJobs);
     }
 
     void append(PropagatorJob *subJob) {
-        _subJobs.append(subJob);
+        _subJobsPriority += subJob->getJobPredicateValue();
+        if(subJob->_priority == JobPriority::ContainerItemsPriority){
+            _containerJobs.append(subJob);
+        } else {
+            _subJobs.insert(subJob->getJobPredicateValue(), subJob);
+        }
     }
 
     virtual bool scheduleNextJob() Q_DECL_OVERRIDE;
@@ -227,6 +283,12 @@ public:
 
     qint64 committedDiskSpace() const Q_DECL_OVERRIDE;
 
+    // this item is prioritized normaly, so get priority by its sub items total size
+    quint64 getJobPredicateValue() const  Q_DECL_OVERRIDE { return _subJobsPriority; }
+
+    // This uses recursion to perform Depth-First Traversal of the directories with changes trees
+    // If the given (this) directory contains _containerJobs, it will call updateJob on that child dir job, otherwise does nothing
+    void updateJobPredicateValues();
 private slots:
     bool possiblyRunNextJob(PropagatorJob *next) {
         if (next->_state == NotYetStarted) {
@@ -252,7 +314,7 @@ class PropagateIgnoreJob : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateIgnoreJob(OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item) {}
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
     void start() Q_DECL_OVERRIDE {
         SyncFileItem::Status status = _item->_status;
         done(status == SyncFileItem::NoStatus ? SyncFileItem::FileIgnored : status, _item->_errorString);

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -110,12 +110,15 @@ class PropagateDownloadFile : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateDownloadFile(OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item), _resumeStart(0), _downloadProgress(0), _deleteExisting(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::NormalPriority), _resumeStart(0), _downloadProgress(0), _deleteExisting(false) {}
     void start() Q_DECL_OVERRIDE;
     qint64 committedDiskSpace() const Q_DECL_OVERRIDE;
 
     // We think it might finish quickly because it is a small file.
     bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < 100*1024; }
+
+    // this item is prioritized normaly, so get priority by its size
+    quint64 getJobPredicateValue() const Q_DECL_OVERRIDE { return _item->_size; }
 
     /**
      * Whether an existing folder with the same name may be deleted before

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -117,8 +117,8 @@ public:
     // We think it might finish quickly because it is a small file.
     bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < 100*1024; }
 
-    // this item is prioritized normaly, so get priority by its size
-    quint64 getJobPredicateValue() const Q_DECL_OVERRIDE { return _item->_size; }
+    // this item is prioritized normaly, so get priority by its modification time
+    quint64 getJobPriorityAttributeValue() const Q_DECL_OVERRIDE { return _item->_modtime; }
 
     /**
      * Whether an existing folder with the same name may be deleted before

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -48,7 +48,7 @@ class PropagateRemoteDelete : public PropagateItemJob {
     QPointer<DeleteJob> _job;
 public:
     PropagateRemoteDelete (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
+        : PropagateItemJob(propagator, item, JobPriority::LastOutPriority) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
 

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -48,7 +48,7 @@ class PropagateRemoteDelete : public PropagateItemJob {
     QPointer<DeleteJob> _job;
 public:
     PropagateRemoteDelete (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item) {}
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
 

--- a/src/libsync/propagateremotemkdir.h
+++ b/src/libsync/propagateremotemkdir.h
@@ -29,7 +29,7 @@ class PropagateRemoteMkdir : public PropagateItemJob {
     friend class PropagateDirectory; // So it can access the _item;
 public:
     PropagateRemoteMkdir (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item), _deleteExisting(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority), _deleteExisting(false) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
 

--- a/src/libsync/propagateremotemkdir.h
+++ b/src/libsync/propagateremotemkdir.h
@@ -29,7 +29,7 @@ class PropagateRemoteMkdir : public PropagateItemJob {
     friend class PropagateDirectory; // So it can access the _item;
 public:
     PropagateRemoteMkdir (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority), _deleteExisting(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::FirstOutPriority), _deleteExisting(false) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
 

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -51,7 +51,7 @@ class PropagateRemoteMove : public PropagateItemJob {
     QPointer<MoveJob> _job;
 public:
     PropagateRemoteMove (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item) {}
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
     JobParallelism parallelism() Q_DECL_OVERRIDE { return OCC::PropagatorJob::WaitForFinishedInParentDirectory; }

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -51,7 +51,7 @@ class PropagateRemoteMove : public PropagateItemJob {
     QPointer<MoveJob> _job;
 public:
     PropagateRemoteMove (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
+        : PropagateItemJob(propagator, item, JobPriority::FirstOutPriority) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
     JobParallelism parallelism() Q_DECL_OVERRIDE { return OCC::PropagatorJob::WaitForFinishedInParentDirectory; }

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -197,7 +197,7 @@ protected:
 
 public:
     PropagateUploadFileCommon(OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item), _finished(false), _deleteExisting(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::NormalPriority), _finished(false), _deleteExisting(false) {}
 
     /**
      * Whether an existing entity with the same name may be deleted before
@@ -210,6 +210,9 @@ public:
     void start() Q_DECL_OVERRIDE;
 
     bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < 100*1024; }
+
+    // this item is prioritized normaly, so get priority by its size
+    quint64 getJobPredicateValue() const Q_DECL_OVERRIDE { return _item->_size; }
 
 private slots:
     void slotComputeContentChecksum();

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -211,8 +211,8 @@ public:
 
     bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < 100*1024; }
 
-    // this item is prioritized normaly, so get priority by its size
-    quint64 getJobPredicateValue() const Q_DECL_OVERRIDE { return _item->_size; }
+    // this item is prioritized normaly, so get priority by its modification time
+    quint64 getJobPriorityAttributeValue() const Q_DECL_OVERRIDE { return _item->_modtime; }
 
 private slots:
     void slotComputeContentChecksum();

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -40,7 +40,8 @@ static const char checkSumAdlerC[] = "Adler32";
 class PropagateLocalRemove : public PropagateItemJob {
     Q_OBJECT
 public:
-    PropagateLocalRemove (OwncloudPropagator* propagator,const SyncFileItemPtr& item)  : PropagateItemJob(propagator, item) {}
+    PropagateLocalRemove (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
     void start() Q_DECL_OVERRIDE;
 private:
     bool removeRecursively(const QString &path);
@@ -55,7 +56,7 @@ class PropagateLocalMkdir : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateLocalMkdir (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item), _deleteExistingFile(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority), _deleteExistingFile(false) {}
     void start() Q_DECL_OVERRIDE;
 
     /**
@@ -77,7 +78,8 @@ private:
 class PropagateLocalRename : public PropagateItemJob {
     Q_OBJECT
 public:
-    PropagateLocalRename (OwncloudPropagator* propagator,const SyncFileItemPtr& item)  : PropagateItemJob(propagator, item) {}
+    PropagateLocalRename (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
+        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
     void start() Q_DECL_OVERRIDE;
     JobParallelism parallelism() Q_DECL_OVERRIDE { return WaitForFinishedInParentDirectory; }
 };

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -41,7 +41,7 @@ class PropagateLocalRemove : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateLocalRemove (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
+        : PropagateItemJob(propagator, item, JobPriority::FirstOutPriority) {}
     void start() Q_DECL_OVERRIDE;
 private:
     bool removeRecursively(const QString &path);
@@ -56,7 +56,7 @@ class PropagateLocalMkdir : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateLocalMkdir (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority), _deleteExistingFile(false) {}
+        : PropagateItemJob(propagator, item, JobPriority::FirstOutPriority), _deleteExistingFile(false) {}
     void start() Q_DECL_OVERRIDE;
 
     /**
@@ -79,7 +79,7 @@ class PropagateLocalRename : public PropagateItemJob {
     Q_OBJECT
 public:
     PropagateLocalRename (OwncloudPropagator* propagator,const SyncFileItemPtr& item)
-        : PropagateItemJob(propagator, item, JobPriority::InsertionOrderHighPriority) {}
+        : PropagateItemJob(propagator, item, JobPriority::FirstOutPriority) {}
     void start() Q_DECL_OVERRIDE;
     JobParallelism parallelism() Q_DECL_OVERRIDE { return WaitForFinishedInParentDirectory; }
 };


### PR DESCRIPTION
Case Scenario 1:
Carlos and his Zombies just went back from holidays, he opens the computer and tries to sync all his photos - 4GB. With his link, to upload all the photos will take around 1 hour. He starts working since next day is monday, and he puts in the various folders his new files. 

Case Scenario 2:
Carlos didnt use sync client for longer time, he want to do the initial sync of his files. He starts sync of a lot of folders with a lot of files. Total sync time will be around 30 minutes. Within all these files, there are some folders on which he collaborates on the document. He want to share the document he is editing during the sync, and this folder is not big (it contains only documents).

EXPECTATIONS:
In the very nested structure, there is a folder with only small changes, and folder with a lot of new files, which sync time will be very long. It is expected, that the folders with small changes will be synced first. If I pause-start sync, my small file schould by synced first

REALITY:
OC client currently is "I just found folder on filesystem and I will try to sync its contents to the cloud" structured. This means, that if you place a small change in some nexted folder tree, and before it there is another nested tree with a lot of files, your document will wait till sync comes to your folder

Solution:
Effect 1:
I removed the caching of the Finished Jobs, and I just remove them from the stack. I am using also Iterator instead of for loop. 

Effect 2:
Oc sync is structurising the sync in the following manner, not regarding on the size of the folders:

THE TREES BELOW ARE TREES OF CHANGES - These folders could contain a lot of unchanged files in each. Tree is being build only basing on size of changes within specific subtree. 

Important note: all file operations(IGNORE, MOVE, ETC) except for PUT and GET, are assigned with HighPriority, it means they will be synced with insertion order (the same as previously). PUT and GET predicates are based on their file sizes and are assigned NormalPriority. Folders (subtrees) are assigned ContainerPriority, which means their predicate is size of the changes within this subtree. REMOVED folders are HighPriority and will be synced old way. 

````
ownCloud Root
├── less-important-folder-10MB/
       ├── nested-folderes-files 9MB
       ├── less-important-file 1MB
       └── nested-folderes-files 4MB
├── Home&Work-10GB/
        ├── folder with nested 10GB of photos to be sync
        ├── very-very-important folder with single documents to sync - 2MB
        └── less-important-document - 1MB
├── important-folder-12MB/
└── less-important-folder - 5MB/
        └── important-file-1MB
````
However, this algorithm (not using loop for all the items, only for folders within folder - complexity 0(n) where n is number of folders in the folder) builds it as follows, looking on size predicate for files and size of items within folders:
````
ownCloud new Execution Tree:
├── less-important-folder-5MB/
       └── important-file-1MB
├── less-important-folder-10MB/
       ├── less-important-file 1MB
       ├── nested-folderes-files 4MB
       └── nested-folderes-files 9MB
├── important-folder-12MB/
├── Home&Work-10GB/
        ├── less-important-document - 1MB
        ├── very-very-important folder with single documents to sync - 2MB
        └── folder with nested 10GB of photos to be sync
````
I have tested it on similar structure and it works really nice :> @ogoffart @DeepDiver1975 @guruz @felixboehm 