### PR TITLE
Add capability to disable parallel chunked upload for V1 protocol

### DIFF
--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -116,5 +116,10 @@ bool Capabilities::chunkingNg() const
     return _capabilities["dav"].toMap()["chunking"].toByteArray() >= "1.0";
 }
 
+bool Capabilities::chunkingV1ParallelUploadDisabled() const
+{
+  return _capabilities["dav"].toMap()["chunkingV1ParallelUploadDisabled"].toBool();
+}
+
 
 }

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -42,6 +42,8 @@ public:
     bool shareResharing() const;
     bool chunkingNg() const;
 
+    bool chunkingV1ParallelUploadDisabled() const;
+
     /// returns true if the capabilities report notifications
     bool notificationsAvailable() const;
 

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -144,6 +144,11 @@ void PropagateUploadFileV1::startNextChunk()
             // internal sever errors (#2743, #2938)
             parallelChunkUpload = false;
         }
+
+	if (_propagator->account()->chunkingV1ParallelUploadDisabled()) {
+	  // Server may also disable parallel chunked upload for any higher version
+	  parallelChunkUpload = false;
+	}
     }
 
     if (_currentChunk + _startChunk >= _chunkCount - 1) {

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -145,7 +145,7 @@ void PropagateUploadFileV1::startNextChunk()
             parallelChunkUpload = false;
         }
 
-	if (_propagator->account()->chunkingV1ParallelUploadDisabled()) {
+	if (_propagator->account()->capabilities().chunkingV1ParallelUploadDisabled()) {
 	  // Server may also disable parallel chunked upload for any higher version
 	  parallelChunkUpload = false;
 	}


### PR DESCRIPTION
This adds a possibility for a server to disable parallel chunk upload (V1) independently of the server version.