### PR TITLE
Regularly retry an unavailable folder

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -507,7 +507,7 @@ restart_sync:
 
     app.exec();
 
-    if (engine.isAnotherSyncNeeded()) {
+    if (engine.isAnotherSyncNeeded() != NoFollowUpSync) {
         if (restartCount < options.restartTimes) {
             restartCount++;
             qDebug() << "Restarting Sync, because another sync is needed" << restartCount;

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -826,7 +826,7 @@ void Folder::slotSyncFinished(bool success)
     _fileLog->finish();
     bubbleUpSyncResult();
 
-    bool anotherSyncNeeded = _engine->isAnotherSyncNeeded();
+    auto anotherSyncNeeded = _engine->isAnotherSyncNeeded();
 
     if (_csyncError) {
         _syncResult.setStatus(SyncResult::Error);
@@ -877,7 +877,7 @@ void Folder::slotSyncFinished(bool success)
     _timeSinceLastSyncDone.restart();
 
     // Increment the follow-up sync counter if necessary.
-    if (anotherSyncNeeded) {
+    if (anotherSyncNeeded == ImmediateFollowUp) {
         _consecutiveFollowUpSyncs++;
         qDebug() << "another sync was requested by the finished sync, this has"
                  << "happened" << _consecutiveFollowUpSyncs << "times";
@@ -886,7 +886,7 @@ void Folder::slotSyncFinished(bool success)
     }
 
     // Maybe force a follow-up sync to take place, but only a couple of times.
-    if (anotherSyncNeeded && _consecutiveFollowUpSyncs <= 3)
+    if (anotherSyncNeeded == ImmediateFollowUp && _consecutiveFollowUpSyncs <= 3)
     {
         // Sometimes another sync is requested because a local file is still
         // changing, so wait at least a small amount of time before syncing

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -148,6 +148,7 @@ int FolderMan::unloadAndDeleteAllFolders()
 void FolderMan::registerFolderMonitor( Folder *folder )
 {
     if( !folder ) return;
+    if( !QDir(folder->path()).exists() ) return;
 
     if( !_folderWatchers.contains(folder->alias() ) ) {
         FolderWatcher *fw = new FolderWatcher(folder->path(), folder);
@@ -730,6 +731,10 @@ void FolderMan::slotStartScheduledFolderSync()
 
     // Start syncing this folder!
     if( folder ) {
+        // Safe to call several times, and necessary to try again if
+        // the folder path didn't exist previously.
+        registerFolderMonitor(folder);
+
         _currentSyncFolder = folder;
         folder->startSync( QStringList() );
     }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -73,7 +73,7 @@ SyncEngine::SyncEngine(AccountPtr account, const QString& localPath,
   , _downloadLimit(0)
   , _newBigFolderSizeLimit(-1)
   , _checksum_hook(journal)
-  , _anotherSyncNeeded(false)
+  , _anotherSyncNeeded(NoFollowUpSync)
 {
     qRegisterMetaType<SyncFileItem>("SyncFileItem");
     qRegisterMetaType<SyncFileItem::Status>("SyncFileItem::Status");
@@ -693,12 +693,13 @@ void SyncEngine::startSync()
     Q_ASSERT(!_syncRunning);
     s_anySyncRunning = true;
     _syncRunning = true;
-    _anotherSyncNeeded = false;
+    _anotherSyncNeeded = NoFollowUpSync;
     _clearTouchedFilesTimer.stop();
 
     _progressInfo->reset();
 
     if (!QDir(_localPath).exists()) {
+        _anotherSyncNeeded = DelayedFollowUp;
         // No _tr, it should only occur in non-mirall
         emit csyncError("Unable to find local sync folder.");
         finalize(false);
@@ -712,6 +713,7 @@ void SyncEngine::startSync()
         qDebug() << "There are" << freeBytes << "bytes available at" << _localPath
                  << "and at least" << minFree << "are required";
         if (freeBytes < minFree) {
+            _anotherSyncNeeded = DelayedFollowUp;
             emit csyncError(tr("Only %1 are available, need at least %2 to start",
                                "Placeholders are postfixed with file sizes using Utility::octetsToString()").arg(
                                 Utility::octetsToString(freeBytes),
@@ -1048,7 +1050,9 @@ void SyncEngine::slotItemCompleted(const SyncFileItem &item, const PropagatorJob
 
 void SyncEngine::slotFinished(bool success)
 {
-    _anotherSyncNeeded = _anotherSyncNeeded || _propagator->_anotherSyncNeeded;
+    if (_propagator->_anotherSyncNeeded && _anotherSyncNeeded == NoFollowUpSync) {
+        _anotherSyncNeeded = ImmediateFollowUp;
+    }
 
     if (success) {
         _journal->setDataFingerprint(_discoveryMainThread->_dataFingerprint);
@@ -1171,7 +1175,7 @@ void SyncEngine::checkForPermission()
                             // be restored. Do that in the next sync by not considering as a rename
                             // but delete and upload. It will then be restored if needed.
                             _journal->avoidRenamesOnNextSync((*it)->_file);
-                            _anotherSyncNeeded = true;
+                            _anotherSyncNeeded = ImmediateFollowUp;
                             qDebug() << "Moving of " << (*it)->_file << " canceled because no permission to add parent folder";
                         }
                         (*it)->_instruction = CSYNC_INSTRUCTION_ERROR;
@@ -1328,7 +1332,7 @@ void SyncEngine::checkForPermission()
                     //  At this point we would need to go back to the propagate phase on both remote to take
                     //  the decision.
                     _journal->avoidRenamesOnNextSync((*it)->_file);
-                    _anotherSyncNeeded = true;
+                    _anotherSyncNeeded = ImmediateFollowUp;
 
 
                     if ((*it)->_isDirectory) {

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -49,6 +49,13 @@ class SyncJournalDb;
 class OwncloudPropagator;
 class PropagatorJob;
 
+enum AnotherSyncNeeded
+{
+    NoFollowUpSync,
+    ImmediateFollowUp, // schedule this again immediately (limited amount of times)
+    DelayedFollowUp // regularly schedule this folder again (around 1/minute, unlimited)
+};
+
 /**
  * @brief The SyncEngine class
  * @ingroup libsync
@@ -82,8 +89,8 @@ public:
     Utility::StopWatch &stopWatch() { return _stopWatch; }
     SyncFileStatusTracker &syncFileStatusTracker() { return *_syncFileStatusTracker; }
 
-    /* Return true if we detected that another sync is needed to complete the sync */
-    bool isAnotherSyncNeeded() { return _anotherSyncNeeded; }
+    /* Returns whether another sync is needed to complete the sync */
+    AnotherSyncNeeded isAnotherSyncNeeded() { return _anotherSyncNeeded; }
 
     /** Get the ms since a file was touched, or -1 if it wasn't.
      *
@@ -259,7 +266,7 @@ private:
     /// Hook for computing checksums from csync_update
     CSyncChecksumHook _checksum_hook;
 
-    bool _anotherSyncNeeded;
+    AnotherSyncNeeded _anotherSyncNeeded;
 
     /** Stores the time since a job touched a file. */
     QHash<QString, QElapsedTimer> _touchedFiles;


### PR DESCRIPTION
Fix for #5317. If the folder isn't there initially, retry occasionally so users don't have to manually restart.

Note that the case of a folder being there, vanishing and then being there again is very likely still broken. (Does the DB reconnect? Do the FolderWatchers do the right thing?)