### PR TITLE
HTTPCreds: remove all cookies when logging out

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -149,10 +149,14 @@ QUrl Account::davUrl() const
     return Utility::concatUrlPath(url(), davPath());
 }
 
+/**
+ * clear all cookies. (Session cookies or not)
+ */
 void Account::clearCookieJar()
 {
     Q_ASSERT(qobject_cast<CookieJar*>(_am->cookieJar()));
-    static_cast<CookieJar*>(_am->cookieJar())->clearSessionCookies();
+    static_cast<CookieJar*>(_am->cookieJar())->setAllCookies(QList<QNetworkCookie>());
+    emit wantsAccountSaved(this);
 }
 
 /*! This shares our official cookie jar (containing all the tasty


### PR DESCRIPTION
Some custom server use persistent cookies with the auth token. So we should
clear all the cookies when disconnecting.
Account::clearCookieJar is only called from the HTTPCredentials. This funciton
is not used for shibboleth.
There is probably no reasons to keep the HTTP cookie anyway.

Issue #5370