### PR TITLE
Delete finished job in the PropagateDirectory scheduleNextJob. #5269

### DIFF
--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -192,14 +192,12 @@ public:
 
     SyncFileItemPtr _item;
 
-    int _jobsFinished; // number of jobs that have completed
     int _runningNow; // number of subJobs running right now
     SyncFileItem::Status _hasError;  // NoStatus,  or NormalError / SoftError if there was an error
-    int _firstUnfinishedSubJob;
 
     explicit PropagateDirectory(OwncloudPropagator *propagator, const SyncFileItemPtr &item = SyncFileItemPtr(new SyncFileItem))
         : PropagatorJob(propagator)
-        , _firstJob(0), _item(item),  _jobsFinished(0), _runningNow(0), _hasError(SyncFileItem::NoStatus), _firstUnfinishedSubJob(0)
+        , _item(item), _runningNow(0), _hasError(SyncFileItem::NoStatus)
     { }
 
     virtual ~PropagateDirectory() {

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -213,6 +213,17 @@ private slots:
         }
     }
 
+    void abortAfterFailedMkdir() {
+        FakeFolder fakeFolder{FileInfo{}};
+        QSignalSpy finishedSpy(&fakeFolder.syncEngine(), SIGNAL(finished(bool)));
+        fakeFolder.serverErrorPaths().append("NewFolder");
+        fakeFolder.localModifier().mkdir("NewFolder");
+        // This should be aborted and would otherwise fail in FileInfo::create.
+        fakeFolder.localModifier().insert("NewFolder/NewFile");
+        fakeFolder.syncOnce();
+        QCOMPARE(finishedSpy.size(), 1);
+        QCOMPARE(finishedSpy.first().first().toBool(), false);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)


### PR DESCRIPTION
Delete finished job in the PropagateDerectory scheduleNextJob. 

This should reduce code complexity from https://github.com/owncloud/client/pull/5274 and solve the issue https://github.com/owncloud/client/pull/5269