### PR TITLE
Correctly handle possible missing GIT_SHA1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 # if we cannot get it from git, directly try .tag (packages)
 # this will work if the tar balls have been properly created
 # via git-archive.
-if (${GIT_SHA1} STREQUAL "GITDIR-NOTFOUND")
+if ("${GIT_SHA1}" STREQUAL "GITDIR-NOTFOUND")
     file(READ ${CMAKE_SOURCE_DIR}/.tag sha1_candidate)
     string(REPLACE "\n" "" sha1_candidate ${sha1_candidate})
     if (NOT ${sha1_candidate} STREQUAL "$Format:%H$")


### PR DESCRIPTION
Currently, if get_git_head_revision() doesn't define GIT_SHA1 (which it doesn't in some cases) it's possible to end up with the following error:

    CMake Error at CMakeLists.txt:69 (if):
      if given arguments:

        "STREQUAL" "GITDIR-NOTFOUND"

      Unknown arguments specified

This PR fixes this issue by making sure both left and right hand arguments to STREQUAL are always strings, even if GIT_SHA1 is undefined.