### PR TITLE
Add capability to disable parallel chunked upload #5364

### DIFF
--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -116,5 +116,9 @@ bool Capabilities::chunkingNg() const
     return _capabilities["dav"].toMap()["chunking"].toByteArray() >= "1.0";
 }
 
+bool Capabilities::chunkingParallelUploadDisabled() const
+{
+    return _capabilities["dav"].toMap()["chunkingParallelUploadDisabled"].toBool();
+}
 
 }

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -42,6 +42,9 @@ public:
     bool shareResharing() const;
     bool chunkingNg() const;
 
+    /// disable parallel upload in chunking
+    bool chunkingParallelUploadDisabled() const;
+
     /// returns true if the capabilities report notifications
     bool notificationsAvailable() const;
 


### PR DESCRIPTION
Reviewed https://github.com/owncloud/client/pull/5364 needed technical correction and tests

Tested agains oc92 in following scenarios:
- **chunking capability set to true on server**: triggers chunkingNG
- **chunking capability set to false on server**: triggers old chunking with parallel chunk upload
- **chunkingParallelUploadDisabled capability not existing** : triggers old chunking with parallel chunk upload
- **chunkingParallelUploadDisabled set to true**: triggers old chunking without parallel chunk upload
- **chunkingParallelUploadDisabled set to false**: triggers old chunking with parallel chunk upload
- **chunking capability set to false on server and chunkingParallelUploadDisabled set to true**: triggers old chunking without parallel chunk upload

@moscicki @ogoffart 