### PR TITLE
Wizard: Let the user know if url is invalid #5398

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -207,10 +207,15 @@ void OwncloudSetupWizard::slotNoOwnCloudFoundAuth(QNetworkReply *reply)
     QString contentType = reply->header(QNetworkRequest::ContentTypeHeader).toString();
 
     // Do this early because reply might be deleted in message box event loop
-    QString msg = tr("Failed to connect to %1 at %2:<br/>%3")
+    QString msg;
+    if (!_ocWizard->account()->url().isValid()) {
+        msg = tr("Invalid URL");
+    } else {
+        msg = tr("Failed to connect to %1 at %2:<br/>%3")
             .arg(Theme::instance()->appNameGUI(),
                  reply->url().toString(),
                  reply->errorString());
+    }
     bool isDowngradeAdvised = checkDowngradeAdvised(reply);
 
     // If a client cert is needed, nginx sends:


### PR DESCRIPTION
It might be that we intentionally don't validate the url before attempting to connect to it. But if there's a connection failure and the url is invalid, the likely cause of the connection failure is the invalid url.

(If we don't intentionally don't validate, checking beforehand would be better!)