### PR TITLE
Wizard: Detach saved account from wizard

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -553,6 +553,13 @@ void OwncloudSetupWizard::slotSkipFolderConfiguration()
 AccountState *OwncloudSetupWizard::applyAccountChanges()
 {
     AccountPtr newAccount = _ocWizard->account();
+
+    // Detach the account that is going to be saved from the
+    // wizard to ensure it doesn't accidentally get modified
+    // later (such as from running cleanup such as
+    // AbstractCredentialsWizardPage::cleanupPage())
+    _ocWizard->setAccount(AccountManager::createAccount());
+
     auto manager = AccountManager::instance();
 
     auto newState = manager->addAccount(newAccount);


### PR DESCRIPTION
Fixes #5408 #5407.

The problem was that cleanup of the credentials page set the
credentials of the account back to dummy, thereby overriding
things like shib usernames.

This should be broken since a932eac832b442cca763197240f036905dd284da.