### PR TITLE
Selective sync: Respect big folder threshold #5421

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -500,7 +500,11 @@ void FolderWizardSelectiveSync::initializePage()
     QString alias        = QFileInfo(targetPath).fileName();
     if (alias.isEmpty())
         alias = Theme::instance()->appName();
-    _selectiveSync->setFolderInfo(targetPath, alias);
+    QStringList initialBlacklist;
+    if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
+        initialBlacklist = QStringList("/");
+    }
+    _selectiveSync->setFolderInfo(targetPath, alias, initialBlacklist);
     QWizardPage::initializePage();
 }
 

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -482,9 +482,8 @@ void FolderWizardRemotePath::showWarn( const QString& msg ) const
 FolderWizardSelectiveSync::FolderWizardSelectiveSync(const AccountPtr& account)
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
-    _treeView = new SelectiveSyncTreeView(account, this);
-    layout->addWidget(new QLabel(tr("Choose What to Sync: You can optionally deselect remote subfolders you do not wish to synchronize.")));
-    layout->addWidget(_treeView);
+    _selectiveSync = new SelectiveSyncWidget(account, this);
+    layout->addWidget(_selectiveSync);
 }
 
 FolderWizardSelectiveSync::~FolderWizardSelectiveSync()
@@ -501,13 +500,13 @@ void FolderWizardSelectiveSync::initializePage()
     QString alias        = QFileInfo(targetPath).fileName();
     if (alias.isEmpty())
         alias = Theme::instance()->appName();
-    _treeView->setFolderInfo(targetPath, alias);
+    _selectiveSync->setFolderInfo(targetPath, alias);
     QWizardPage::initializePage();
 }
 
 bool FolderWizardSelectiveSync::validatePage()
 {
-    wizard()->setProperty("selectiveSyncBlackList", QVariant(_treeView->createBlackList()));
+    wizard()->setProperty("selectiveSyncBlackList", QVariant(_selectiveSync->createBlackList()));
     return true;
 }
 
@@ -517,7 +516,7 @@ void FolderWizardSelectiveSync::cleanupPage()
     QString alias        = QFileInfo(targetPath).fileName();
     if (alias.isEmpty())
         alias = Theme::instance()->appName();
-    _treeView->setFolderInfo(targetPath, alias);
+    _selectiveSync->setFolderInfo(targetPath, alias);
     QWizardPage::cleanupPage();
 }
 

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -27,7 +27,7 @@
 
 namespace OCC {
 
-class SelectiveSyncTreeView;
+class SelectiveSyncWidget;
 
 class ownCloudInfo;
 
@@ -127,7 +127,7 @@ public:
     virtual void cleanupPage() Q_DECL_OVERRIDE;
 
 private:
-    SelectiveSyncTreeView *_treeView;
+    SelectiveSyncWidget *_selectiveSync;
 
 };
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -62,7 +62,7 @@ SelectiveSyncWidget::SelectiveSyncWidget(AccountPtr account, QWidget *parent)
     , _inserting(false)
     , _folderTree(new QTreeWidget(this))
 {
-    _loading = new QLabel(tr("Loading ..."), this);
+    _loading = new QLabel(tr("Loading ..."), _folderTree);
 
     auto layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -26,40 +26,50 @@ namespace OCC {
 class Folder;
 
 /**
- * @brief The SelectiveSyncTreeView class
+ * @brief The SelectiveSyncWidget contains a folder tree with labels
  * @ingroup gui
  */
-class SelectiveSyncTreeView : public QTreeWidget {
+class SelectiveSyncWidget : public QWidget {
     Q_OBJECT
 public:
-    explicit SelectiveSyncTreeView(AccountPtr account, QWidget* parent = 0);
+    explicit SelectiveSyncWidget(AccountPtr account, QWidget* parent = 0);
 
     /// Returns a list of blacklisted paths, each including the trailing /
     QStringList createBlackList(QTreeWidgetItem* root = 0) const;
+
+    /** Returns the oldBlackList passed into setFolderInfo(), except that
+     *  a "/" entry is expanded to all top-level folder names.
+     */
     QStringList oldBlackList() const;
 
     // Estimates the total size of checked items (recursively)
     qint64 estimatedSize(QTreeWidgetItem *root = 0);
-    void refreshFolders();
 
     // oldBlackList is a list of excluded paths, each including a trailing /
     void setFolderInfo(const QString &folderPath, const QString &rootName,
                        const QStringList &oldBlackList = QStringList());
 
     QSize sizeHint() const Q_DECL_OVERRIDE;
+
 private slots:
     void slotUpdateDirectories(QStringList);
     void slotItemExpanded(QTreeWidgetItem *);
     void slotItemChanged(QTreeWidgetItem*,int);
     void slotLscolFinishedWithError(QNetworkReply*);
 private:
+    void refreshFolders();
     void recursiveInsert(QTreeWidgetItem* parent, QStringList pathTrail, QString path, qint64 size);
+
+    AccountPtr _account;
+
     QString _folderPath;
     QString _rootName;
     QStringList _oldBlackList;
+
     bool _inserting; // set to true when we are inserting new items on the list
-    AccountPtr _account;
     QLabel *_loading;
+
+    QTreeWidget *_folderTree;
 };
 
 /**
@@ -85,9 +95,9 @@ public:
 
 private:
 
-    void init(const AccountPtr &account, const QString &label);
+    void init(const AccountPtr &account);
 
-    SelectiveSyncTreeView *_treeView;
+    SelectiveSyncWidget *_selectiveSync;
 
     Folder *_folder;
     QPushButton *_okButton;


### PR DESCRIPTION
When creating a folder sync connection through the account or folder
wizard we didn't take the big folder threshold into account when
presenting the user the selective sync folder list.

Now big folders are deselected by default. And if that happens a label
is displayed that notifies the user of that fact.