### PR TITLE
Symlink Support for Dolphin Plugins

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
@@ -24,6 +24,7 @@
 #include <KIOCore/kfileitem.h>
 #include <KIOCore/KFileItemListProperties>
 #include <QtWidgets/QAction>
+#include <QtCore/QDir>
 #include <QtCore/QTimer>
 #include "ownclouddolphinpluginhelper.h"
 
@@ -43,7 +44,8 @@ public:
         auto url = urls.first();
         if (!url.isLocalFile())
             return {};
-        auto localFile = url.toLocalFile();
+        QDir localPath(url.toLocalFile());
+        auto localFile = localPath.canonicalPath();
 
         const auto paths = helper->paths();
         if (!std::any_of(paths.begin(), paths.end(), [&](const QString &s) {

--- a/shell_integration/dolphin/ownclouddolphinoverlayplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinoverlayplugin.cpp
@@ -21,6 +21,7 @@
 #include <KPluginFactory>
 #include <QtNetwork/QLocalSocket>
 #include <KIOCore/kfileitem.h>
+#include <QDir>
 #include <QTimer>
 #include "ownclouddolphinpluginhelper.h"
 
@@ -46,7 +47,8 @@ public:
             return QStringList();
         if (!url.isLocalFile())
             return QStringList();
-        const QByteArray localFile = url.toLocalFile().toUtf8();
+        QDir localPath(url.toLocalFile());
+        const QByteArray localFile = localPath.canonicalPath().toUtf8();
 
         helper->sendCommand(QByteArray("RETRIEVE_FILE_STATUS:" + localFile + "\n"));
 


### PR DESCRIPTION
I use the owncloud client by having a directory `~/.owncloud` which is getting synced and placing symlinks in my home directory `ln -s ~/.owncloud/documents ~/Dokumente`. With the current owncloud client my Dolphin file manager does not show the status of the files when I open the symlinked folders and I cannot use the sharing functionality either.

Therefore, this patch normalizes the directories, to let the plugin know, that the files in the symlinked directories are part of the owncloud sync directory.