### PR TITLE
Reset stuck chunked uploads eventually #5344

### DIFF
--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -121,4 +121,13 @@ bool Capabilities::chunkingParallelUploadDisabled() const
     return _capabilities["dav"].toMap()["chunkingParallelUploadDisabled"].toBool();
 }
 
+QList<int> Capabilities::httpErrorCodesThatResetFailingChunkedUploads() const
+{
+    QList<int> list;
+    foreach (const auto & t, _capabilities["dav"].toMap()["httpErrorCodesThatResetFailingChunkedUploads"].toList()) {
+        list.push_back(t.toInt());
+    }
+    return list;
+}
+
 }

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -81,6 +81,25 @@ public:
      */
     QByteArray uploadChecksumType() const;
 
+    /**
+     * List of HTTP error codes should be guaranteed to eventually reset
+     * failing chunked uploads.
+     *
+     * The resetting works by tracking UploadInfo::errorCount.
+     *
+     * Note that other error codes than the ones listed here may reset the
+     * upload as well.
+     *
+     * Motivation: See #5344. They should always be reset on 412 (possibly
+     * checksum error), but broken servers may also require resets on
+     * unusual error codes such as 503.
+     *
+     * Path: dav/httpErrorCodesThatResetFailingChunkedUploads
+     * Default: []
+     * Example: [503, 500]
+     */
+    QList<int> httpErrorCodesThatResetFailingChunkedUploads() const;
+
 private:
     QVariantMap _capabilities;
 };

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -232,6 +232,13 @@ private slots:
     void slotPollFinished();
 
 protected:
+    /**
+     * Checks whether the current error is one that should reset the whole
+     * transfer if it happens too often. If so: Bump UploadInfo::errorCount
+     * and maybe perform the reset.
+     */
+    void checkResettingErrors();
+
     // Bases headers that need to be sent with every chunk
     QMap<QByteArray, QByteArray> headers();
 

--- a/src/libsync/syncjournalfilerecord.cpp
+++ b/src/libsync/syncjournalfilerecord.cpp
@@ -121,7 +121,7 @@ bool SyncJournalErrorBlacklistRecord::isValid() const
 {
     return ! _file.isEmpty()
         && (!_lastTryEtag.isEmpty() || _lastTryModtime != 0)
-        && _lastTryTime > 0 && _ignoreDuration > 0;
+        && _lastTryTime > 0;
 }
 
 SyncJournalErrorBlacklistRecord SyncJournalErrorBlacklistRecord::update(
@@ -163,6 +163,7 @@ SyncJournalErrorBlacklistRecord SyncJournalErrorBlacklistRecord::update(
         qDebug() << "Fatal Error condition" << item._httpErrorCode << ", maximum blacklist ignore time!";
         entry._ignoreDuration = maxBlacklistTime;
     }
+
     entry._ignoreDuration = qBound(minBlacklistTime, entry._ignoreDuration, maxBlacklistTime);
 
     qDebug() << "blacklisting " << item._file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ if(HAVE_QT5 AND NOT BUILD_WITH_QT4)
     owncloud_add_test(SyncEngine "syncenginetestutils.h")
     owncloud_add_test(SyncFileStatusTracker "syncenginetestutils.h")
     owncloud_add_test(ChunkingNg "syncenginetestutils.h")
+    owncloud_add_test(UploadReset "syncenginetestutils.h")
 endif(HAVE_QT5 AND NOT BUILD_WITH_QT4)
 
 SET(FolderMan_SRC ../src/gui/folderman.cpp)

--- a/test/testuploadreset.cpp
+++ b/test/testuploadreset.cpp
@@ -1,0 +1,75 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include "syncenginetestutils.h"
+#include <syncengine.h>
+#include <syncjournaldb.h>
+
+using namespace OCC;
+
+class TestUploadReset : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    // Verify that the chunked transfer eventually gets reset with the new chunking
+    void testFileUploadNg() {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+
+        fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{
+                {"chunking", "1.0"},
+                {"httpErrorCodesThatResetFailingChunkedUploads", QVariantList{500} } } } });
+
+        const int size = 100 * 1000 * 1000; // 100 MB
+        fakeFolder.localModifier().insert("A/a0", size);
+        QDateTime modTime = QDateTime::currentDateTime();
+        fakeFolder.localModifier().setModTime("A/a0", modTime);
+
+        // Create a transfer id, so we can make the final MOVE fail
+        SyncJournalDb::UploadInfo uploadInfo;
+        uploadInfo._transferid = 1;
+        uploadInfo._valid = true;
+        uploadInfo._modtime = modTime;
+        fakeFolder.syncEngine().journal()->setUploadInfo("A/a0", uploadInfo);
+
+        fakeFolder.uploadState().mkdir("1");
+        fakeFolder.serverErrorPaths().append("1/.file");
+
+        QVERIFY(!fakeFolder.syncOnce());
+
+        uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
+        QCOMPARE(uploadInfo._errorCount, 1);
+        QCOMPARE(uploadInfo._transferid, 1);
+
+        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(!fakeFolder.syncOnce());
+
+        uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
+        QCOMPARE(uploadInfo._errorCount, 2);
+        QCOMPARE(uploadInfo._transferid, 1);
+
+        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(!fakeFolder.syncOnce());
+
+        uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
+        QCOMPARE(uploadInfo._errorCount, 3);
+        QCOMPARE(uploadInfo._transferid, 1);
+
+        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(!fakeFolder.syncOnce());
+
+        uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
+        QCOMPARE(uploadInfo._errorCount, 0);
+        QCOMPARE(uploadInfo._transferid, 0);
+        QVERIFY(!uploadInfo._valid);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestUploadReset)
+#include "testuploadreset.moc"


### PR DESCRIPTION
Previously this wasn't happening for errors that were not
NormalErrors because they don't end up in the blacklist.

This revises the resetting logic to be independent of the
error blacklist and make use of UploadInfo::errorCount
instead.

412 errors should reset chunked uploads because they might be
indicative of a checksum error.

Additionally, server bugs might require that additional
errors cause an upload reset. To allow that, a new capability
is added that can be used to advise the client about this.