### PR TITLE
Reference to build Qt5 with qtwebkit support in the docs #5129

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -77,25 +77,29 @@ To set up your build environment for development using HomeBrew_:
 
     brew tap owncloud/owncloud
 
-5. Install any missing dependencies::
+5. Install a Qt5 version with qtwebkit support::
+
+    brew install qt5 --with-qtwebkit
+
+6. Install any missing dependencies::
 
     brew install $(brew deps owncloud-client)
 
-3. Add Qt from brew to the path::
+7. Add Qt from brew to the path::
 
     export PATH=/usr/local/Cellar/qt5/5.x.y/bin:$PATH
 
-   Where ``x.z`` is the current version of Qt 5 that brew has installed
+   Where ``x.y`` is the current version of Qt 5 that brew has installed
    on your machine.
-4. Install qtkeychain from here:  git clone https://github.com/frankosterfeld/qtkeychain.git
+8. Install qtkeychain from here:  git clone https://github.com/frankosterfeld/qtkeychain.git
    make sure you make the same install prefix as later while building the client e.g.  -            
    ``DCMAKE_INSTALL_PREFIX=/Path/to/client-install``
 
-5. For compilation of the client, follow the :ref:`generic-build-instructions`.
+9. For compilation of the client, follow the :ref:`generic-build-instructions`.
 
-6. Install the Packages_ package creation tool.
+10. Install the Packages_ package creation tool.
 
-7. In the build directory, run ``admin/osx/create_mac.sh <build_dir>
+11. In the build directory, run ``admin/osx/create_mac.sh <build_dir>
    <install_dir>``. If you have a developer signing certificate, you can specify
    its Common Name as a third parameter (use quotes) to have the package
    signed automatically.


### PR DESCRIPTION
This addresses the issue only on OS X through homebrew. It should be stated though, that qtwebkit is not part of the qt5core lib and therefore a requirement for the project to build in the rest of the OSS