### PR TITLE
ChunkingNG: add '0' padding on the filename

### DIFF
--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -300,7 +300,8 @@ private:
 
     // Map chunk number with its size  from the PROPFIND on resume.
     // (Only used from slotPropfindIterate/slotPropfindFinished because the LsColJob use signals to report data.)
-    QMap<int, quint64> _serverChunks;
+    struct ServerChunkInfo { quint64 size; QString originalName; };
+    QMap<int, ServerChunkInfo> _serverChunks;
 
     quint64 chunkSize() const { return propagator()->chunkSize(); }
     /**

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -589,9 +589,10 @@ public:
         char payload = '*';
 
         do {
-            if (!sourceFolder->children.contains(QString::number(count)))
+            QString chunkName = QString::number(count).rightJustified(8, '0');
+            if (!sourceFolder->children.contains(chunkName))
                 break;
-            auto &x = sourceFolder->children[QString::number(count)];
+            auto &x = sourceFolder->children[chunkName];
             Q_ASSERT(!x.isDir);
             Q_ASSERT(x.size > 0); // There should not be empty chunks
             size += x.size;


### PR DESCRIPTION
The server sorts the chunk by name alphabetically. So if we want to keep
the chunk in order, we need to add a few '0' in front of the chunk name