### PR TITLE
Shib: Use different keychain entry per account #5469

### DIFF
--- a/src/gui/creds/shibbolethcredentials.cpp
+++ b/src/gui/creds/shibbolethcredentials.cpp
@@ -130,7 +130,7 @@ void ShibbolethCredentials::fetchFromKeychain()
         ReadPasswordJob *job = new ReadPasswordJob(Theme::instance()->appName());
         job->setSettings(Utility::settingsWithGroup(Theme::instance()->appName(), job).release());
         job->setInsecureFallback(false);
-        job->setKey(keychainKey(_account->url().toString(), "shibAssertion"));
+        job->setKey(keychainKey(_account->url().toString(), user()));
         connect(job, SIGNAL(finished(QKeychain::Job*)), SLOT(slotReadJobDone(QKeychain::Job*)));
         job->start();
     }
@@ -309,7 +309,7 @@ void ShibbolethCredentials::storeShibCookie(const QNetworkCookie &cookie)
     job->setSettings(Utility::settingsWithGroup(Theme::instance()->appName(), job).release());
     // we don't really care if it works...
     //connect(job, SIGNAL(finished(QKeychain::Job*)), SLOT(slotWriteJobDone(QKeychain::Job*)));
-    job->setKey(keychainKey(_account->url().toString(), "shibAssertion"));
+    job->setKey(keychainKey(_account->url().toString(), user()));
     job->setTextData(QString::fromUtf8(cookie.toRawForm()));
     job->start();
 }
@@ -318,7 +318,7 @@ void ShibbolethCredentials::removeShibCookie()
 {
     DeletePasswordJob *job = new DeletePasswordJob(Theme::instance()->appName());
     job->setSettings(Utility::settingsWithGroup(Theme::instance()->appName(), job).release());
-    job->setKey(keychainKey(_account->url().toString(), "shibAssertion"));
+    job->setKey(keychainKey(_account->url().toString(), user()));
     job->start();
 }
 


### PR DESCRIPTION
Previously shib multiaccount didn't work at all because the
session cookie was stored in the same keychain entry.