### PR TITLE
Delete SyncFileItems after propagation

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -692,10 +692,9 @@ bool Folder::setIgnoredFiles()
     // a QSet of files to load.
     ConfigFile cfg;
     QString systemList = cfg.excludeFile(ConfigFile::SystemScope);
-    if( QFile::exists(systemList) ) {
-        qDebug() << "==== adding system ignore list to csync:" << systemList;
-        _engine->excludedFiles().addExcludeFilePath(systemList);
-    }
+    qDebug() << "==== adding system ignore list to csync:" << systemList;
+    _engine->excludedFiles().addExcludeFilePath(systemList);
+
     QString userList = cfg.excludeFile(ConfigFile::UserScope);
     if( QFile::exists(userList) ) {
         qDebug() << "==== adding user defined ignore list to csync:" << userList;
@@ -739,6 +738,8 @@ void Folder::startSync(const QStringList &pathList)
     qDebug() << "*** Start syncing " << remoteUrl().toString() << " - client version"
              << qPrintable(Theme::instance()->version());
 
+    _fileLog->start(path());
+
     if (!setIgnoredFiles())
     {
         slotSyncError(tr("Could not read system exclude file"));
@@ -754,8 +755,6 @@ void Folder::startSync(const QStringList &pathList)
     _engine->setNewBigFolderSizeLimit(limit);
 
     _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
-
-    _fileLog->start(path());
 
     QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -102,8 +102,8 @@ Folder::Folder(const FolderDefinition& definition,
             SLOT(slotAboutToRestoreBackup(bool*)));
     connect(_engine.data(), SIGNAL(folderDiscovered(bool,QString)), this, SLOT(slotFolderDiscovered(bool,QString)));
     connect(_engine.data(), SIGNAL(transmissionProgress(ProgressInfo)), this, SLOT(slotTransmissionProgress(ProgressInfo)));
-    connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
-            this, SLOT(slotItemCompleted(const SyncFileItem &, const PropagatorJob &)));
+    connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
+            this, SLOT(slotItemCompleted(const SyncFileItem &)));
     connect(_engine.data(), SIGNAL(newBigFolder(QString)), this, SLOT(slotNewBigFolderDiscovered(QString)));
     connect(_engine.data(), SIGNAL(seenLockedFile(QString)), FolderMan::instance(), SLOT(slotSyncOnceFileUnlocks(QString)));
     connect(_engine.data(), SIGNAL(aboutToPropagate(SyncFileItemVector&)),
@@ -917,14 +917,14 @@ void Folder::slotTransmissionProgress(const ProgressInfo &pi)
 }
 
 // a item is completed: count the errors and forward to the ProgressDispatcher
-void Folder::slotItemCompleted(const SyncFileItem &item, const PropagatorJob& job)
+void Folder::slotItemCompleted(const SyncFileItem &item)
 {
     if (Progress::isWarningKind(item._status)) {
         // Count all error conditions.
         _syncResult.setWarnCount(_syncResult.warnCount()+1);
     }
     _fileLog->logItem(item);
-    emit ProgressDispatcher::instance()->itemCompleted(alias(), item, job);
+    emit ProgressDispatcher::instance()->itemCompleted(alias(), item);
 }
 
 void Folder::slotNewBigFolderDiscovered(const QString &newF)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -102,8 +102,8 @@ Folder::Folder(const FolderDefinition& definition,
             SLOT(slotAboutToRestoreBackup(bool*)));
     connect(_engine.data(), SIGNAL(folderDiscovered(bool,QString)), this, SLOT(slotFolderDiscovered(bool,QString)));
     connect(_engine.data(), SIGNAL(transmissionProgress(ProgressInfo)), this, SLOT(slotTransmissionProgress(ProgressInfo)));
-    connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
-            this, SLOT(slotItemCompleted(const SyncFileItem &)));
+    connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
+            this, SLOT(slotItemCompleted(const SyncFileItemPtr &)));
     connect(_engine.data(), SIGNAL(newBigFolder(QString)), this, SLOT(slotNewBigFolderDiscovered(QString)));
     connect(_engine.data(), SIGNAL(seenLockedFile(QString)), FolderMan::instance(), SLOT(slotSyncOnceFileUnlocks(QString)));
     connect(_engine.data(), SIGNAL(aboutToPropagate(SyncFileItemVector&)),
@@ -917,13 +917,13 @@ void Folder::slotTransmissionProgress(const ProgressInfo &pi)
 }
 
 // a item is completed: count the errors and forward to the ProgressDispatcher
-void Folder::slotItemCompleted(const SyncFileItem &item)
+void Folder::slotItemCompleted(const SyncFileItemPtr &item)
 {
-    if (Progress::isWarningKind(item._status)) {
+    if (Progress::isWarningKind(item->_status)) {
         // Count all error conditions.
         _syncResult.setWarnCount(_syncResult.warnCount()+1);
     }
-    _fileLog->logItem(item);
+    _fileLog->logItem(*item);
     emit ProgressDispatcher::instance()->itemCompleted(alias(), item);
 }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -286,8 +286,6 @@ private slots:
     void etagRetreived(const QString &);
     void etagRetreivedFromSyncEngine(const QString &);
 
-    void slotThreadTreeWalkResult(const SyncFileItemVector& ); // after sync is done
-
     void slotEmitFinishedDelayed();
 
     void slotNewBigFolderDiscovered(const QString &);
@@ -302,7 +300,7 @@ private slots:
 private:
     bool setIgnoredFiles();
 
-    void bubbleUpSyncResult();
+    void showSyncResultPopup();
 
     void checkLocalPath();
 
@@ -325,8 +323,6 @@ private:
 
     SyncResult _syncResult;
     QScopedPointer<SyncEngine> _engine;
-    QStringList  _errors;
-    bool         _csyncError;
     bool         _csyncUnavail;
     bool         _wipeDb;
     bool         _proxyDirty;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -280,7 +280,7 @@ private slots:
 
     void slotFolderDiscovered(bool local, QString folderName);
     void slotTransmissionProgress(const ProgressInfo& pi);
-    void slotItemCompleted(const SyncFileItem&, const PropagatorJob&);
+    void slotItemCompleted(const SyncFileItem&);
 
     void slotRunEtagJob();
     void etagRetreived(const QString &);

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -280,7 +280,7 @@ private slots:
 
     void slotFolderDiscovered(bool local, QString folderName);
     void slotTransmissionProgress(const ProgressInfo& pi);
-    void slotItemCompleted(const SyncFileItem&);
+    void slotItemCompleted(const SyncFileItemPtr&);
 
     void slotRunEtagJob();
     void etagRetreived(const QString &);

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1121,7 +1121,7 @@ void FolderMan::setDirtyNetworkLimits()
 
 SyncResult FolderMan::accountStatus(const QList<Folder*> &folders)
 {
-    SyncResult overallResult(SyncResult::Undefined);
+    SyncResult overallResult;
 
     int cnt = folders.count();
 
@@ -1235,10 +1235,10 @@ SyncResult FolderMan::accountStatus(const QList<Folder*> &folders)
     return overallResult;
 }
 
-QString FolderMan::statusToString( SyncResult syncStatus, bool paused ) const
+QString FolderMan::statusToString( SyncResult::Status syncStatus, bool paused ) const
 {
     QString folderMessage;
-    switch( syncStatus.status() ) {
+    switch( syncStatus ) {
     case SyncResult::Undefined:
         folderMessage = tr( "Undefined State." );
         break;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -106,7 +106,7 @@ public:
     /** Creates a new and empty local directory. */
     bool startFromScratch( const QString& );
 
-    QString statusToString(SyncResult, bool paused ) const;
+    QString statusToString(SyncResult::Status, bool paused ) const;
 
     static SyncResult accountStatus( const QList<Folder*> &folders );
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -1012,18 +1012,10 @@ void FolderStatusModel::slotFolderSyncStateChange(Folder *f)
     // update the icon etc. now
     slotUpdateFolderState(f);
 
-    if (state == SyncResult::Success) {
-        foreach (const SyncFileItemPtr &i, f->syncResult().syncFileItemVector()) {
-            if (i->_isDirectory && (i->_instruction == CSYNC_INSTRUCTION_NEW
-                    || i->_instruction == CSYNC_INSTRUCTION_TYPE_CHANGE
-                    || i->_instruction == CSYNC_INSTRUCTION_REMOVE
-                    || i->_instruction == CSYNC_INSTRUCTION_RENAME)) {
-                // There is a new or a removed folder. reset all data
-                auto & info = _folders[folderIndex];
-                info.resetSubs(this, index(folderIndex));
-                return;
-            }
-        }
+    if (state == SyncResult::Success && f->syncResult().folderStructureWasChanged()) {
+        // There is a new or a removed folder. reset all data
+        auto & info = _folders[folderIndex];
+        info.resetSubs(this, index(folderIndex));
     }
 }
 

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -44,8 +44,8 @@ ProtocolWidget::ProtocolWidget(QWidget *parent) :
 
     connect(ProgressDispatcher::instance(), SIGNAL(progressInfo(QString,ProgressInfo)),
             this, SLOT(slotProgressInfo(QString,ProgressInfo)));
-    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString,SyncFileItem)),
-            this, SLOT(slotItemCompleted(QString,SyncFileItem)));
+    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString,SyncFileItemPtr)),
+            this, SLOT(slotItemCompleted(QString,SyncFileItemPtr)));
 
     connect(_ui->_treeWidget, SIGNAL(itemActivated(QTreeWidgetItem*,int)), SLOT(slotOpenFile(QTreeWidgetItem*,int)));
 
@@ -221,11 +221,11 @@ void ProtocolWidget::slotProgressInfo( const QString& folder, const ProgressInfo
     }
 }
 
-void ProtocolWidget::slotItemCompleted(const QString &folder, const SyncFileItem &item)
+void ProtocolWidget::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
 {
-    QTreeWidgetItem *line = createCompletedTreewidgetItem(folder, item);
+    QTreeWidgetItem *line = createCompletedTreewidgetItem(folder, *item);
     if(line) {
-       if( item.hasErrorStatus() ) {
+       if( item->hasErrorStatus() ) {
             _issueItemView->insertTopLevelItem(0, line);
             emit issueItemCountUpdated(_issueItemView->topLevelItemCount());
         } else {

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -27,7 +27,6 @@
 #include "syncfileitem.h"
 #include "folder.h"
 #include "openfilemanager.h"
-#include "owncloudpropagator.h"
 #include "activityitemdelegate.h"
 
 #include "ui_protocolwidget.h"
@@ -45,8 +44,8 @@ ProtocolWidget::ProtocolWidget(QWidget *parent) :
 
     connect(ProgressDispatcher::instance(), SIGNAL(progressInfo(QString,ProgressInfo)),
             this, SLOT(slotProgressInfo(QString,ProgressInfo)));
-    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString,SyncFileItem,PropagatorJob)),
-            this, SLOT(slotItemCompleted(QString,SyncFileItem,PropagatorJob)));
+    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString,SyncFileItem)),
+            this, SLOT(slotItemCompleted(QString,SyncFileItem)));
 
     connect(_ui->_treeWidget, SIGNAL(itemActivated(QTreeWidgetItem*,int)), SLOT(slotOpenFile(QTreeWidgetItem*,int)));
 
@@ -222,12 +221,8 @@ void ProtocolWidget::slotProgressInfo( const QString& folder, const ProgressInfo
     }
 }
 
-void ProtocolWidget::slotItemCompleted(const QString &folder, const SyncFileItem &item, const PropagatorJob &job)
+void ProtocolWidget::slotItemCompleted(const QString &folder, const SyncFileItem &item)
 {
-    if (qobject_cast<const PropagateDirectory*>(&job)) {
-        return;
-    }
-
     QTreeWidgetItem *line = createCompletedTreewidgetItem(folder, item);
     if(line) {
        if( item.hasErrorStatus() ) {

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -52,7 +52,7 @@ public:
 
 public slots:
     void slotProgressInfo( const QString& folder, const ProgressInfo& progress );
-    void slotItemCompleted( const QString& folder, const SyncFileItem& item);
+    void slotItemCompleted( const QString& folder, const SyncFileItemPtr& item);
     void slotOpenFile( QTreeWidgetItem* item, int );
 
 protected:

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -52,7 +52,7 @@ public:
 
 public slots:
     void slotProgressInfo( const QString& folder, const ProgressInfo& progress );
-    void slotItemCompleted( const QString& folder, const SyncFileItem& item, const PropagatorJob& job);
+    void slotItemCompleted( const QString& folder, const SyncFileItem& item);
     void slotOpenFile( QTreeWidgetItem* item, int );
 
 protected:

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -172,7 +172,7 @@ void PropagateItemJob::done(SyncFileItem::Status status, const QString &errorStr
 
     _item->_status = status;
 
-    emit itemCompleted(*_item, *this);
+    emit itemCompleted(*_item);
     emit finished(status);
 }
 
@@ -221,7 +221,7 @@ bool PropagateItemJob::checkForProblemsWithShared(int httpStatusCode, const QStr
         if( newJob )  {
             newJob->setRestoreJobMsg(msg);
             _restoreJob.reset(newJob);
-            connect(_restoreJob.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &, const PropagatorJob &)),
+            connect(_restoreJob.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
                     this, SLOT(slotRestoreJobCompleted(const SyncFileItemPtr &)));
             QMetaObject::invokeMethod(newJob, "start");
         }
@@ -403,8 +403,8 @@ void OwncloudPropagator::start(const SyncFileItemVector& items)
         _rootJob->append(it);
     }
 
-    connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
-            this, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+    connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
+            this, SIGNAL(itemCompleted(const SyncFileItem &)));
     connect(_rootJob.data(), SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
     connect(_rootJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(emitFinished(SyncFileItem::Status)));
     connect(_rootJob.data(), SIGNAL(ready()), this, SLOT(scheduleNextJob()), Qt::QueuedConnection);

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -172,7 +172,7 @@ void PropagateItemJob::done(SyncFileItem::Status status, const QString &errorStr
 
     _item->_status = status;
 
-    emit itemCompleted(*_item);
+    emit itemCompleted(_item);
     emit finished(status);
 }
 
@@ -403,8 +403,8 @@ void OwncloudPropagator::start(const SyncFileItemVector& items)
         _rootJob->append(it);
     }
 
-    connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
-            this, SIGNAL(itemCompleted(const SyncFileItem &)));
+    connect(_rootJob.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
+            this, SIGNAL(itemCompleted(const SyncFileItemPtr &)));
     connect(_rootJob.data(), SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
     connect(_rootJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(emitFinished(SyncFileItem::Status)));
     connect(_rootJob.data(), SIGNAL(ready()), this, SLOT(scheduleNextJob()), Qt::QueuedConnection);

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -114,7 +114,7 @@ signals:
     /**
      * Emitted when one item has been completed within a job.
      */
-    void itemCompleted(const SyncFileItem &);
+    void itemCompleted(const SyncFileItemPtr &);
 
     /**
      * Emitted when all the sub-jobs have been finished and
@@ -231,7 +231,7 @@ private slots:
     bool possiblyRunNextJob(PropagatorJob *next) {
         if (next->_state == NotYetStarted) {
             connect(next, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobFinished(SyncFileItem::Status)), Qt::QueuedConnection);
-            connect(next, SIGNAL(itemCompleted(const SyncFileItem &)), this, SIGNAL(itemCompleted(const SyncFileItem &)));
+            connect(next, SIGNAL(itemCompleted(const SyncFileItemPtr &)), this, SIGNAL(itemCompleted(const SyncFileItemPtr &)));
             connect(next, SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
             connect(next, SIGNAL(ready()), this, SIGNAL(ready()));
             _runningNow++;
@@ -355,7 +355,7 @@ private slots:
     void scheduleNextJob();
 
 signals:
-    void itemCompleted(const SyncFileItem &);
+    void itemCompleted(const SyncFileItemPtr &);
     void progress(const SyncFileItem&, quint64 bytes);
     void finished(bool success);
 

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -114,7 +114,7 @@ signals:
     /**
      * Emitted when one item has been completed within a job.
      */
-    void itemCompleted(const SyncFileItem &, const PropagatorJob &);
+    void itemCompleted(const SyncFileItem &);
 
     /**
      * Emitted when all the sub-jobs have been finished and
@@ -231,8 +231,7 @@ private slots:
     bool possiblyRunNextJob(PropagatorJob *next) {
         if (next->_state == NotYetStarted) {
             connect(next, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobFinished(SyncFileItem::Status)), Qt::QueuedConnection);
-            connect(next, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
-                    this, SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+            connect(next, SIGNAL(itemCompleted(const SyncFileItem &)), this, SIGNAL(itemCompleted(const SyncFileItem &)));
             connect(next, SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
             connect(next, SIGNAL(ready()), this, SIGNAL(ready()));
             _runningNow++;
@@ -356,7 +355,7 @@ private slots:
     void scheduleNextJob();
 
 signals:
-    void itemCompleted(const SyncFileItem &, const PropagatorJob &);
+    void itemCompleted(const SyncFileItem &);
     void progress(const SyncFileItem&, quint64 bytes);
     void finished(bool success);
 

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -250,7 +250,7 @@ signals:
     /**
      * @brief: the item was completed by a job
      */
-    void itemCompleted(const QString &folder, const SyncFileItem & item);
+    void itemCompleted(const QString &folder, const SyncFileItemPtr & item);
 
 protected:
     void setProgressInfo(const QString& folder, const ProgressInfo& progress);

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -28,8 +28,6 @@
 
 namespace OCC {
 
-class PropagatorJob;
-
 /**
  * @brief The ProgressInfo class
  * @ingroup libsync
@@ -252,9 +250,7 @@ signals:
     /**
      * @brief: the item was completed by a job
      */
-    void itemCompleted(const QString &folder,
-                       const SyncFileItem & item,
-                       const PropagatorJob & job);
+    void itemCompleted(const QString &folder, const SyncFileItem & item);
 
 protected:
     void setProgressInfo(const QString& folder, const ProgressInfo& progress);

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -76,6 +76,7 @@ SyncEngine::SyncEngine(AccountPtr account, const QString& localPath,
   , _anotherSyncNeeded(NoFollowUpSync)
 {
     qRegisterMetaType<SyncFileItem>("SyncFileItem");
+    qRegisterMetaType<SyncFileItemPtr>("SyncFileItemPtr");
     qRegisterMetaType<SyncFileItem::Status>("SyncFileItem::Status");
     qRegisterMetaType<SyncFileStatus>("SyncFileStatus");
     qRegisterMetaType<SyncFileItemVector>("SyncFileItemVector");
@@ -994,8 +995,8 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
 
     _propagator = QSharedPointer<OwncloudPropagator>(
         new OwncloudPropagator (_account, _localPath, _remotePath, _journal));
-    connect(_propagator.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
-            this, SLOT(slotItemCompleted(const SyncFileItem &)));
+    connect(_propagator.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
+            this, SLOT(slotItemCompleted(const SyncFileItemPtr &)));
     connect(_propagator.data(), SIGNAL(progress(const SyncFileItem &,quint64)),
             this, SLOT(slotProgress(const SyncFileItem &,quint64)));
     connect(_propagator.data(), SIGNAL(finished(bool)), this, SLOT(slotFinished(bool)), Qt::QueuedConnection);
@@ -1051,15 +1052,15 @@ void SyncEngine::setNetworkLimits(int upload, int download)
     }
 }
 
-void SyncEngine::slotItemCompleted(const SyncFileItem &item)
+void SyncEngine::slotItemCompleted(const SyncFileItemPtr &item)
 {
-    const char * instruction_str = csync_instruction_str(item._instruction);
-    qDebug() << Q_FUNC_INFO << item._file << instruction_str << item._status << item._errorString;
+    const char * instruction_str = csync_instruction_str(item->_instruction);
+    qDebug() << Q_FUNC_INFO << item->_file << instruction_str << item->_status << item->_errorString;
 
-    _progressInfo->setProgressComplete(item);
+    _progressInfo->setProgressComplete(*item);
 
-    if (item._status == SyncFileItem::FatalError) {
-        emit csyncError(item._errorString);
+    if (item->_status == SyncFileItem::FatalError) {
+        emit csyncError(item->_errorString);
     }
 
     emit transmissionProgress(*_progressInfo);

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -994,8 +994,8 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
 
     _propagator = QSharedPointer<OwncloudPropagator>(
         new OwncloudPropagator (_account, _localPath, _remotePath, _journal));
-    connect(_propagator.data(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)),
-            this, SLOT(slotItemCompleted(const SyncFileItem &, const PropagatorJob &)));
+    connect(_propagator.data(), SIGNAL(itemCompleted(const SyncFileItem &)),
+            this, SLOT(slotItemCompleted(const SyncFileItem &)));
     connect(_propagator.data(), SIGNAL(progress(const SyncFileItem &,quint64)),
             this, SLOT(slotProgress(const SyncFileItem &,quint64)));
     connect(_propagator.data(), SIGNAL(finished(bool)), this, SLOT(slotFinished(bool)), Qt::QueuedConnection);
@@ -1051,7 +1051,7 @@ void SyncEngine::setNetworkLimits(int upload, int download)
     }
 }
 
-void SyncEngine::slotItemCompleted(const SyncFileItem &item, const PropagatorJob &job)
+void SyncEngine::slotItemCompleted(const SyncFileItem &item)
 {
     const char * instruction_str = csync_instruction_str(item._instruction);
     qDebug() << Q_FUNC_INFO << item._file << instruction_str << item._status << item._errorString;
@@ -1063,7 +1063,7 @@ void SyncEngine::slotItemCompleted(const SyncFileItem &item, const PropagatorJob
     }
 
     emit transmissionProgress(*_progressInfo);
-    emit itemCompleted(item, job);
+    emit itemCompleted(item);
 }
 
 void SyncEngine::slotFinished(bool success)

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -267,11 +267,11 @@ bool SyncEngine::checkErrorBlacklisting( SyncFileItem &item )
     return true;
 }
 
-void SyncEngine::deleteStaleDownloadInfos()
+void SyncEngine::deleteStaleDownloadInfos(const SyncFileItemVector &syncItems)
 {
     // Find all downloadinfo paths that we want to preserve.
     QSet<QString> download_file_paths;
-    foreach(const SyncFileItemPtr &it, _syncedItems) {
+    foreach(const SyncFileItemPtr &it, syncItems) {
         if (it->_direction == SyncFileItem::Down
                 && it->_type == SyncFileItem::File)
         {
@@ -289,11 +289,11 @@ void SyncEngine::deleteStaleDownloadInfos()
     }
 }
 
-void SyncEngine::deleteStaleUploadInfos()
+void SyncEngine::deleteStaleUploadInfos(const SyncFileItemVector &syncItems)
 {
     // Find all blacklisted paths that we want to preserve.
     QSet<QString> upload_file_paths;
-    foreach(const SyncFileItemPtr &it, _syncedItems) {
+    foreach(const SyncFileItemPtr &it, syncItems) {
         if (it->_direction == SyncFileItem::Up
                 && it->_type == SyncFileItem::File)
         {
@@ -305,11 +305,11 @@ void SyncEngine::deleteStaleUploadInfos()
     _journal->deleteStaleUploadInfos(upload_file_paths);
 }
 
-void SyncEngine::deleteStaleErrorBlacklistEntries()
+void SyncEngine::deleteStaleErrorBlacklistEntries(const SyncFileItemVector &syncItems)
 {
     // Find all blacklisted paths that we want to preserve.
     QSet<QString> blacklist_file_paths;
-    foreach(const SyncFileItemPtr &it, _syncedItems) {
+    foreach(const SyncFileItemPtr &it, syncItems) {
         if (it->_hasBlacklistEntry)
             blacklist_file_paths.insert(it->_file);
     }
@@ -744,7 +744,6 @@ void SyncEngine::startSync()
         qDebug() << "Could not determine free space available at" << _localPath;
     }
 
-    _syncedItems.clear();
     _syncItemMap.clear();
     _needsUpdate = false;
 
@@ -912,12 +911,12 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     csync_commit(_csync_ctx);
 
     // The map was used for merging trees, convert it to a list:
-    _syncedItems = _syncItemMap.values().toVector();
+    SyncFileItemVector syncItems = _syncItemMap.values().toVector();
     _syncItemMap.clear(); // free memory
 
     // Adjust the paths for the renames.
-    for (SyncFileItemVector::iterator it = _syncedItems.begin();
-            it != _syncedItems.end(); ++it) {
+    for (SyncFileItemVector::iterator it = syncItems.begin();
+            it != syncItems.end(); ++it) {
         (*it)->_file = adjustRenamedPath((*it)->_file);
     }
 
@@ -925,7 +924,7 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     if (_account->serverVersionInt() < 0x080100) {
         // Server version older than 8.1 don't support these character in filename.
         static const QRegExp invalidCharRx("[\\\\:?*\"<>|]");
-        for (auto it = _syncedItems.begin(); it != _syncedItems.end(); ++it) {
+        for (auto it = syncItems.begin(); it != syncItems.end(); ++it) {
             if ((*it)->_direction == SyncFileItem::Up &&
                     (*it)->destination().contains(invalidCharRx)) {
                 (*it)->_errorString  = tr("File name contains at least one invalid character");
@@ -937,7 +936,7 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     if (!_hasNoneFiles && _hasRemoveFile) {
         qDebug() << Q_FUNC_INFO << "All the files are going to be changed, asking the user";
         bool cancel = false;
-        emit aboutToRemoveAllFiles(_syncedItems.first()->_direction, &cancel);
+        emit aboutToRemoveAllFiles(syncItems.first()->_direction, &cancel);
         if (cancel) {
             qDebug() << Q_FUNC_INFO << "Abort sync";
             finalize(false);
@@ -952,7 +951,7 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     if (!databaseFingerprint.isNull()
             && _discoveryMainThread->_dataFingerprint != databaseFingerprint) {
         qDebug() << "data fingerprint changed, assume restore from backup" << databaseFingerprint << _discoveryMainThread->_dataFingerprint;
-        restoreOldFiles();
+        restoreOldFiles(syncItems);
     } else if (!_hasForwardInTimeFiles && _backInTimeFiles >= 2 && _account->serverVersionInt() < 0x090100) {
         // The server before ownCloud 9.1 did not have the data-fingerprint property. So in that
         // case we use heuristics to detect restored backup.  This is disabled with newer version
@@ -962,18 +961,18 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
         bool restore = false;
         emit aboutToRestoreBackup(&restore);
         if (restore) {
-            restoreOldFiles();
+            restoreOldFiles(syncItems);
         }
     }
 
     // Sort items per destination
-    std::sort(_syncedItems.begin(), _syncedItems.end());
+    std::sort(syncItems.begin(), syncItems.end());
 
     // make sure everything is allowed
-    checkForPermission();
+    checkForPermission(syncItems);
 
     // To announce the beginning of the sync
-    emit aboutToPropagate(_syncedItems);
+    emit aboutToPropagate(syncItems);
     // it's important to do this before ProgressInfo::start(), to announce start of new sync
     emit transmissionProgress(*_progressInfo);
     _progressInfo->startEstimateUpdates();
@@ -1006,16 +1005,16 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     // apply the network limits to the propagator
     setNetworkLimits(_uploadLimit, _downloadLimit);
 
-    deleteStaleDownloadInfos();
-    deleteStaleUploadInfos();
-    deleteStaleErrorBlacklistEntries();
+    deleteStaleDownloadInfos(syncItems);
+    deleteStaleUploadInfos(syncItems);
+    deleteStaleErrorBlacklistEntries(syncItems);
     _journal->commit("post stale entry removal");
 
     // Emit the started signal only after the propagator has been set up.
     if (_needsUpdate)
         emit(started());
 
-    _propagator->start(_syncedItems);
+    _propagator->start(syncItems);
 
     qDebug() << "<<#### Post-Reconcile end #################################################### " << _stopWatch.addLapTime(QLatin1String("Post-Reconcile Finished"));
 }
@@ -1088,7 +1087,6 @@ void SyncEngine::slotFinished(bool success)
     // files needed propagation
     emit transmissionProgress(*_progressInfo);
 
-    emit treeWalkResult(_syncedItems);
     finalize(success);
 }
 
@@ -1138,13 +1136,13 @@ QString SyncEngine::adjustRenamedPath(const QString& original)
  * Make sure that we are allowed to do what we do by checking the permissions and the selective sync list
  *
  */
-void SyncEngine::checkForPermission()
+void SyncEngine::checkForPermission(SyncFileItemVector &syncItems)
 {
     bool selectiveListOk;
     auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &selectiveListOk);
     std::sort(selectiveSyncBlackList.begin(), selectiveSyncBlackList.end());
 
-    for (SyncFileItemVector::iterator it = _syncedItems.begin(); it != _syncedItems.end(); ++it) {
+    for (SyncFileItemVector::iterator it = syncItems.begin(); it != syncItems.end(); ++it) {
         if ((*it)->_direction != SyncFileItem::Up) {
             // Currently we only check server-side permissions
             continue;
@@ -1161,7 +1159,7 @@ void SyncEngine::checkForPermission()
             (*it)->_errorString = tr("Ignored because of the \"choose what to sync\" blacklist");
 
             if ((*it)->_isDirectory) {
-                for (SyncFileItemVector::iterator it_next = it + 1; it_next != _syncedItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
+                for (SyncFileItemVector::iterator it_next = it + 1; it_next != syncItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
                     it = it_next;
                     (*it)->_instruction = CSYNC_INSTRUCTION_IGNORE;
                     (*it)->_status = SyncFileItem::FileIgnored;
@@ -1186,7 +1184,7 @@ void SyncEngine::checkForPermission()
                     (*it)->_status = SyncFileItem::NormalError;
                     (*it)->_errorString = tr("Not allowed because you don't have permission to add subfolders to that folder");
 
-                    for (SyncFileItemVector::iterator it_next = it + 1; it_next != _syncedItems.end() && (*it_next)->destination().startsWith(path); ++it_next) {
+                    for (SyncFileItemVector::iterator it_next = it + 1; it_next != syncItems.end() && (*it_next)->destination().startsWith(path); ++it_next) {
                         it = it_next;
                         if ((*it)->_instruction == CSYNC_INSTRUCTION_RENAME) {
                             // The file was most likely moved in this directory.
@@ -1246,7 +1244,7 @@ void SyncEngine::checkForPermission()
                     if ((*it)->_isDirectory) {
                         // restore all sub items
                         for (SyncFileItemVector::iterator it_next = it + 1;
-                             it_next != _syncedItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
+                             it_next != syncItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
                             it = it_next;
 
                             if ((*it)->_instruction != CSYNC_INSTRUCTION_REMOVE) {
@@ -1272,12 +1270,12 @@ void SyncEngine::checkForPermission()
                     // underneath, propagator sees that.
                     if( (*it)->_isDirectory ) {
                         // put a more descriptive message if a top level share dir really is removed.
-                        if( it == _syncedItems.begin() || !(path.startsWith((*(it-1))->_file)) ) {
+                        if( it == syncItems.begin() || !(path.startsWith((*(it-1))->_file)) ) {
                             (*it)->_errorString = tr("Local files and share folder removed.");
                         }
 
                         for (SyncFileItemVector::iterator it_next = it + 1;
-                             it_next != _syncedItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
+                             it_next != syncItems.end() && (*it_next)->_file.startsWith(path); ++it_next) {
                             it = it_next;
                         }
                     }
@@ -1356,7 +1354,7 @@ void SyncEngine::checkForPermission()
 
                     if ((*it)->_isDirectory) {
                         for (SyncFileItemVector::iterator it_next = it + 1;
-                             it_next != _syncedItems.end() && (*it_next)->destination().startsWith(path); ++it_next) {
+                             it_next != syncItems.end() && (*it_next)->destination().startsWith(path); ++it_next) {
                             it = it_next;
                             (*it)->_instruction = CSYNC_INSTRUCTION_ERROR;
                             (*it)->_status = SyncFileItem::NormalError;
@@ -1385,7 +1383,7 @@ QByteArray SyncEngine::getPermissions(const QString& file) const
     return _remotePerms.value(file);
 }
 
-void SyncEngine::restoreOldFiles()
+void SyncEngine::restoreOldFiles(SyncFileItemVector &syncItems)
 {
     /* When the server is trying to send us lots of file in the past, this means that a backup
        was restored in the server.  In that case, we should not simply overwrite the newer file
@@ -1393,7 +1391,7 @@ void SyncEngine::restoreOldFiles()
        upload the client file. But we still downloaded the old file in a conflict file just in case
     */
 
-    for (auto it = _syncedItems.begin(); it != _syncedItems.end(); ++it) {
+    for (auto it = syncItems.begin(); it != syncItems.end(); ++it) {
         if ((*it)->_direction != SyncFileItem::Down)
             continue;
 

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -121,7 +121,7 @@ signals:
     void aboutToPropagate(SyncFileItemVector&);
 
     // after each item completed by a job (successful or not)
-    void itemCompleted(const SyncFileItem&);
+    void itemCompleted(const SyncFileItemPtr&);
 
     // after sync is done
     void treeWalkResult(const SyncFileItemVector&);
@@ -155,7 +155,7 @@ signals:
 
 private slots:
     void slotRootEtagReceived(const QString &);
-    void slotItemCompleted(const SyncFileItem& item);
+    void slotItemCompleted(const SyncFileItemPtr& item);
     void slotFinished(bool success);
     void slotProgress(const SyncFileItem& item, quint64 curent);
     void slotDiscoveryJobFinished(int updateResult);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -47,7 +47,6 @@ namespace OCC {
 class SyncJournalFileRecord;
 class SyncJournalDb;
 class OwncloudPropagator;
-class PropagatorJob;
 
 enum AnotherSyncNeeded
 {
@@ -122,7 +121,7 @@ signals:
     void aboutToPropagate(SyncFileItemVector&);
 
     // after each item completed by a job (successful or not)
-    void itemCompleted(const SyncFileItem&, const PropagatorJob&);
+    void itemCompleted(const SyncFileItem&);
 
     // after sync is done
     void treeWalkResult(const SyncFileItemVector&);
@@ -156,7 +155,7 @@ signals:
 
 private slots:
     void slotRootEtagReceived(const QString &);
-    void slotItemCompleted(const SyncFileItem& item, const PropagatorJob & job);
+    void slotItemCompleted(const SyncFileItem& item);
     void slotFinished(bool success);
     void slotProgress(const SyncFileItem& item, quint64 curent);
     void slotDiscoveryJobFinished(int updateResult);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -123,9 +123,6 @@ signals:
     // after each item completed by a job (successful or not)
     void itemCompleted(const SyncFileItemPtr&);
 
-    // after sync is done
-    void treeWalkResult(const SyncFileItemVector&);
-
     void transmissionProgress( const ProgressInfo& progress );
 
     void finished(bool success);
@@ -179,13 +176,13 @@ private:
 
     // Cleans up unnecessary downloadinfo entries in the journal as well
     // as their temporary files.
-    void deleteStaleDownloadInfos();
+    void deleteStaleDownloadInfos(const SyncFileItemVector &syncItems);
 
     // Removes stale uploadinfos from the journal.
-    void deleteStaleUploadInfos();
+    void deleteStaleUploadInfos(const SyncFileItemVector &syncItems);
 
     // Removes stale error blacklist entries from the journal.
-    void deleteStaleErrorBlacklistEntries();
+    void deleteStaleErrorBlacklistEntries(const SyncFileItemVector &syncItems);
 
     // cleanup and emit the finished signal
     void finalize(bool success);
@@ -194,10 +191,6 @@ private:
 
     // Must only be acessed during update and reconcile
     QMap<QString, SyncFileItemPtr> _syncItemMap;
-
-    // should be called _syncItems (present tense). It's the items from the _syncItemMap but
-    // sorted and re-adjusted based on permissions.
-    SyncFileItemVector _syncedItems;
 
     AccountPtr _account;
     CSYNC *_csync_ctx;
@@ -240,13 +233,13 @@ private:
      * check if we are allowed to propagate everything, and if we are not, adjust the instructions
      * to recover
      */
-    void checkForPermission();
+    void checkForPermission(SyncFileItemVector &syncItems);
     QByteArray getPermissions(const QString& file) const;
 
     /**
      * Instead of downloading files from the server, upload the files to the server
      */
-    void restoreOldFiles();
+    void restoreOldFiles(SyncFileItemVector &syncItems);
 
     bool _hasNoneFiles; // true if there is at least one file which was not changed on the server
     bool _hasRemoveFile; // true if there is at leasr one file with instruction REMOVE

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -202,5 +202,6 @@ typedef QVector<SyncFileItemPtr> SyncFileItemVector;
 }
 
 Q_DECLARE_METATYPE(OCC::SyncFileItem)
+Q_DECLARE_METATYPE(OCC::SyncFileItemPtr)
 
 #endif // SYNCFILEITEM_H

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -77,7 +77,7 @@ SyncFileStatusTracker::SyncFileStatusTracker(SyncEngine *syncEngine)
 {
     connect(syncEngine, SIGNAL(aboutToPropagate(SyncFileItemVector&)),
             SLOT(slotAboutToPropagate(SyncFileItemVector&)));
-    connect(syncEngine, SIGNAL(itemCompleted(const SyncFileItem&, const PropagatorJob&)),
+    connect(syncEngine, SIGNAL(itemCompleted(const SyncFileItem&)),
             SLOT(slotItemCompleted(const SyncFileItem&)));
     connect(syncEngine, SIGNAL(finished(bool)), SLOT(slotSyncFinished()));
     connect(syncEngine, SIGNAL(started()), SLOT(slotSyncEngineRunningChanged()));

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -46,7 +46,7 @@ signals:
 
 private slots:
     void slotAboutToPropagate(SyncFileItemVector& items);
-    void slotItemCompleted(const SyncFileItem& item);
+    void slotItemCompleted(const SyncFileItemPtr& item);
     void slotSyncFinished();
     void slotSyncEngineRunningChanged();
 

--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -47,19 +47,12 @@ public:
     };
 
     SyncResult();
-    SyncResult( Status status );
-    ~SyncResult();
-    void    setErrorString( const QString& );
-    void    setErrorStrings( const QStringList& );
+    void reset();
+
+    void    appendErrorString( const QString& );
     QString errorString() const;
     QStringList errorStrings() const;
-    int     warnCount() const;
-    void    setWarnCount(int wc);
     void    clearErrors();
-
-    // handle a list of changed items.
-    void    setSyncFileItemVector( const SyncFileItemVector& );
-    SyncFileItemVector syncFileItemVector() const;
 
     void setStatus( Status );
     Status status() const;
@@ -67,6 +60,25 @@ public:
     QDateTime syncTime() const;
     void setFolder(const QString& folder);
     QString folder() const;
+
+    bool foundFilesNotSynced() const { return _foundFilesNotSynced; }
+    bool folderStructureWasChanged() const { return _folderStructureWasChanged; }
+
+    int numNewItems() const { return _numNewItems; }
+    int numRemovedItems() const { return _numRemovedItems; }
+    int numUpdatedItems() const { return _numUpdatedItems; }
+    int numRenamedItems() const { return _numRenamedItems; }
+    int numConflictItems() const { return _numConflictItems; }
+    int numErrorItems() const { return _numErrorItems; }
+
+    const SyncFileItemPtr& firstItemNew() const { return _firstItemNew; }
+    const SyncFileItemPtr& firstItemDeleted() const { return _firstItemDeleted; }
+    const SyncFileItemPtr& firstItemUpdated() const { return _firstItemUpdated; }
+    const SyncFileItemPtr& firstItemRenamed() const { return _firstItemRenamed; }
+    const SyncFileItemPtr& firstConflictItem() const { return _firstConflictItem; }
+    const SyncFileItemPtr& firstItemError() const { return _firstItemError; }
+
+    void processCompletedItem(const SyncFileItemPtr &item);
 
 private:
     Status             _status;
@@ -77,7 +89,23 @@ private:
      * when the sync tool support this...
      */
     QStringList        _errors;
-    int                _warnCount;
+    bool _foundFilesNotSynced;
+    bool _folderStructureWasChanged;
+
+    // count new, removed and updated items
+    int _numNewItems;
+    int _numRemovedItems;
+    int _numUpdatedItems;
+    int _numRenamedItems;
+    int _numConflictItems;
+    int _numErrorItems;
+
+    SyncFileItemPtr _firstItemNew;
+    SyncFileItemPtr _firstItemDeleted;
+    SyncFileItemPtr _firstItemUpdated;
+    SyncFileItemPtr _firstItemRenamed;
+    SyncFileItemPtr _firstConflictItem;
+    SyncFileItemPtr _firstItemError;
 };
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ if(HAVE_QT5 AND NOT BUILD_WITH_QT4)
     owncloud_add_test(SyncFileStatusTracker "syncenginetestutils.h")
     owncloud_add_test(ChunkingNg "syncenginetestutils.h")
     owncloud_add_test(UploadReset "syncenginetestutils.h")
+    owncloud_add_benchmark(LargeSync "syncenginetestutils.h")
 endif(HAVE_QT5 AND NOT BUILD_WITH_QT4)
 
 SET(FolderMan_SRC ../src/gui/folderman.cpp)

--- a/test/benchmarks/benchlargesync.cpp
+++ b/test/benchmarks/benchlargesync.cpp
@@ -1,0 +1,43 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include "syncenginetestutils.h"
+#include <syncengine.h>
+
+using namespace OCC;
+
+int numDirs = 0;
+int numFiles = 0;
+
+template<int filesPerDir, int dirPerDir, int maxDepth>
+void addBunchOfFiles(int depth, const QString &path, FileModifier &fi) {
+    for (int fileNum = 1; fileNum <= filesPerDir; ++fileNum) {
+        QString name = QStringLiteral("file") + QString::number(fileNum);
+        fi.insert(path.isEmpty() ? name : path + "/" + name);
+        numFiles++;
+    }
+    if (depth >= maxDepth)
+        return;
+    for (char dirNum = 1; dirNum <= dirPerDir; ++dirNum) {
+        QString name = QStringLiteral("dir") + QString::number(dirNum);
+        QString subPath = path.isEmpty() ? name : path + "/" + name;
+        fi.mkdir(subPath);
+        numDirs++;
+        addBunchOfFiles<filesPerDir, dirPerDir, maxDepth>(depth + 1, subPath, fi);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    FakeFolder fakeFolder{FileInfo{}};
+    addBunchOfFiles<10, 8, 4>(0, "", fakeFolder.localModifier());
+
+    qDebug() << "NUMFILES" << numFiles;
+    qDebug() << "NUMDIRS" << numDirs;
+    return fakeFolder.syncOnce() ? 0 : -1;
+}

--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -24,3 +24,30 @@ macro(owncloud_add_test test_class additional_cpp)
     add_definitions(-DOWNCLOUD_BIN_PATH=${CMAKE_BINARY_DIR}/bin)
     add_test(NAME ${OWNCLOUD_TEST_CLASS}Test COMMAND ${OWNCLOUD_TEST_CLASS}Test)
 endmacro()
+
+macro(owncloud_add_benchmark test_class additional_cpp)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+                        ${QT_INCLUDES}
+                        "${PROJECT_SOURCE_DIR}/src/gui"
+                        "${PROJECT_SOURCE_DIR}/src/libsync"
+                        "${CMAKE_BINARY_DIR}/src/libsync"
+                        "${CMAKE_CURRENT_BINARY_DIR}"
+                       )
+
+    set(CMAKE_AUTOMOC TRUE)
+    set(OWNCLOUD_TEST_CLASS ${test_class})
+    string(TOLOWER "${OWNCLOUD_TEST_CLASS}" OWNCLOUD_TEST_CLASS_LOWERCASE)
+
+    add_executable(${OWNCLOUD_TEST_CLASS}Bench benchmarks/bench${OWNCLOUD_TEST_CLASS_LOWERCASE}.cpp ${additional_cpp})
+    qt5_use_modules(${OWNCLOUD_TEST_CLASS}Bench Test Sql Xml Network)
+
+    target_link_libraries(${OWNCLOUD_TEST_CLASS}Bench
+        updater
+        ${APPLICATION_EXECUTABLE}sync
+        ${QT_QTTEST_LIBRARY}
+        ${QT_QTCORE_LIBRARY}
+    )
+
+    add_definitions(-DOWNCLOUD_TEST)
+    add_definitions(-DOWNCLOUD_BIN_PATH=${CMAKE_BINARY_DIR}/bin)
+endmacro()

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -267,6 +267,15 @@ public:
         return (parentPath.isEmpty() ? QString() : (parentPath + '/')) + name;
     }
 
+    void fixupParentPathRecursively() {
+        auto p = path();
+        for (auto it = children.begin(); it != children.end(); ++it) {
+            Q_ASSERT(it.key() == it->name);
+            it->parentPath = p;
+            it->fixupParentPathRecursively();
+        }
+    }
+
     QString name;
     bool isDir = true;
     bool isShared = false;
@@ -283,15 +292,6 @@ public:
 private:
     FileInfo *findInvalidatingEtags(const PathComponents &pathComponents) {
         return find(pathComponents, true);
-    }
-
-    void fixupParentPathRecursively() {
-        auto p = path();
-        for (auto it = children.begin(); it != children.end(); ++it) {
-            Q_ASSERT(it.key() == it->name);
-            it->parentPath = p;
-            it->fixupParentPathRecursively();
-        }
     }
 
     friend inline QDebug operator<<(QDebug dbg, const FileInfo& fi) {
@@ -766,6 +766,7 @@ public:
         QDir rootDir{_tempDir.path()};
         FileInfo rootTemplate;
         fromDisk(rootDir, rootTemplate);
+        rootTemplate.fixupParentPathRecursively();
         return rootTemplate;
     }
 
@@ -809,7 +810,7 @@ public:
 
     bool execUntilFinished() {
         QSignalSpy spy(_syncEngine.get(), SIGNAL(finished(bool)));
-        bool ok = spy.wait(60000);
+        bool ok = spy.wait(3600000);
         Q_ASSERT(ok && "Sync timed out");
         return spy[0][0].toBool();
     }
@@ -842,8 +843,8 @@ private:
             if (diskChild.isDir()) {
                 QDir subDir = dir;
                 subDir.cd(diskChild.fileName());
-                templateFi.children.insert(diskChild.fileName(), FileInfo{diskChild.fileName()});
-                fromDisk(subDir, templateFi.children.last());
+                FileInfo &subFi = templateFi.children[diskChild.fileName()] = FileInfo{diskChild.fileName()};
+                fromDisk(subDir, subFi);
             } else {
                 QFile f{diskChild.filePath()};
                 f.open(QFile::ReadOnly);

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -793,15 +793,15 @@ public:
     }
 
     void execUntilItemCompleted(const QString &relativePath) {
-        QSignalSpy spy(_syncEngine.get(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy spy(_syncEngine.get(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         QElapsedTimer t;
         t.start();
         while (t.elapsed() < 5000) {
             spy.clear();
             QVERIFY(spy.wait());
             for(const QList<QVariant> &args : spy) {
-                auto item = args[0].value<OCC::SyncFileItem>();
-                if (item.destination() == relativePath)
+                auto item = args[0].value<OCC::SyncFileItemPtr>();
+                if (item->destination() == relativePath)
                     return;
             }
         }

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -793,7 +793,7 @@ public:
     }
 
     void execUntilItemCompleted(const QString &relativePath) {
-        QSignalSpy spy(_syncEngine.get(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy spy(_syncEngine.get(), SIGNAL(itemCompleted(const SyncFileItem &)));
         QElapsedTimer t;
         t.start();
         while (t.elapsed() < 5000) {

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -14,8 +14,8 @@ using namespace OCC;
 bool itemDidComplete(const QSignalSpy &spy, const QString &path)
 {
     for(const QList<QVariant> &args : spy) {
-        SyncFileItem item = args[0].value<SyncFileItem>();
-        if (item.destination() == path)
+        auto item = args[0].value<SyncFileItemPtr>();
+        if (item->destination() == path)
             return true;
     }
     return false;
@@ -24,9 +24,9 @@ bool itemDidComplete(const QSignalSpy &spy, const QString &path)
 bool itemDidCompleteSuccessfully(const QSignalSpy &spy, const QString &path)
 {
     for(const QList<QVariant> &args : spy) {
-        SyncFileItem item = args[0].value<SyncFileItem>();
-        if (item.destination() == path)
-            return item._status == SyncFileItem::Success;
+        auto item = args[0].value<SyncFileItemPtr>();
+        if (item->destination() == path)
+            return item->_status == SyncFileItem::Success;
     }
     return false;
 }
@@ -38,7 +38,7 @@ class TestSyncEngine : public QObject
 private slots:
     void testFileDownload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.remoteModifier().insert("A/a0");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a0"));
@@ -47,7 +47,7 @@ private slots:
 
     void testFileUpload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.localModifier().insert("A/a0");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a0"));
@@ -56,7 +56,7 @@ private slots:
 
     void testDirDownload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.remoteModifier().mkdir("Y");
         fakeFolder.remoteModifier().mkdir("Z");
         fakeFolder.remoteModifier().insert("Z/d0");
@@ -69,7 +69,7 @@ private slots:
 
     void testDirUpload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.localModifier().mkdir("Y");
         fakeFolder.localModifier().mkdir("Z");
         fakeFolder.localModifier().insert("Z/d0");
@@ -82,7 +82,7 @@ private slots:
 
     void testLocalDelete() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.remoteModifier().remove("A/a1");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a1"));
@@ -91,7 +91,7 @@ private slots:
 
     void testRemoteDelete() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         fakeFolder.localModifier().remove("A/a1");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a1"));
@@ -107,7 +107,7 @@ private slots:
         // fakeFolder.syncOnce();
         fakeFolder.syncOnce();
 
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
         // Touch the file without changing the content, shouldn't upload
         fakeFolder.localModifier().setContents("a1.eml", 'A');
         // Change the content/size
@@ -204,7 +204,7 @@ private slots:
             QCOMPARE(fakeFolder.currentLocalState(), remoteState);
 
             expectedServerState = fakeFolder.currentRemoteState();
-            QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
+            QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItemPtr &)));
             fakeFolder.syncOnce(); // This sync should do nothing
             QCOMPARE(completeSpy.count(), 0);
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -38,7 +38,7 @@ class TestSyncEngine : public QObject
 private slots:
     void testFileDownload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.remoteModifier().insert("A/a0");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a0"));
@@ -47,7 +47,7 @@ private slots:
 
     void testFileUpload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.localModifier().insert("A/a0");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a0"));
@@ -56,7 +56,7 @@ private slots:
 
     void testDirDownload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.remoteModifier().mkdir("Y");
         fakeFolder.remoteModifier().mkdir("Z");
         fakeFolder.remoteModifier().insert("Z/d0");
@@ -69,7 +69,7 @@ private slots:
 
     void testDirUpload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.localModifier().mkdir("Y");
         fakeFolder.localModifier().mkdir("Z");
         fakeFolder.localModifier().insert("Z/d0");
@@ -82,7 +82,7 @@ private slots:
 
     void testLocalDelete() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.remoteModifier().remove("A/a1");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a1"));
@@ -91,7 +91,7 @@ private slots:
 
     void testRemoteDelete() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         fakeFolder.localModifier().remove("A/a1");
         fakeFolder.syncOnce();
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/a1"));
@@ -107,7 +107,7 @@ private slots:
         // fakeFolder.syncOnce();
         fakeFolder.syncOnce();
 
-        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+        QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
         // Touch the file without changing the content, shouldn't upload
         fakeFolder.localModifier().setContents("a1.eml", 'A');
         // Change the content/size
@@ -204,7 +204,7 @@ private slots:
             QCOMPARE(fakeFolder.currentLocalState(), remoteState);
 
             expectedServerState = fakeFolder.currentRemoteState();
-            QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &, const PropagatorJob &)));
+            QSignalSpy completeSpy(&fakeFolder.syncEngine(), SIGNAL(itemCompleted(const SyncFileItem &)));
             fakeFolder.syncOnce(); // This sync should do nothing
             QCOMPARE(completeSpy.count(), 0);
 


### PR DESCRIPTION
This improves the number of files that can be synced in one shot.

Issue #5237
This depends on #5400 to work properly