### PR TITLE
Local massive deletion message improvements

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -883,17 +883,22 @@ void Folder::setSaveBackwardsCompatible(bool save)
     _saveBackwardsCompatible = save;
 }
 
-void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction, bool *cancel)
+void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, bool *cancel)
 {
     ConfigFile cfgFile;
     if (!cfgFile.promptDeleteFiles())
         return;
 
-    QString msg =
-        tr("This sync would remove all the files in the sync folder '%1'.\n"
-           "This might be because the folder was silently reconfigured, or that all "
-           "the files were manually removed.\n"
-           "Are you sure you want to perform this operation?");
+    QString msg = dir == SyncFileItem::Down ?
+        tr("All files in the sync folder '%1' folder were deleted on the server.\n"
+            "These deletes will be synchronized to your local sync folder, making such files "
+            "unavailable unless you have a right to restore. \n"
+            "If you decide to keep the files, they will be re-synced with the server if you have rights to do so.\n"
+            "If you decide to delete the files, they will be unavailable to you, unless you are the owner.") :
+        tr("All the files in your local sync folder '%1' were deleted. These deletes will be "
+            "synchronized with your server, making such files unavailable unless restored.\n"
+            "Are you sure you want to sync those actions with the server?\n"
+            "If this was an accident and you decide to keep your files, they will be re-synced from the server.");
     QMessageBox msgBox(QMessageBox::Warning, tr("Remove All Files?"),
                        msg.arg(shortGuiLocalPath()));
     msgBox.addButton(tr("Remove all files"), QMessageBox::DestructiveRole);


### PR DESCRIPTION
As discussed in #5494 and https://github.com/owncloud/enterprise/issues/1780 this changes the message and makes the "Remove All Files" dialog to be on top of other windows to avoid it going unnoticed or lost without picking a strategy:

![on_top_dialog](https://cloud.githubusercontent.com/assets/2644445/22422752/61d46ba0-e6ee-11e6-8509-cadfc03b6089.gif)
