### PR TITLE
Remove all conditional checks for Qt 4.x

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -215,9 +215,7 @@ QNetworkAccessManager *Account::networkAccessManager()
 QNetworkReply *Account::sendRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data)
 {
     req.setUrl(url);
-#if QT_VERSION > QT_VERSION_CHECK(4, 8, 4)
     req.setSslConfiguration(this->getOrCreateSslConfig());
-#endif
     if (verb == "HEAD" && !data) {
         return _am->head(req);
     } else if (verb == "GET" && !data) {
@@ -248,7 +246,7 @@ QSslConfiguration Account::getOrCreateSslConfig()
     // if setting the client certificate fails, you will probably get an error similar to this:
     //  "An internal error number 1060 happened. SSL handshake failed, client certificate was requested: SSL error: sslv3 alert handshake failure"
     QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
-    
+
 #if QT_VERSION > QT_VERSION_CHECK(5, 2, 0)
     // Try hard to re-use session for different requests
     sslConfig.setSslOption(QSsl::SslOptionDisableSessionTickets, false);
@@ -447,7 +445,7 @@ void Account::setNonShib(bool nonShib)
         _davPath = Theme::instance()->webDavPathNonShib();
     } else {
         _davPath = Theme::instance()->webDavPath();
-    } 
+    }
 }
 
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -89,10 +89,7 @@ void PUTFileJob::start() {
     // For Qt versions not including https://codereview.qt-project.org/110150
     // Also do the runtime check if compiled with an old Qt but running with fixed one.
     // (workaround disabled on windows and mac because the binaries we ship have patched qt)
-#if QT_VERSION < QT_VERSION_CHECK(4, 8, 7)
-    if (QLatin1String(qVersion()) < QLatin1String("4.8.7"))
-        connect(_device, SIGNAL(wasReset()), this, SLOT(slotSoftAbort()));
-#elif QT_VERSION > QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(5, 4, 2) && !defined Q_OS_WIN && !defined Q_OS_MAC
+#if QT_VERSION < QT_VERSION_CHECK(5, 4, 2) && !defined Q_OS_WIN && !defined Q_OS_MAC
     if (QLatin1String(qVersion()) < QLatin1String("5.4.2"))
         connect(_device, SIGNAL(wasReset()), this, SLOT(slotSoftAbort()));
 #endif


### PR DESCRIPTION
Now that #2558 has been closed there is no point of having to check whether Qt is <5.0.