### PR TITLE
Settings: Don't migrate settings on access error #5499

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -46,11 +46,17 @@ AccountManager *AccountManager::instance()
 bool AccountManager::restore()
 {
     auto settings = Utility::settingsWithGroup(QLatin1String(accountsC));
+    if (settings->status() != QSettings::NoError) {
+        qDebug() << "Could not read settings from" << settings->fileName()
+                 << settings->status();
+        return false;
+    }
 
     // If there are no accounts, check the old format.
     if (settings->childGroups().isEmpty()
             && !settings->contains(QLatin1String(versionC))) {
-        return restoreFromLegacySettings();
+        restoreFromLegacySettings();
+        return true;
     }
 
     foreach (const auto& accountId, settings->childGroups()) {
@@ -69,6 +75,9 @@ bool AccountManager::restore()
 
 bool AccountManager::restoreFromLegacySettings()
 {
+    qDebug() << "Migrate: restoreFromLegacySettings, checking settings group"
+             << Theme::instance()->appName();
+
     // try to open the correctly themed settings
     auto settings = Utility::settingsWithGroup(Theme::instance()->appName());
 

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -36,7 +36,9 @@ public:
 
     /**
      * Creates account objects from a given settings file.
-     * return true if the account was restored
+     *
+     * Returns false if there was an error reading the settings,
+     * but note that settings not existing is not an error.
      */
     bool restore();
 


### PR DESCRIPTION
Previously, we'd try migrating from legacy settings if reading
the settings failed with an error. Now, we try again after a
couple of seconds and eventually give up.