### PR TITLE
AccessManager: don't set an invalid network configuration on linux

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -37,8 +37,11 @@ AccessManager::AccessManager(QObject* parent)
     proxy.setHostName(" ");
     setProxy(proxy);
 #endif
+
+#ifndef Q_OS_LINUX
     // Atempt to workaround for https://github.com/owncloud/client/issues/3969
     setConfiguration(QNetworkConfiguration());
+#endif
     setCookieJar(new CookieJar);
 }
 


### PR DESCRIPTION
If we call
 setConfiguration(QNetworkConfiguration());
This sets an invalid configuration on the QNAM.
But later, when we really go online because interfaces are discovered,
QNetworkAccessManagerPrivate::_q_onlineStateChanged is called (with isOnline=true).
And this will set the state to disconnected because customNetworkConfiguration is
true, and the networkConfiguration state is disabled.

The workaround we to fix another bug on Windows in which the default network
configuration was not behaving properly.

The issue on linux is hard to reproduce and only happen in some condition,
but it was reproduced on smashbox when they run two owncloudcmd at the same time.

Issues: #4720 , #3600