### PR TITLE
Create PropagateItemJobs on the fly

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -621,14 +621,9 @@ bool PropagateDirectory::scheduleNextJob()
         return false;
     }
 
-    bool stopAtDirectory = false;
     for (int i = 0; i < _subJobs.size(); ++i) {
         if (_subJobs.at(i)->_state == Finished) {
             continue;
-        }
-
-        if (stopAtDirectory && qobject_cast<PropagateDirectory*>(_subJobs.at(i))) {
-            return false;
         }
 
         if (possiblyRunNextJob(_subJobs.at(i))) {
@@ -640,9 +635,6 @@ bool PropagateDirectory::scheduleNextJob()
         auto paral = _subJobs.at(i)->parallelism();
         if (paral == WaitForFinished) {
             return false;
-        }
-        if (paral == WaitForFinishedInParentDirectory) {
-            stopAtDirectory = true;
         }
     }
     return false;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -171,6 +171,11 @@ void PropagateItemJob::done(SyncFileItem::Status status, const QString &errorStr
 
     emit propagator()->itemCompleted(_item);
     emit finished(status);
+
+    if (status == SyncFileItem::FatalError) {
+        // Abort all remaining jobs.
+        propagator()->abort();
+    }
 }
 
 /**
@@ -669,12 +674,9 @@ void PropagatorCompositeJob::slotSubJobFinished(SyncFileItem::Status status)
     ASSERT(i >= 0);
     _runningJobs.remove(i);
 
-    if (status == SyncFileItem::FatalError) {
-        abort();
-        _state = Finished;
-        emit finished(status);
-        return;
-    } else if (status == SyncFileItem::NormalError || status == SyncFileItem::SoftError) {
+    if (status == SyncFileItem::FatalError
+        || status == SyncFileItem::NormalError
+        || status == SyncFileItem::SoftError) {
         _hasError = status;
     }
 

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -76,12 +76,6 @@ public:
             So this job is guaranteed to finish before any jobs below it
             are executed. */
         WaitForFinished,
-
-        /** A job with this parallelism will allow later jobs to start and
-            run in parallel as long as they aren't PropagateDirectory jobs.
-            When the first directory job is encountered, no further jobs
-            will be started until this one is finished. */
-        WaitForFinishedInParentDirectory
     };
 
     virtual JobParallelism parallelism() { return FullParallelism; }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -177,7 +177,8 @@ public slots:
 class PropagatorCompositeJob : public PropagatorJob {
     Q_OBJECT
 public:
-    QVector<PropagatorJob *> _subJobs;
+    QVector<PropagatorJob *> _jobsToDo;
+    QVector<PropagatorJob *> _runningJobs;
     SyncFileItem::Status _hasError;  // NoStatus,  or NormalError / SoftError if there was an error
 
     explicit PropagatorCompositeJob(OwncloudPropagator *propagator)
@@ -186,17 +187,18 @@ public:
     { }
 
     virtual ~PropagatorCompositeJob() {
-        qDeleteAll(_subJobs);
+        qDeleteAll(_jobsToDo);
+        qDeleteAll(_runningJobs);
     }
 
     void append(PropagatorJob *subJob) {
-        _subJobs.append(subJob);
+        _jobsToDo.append(subJob);
     }
 
     virtual bool scheduleNextJob() Q_DECL_OVERRIDE;
     virtual JobParallelism parallelism() Q_DECL_OVERRIDE;
     virtual void abort() Q_DECL_OVERRIDE {
-        foreach (PropagatorJob *j, _subJobs)
+        foreach (PropagatorJob *j, _runningJobs)
             j->abort();
     }
 

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -227,7 +227,7 @@ public:
 private slots:
     bool possiblyRunNextJob(PropagatorJob *next) {
         if (next->_state == NotYetStarted) {
-            connect(next, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobFinished(SyncFileItem::Status)), Qt::QueuedConnection);
+            connect(next, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobFinished(SyncFileItem::Status)));
             connect(next, SIGNAL(itemCompleted(const SyncFileItemPtr &)), this, SIGNAL(itemCompleted(const SyncFileItemPtr &)));
             connect(next, SIGNAL(progress(const SyncFileItem &,quint64)), this, SIGNAL(progress(const SyncFileItem &,quint64)));
             connect(next, SIGNAL(ready()), this, SIGNAL(ready()));

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -178,6 +178,7 @@ class PropagatorCompositeJob : public PropagatorJob {
     Q_OBJECT
 public:
     QVector<PropagatorJob *> _jobsToDo;
+    SyncFileItemVector _tasksToDo;
     QVector<PropagatorJob *> _runningJobs;
     SyncFileItem::Status _hasError;  // NoStatus,  or NormalError / SoftError if there was an error
 
@@ -191,8 +192,11 @@ public:
         qDeleteAll(_runningJobs);
     }
 
-    void append(PropagatorJob *subJob) {
-        _jobsToDo.append(subJob);
+    void appendJob(PropagatorJob *job) {
+        _jobsToDo.append(job);
+    }
+    void appendTask(const SyncFileItemPtr &item) {
+        _tasksToDo.append(item);
     }
 
     virtual bool scheduleNextJob() Q_DECL_OVERRIDE;
@@ -216,6 +220,7 @@ private slots:
     }
 
     void slotSubJobFinished(SyncFileItem::Status status);
+    void finalize();
 };
 
 /**
@@ -233,8 +238,12 @@ public:
 
     explicit PropagateDirectory(OwncloudPropagator *propagator, const SyncFileItemPtr &item = SyncFileItemPtr(new SyncFileItem));
 
-    void append(PropagatorJob *subJob) {
-        _subJobs.append(subJob);
+    void appendJob(PropagatorJob *job) {
+        _subJobs.appendJob(job);
+    }
+
+    void appendTask(const SyncFileItemPtr &item) {
+        _subJobs.appendTask(item);
     }
 
     virtual bool scheduleNextJob() Q_DECL_OVERRIDE;

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -331,9 +331,11 @@ public:
     void abort() {
         _abortRequested.fetchAndStoreOrdered(true);
         if (_rootJob) {
-            _rootJob->abort();
+            // We're possibly already in an item's finished stack
+            QMetaObject::invokeMethod(_rootJob.data(), "abort", Qt::QueuedConnection);
         }
-        emitFinished(SyncFileItem::NormalError);
+        // abort() of all jobs will likely have already resulted in finished being emitted, but just in case.
+        QMetaObject::invokeMethod(this, "emitFinished", Qt::QueuedConnection, Q_ARG(SyncFileItem::Status, SyncFileItem::NormalError));
     }
 
     // timeout in seconds

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -333,7 +333,7 @@ void PropagateDownloadFile::start()
         return;
     }
 
-    emit progress(*_item, 0);
+    propagator()->reportProgress(*_item, 0);
 
     QString tmpFileName;
     QByteArray expectedEtagForResume;
@@ -834,7 +834,7 @@ void PropagateDownloadFile::slotDownloadProgress(qint64 received, qint64)
 {
     if (!_job) return;
     _downloadProgress = received;
-    emit progress(*_item, _resumeStart + received);
+    propagator()->reportProgress(*_item, _resumeStart + received);
 }
 
 

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -54,7 +54,7 @@ public:
         : PropagateItemJob(propagator, item) {}
     void start() Q_DECL_OVERRIDE;
     void abort() Q_DECL_OVERRIDE;
-    JobParallelism parallelism() Q_DECL_OVERRIDE { return OCC::PropagatorJob::WaitForFinishedInParentDirectory; }
+    JobParallelism parallelism() Q_DECL_OVERRIDE { return _item->_isDirectory ? WaitForFinished : FullParallelism; }
 
     /**
      * Rename the directory in the selective sync list

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -225,7 +225,7 @@ void PropagateUploadFileNG::startNewUpload()
     _sent = 0;
     _currentChunk = 0;
 
-    emit progress(*_item, 0);
+    propagator()->reportProgress(*_item, 0);
 
     SyncJournalDb::UploadInfo pi;
     pi._valid = true;
@@ -507,7 +507,7 @@ void PropagateUploadFileNG::slotUploadProgress(qint64 sent, qint64 total)
     if (sent == 0 && total == 0) {
         return;
     }
-    emit progress(*_item, _sent + sent - total);
+    propagator()->reportProgress(*_item, _sent + sent - total);
 }
 
 }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -51,7 +51,7 @@ void PropagateUploadFileV1::doStartUpload()
 
     _currentChunk = 0;
 
-    emit progress(*_item, 0);
+    propagator()->reportProgress(*_item, 0);
     startNextChunk();
 }
 
@@ -165,7 +165,7 @@ void PropagateUploadFileV1::startNextChunk()
         startNextChunk();
     }
     if (!parallelChunkUpload || _chunkCount - _currentChunk <= 0) {
-        emit ready();
+        propagator()->scheduleNextJob();
     }
 }
 
@@ -386,7 +386,7 @@ void PropagateUploadFileV1::slotUploadProgress(qint64 sent, qint64 total)
         // sender() is the only current job, no need to look at the byteWritten properties
         amount += sent;
     }
-    emit progress(*_item, amount);
+    propagator()->reportProgress(*_item, amount);
 }
 
 }

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -131,7 +131,7 @@ void PropagateLocalRemove::start()
             return;
         }
     }
-    emit progress(*_item, 0);
+    propagator()->reportProgress(*_item, 0);
     propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->_isDirectory);
     propagator()->_journal->commit("Local remove");
     done(SyncFileItem::Success);
@@ -202,7 +202,7 @@ void PropagateLocalRename::start()
     // if the file is a file underneath a moved dir, the _item->file is equal
     // to _item->renameTarget and the file is not moved as a result.
     if (_item->_file != _item->_renameTarget) {
-        emit progress(*_item, 0);
+        propagator()->reportProgress(*_item, 0);
         qDebug() << "MOVE " << existingFile << " => " << targetFile;
 
         if (QString::compare(_item->_file, _item->_renameTarget, Qt::CaseInsensitive) != 0

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -79,7 +79,7 @@ class PropagateLocalRename : public PropagateItemJob {
 public:
     PropagateLocalRename (OwncloudPropagator* propagator,const SyncFileItemPtr& item)  : PropagateItemJob(propagator, item) {}
     void start() Q_DECL_OVERRIDE;
-    JobParallelism parallelism() Q_DECL_OVERRIDE { return WaitForFinishedInParentDirectory; }
+    JobParallelism parallelism() Q_DECL_OVERRIDE { return _item->_isDirectory ? WaitForFinished : FullParallelism; }
 };
 
 }

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -214,7 +214,6 @@ private slots:
     }
 
     void abortAfterFailedMkdir() {
-        QSKIP("Skip for 2.3");
         FakeFolder fakeFolder{FileInfo{}};
         QSignalSpy finishedSpy(&fakeFolder.syncEngine(), SIGNAL(finished(bool)));
         fakeFolder.serverErrorPaths().append("NewFolder");


### PR DESCRIPTION
This is pull request finishes the work to fix TestSyncEngine::abortAfterFailedMkdir by ensuring that we either go down in the job tree (e.g. scheduleNextJob, abort), or up (finished) on a stack to avoid reentrancy.

This is mixed with refactoring to split the subjob logic from PropagateDirectory in a PropagateCompositeJob class to make it easier to add a dynamic creation of item jobs.