### PR TITLE
Fix grammar and spelling errors in the documentation

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -153,8 +153,7 @@ By default, the ownCloud Client ignores the following files:
 
 * Files matched by one of the patterns defined in the Ignored Files Editor
 * Files containing characters that do not work on certain file systems ``(`\, /, :, ?, *, ", >, <, |`)``.
-* Files starting with ``._sync_xxxxxxx.db`` and the old format ``.csync_journal.db``, 
-as these files are reserved for journalling.
+* Files starting with ``._sync_xxxxxxx.db`` and the old format ``.csync_journal.db``,  as these files are reserved for journalling.
 
 If a pattern selected using a checkbox in the `ignoredFilesEditor-label` (or if
 a line in the exclude file starts with the character ``]`` directly followed by
@@ -163,12 +162,12 @@ data*. These files are ignored and *removed* by the client if found in the
 synchronized folder. This is suitable for meta files created by some
 applications that have no sustainable meaning.
 
-If a pattern ends with the forwardslash (``/``) character, only directories are
+If a pattern ends with the forward slash (``/``) character, only directories are
 matched. The pattern is only applied for directory components of filenames
 selected using the checkbox.
 
-To match filenames against the exclude patterns, the unix standard C library
-function fnmatch is used. This process checks the filename against the
+To match filenames against the exclude patterns, the UNIX standard C library
+function ``fnmatch`` is used. This process checks the filename against the
 specified pattern using standard shell wildcard pattern matching. For more
 information, please refer to `The opengroup website
 <http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01>`_.
@@ -207,9 +206,9 @@ In the communication between client and server a couple of custom WebDAV propert
 were introduced. They are either needed for sync functionality or help have a positive
 effect on synchronization performance.
 
-This chapter describes additional xml elements which the server returns in response
+This chapter describes additional XML elements which the server returns in response
 to a successful PROPFIND request on a file or directory. The elements are returned in
-the namespace oc.
+the namespace ``oc``.
 
 Server Side  Permissions
 ------------------------
@@ -218,27 +217,27 @@ The XML element ``<oc:permissions>`` represents the permission- and sharing stat
 item. It is a list of characters, and each of the chars has a meaning as outlined
 in the table below:
 
-+----+----------------+-------------------------------------------+
-|Code|   Resource     |  Description                              |
-+----+----------------+-------------------------------------------+
-| S  | File or Folder | is shared                                 |
-+----+----------------+-------------------------------------------+
-| R  | File or Folder | can share (includes reshare)              |
-+----+----------------+-------------------------------------------+
-| M  | File or Folder | is mounted (like on DropBox, Samba, etc.) |
-+----+----------------+-------------------------------------------+
-| W  | File           | can write file                            |
-+----+----------------+-------------------------------------------+
-| C  | Folder         |can create file in folder                  |
-+----+----------------+-------------------------------------------+
-| K  | Folder         | can create folder (mkdir)                 |
-+----+----------------+-------------------------------------------+
-| D  | File or Folder |can delete file or folder                  |
-+----+----------------+-------------------------------------------+
-| N  | File or Folder | can rename file or folder                 |
-+----+----------------+-------------------------------------------+
-| V  | File or Folder | can move file or folder                   |
-+----+----------------+-------------------------------------------+
++------+----------------+-------------------------------------------+
+| Code |   Resource     |  Description                              |
++------+----------------+-------------------------------------------+
+| S    | File or Folder | is shared                                 |
++------+----------------+-------------------------------------------+
+| R    | File or Folder | can share (includes re-share)             |
++------+----------------+-------------------------------------------+
+| M    | File or Folder | is mounted (like on Dropbox, Samba, etc.) |
++------+----------------+-------------------------------------------+
+| W    | File           | can write file                            |
++------+----------------+-------------------------------------------+
+| C    | Folder         | can create file in folder                 |
++------+----------------+-------------------------------------------+
+| K    | Folder         | can create folder (mkdir)                 |
++------+----------------+-------------------------------------------+
+| D    | File or Folder | can delete file or folder                 |
++------+----------------+-------------------------------------------+
+| N    | File or Folder | can rename file or folder                 |
++------+----------------+-------------------------------------------+
+| V    | File or Folder | can move file or folder                   |
++------+----------------+-------------------------------------------+
 
 
 Example:

--- a/doc/autoupdate.rst
+++ b/doc/autoupdate.rst
@@ -59,7 +59,7 @@ the auto-updater entirely.  The following sections describe how to disable the
 auto-update mechanism for different operating systems.
 
 Preventing Automatic Updates in Windows Environments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Users may disable automatic updates by adding this line to the [General] 
 section of their ``owncloud.cfg`` files::

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -106,7 +106,7 @@ To set up your build environment for development using HomeBrew_:
              work correctly.
 
 Windows Development Build
------------------------
+-------------------------
 
 If you want to test some changes and deploy them locally, you can build natively
 on Windows using MinGW. If you want to generate an installer for deployment, please
@@ -206,7 +206,7 @@ In order to make setup simple, you can use the provided Dockerfile to build your
                -in ${unsigned_file} \
                -out ${installer_file}
 
-   for ``-in``, use the URL to the time stamping server provided by your CA along with the Authenticode certificate. Alternatively,
+   For ``-in``, use the URL to the time stamping server provided by your CA along with the Authenticode certificate. Alternatively,
    you may use the official Microsoft ``signtool`` utility on Microsoft Windows.
 
    If you're familiar with docker, you can use the version of ``osslsigncode`` that is part of the docker image.

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -29,5 +29,5 @@ improvements. (See the `complete changelog
   * Improved user notifications about ignored files and conflicts
   * Add warnings for old server versions
   * Update of QtKeyChain to support Windows credential store
-  * Packaging of dolphin overlay icon module for bleeding edge distros
+  * Packaging of dolphin overlay icon module for bleeding edge distributions
   

--- a/doc/navigating.rst
+++ b/doc/navigating.rst
@@ -236,7 +236,7 @@ also to limit download and upload bandwidth.
 
 .. figure:: images/settings_network.png
 
-.. _ignoredFilesEditor-label:
+.. _usingIgnoredFilesEditor-label:
 
 Using the Ignored Files Editor
 ------------------------------

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -26,3 +26,5 @@ The other options are:
 
 ``--confdir`` `<dirname>`
         Uses the specified configuration directory.
+        
+

--- a/doc/owncloudcmd.1.rst
+++ b/doc/owncloudcmd.1.rst
@@ -60,7 +60,7 @@ OPTIONS
       Exclude list file
 
 ``--unsyncedfolders [file]``
-      File containing the list of unsynced folders (selective sync)
+      File containing the list of un-synced folders (selective sync)
 
 ``--max-sync-retries [n]``
       Retries maximum n times (defaults to 3)

--- a/doc/owncloudcmd.rst
+++ b/doc/owncloudcmd.rst
@@ -49,7 +49,7 @@ Other command line switches supported by ``owncloudcmd`` include the following:
       Exclude list file
 
 ``--unsyncedfolders [file]``
-      File containing the list of unsynced remote folders (selective sync)
+      File containing the list of un-synced remote folders (selective sync)
 
 ``--max-sync-retries [n]``
       Retries maximum n times (defaults to 3)

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -27,7 +27,7 @@ Identifying Basic Functionality Problems
   misconfiguration of the WebDAV API.
 
   The ownCloud Client uses the built-in WebDAV access of the server content.
-  Verify that you can log on to ownClouds WebDAV server. To verify connectivity
+  Verify that you can log on to ownCloud's WebDAV server. To verify connectivity
   with the ownCloud WebDAV server:
 
   - Open a browser window and enter the address to the ownCloud WebDAV server. 
@@ -63,17 +63,17 @@ Other issues can affect synchronization of your ownCloud files:
 
 - Synchronizing the same directory with ownCloud and other synchronization
   software such as Unison, rsync, Microsoft Windows Offline Folders, or other
-  cloud services such as DropBox or Microsoft SkyDrive is not supported and
+  cloud services such as Dropbox or Microsoft SkyDrive is not supported and
   should not be attempted. In the worst case, it is possible that synchronizing
   folders or files using ownCloud and other synchronization software or
   services can result in data loss.
 
-- If you find that only specific files are not synrchronized, the
+- If you find that only specific files are not synchronized, the
   synchronization protocol might be having an effect. Some files are
   automatically ignored because they are system files, other files might be
   ignored because their filename contains characters that are not supported on
   certain file systems. For more information about ignored files, see
-  :ref:`_ignored-files-label`.
+  :ref:`ignored-files-label`.
 
 - If you are operating your own server, and use the local storage backend (the
   default), make sure that ownCloud has exclusive access to the directory.
@@ -119,7 +119,7 @@ To obtain the client log file:
 
 5. Name the log file and click the 'Save' button.
 
-  The log file is saved in the location specifed.
+  The log file is saved in the location specified.
 
 Alternatively, you can launch the ownCloud Log Output window using the
 ``--logwindow`` command. After issuing this command, the Log Output window
@@ -182,7 +182,7 @@ directly from the file system in the ownCloud server data directory.
 Webserver Log Files
 ~~~~~~~~~~~~~~~~~~~
 
-It can be helpful to view your webservers error log file to isolate any
+It can be helpful to view your webserver's error log file to isolate any
 ownCloud-related problems. For Apache on Linux, the error logs are typically
 located in the ``/var/log/apache2`` directory. Some helpful files include the
 following:

--- a/doc/visualtour.rst
+++ b/doc/visualtour.rst
@@ -61,7 +61,7 @@ Where:
   desired.
 * ``Storage Usage``: Provides further details on the storage utilization on the
   ownCloud server.
-* ``Edit Ignored Files``: Provides a list of files which will be ignored, i.e.
+* ``Edit Ignored Files``: Provides a list of files which will be ignored, i.e.,
   will not sync between the client and server. The ignored files editor allows
   adding patterns for files or directories that should be excluded from the
   sync process. Besides normal characters, wild cards may be used, an asterisk
@@ -124,7 +124,7 @@ The tab provides several useful options:
    :scale: 50 %
 
 * ``Launch on System Startup``: This option is automatically activated
-  once a user has conimaged his account. Unchecking the box will cause
+  once a user has conimaged his account. Un-checking the box will cause
   ownCloud client to not launch on startup for a particular user.
 * ``Show Desktop Nofications``: When checked, bubble notifications when
   a set of sync operations has been performed are provided.


### PR DESCRIPTION
As I was going through the docs to fix #5444, I noticed a number of grammar and spelling issues. This PR sorts out the issues that I found. Also, when attempting to build the docs, it pointed out a number of errors as well. These are also fixed in this PR.