### PR TITLE
Don't upload if it would exceed remote quota #5537

### DIFF
--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -40,7 +40,6 @@ namespace OCC {
 class AbstractCredentials;
 class Account;
 typedef QSharedPointer<Account> AccountPtr;
-class QuotaInfo;
 class AccessManager;
 
 
@@ -217,7 +216,6 @@ private:
     Capabilities _capabilities;
     QString _serverVersion;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
-    QuotaInfo *_quotaInfo;
     QSharedPointer<QNetworkAccessManager> _am;
     QSharedPointer<AbstractCredentials> _credentials;
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -568,6 +568,32 @@ OwncloudPropagator::DiskSpaceResult OwncloudPropagator::diskSpaceCheck() const
     return DiskSpaceOk;
 }
 
+bool OwncloudPropagator::quotaCheck(quint64 newSize, quint64 oldSize) const
+{
+    // It's okay if newSize < oldSize.
+    return qint64(newSize - oldSize) < freeQuota();
+}
+
+void OwncloudPropagator::setFreeQuota(qint64 quota)
+{
+    _freeQuota = quota;
+}
+
+qint64 OwncloudPropagator::freeQuota() const
+{
+    if (_freeQuota < 0) {
+        return std::numeric_limits<qint64>::max();
+    }
+    return _freeQuota;
+}
+
+void OwncloudPropagator::adjustFreeQuota(qint64 adjustment)
+{
+    if (_freeQuota < 0)
+        return;
+    _freeQuota = qMax(0LL, _freeQuota + adjustment);
+}
+
 // ================================================================================
 
 PropagatorJob::PropagatorJob(OwncloudPropagator *propagator)

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -278,6 +278,7 @@ public:
             , _bandwidthManager(this)
             , _anotherSyncNeeded(false)
             , _account(account)
+            , _freeQuota(-1)
     { }
 
     ~OwncloudPropagator();
@@ -338,6 +339,28 @@ public:
      */
     DiskSpaceResult diskSpaceCheck() const;
 
+    /** Checks whether a file that's now \a new_size and used to have
+     *  \a old_size can be successfully uploaded.
+     */
+    bool quotaCheck(quint64 newSize, quint64 oldSize) const;
+
+    /** Sets the amount of space availabe on the server.
+     *
+     * Negative values indicate that the quota is unknown.
+     */
+    void setFreeQuota(qint64 quota);
+
+    /** Returns the amount of free quota remaining.
+     *
+     * Can return qint64::max if quota is unknown.
+     */
+    qint64 freeQuota() const;
+
+    /** Adjusts the amount of free quota
+     *
+     * Safe to use when quota is unknown (no effect)
+     */
+    void adjustFreeQuota(qint64 adjustment);
 
 
 private slots:
@@ -369,6 +392,7 @@ signals:
 private:
 
     AccountPtr _account;
+    qint64 _freeQuota;
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     // access to signals which are protected in Qt4

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -120,6 +120,10 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
         return;
     }
 
+    // Add all the file sizes from the file or directory, recursively, to free space
+    auto freedSpace = propagator()->_journal->queryRecursiveSize(_item->_originalFile);
+    propagator()->adjustFreeQuota(freedSpace);
+
     propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->_isDirectory);
     propagator()->_journal->commit("Remote Remove");
     done(SyncFileItem::Success);

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -240,6 +240,9 @@ protected:
      */
     void checkResettingErrors();
 
+    /// Checks 507 Insufficent Storage
+    void checkInsufficentStorageError();
+
     // Bases headers that need to be sent with every chunk
     QMap<QByteArray, QByteArray> headers();
 

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -387,6 +387,8 @@ void PropagateUploadFileNG::slotPutFinished()
         // Ensure errors that should eventually reset the chunked upload are tracked.
         checkResettingErrors();
 
+        checkInsufficentStorageError();
+
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
                                                     &propagator()->_anotherSyncNeeded);
         abortWithError(status, errorString);
@@ -452,6 +454,8 @@ void PropagateUploadFileNG::slotMoveJobFinished()
 
         // Ensure errors that should eventually reset the chunked upload are tracked.
         checkResettingErrors();
+
+        checkInsufficentStorageError();
 
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
                                                     &propagator()->_anotherSyncNeeded);

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -228,6 +228,8 @@ void PropagateUploadFileV1::slotPutFinished()
         // Ensure errors that should eventually reset the chunked upload are tracked.
         checkResettingErrors();
 
+        checkInsufficentStorageError();
+
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
                                                     &propagator()->_anotherSyncNeeded);
         abortWithError(status, errorString);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -153,6 +153,8 @@ private slots:
     void slotFinished(bool success);
     void slotProgress(const SyncFileItem& item, quint64 curent);
     void slotDiscoveryJobFinished(int updateResult);
+    void slotQuotaJobFinished(const QVariantMap &result);
+    void slotQuotaJobFailed();
     void slotCleanPollsJobAborted(const QString &error);
 
     /** Records that a file was touched by a job. */
@@ -188,6 +190,9 @@ private:
 
     // Must only be acessed during update and reconcile
     QMap<QString, SyncFileItemPtr> _syncItemMap;
+
+    // Only temporarily filled while the quota job is running
+    SyncFileItemVector _syncItems;
 
     AccountPtr _account;
     CSYNC *_csync_ctx;

--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -63,6 +63,10 @@ public:
                                   const QByteArray& contentChecksumType);
     bool updateLocalMetadata(const QString& filename,
                              qint64 modtime, quint64 size, quint64 inode);
+
+    /// Retrieves the size of a file, or a directory and all its contents.
+    qint64 queryRecursiveSize(const QString& filename);
+
     bool exists();
     void walCheckpoint();
 
@@ -226,6 +230,7 @@ private:
     QScopedPointer<SqlQuery> _getDataFingerprintQuery;
     QScopedPointer<SqlQuery> _setDataFingerprintQuery1;
     QScopedPointer<SqlQuery> _setDataFingerprintQuery2;
+    QScopedPointer<SqlQuery> _queryRecursiveSize;
 
     /* This is the list of paths we called avoidReadFromDbOnNextSync on.
      * It means that they should not be written to the DB in any case since doing

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ if(HAVE_QT5 AND NOT BUILD_WITH_QT4)
     owncloud_add_test(ChunkingNg "syncenginetestutils.h")
     owncloud_add_test(UploadReset "syncenginetestutils.h")
     owncloud_add_test(AllFilesDeleted "syncenginetestutils.h")
+    owncloud_add_test(Quota "syncenginetestutils.h")
     owncloud_add_test(FolderWatcher "${FolderWatcher_SRC}")
 
     if( UNIX AND NOT APPLE )

--- a/test/testquota.cpp
+++ b/test/testquota.cpp
@@ -1,0 +1,74 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include "syncenginetestutils.h"
+#include <syncengine.h>
+#include <syncjournaldb.h>
+
+using namespace OCC;
+
+class TestQuota : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    // Verify that too low quota leads to skipping uploads
+    void testSkipUpload() {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+
+        fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{
+                {"chunking", "1.0"} } } });
+
+        fakeFolder.remoteModifier().quota_available = 5 * 1000 * 1000; // 5 MB
+
+        int size;
+
+        // TEST: Upload of smaller file succeeds
+        // (note that this doesn't change quota_available)
+        size = 4 * 1000 * 1000; // 4 MB
+        fakeFolder.localModifier().insert("A/new0", size);
+        QVERIFY(fakeFolder.syncOnce());
+
+
+        // TEST: Increasing the size of an existing file by an amount
+        // smaller than the quota succeeds
+        size = 6 * 1000 * 1000; // 6 MB (going from 4 MB to 6 MB)
+        fakeFolder.localModifier().remove("A/new0");
+        fakeFolder.localModifier().insert("A/new0", size);
+        QVERIFY(fakeFolder.syncOnce());
+
+
+        // TEST: Upload of larger file fails
+        size = 6 * 1000 * 1000; // 6 MB
+        fakeFolder.localModifier().insert("A/new1", size);
+        QVERIFY(!fakeFolder.syncOnce());
+        fakeFolder.localModifier().remove("A/new1");
+
+
+        // TEST: Exceeding the quota gradually works and makes
+        // some uploads succeed. This also tests parallelism
+        // in uploads interacting with quota checks.
+        size = 2 * 1000 * 1000; // 2 MB
+        fakeFolder.localModifier().insert("A/new2", size);
+        fakeFolder.localModifier().insert("A/new3", size);
+        fakeFolder.localModifier().insert("A/new4", size);
+        // the last of these three will fail
+        QVERIFY(!fakeFolder.syncOnce());
+
+        auto folderA = fakeFolder.currentRemoteState().children["A"];
+        int successes =
+            folderA.children.count("new2")
+            + folderA.children.count("new3")
+            + folderA.children.count("new4");
+        QVERIFY(successes == 2);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestQuota)
+#include "testquota.moc"


### PR DESCRIPTION
Targetting master since it's uncertain whether this should be in 2.3.1 or 2.4.0! Assigning to 2.3.1 for now - opinions?

* Run a Propfind to determine the available quota before each sync run.
* Keep the available quota up to date with each upload and delete job.
* Don't start upload jobs if there's not enough available space.
* If we (unexpectedly) receive a 507 Insufficent Storage error, adjust
  the expectation of available remote space downwards.