### PR TITLE
Make sure account state is not NULL before fetch

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -116,7 +116,7 @@ bool ActivityListModel::canFetchMore(const QModelIndex& ) const
 
 void ActivityListModel::startFetchJob(AccountState* s)
 {
-    if( !s->isConnected() ) {
+    if( !s || !s->isConnected() ) {
         return;
     }
     JsonApiJob *job = new JsonApiJob(s->account(), QLatin1String("ocs/v1.php/cloud/activity"), this);


### PR DESCRIPTION
In `slotRefreshActivity` is assumed that given `ast` could be NULL and
yet is still being passed to `startFetchJob` which could segfault while
checking if connected.

This makes sure that `ast` is not NULL before using it.