### PR TITLE
Traymenu quota info

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -348,12 +348,14 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
     actionOpenoC->setProperty(propertyAccountC, QVariant::fromValue(accountState->account()));
     QObject::connect(actionOpenoC, SIGNAL(triggered(bool)), SLOT(slotOpenOwnCloud()));
 
-    menu->addSeparator();
+    if (accountState->state() == AccountState::Connected) {
+        menu->addSeparator();
 
-    QString quotaInfo = tr("Fetching Quota");
-    auto actionQuotaInfo = menu->addAction(quotaInfo);
-    actionQuotaInfo->setEnabled(false);
-    new QuotaAction(actionQuotaInfo, accountState);
+        QString quotaInfo = tr("Fetching Quota");
+        auto actionQuotaInfo = menu->addAction(quotaInfo);
+        actionQuotaInfo->setEnabled(false);
+        new QuotaAction(actionQuotaInfo, accountState);
+    }
 
     FolderMan *folderMan = FolderMan::instance();
     bool firstFolder = true;

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -37,6 +37,7 @@ class ShareDialog;
 class Application;
 class LogBrowser;
 class AccountState;
+class QuotaInfo;
 
 /**
  * @brief The ownCloudGui class
@@ -140,6 +141,24 @@ private:
     QSignalMapper *_recentItemsMapper;
 
     Application *_app;
+};
+
+/**
+  * @brief Quota info menu item
+  * @ingroup gui
+  */
+class QuotaAction : public QObject {
+    Q_OBJECT
+public:
+    explicit QuotaAction(QAction *action, AccountStatePtr accountState);
+
+private slots:
+    void slotUpdateQuota(qint64, qint64);
+
+private:
+    AccountStatePtr _accountState;
+    QAction *_action;
+    QuotaInfo *_quotaInfo;
 };
 
 } // namespace OCC


### PR DESCRIPTION
Adds a section to the traymenu to show the quota info (or just used space if there is no quota). Just like in the account panel.

Looks like:
![sh](https://cloud.githubusercontent.com/assets/45821/23309017/65f3eb70-faad-11e6-85c1-ed31de9e7651.png)
