### PR TITLE
Update client version from 2.2 to 2.3

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -11,7 +11,7 @@ desktop client.
 .. note:: Build instructions are subject to change as development proceeds.
   Please check the version for which you want to build.
 
-These instructions are updated to work with version 2.2 of the ownCloud Client.
+These instructions are updated to work with version |version| of the ownCloud Client.
 
 Getting Source Code
 -------------------

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -19,7 +19,7 @@ recommended to keep your client updated.
 Improvements and New Features
 -----------------------------
 
-The 2.2 release of the ownCloud desktop sync client has many new features and 
+The |version| release of the ownCloud desktop sync client has many new features and 
 improvements. (See the `complete changelog 
 <https://owncloud.org/changelog/desktop/>`_.)
  


### PR DESCRIPTION
This PR:

- Updates the docs to use the Sphinx-doc `|version|` tag to represent the version, so that it's always interpolated to the latest version, instead of a hard-coded version.

### Relates To 

- owncloud/documentation/issues/2848