### PR TITLE
AbstractNetworkJob: Improve redirect handling #5555

### DIFF
--- a/src/gui/notificationconfirmjob.cpp
+++ b/src/gui/notificationconfirmjob.cpp
@@ -54,9 +54,7 @@ void NotificationConfirmJob::start()
     req.setRawHeader("Ocs-APIREQUEST", "true");
     req.setRawHeader("Content-Type", "application/x-www-form-urlencoded");
 
-    QIODevice *iodevice = 0;
-    setReply(davRequest(_verb, _link, req, iodevice));
-    setupConnections(reply());
+    sendRequest(_verb, _link, req);
 
     AbstractNetworkJob::start();
 }

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -93,9 +93,7 @@ void OcsJob::start()
     queryItems.append(qMakePair(QByteArray("format"), QByteArray("json")));
     url.setEncodedQueryItems(queryItems);
 
-    setReply(davRequest(_verb, url, req, buffer));
-    setupConnections(reply());
-    buffer->setParent(reply());
+    sendRequest(_verb, url, req, buffer);
     AbstractNetworkJob::start();
 }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -594,9 +594,7 @@ DetermineAuthTypeJob::DetermineAuthTypeJob(AccountPtr account, QObject *parent)
 
 void DetermineAuthTypeJob::start()
 {
-    QNetworkReply *reply = getRequest(account()->davPath());
-    setReply(reply);
-    setupConnections(reply);
+    sendRequest("GET", account()->davUrl());
     AbstractNetworkJob::start();
 }
 
@@ -613,8 +611,7 @@ bool DetermineAuthTypeJob::finished()
         // do a new run
         _redirects++;
         resetTimeout();
-        setReply(getRequest(redirection));
-        setupConnections(reply());
+        sendRequest("GET", redirection);
         return false; // don't discard
     } else {
 #ifndef NO_SHIBBOLETH

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -27,8 +27,7 @@ ThumbnailJob::ThumbnailJob(const QString &path, AccountPtr account, QObject* par
 
 void ThumbnailJob::start()
 {
-    setReply(getRequest(path()));
-    setupConnections(reply());
+    sendRequest("GET", makeAccountUrl(path()));
     AbstractNetworkJob::start();
 }
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -202,54 +202,23 @@ QNetworkAccessManager *Account::networkAccessManager()
     return _am.data();
 }
 
-QNetworkReply *Account::headRequest(const QString &relPath)
-{
-    return headRequest(Utility::concatUrlPath(url(), relPath));
-}
-
-QNetworkReply *Account::headRequest(const QUrl &url)
-{
-    QNetworkRequest request(url);
-#if QT_VERSION > QT_VERSION_CHECK(4, 8, 4)
-    request.setSslConfiguration(this->getOrCreateSslConfig());
-#endif
-    return _am->head(request);
-}
-
-QNetworkReply *Account::getRequest(const QString &relPath)
-{
-    return getRequest(Utility::concatUrlPath(url(), relPath));
-}
-
-QNetworkReply *Account::getRequest(const QUrl &url)
-{
-    QNetworkRequest request(url);
-#if QT_VERSION > QT_VERSION_CHECK(4, 8, 4)
-    request.setSslConfiguration(this->getOrCreateSslConfig());
-#endif
-    return _am->get(request);
-}
-
-QNetworkReply *Account::deleteRequest( const QUrl &url)
-{
-    QNetworkRequest request(url);
-#if QT_VERSION > QT_VERSION_CHECK(4, 8, 4)
-    request.setSslConfiguration(this->getOrCreateSslConfig());
-#endif
-    return _am->deleteResource(request);
-}
-
-QNetworkReply *Account::davRequest(const QByteArray &verb, const QString &relPath, QNetworkRequest req, QIODevice *data)
-{
-    return davRequest(verb, Utility::concatUrlPath(davUrl(), relPath), req, data);
-}
-
-QNetworkReply *Account::davRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data)
+QNetworkReply *Account::sendRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data)
 {
     req.setUrl(url);
 #if QT_VERSION > QT_VERSION_CHECK(4, 8, 4)
     req.setSslConfiguration(this->getOrCreateSslConfig());
 #endif
+    if (verb == "HEAD" && !data) {
+        return _am->head(req);
+    } else if (verb == "GET" && !data) {
+        return _am->get(req);
+    } else if (verb == "POST") {
+        return _am->post(req, data);
+    } else if (verb == "PUT") {
+        return _am->put(req, data);
+    } else if (verb == "DELETE" && !data) {
+        return _am->deleteResource(req);
+    }
     return _am->sendCustomRequest(req, verb, data);
 }
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -106,14 +106,10 @@ public:
 
 
     // For creating various network requests
-    QNetworkReply* headRequest(const QString &relPath);
-    QNetworkReply* headRequest(const QUrl &url);
-    QNetworkReply* getRequest(const QString &relPath);
-    QNetworkReply* getRequest(const QUrl &url);
-    QNetworkReply* deleteRequest( const QUrl &url);
-    QNetworkReply* davRequest(const QByteArray &verb, const QString &relPath, QNetworkRequest req, QIODevice *data = 0);
-    QNetworkReply* davRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data = 0);
-
+    QNetworkReply* sendRequest(const QByteArray &verb,
+                               const QUrl &url,
+                               QNetworkRequest req = QNetworkRequest(),
+                               QIODevice *data = 0);
 
     /** The ssl configuration during the first connection */
     QSslConfiguration getOrCreateSslConfig();

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -100,12 +100,11 @@ void GETFileJob::start() {
     }
 
     if (_directDownloadUrl.isEmpty()) {
-        setReply(davRequest("GET", path(), req));
+        sendRequest("GET", makeDavUrl(path()), req);
     } else {
         // Use direct URL
-        setReply(davRequest("GET", _directDownloadUrl, req));
+        sendRequest("GET", _directDownloadUrl, req);
     }
-    setupConnections(reply());
 
     reply()->setReadBufferSize(16 * 1024); // keep low so we can easier limit the bandwidth
     qDebug() << Q_FUNC_INFO << _bandwidthManager << _bandwidthChoked << _bandwidthLimited;

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -30,8 +30,11 @@ DeleteJob::DeleteJob(AccountPtr account, const QUrl& url, QObject* parent)
 void DeleteJob::start()
 {
     QNetworkRequest req;
-    setReply(_url.isValid() ? davRequest("DELETE", _url, req) : davRequest("DELETE", path(), req));
-    setupConnections(reply());
+    if (_url.isValid()) {
+        sendRequest("DELETE", _url, req);
+    } else {
+        sendRequest("DELETE", makeDavUrl(path()), req);
+    }
 
     if( reply()->error() != QNetworkReply::NoError ) {
         qWarning() << Q_FUNC_INFO << " Network error: " << reply()->errorString();

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -43,8 +43,11 @@ void MoveJob::start()
     for(auto it = _extraHeaders.constBegin(); it != _extraHeaders.constEnd(); ++it) {
         req.setRawHeader(it.key(), it.value());
     }
-    setReply(_url.isValid() ? davRequest("MOVE", _url, req) : davRequest("MOVE", path(), req));
-    setupConnections(reply());
+    if (_url.isValid()) {
+        sendRequest("MOVE", _url, req);
+    } else {
+        sendRequest("MOVE", makeDavUrl(path()), req);
+    }
 
     if( reply()->error() != QNetworkReply::NoError ) {
         qWarning() << Q_FUNC_INFO << " Network error: " << reply()->errorString();

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -86,7 +86,7 @@ class PUTFileJob : public AbstractNetworkJob {
     Q_OBJECT
 
 private:
-    QScopedPointer<QIODevice> _device;
+    QIODevice* _device;
     QMap<QByteArray, QByteArray> _headers;
     QString _errorString;
     QUrl _url;
@@ -95,11 +95,17 @@ public:
     // Takes ownership of the device
     explicit PUTFileJob(AccountPtr account, const QString& path, QIODevice *device,
                         const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent = 0)
-        : AbstractNetworkJob(account, path, parent), _device(device), _headers(headers), _chunk(chunk) {}
+        : AbstractNetworkJob(account, path, parent), _device(device), _headers(headers), _chunk(chunk)
+    {
+        _device->setParent(this);
+    }
     explicit PUTFileJob(AccountPtr account, const QUrl& url, QIODevice *device,
                         const QMap<QByteArray, QByteArray> &headers, int chunk, QObject* parent = 0)
         : AbstractNetworkJob(account, QString(), parent), _device(device), _headers(headers)
-        , _url(url), _chunk(chunk) {}
+        , _url(url), _chunk(chunk)
+    {
+        _device->setParent(this);
+    }
     ~PUTFileJob();
 
     int _chunk;

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -712,13 +712,13 @@ protected:
         if (verb == QLatin1String("PROPFIND"))
             // Ignore outgoingData always returning somethign good enough, works for now.
             return new FakePropfindReply{info, op, request, this};
-        else if (verb == QLatin1String("GET"))
+        else if (verb == QLatin1String("GET") || op == QNetworkAccessManager::GetOperation)
             return new FakeGetReply{info, op, request, this};
-        else if (verb == QLatin1String("PUT"))
+        else if (verb == QLatin1String("PUT") || op == QNetworkAccessManager::PutOperation)
             return new FakePutReply{info, op, request, outgoingData->readAll(), this};
         else if (verb == QLatin1String("MKCOL"))
             return new FakeMkcolReply{info, op, request, this};
-        else if (verb == QLatin1String("DELETE"))
+        else if (verb == QLatin1String("DELETE") || op == QNetworkAccessManager::DeleteOperation)
             return new FakeDeleteReply{info, op, request, this};
         else if (verb == QLatin1String("MOVE") && !isUpload)
             return new FakeMoveReply{info, op, request, this};


### PR DESCRIPTION
* For requests:
  - reuse the original QNetworkRequest, so headers and attributes
    are the same as in the original request
  - determine the original http method from the reply and the request
    attributes
  - keep the original request body around such that it can be sent
    again in case the request is redirected

* Simplify the interface that is used for creating new requests in
  AbstractNetworkJob.