### PR TITLE
Propagator: Attempt to fix a crash in OwncloudPropagator::scheduleNex…

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -94,6 +94,16 @@ int OwncloudPropagator::hardMaximumActiveJob()
     return max;
 }
 
+PropagateItemJob::~PropagateItemJob()
+{
+    if (auto p = propagator()) {
+        // Normally, every job should clean itself from the _activeJobList. So this should not be
+        // needed. But if a job has a bug or is deleted before the network jobs signal get received,
+        // we might risk end up with dangling pointer in the list which may cause crashes.
+        p->_activeJobList.removeAll(this);
+    }
+}
+
 /** Updates, creates or removes a blacklist entry for the given item.
  *
  * Returns whether the error should be suppressed.

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -160,6 +160,7 @@ private:
 public:
     PropagateItemJob(OwncloudPropagator* propagator, const SyncFileItemPtr &item)
         : PropagatorJob(propagator), _item(item) {}
+    ~PropagateItemJob();
 
     bool scheduleNextJob() Q_DECL_OVERRIDE {
         if (_state != NotYetStarted) {


### PR DESCRIPTION
…tJob

The crash reporter shows many crashes in OwncloudPropagator::scheduleNextJob.
We don't really know what could be the cause, but it's probably because
the _activeJobList contains dangling pointer.
So this patch makes sure to remove all the jobs from this list as they get
destroyed.