### PR TITLE
Using different window flags on the connection method dialog

### DIFF
--- a/src/gui/wizard/owncloudconnectionmethoddialog.cpp
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.cpp
@@ -20,7 +20,7 @@
 namespace OCC {
 
 OwncloudConnectionMethodDialog::OwncloudConnectionMethodDialog(QWidget *parent) :
-    QDialog(parent),
+    QDialog(parent, Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::MSWindowsFixedSizeDialogHint),
     ui(new Ui::OwncloudConnectionMethodDialog)
 {
     ui->setupUi(this);


### PR DESCRIPTION
This is a possible fix for #3850, applying custom window flags (http://doc.qt.io/qt-5.8/qt.html#WindowType-enum) on the connection method dialog. These avoid resizing the dialog and displaying a maximize button on OS X and context help button on Windows.

## *Previously, on Connection Failed...* 

### Maximize button on OS X:

<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/2644445/23913960/cff87122-08e4-11e7-9125-041124a185ba.png"/>
</p>


### Help button on Windows:

<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/2644445/23913913/aab9f200-08e4-11e7-82e7-44b5d8f62a55.png"/>
</p>

## Now: 

<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/2644445/23914026/fe195512-08e4-11e7-93d3-fd7b728ba511.png"/>
</p>

And:

<p align="center">
  <img src="https://cloud.githubusercontent.com/assets/2644445/23913999/eb87f656-08e4-11e7-953a-b45f24cb8449.png"/>
</p>


