### PR TITLE
SyncEngine: fix test regression in TestChunkingNG::testCreateConflict…

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -230,7 +230,7 @@ bool SyncEngine::checkErrorBlacklisting( SyncFileItem &item )
 
     // If duration has expired, it's not blacklisted anymore
     time_t now = Utility::qDateTimeToTime_t(QDateTime::currentDateTime());
-    if( now > entry._lastTryTime + entry._ignoreDuration ) {
+    if( now >= entry._lastTryTime + entry._ignoreDuration ) {
         qDebug() << "blacklist entry for " << item._file << " has expired!";
         return false;
     }


### PR DESCRIPTION
…WhileSyncing

In 8ef11a38c99c6a33b175f1ad792ec02b52f88d25, we started blacklisting
SoftError for 0 seconds.  But if the two sync happen with less than
1s interval, we would still prevent them to happen.
So make sure we expire if 0 seconds have expired