### PR TITLE
ActivityListModel: attempt to fix a crash.

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -47,6 +47,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
 
     a = _finalList.at(index.row());
     AccountStatePtr ast = AccountManager::instance()->account(a._accName);
+    if (!ast)
+        return QVariant();
     QStringList list;
 
     switch (role) {


### PR DESCRIPTION
The backtrace seems to indicate that the account is invalid.
I don't know how this can happen, maybe the account's display
name was changed while the app is running?

Backtrace:
Crash: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS at 0x18
  Module "owncloud", in OCC::AccountState::account
  Module "owncloud", in OCC::ActivityListModel::data
  Module "owncloud", in OCC::ActivityItemDelegate::paint
  Module "QtWidgets", in QListView::paintEvent
  Module "QtWidgets", in QWidget::event
  Module "QtWidgets", in QFrame::event
  Module "QtWidgets", in QAbstractScrollArea::viewportEvent
  Module "QtWidgets", in QAbstractItemView::viewportEvent
  Module "QtWidgets", in QAbstractScrollAreaFilter::eventFilter
  Module "QtCore", in QCoreApplicationPrivate::sendThroughObjectEventFilters