### PR TITLE
Folder::showSyncResultPopup: Fix undefined behavior when there is no …

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -345,7 +345,9 @@ void Folder::showSyncResultPopup()
     if( _syncResult.firstConflictItem() ) {
         createGuiLog( _syncResult.firstConflictItem()->_file, LogStatusConflict, _syncResult.numConflictItems() );
     }
-    createGuiLog( _syncResult.firstItemError()->_file, LogStatusError, _syncResult.numErrorItems() );
+    if (int errorCount = _syncResult.numErrorItems()) {
+        createGuiLog( _syncResult.firstItemError()->_file, LogStatusError, errorCount );
+    }
 
     qDebug() << "OO folder slotSyncFinished: result: " << int(_syncResult.status());
 }


### PR DESCRIPTION
…errors

When there is no errors  _syncResult.firstItemError() is NULL, and accessing
it's _file member is an undefined behavior. (Thankfully, createGuiLog did not
use the string when the count was 0, but we are not supposed to create
null references.

Found with the UB sanitizer:

src/gui/folder.cpp:348:49: runtime error: member access within null pointer of type 'OCC::SyncFileItem'
src/gui/folder.cpp:348:19: runtime error: reference binding to null pointer of type 'const QString'