### PR TITLE
Including some info on the proxy config. in the docs.

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -16,20 +16,50 @@ format. You can overwrite changes using the ownCloud configuration dialog.
 .. note:: Use caution when making changes to the ownCloud Client configuration
    file.  Incorrect settings can produce unintended results.
 
-You can change the following configuration settings in the ``[ownCloud]`` section:
+Some interesting values that can be set on the configuration file are:
 
-- ``remotePollInterval`` (default: ``30000``) -- Specifies the poll time for the remote repository in milliseconds.
++----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``[ownCloud]`` section                                                                                                                                   |
++=================================+===============+========================================================================================================+
+| Variable                        | Default       | Meaning                                                                                                |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``remotePollInterval``          | ``30000``     | Specifies the poll time for the remote repository in milliseconds.                                     |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``forceSyncInterval``           | ``7200000``   | The duration of no activity after which a synchronization run shall be triggered automatically.        |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``notificationRefreshInterval`` | ``300000``    | Specifies the default interval of checking for new server notifications in milliseconds.               |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
 
-- ``forceSyncInterval`` (default: ``7200000``) -- The duration of no activity after which a synchronization run shall be triggered automatically.
 
-- ``notificationRefreshInterval`` (default: ``300000``)  -- Specifies the default interval of checking for new server notifications in milliseconds.
++----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``[General]`` section                                                                                                                                    |
++=================================+===============+========================================================================================================+
+| Variable                        | Default       | Meaning                                                                                                |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``chunkSize``                   | ``5242880``   | Specifies the chunk size of uploaded files in bytes.                                                   |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``promptDeleteAllFiles``        | ``true``      | If a UI prompt should ask for confirmation if it was detected that all files and folders were deleted. |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``maxLogLines``                 | ``20000``     | Specifies the maximum number of log lines displayed in the log window.                                 |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``timeout``                     | ``300``       | The timeout for network connections in seconds.                                                        |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
 
-You can change the following configuration settings in the ``[General]`` section:
 
-- ``chunkSize`` (default:  ``5242880``) -- Specifies the chunk size of uploaded files in bytes.
-
-- ``promptDeleteAllFiles`` (default:  ``true``) -- If a UI prompt should ask for confirmation if it was detected that all files and folders were deleted.
-
-- ``maxLogLines`` (default:  ``20000``) -- Specifies the maximum number of log lines displayed in the log window.
-
-- ``timeout`` (default: ``300``) -- The timeout for network connections in seconds.
++----------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``[Proxy]`` section                                                                                                                                      |
++=================================+===============+========================================================================================================+
+| Variable                        | Default       | Meaning                                                                                                |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``host``                        | ``127.0.0.1`` | The address of the proxy server.                                                                       |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``port``                        | ``8080``      | The port were the proxy is listening.                                                                  |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``type``                        | ``2``         | ``0`` for System Proxy.                                                                                |
++                                 +               +--------------------------------------------------------------------------------------------------------+
+|                                 |               | ``1`` for SOCKS5 Proxy.                                                                                |
++                                 +               +--------------------------------------------------------------------------------------------------------+
+|                                 |               | ``2`` for No Proxy.                                                                                    |
++                                 +               +--------------------------------------------------------------------------------------------------------+
+|                                 |               | ``3`` for HTTP(S) Proxy.                                                                               |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This was a request of @michaelstingl to document how to configure the proxy manually via the .cfg file for config provisioning purposes.
- Restructured the bullet points into 3 different tables; I believe it's a cleaner approach; maybe this is also applicable to other sections.
- Would be logical to include also settings on proxy auth?

It does look like this:

![screenshot 2017-03-17 13 21 39](https://cloud.githubusercontent.com/assets/2644445/24042974/afae12e6-0b14-11e7-91dc-c9fee37c8704.png)

@settermjd maybe some changes would make the tables look better; what do you think? 🤔