### PR TITLE
Improve http error messages; cleanup

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -420,10 +420,7 @@ void ActivityWidget::slotNotifyNetworkError( QNetworkReply *reply)
         return;
     }
 
-    int resultCode =0;
-    if( reply ) {
-        resultCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    }
+    int resultCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
     endNotificationRequest(job->widget(), resultCode);
     qDebug() << Q_FUNC_INFO << "Server notify job failed with code " << resultCode;

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -220,7 +220,7 @@ void FolderWizardRemotePath::slotCreateRemoteFolderFinished(QNetworkReply::Netwo
 void FolderWizardRemotePath::slotHandleMkdirNetworkError(QNetworkReply *reply)
 {
     qDebug() << "** webdav mkdir request failed:" << reply->error();
-    if( reply && !_account->credentials()->stillValid(reply) ) {
+    if( !_account->credentials()->stillValid(reply) ) {
         showWarn(tr("Authentication failed accessing %1").arg(Theme::instance()->appNameGUI()));
     } else {
         showWarn(tr("Failed to create the folder on %1. Please check manually.")
@@ -228,10 +228,11 @@ void FolderWizardRemotePath::slotHandleMkdirNetworkError(QNetworkReply *reply)
     }
 }
 
-void FolderWizardRemotePath::slotHandleLsColNetworkError(QNetworkReply *reply)
+void FolderWizardRemotePath::slotHandleLsColNetworkError(QNetworkReply */*reply*/)
 {
+    auto job = qobject_cast<MkColJob *>(sender());
     showWarn(tr("Failed to list a folder. Error: %1")
-             .arg(errorMessage(reply->errorString(), reply->readAll())));
+             .arg(job->errorStringParsingBody()));
 }
 
 static QTreeWidgetItem* findFirstChild(QTreeWidgetItem *parent, const QString& text)

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -202,6 +202,7 @@ void OwncloudSetupWizard::slotOwnCloudFoundAuth(const QUrl& url, const QVariantM
 
 void OwncloudSetupWizard::slotNoOwnCloudFoundAuth(QNetworkReply *reply)
 {
+    auto job = qobject_cast<CheckServerJob *>(sender());
     int resultCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     QString contentType = reply->header(QNetworkRequest::ContentTypeHeader).toString();
 
@@ -213,7 +214,7 @@ void OwncloudSetupWizard::slotNoOwnCloudFoundAuth(QNetworkReply *reply)
         msg = tr("Failed to connect to %1 at %2:<br/>%3")
                   .arg(Utility::escape(Theme::instance()->appNameGUI()),
                        Utility::escape(reply->url().toString()),
-                       Utility::escape(reply->errorString()));
+                       Utility::escape(job->errorString()));
     }
     bool isDowngradeAdvised = checkDowngradeAdvised(reply);
 
@@ -322,7 +323,7 @@ void OwncloudSetupWizard::slotAuthError()
                           "<a href=\"%1\">click here</a> to access the service with your browser.")
                            .arg(Utility::escape(_ocWizard->account()->url().toString()));
         } else {
-            errorMsg = errorMessage(reply->errorString(), reply->readAll());
+            errorMsg = job->errorStringParsingBody();
         }
 
     // Something else went wrong, maybe the response was 200 but with invalid data.
@@ -398,6 +399,7 @@ void OwncloudSetupWizard::slotCreateLocalAndRemoteFolders(const QString& localFo
 // ### TODO move into EntityExistsJob once we decide if/how to return gui strings from jobs
 void OwncloudSetupWizard::slotRemoteFolderExists(QNetworkReply *reply)
 {
+    auto job = qobject_cast<EntityExistsJob *>(sender());
     bool ok = true;
     QString error;
     QNetworkReply::NetworkError errId = reply->error();
@@ -412,7 +414,7 @@ void OwncloudSetupWizard::slotRemoteFolderExists(QNetworkReply *reply)
             createRemoteFolder();
         }
     } else {
-        error = tr("Error: %1").arg(reply->errorString());
+        error = tr("Error: %1").arg(job->errorString());
         ok = false;
     }
 

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -385,7 +385,7 @@ void CheckServerJob::start()
     AbstractNetworkJob::start();
 }
 
-void CheckServerJob::slotTimeout()
+void CheckServerJob::onTimedOut()
 {
     qDebug() << "TIMEOUT" << Q_FUNC_INFO;
     if (reply() && reply()->isRunning()) {
@@ -702,7 +702,7 @@ bool JsonApiJob::finished()
     int statusCode = 0;
 
     if (reply()->error() != QNetworkReply::NoError) {
-        qWarning() << "Network error: " << path() << reply()->errorString() << reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+        qWarning() << "Network error: " << path() << errorString() << reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute);
         emit jsonReceived(QVariantMap(), statusCode);
         return true;
     }

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -203,12 +203,18 @@ public:
 
 signals:
     void instanceFound(const QUrl&url, const QVariantMap &info);
+
+    /** Emitted on invalid status.php reply.
+     *
+     * \a reply is never null
+     */
     void instanceNotFound(QNetworkReply *reply);
     void timeout(const QUrl&url);
 
+private:
+    bool finished() Q_DECL_OVERRIDE;
+    void onTimedOut() Q_DECL_OVERRIDE;
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
-    virtual void slotTimeout() Q_DECL_OVERRIDE;
     virtual void metaDataChangedSlot();
     virtual void encryptedSlot();
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -113,7 +113,7 @@ void GETFileJob::start() {
     }
 
     if( reply()->error() != QNetworkReply::NoError ) {
-        qWarning() << Q_FUNC_INFO << " Network error: " << reply()->errorString();
+        qWarning() << Q_FUNC_INFO << " Network error: " << errorString();
     }
 
     connect(reply(), SIGNAL(metaDataChanged()), this, SLOT(slotMetaDataChanged()));
@@ -254,7 +254,7 @@ void GETFileJob::slotReadyRead()
 
         qint64 r = reply()->read(buffer.data(), toRead);
         if (r < 0) {
-            _errorString = reply()->errorString();
+            _errorString = networkReplyErrorString(*reply());
             _errorStatus = SyncFileItem::NormalError;
             qDebug() << "Error while reading from device: " << _errorString;
             reply()->abort();
@@ -287,7 +287,7 @@ void GETFileJob::slotReadyRead()
     }
 }
 
-void GETFileJob::slotTimeout()
+void GETFileJob::onTimedOut()
 {
     qDebug() << "Timeout" << (reply() ? reply()->request().url() : path());
     if (!reply())
@@ -301,11 +301,8 @@ QString GETFileJob::errorString() const
 {
     if (!_errorString.isEmpty()) {
         return _errorString;
-    } else if (reply()->hasRawHeader("OC-ErrorString")) {
-        return reply()->rawHeader("OC-ErrorString");
-    } else {
-        return reply()->errorString();
     }
+    return AbstractNetworkJob::errorString();
 }
 
 void PropagateDownloadFile::start()
@@ -445,7 +442,7 @@ void PropagateDownloadFile::slotGetFinished()
 
     qDebug() << Q_FUNC_INFO << job->reply()->request().url() << "FINISHED WITH STATUS"
              << job->reply()->error()
-             << (job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : job->reply()->errorString())
+             << (job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : job->errorString())
              << _item->_httpErrorCode
              << _tmpFile.size() << _item->_size << job->resumeStart()
              << job->reply()->rawHeader("Content-Range") << job->reply()->rawHeader("Content-Length");

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -87,7 +87,7 @@ public:
     SyncFileItem::Status errorStatus() { return _errorStatus; }
     void setErrorStatus(const SyncFileItem::Status & s) { _errorStatus = s; }
 
-    virtual void slotTimeout() Q_DECL_OVERRIDE;
+    void onTimedOut() Q_DECL_OVERRIDE;
 
     QByteArray &etag() { return _etag; }
     quint64 resumeStart() { return _resumeStart; }

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -42,18 +42,6 @@ void DeleteJob::start()
     AbstractNetworkJob::start();
 }
 
-
-QString DeleteJob::errorString()
-{
-    if (_timedout) {
-        return tr("Connection timed out");
-    } else if (reply()->hasRawHeader("OC-ErrorString")) {
-        return reply()->rawHeader("OC-ErrorString");
-    } else {
-        return reply()->errorString();
-    }
-}
-
 bool DeleteJob::finished()
 {
     emit finishedSignal();
@@ -89,7 +77,7 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
 
     qDebug() << Q_FUNC_INFO << _job->reply()->request().url() << "FINISHED WITH STATUS"
         << _job->reply()->error()
-        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->reply()->errorString());
+        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->errorString());
 
     QNetworkReply::NetworkError err = _job->reply()->error();
     const int httpStatus = _job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -32,9 +32,6 @@ public:
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
 
-    QString errorString();
-    bool timedOut() { return _timedout; }
-
 signals:
     void finishedSignal();
 };

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -75,7 +75,7 @@ void PropagateRemoteMkdir::slotMkcolJobFinished()
 
     qDebug() << Q_FUNC_INFO << _job->reply()->request().url() << "FINISHED WITH STATUS"
         << _job->reply()->error()
-        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->reply()->errorString());
+        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->errorString());
 
     QNetworkReply::NetworkError err = _job->reply()->error();
     _item->_httpErrorCode = _job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
@@ -85,11 +85,7 @@ void PropagateRemoteMkdir::slotMkcolJobFinished()
     } else if (err != QNetworkReply::NoError) {
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
                                                     &propagator()->_anotherSyncNeeded);
-        auto errorString = _job->reply()->errorString();
-        if (_job->reply()->hasRawHeader("OC-ErrorString")) {
-            errorString = _job->reply()->rawHeader("OC-ErrorString");
-        }
-        done(status, errorString);
+        done(status, _job->errorString());
         return;
     } else if (_item->_httpErrorCode != 201) {
         // Normally we expect "201 Created"

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -56,17 +56,6 @@ void MoveJob::start()
 }
 
 
-QString MoveJob::errorString()
-{
-    if (_timedout) {
-        return tr("Connection timed out");
-    } else if (reply()->hasRawHeader("OC-ErrorString")) {
-        return reply()->rawHeader("OC-ErrorString");
-    } else {
-        return reply()->errorString();
-    }
-}
-
 bool MoveJob::finished()
 {
     emit finishedSignal();
@@ -131,7 +120,7 @@ void PropagateRemoteMove::slotMoveJobFinished()
 
     qDebug() << Q_FUNC_INFO << _job->reply()->request().url() << "FINISHED WITH STATUS"
         << _job->reply()->error()
-        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->reply()->errorString());
+        << (_job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : _job->errorString());
 
     QNetworkReply::NetworkError err = _job->reply()->error();
     _item->_httpErrorCode = _job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -35,9 +35,6 @@ public:
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
 
-    QString errorString();
-    bool timedOut() { return _timedout; }
-
 signals:
     void finishedSignal();
 };

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -101,14 +101,6 @@ void PUTFileJob::start() {
     AbstractNetworkJob::start();
 }
 
-void PUTFileJob::slotTimeout() {
-    qDebug() << "Timeout" << (reply() ? reply()->request().url() : path());
-    if (!reply())
-        return;
-    _errorString =  tr("Connection Timeout");
-    reply()->abort();
-}
-
 #if QT_VERSION < QT_VERSION_CHECK(5, 4, 2)
 void PUTFileJob::slotSoftAbort() {
     reply()->setProperty(owncloudShouldSoftCancelPropertyName, true);
@@ -133,11 +125,7 @@ bool PollJob::finished()
     if (err != QNetworkReply::NoError) {
         _item->_httpErrorCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         _item->_status = classifyError(err, _item->_httpErrorCode);
-        _item->_errorString = reply()->errorString();
-
-        if (reply()->hasRawHeader("OC-ErrorString")) {
-            _item->_errorString = reply()->rawHeader("OC-ErrorString");
-        }
+        _item->_errorString = errorString();
 
         if (_item->_status == SyncFileItem::FatalError || _item->_httpErrorCode >= 400) {
             if (_item->_status != SyncFileItem::FatalError

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -120,15 +120,12 @@ public:
     }
 
     QString errorString() {
-        return _errorString.isEmpty() ? reply()->errorString() : _errorString;
+        return _errorString.isEmpty() ? AbstractNetworkJob::errorString() : _errorString;
     }
-
-    virtual void slotTimeout() Q_DECL_OVERRIDE;
 
     quint64 msSinceStart() const {
         return _requestTimer.elapsed();
     }
-
 
 signals:
     void finishedSignal();
@@ -160,12 +157,6 @@ public:
 
     void start() Q_DECL_OVERRIDE;
     bool finished() Q_DECL_OVERRIDE;
-    void slotTimeout() Q_DECL_OVERRIDE {
-//      emit finishedSignal(false);
-//      deleteLater();
-        qDebug() << Q_FUNC_INFO;
-        reply()->abort();
-    }
 
 signals:
     void finishedSignal();

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -178,7 +178,7 @@ void PropagateUploadFileV1::slotPutFinished()
 
     qDebug() << Q_FUNC_INFO << job->reply()->request().url() << "FINISHED WITH STATUS"
              << job->reply()->error()
-             << (job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : job->reply()->errorString())
+             << (job->reply()->error() == QNetworkReply::NoError ? QLatin1String("") : job->errorString())
              << job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute)
              << job->reply()->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
 
@@ -208,13 +208,9 @@ void PropagateUploadFileV1::slotPutFinished()
                "It is restored and your edit is in the conflict file."))) {
             return;
         }
-        QByteArray replyContent = job->reply()->readAll();
+        QByteArray replyContent;
+        QString errorString = job->errorStringParsingBody(&replyContent);
         qDebug() << replyContent; // display the XML error in the debug
-        QString errorString = errorMessage(job->errorString(), replyContent);
-
-        if (job->reply()->hasRawHeader("OC-ErrorString")) {
-            errorString = job->reply()->rawHeader("OC-ErrorString");
-        }
 
         if (_item->_httpErrorCode == 412) {
             // Precondition Failed: Either an etag or a checksum mismatch.


### PR DESCRIPTION
By default QNetworkReply::errorString() often produces messages like
   `"Error downloading <url> - server replied: <reason>"`
but the "downloading" part invariably confuses people since the
error might very well have been produced by a PUT request.

This commit produces clearer error messages for HTTP errors.

Additionally:
* Remove some unnecessary null checks from slots connected to
  network job signals and document that these signals never send
  null replies.
* There was a bug where AbstractNetworkJob::_timedout wasn't
  set when derived classes overrode slotTimeout. We now ensure
  it's always set by disallowing overrides of slotTimeout.
  Instead it now calls onTimedOut, which allows custom handling.
* Several subclasses declared errorString, isTimedOut. Move
  these to AbstractNetworkJob.
* Unify handling of OC-ErrorString (via the new, general
  Job::errorString)
* Add documentation in various places.