### PR TITLE
complete url when using themed wizardUrlPostfix

### DIFF
--- a/src/gui/wizard/owncloudwizardresultpage.cpp
+++ b/src/gui/wizard/owncloudwizardresultpage.cpp
@@ -97,7 +97,8 @@ void OwncloudWizardResultPage::slotOpenLocal()
 
 void OwncloudWizardResultPage::slotOpenServer()
 {
-    QUrl url = field("OCUrl").toUrl();
+    Theme* theme = Theme::instance();
+    QUrl url = QUrl(field("OCUrl").toString() + theme->wizardUrlPostfix());
     qDebug() << Q_FUNC_INFO << url;
     QDesktopServices::openUrl(url);
 }


### PR DESCRIPTION
Before we would only open the part of the url that the users entered.
Now if the wizardUrlPostfix is used this should be appended to that
when opening the browser on the result page.