### PR TITLE
Share Dialog: Bring to top on tray click #5515

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -32,6 +32,7 @@
 #include "accountmanager.h"
 #include "clientproxy.h"
 #include "filesystem.h"
+#include "owncloudgui.h"
 
 #include "creds/credentialsfactory.h"
 #include "creds/abstractcredentials.h"
@@ -64,10 +65,10 @@ OwncloudSetupWizard::~OwncloudSetupWizard()
     _ocWizard->deleteLater();
 }
 
+static QPointer<OwncloudSetupWizard> wiz = 0;
+
 void OwncloudSetupWizard::runWizard(QObject* obj, const char* amember, QWidget *parent)
 {
-    static QPointer<OwncloudSetupWizard> wiz;
-
     if (!wiz.isNull()) {
         return;
     }
@@ -76,6 +77,16 @@ void OwncloudSetupWizard::runWizard(QObject* obj, const char* amember, QWidget *
     connect( wiz, SIGNAL(ownCloudWizardDone(int)), obj, amember);
     FolderMan::instance()->setSyncEnabled(false);
     wiz->startWizard();
+}
+
+bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
+{
+    if (wiz.isNull()) {
+        return false;
+    }
+
+    ownCloudGui::raiseDialog(wiz->_ocWizard);
+    return true;
 }
 
 void OwncloudSetupWizard::startWizard()

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -60,6 +60,7 @@ class OwncloudSetupWizard : public QObject
 public:
     /** Run the wizard */
     static void runWizard(QObject *obj, const char* amember, QWidget *parent = 0 );
+    static bool bringWizardToFrontIfVisible();
 signals:
     // overall dialog close signal.
     void ownCloudWizardDone( int );


### PR DESCRIPTION
On my OS X, it might get hidden under other apps while I opened it and then want to quickly
verify something in another app.