### PR TITLE
Missing dot at end of string on connection error

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -47,6 +47,7 @@
 #include <QIcon>
 #include <QVariant>
 #include <QToolTip>
+#include <QStringBuilder>
 #include <qstringlistmodel.h>
 #include <qpropertyanimation.h>
 
@@ -573,7 +574,7 @@ void AccountSettings::slotAccountStateChanged(int state)
         } else {
             showConnectionLabel(tr("No connection to %1 at %2.")
                                     .arg(Utility::escape(Theme::instance()->appNameGUI()), server),
-                                _accountState->connectionErrors());
+                                _accountState->connectionErrors() % QChar('.'));
         }
     } else {
         // ownCloud is not yet configured.


### PR DESCRIPTION
The string misses a final dot because the network library doesn't end error messages with a dot.
Cf. the following discussion https://central.owncloud.org/t/owncloud-client-unable-to-find-a-string-to-improve-french-translation/6164/5
Unsure whether QStringBuilder is already included in another header or not, so in doubt I preferred specifiying it