### PR TITLE
Fix a crash in ProxyAuthHandler

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -202,6 +202,11 @@ QNetworkAccessManager *Account::networkAccessManager()
     return _am.data();
 }
 
+QSharedPointer<QNetworkAccessManager> Account::sharedNetworkAccessManager()
+{
+    return _am;
+}
+
 QNetworkReply *Account::sendRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data)
 {
     req.setUrl(url);

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -185,6 +185,7 @@ public:
 
     void resetNetworkAccessManager();
     QNetworkAccessManager* networkAccessManager();
+    QSharedPointer<QNetworkAccessManager> sharedNetworkAccessManager();
 
     /// Called by network jobs on credential errors, emits invalidCredentials()
     void handleInvalidCredentials();


### PR DESCRIPTION
See
https://sentry.io/owncloud/desktop-win-and-mac/issues/243433178/activity/
https://sentry.io/owncloud/desktop-win-and-mac/issues/234182688/activity/

The problem was that an account's QNetworkAccessManager can be deleted
when reentering the event loop.