### PR TITLE
FolderStatusModel: Fix crash for empty relativePath

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -652,7 +652,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
         newInfo._size = job->_sizes.value(path);
         newInfo._isExternal = permissionMap.value(removeTrailingSlash(path)).toString().contains("M");
         newInfo._path = relativePath;
-        newInfo._name = relativePath.split('/', QString::SkipEmptyParts).last();
+        newInfo._name = removeTrailingSlash(relativePath).split('/').last();
 
         if (relativePath.isEmpty())
             continue;


### PR DESCRIPTION
The problem was that split("", SkipEmptyParts) is the empty list.

See
https://sentry.io/owncloud/desktop-win-and-mac/issues/251167186/