### PR TITLE
Wizard: Don't show not-so-useful result page #5726

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -333,24 +333,6 @@ void Application::slotownCloudWizardDone( int res )
     folderMan->setSyncEnabled(true);
 
     if( res == QDialog::Accepted ) {
-        // Open the settings page for the new account if no folders
-        // were configured. Using the last account for this check is
-        // not exactly correct, but good enough.
-        if (!accountMan->accounts().isEmpty()) {
-            AccountStatePtr newAccount = accountMan->accounts().last();
-            bool hasFolder = false;
-            foreach (Folder* folder, folderMan->map()) {
-                if (folder->accountState() == newAccount.data()) {
-                    hasFolder = true;
-                    break;
-                }
-            }
-
-            if (!hasFolder) {
-                _gui->slotShowSettings();
-            }
-        }
-
         // Check connectivity of the newly created account
         _checkConnectionTimer.start();
         slotCheckConnection();
@@ -363,6 +345,8 @@ void Application::slotownCloudWizardDone( int res )
                 && QCoreApplication::applicationDirPath().startsWith("/Applications/");
 #endif
         Utility::setLaunchOnStartup(_theme->appName(), _theme->appNameGUI(), shouldSetAutoStart);
+
+        _gui->slotShowSettings();
     }
 }
 

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -185,6 +185,8 @@ void OwncloudWizard::slotCurrentPageChanged( int id )
         disconnect(this, SIGNAL(finished(int)), this, SIGNAL(basicSetupFinished(int)));
         emit basicSetupFinished(QDialog::Accepted);
         appendToConfigurationLog( QString::null );
+        // Immediately close on show, we currently don't want this page anymore
+        close();
     }
 
     setOption(QWizard::HaveCustomButton1, id == WizardCommon::Page_AdvancedSetup);


### PR DESCRIPTION
Better immediately show the settings dialog where people can see what's going on.
They can go to sync folder or webinterface from there.