### PR TITLE
SSL error handling: Remove unnecessary confusing code

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -366,11 +366,8 @@ void Account::slotHandleSslErrors(QNetworkReply *reply , QList<QSslError> errors
                 _rejectedCertificates.append(error.certificate());
             }
         }
-        // if during normal operation, a new certificate was MITM'ed, and the user does not
-        // ACK it, the running request must be aborted and the QNAM must be reset, to not
-        // treat the new cert as granted. See bug #3283
-        reply->abort();
-        resetNetworkAccessManager();
+
+        // Not calling ignoreSslErrors will make the SSL handshake fail.
         return;
     }
 }


### PR DESCRIPTION
I'm confident this is unnecessary. The original bug in #3283 was
to call ignoreSslErrors() without an argument in the 'accept'
case, which meant ignoring *all* subsequent SSL errors.

With that fixed, explicitly aborting the reply and resetting QNAM
is not needed since not ignoring the error will lead to the SSL
handshake failing.

See also:
  75b38d1a2ffe57d0f1eb3ebb8c5f30b8b2a185e4 (workaround introduced)
  89376e14d6135a6f39a6df99d54fde253573575c (real fix)
  76ce5adbf02af052ab8d7596b8ded75c7d4d7fcb (cherry-pick of workaround)