### PR TITLE
Exclude list: remove .htaccess

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -21,7 +21,6 @@ System Volume Information
 .fseventd
 .apdisk
 
-.htaccess
 .directory
 
 *.part


### PR DESCRIPTION
As per issue #5701, if the server does not support it, let the server
show return an error, but we should not blacklist it localy