### PR TITLE
Detect maintenance mode #4485

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -601,6 +601,8 @@ void AccountSettings::slotAccountStateChanged(int state)
             showConnectionLabel( tr("Connected to %1.").arg(serverWithUser), errors );
         } else if (state == AccountState::ServiceUnavailable) {
             showConnectionLabel( tr("Server %1 is temporarily unavailable.").arg(server) );
+        } else if (state == AccountState::MaintenanceMode) {
+            showConnectionLabel( tr("Server %1 is currently in maintenance mode.").arg(server) );
         } else if (state == AccountState::SignedOut) {
             showConnectionLabel( tr("Signed out from %1.").arg(serverWithUser) );
         } else {

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -54,6 +54,10 @@ public:
         /// don't bother the user too much and try again.
         ServiceUnavailable,
 
+        /// Similar to ServiceUnavailable, but we know the server is down
+        /// for maintenance
+        MaintenanceMode,
+
         /// Could not communicate with the server for some reason.
         /// We assume this may resolve itself over time and will try
         /// again automatically.
@@ -101,7 +105,6 @@ public:
     void signIn();
 
     bool isConnected() const;
-    bool isConnectedOrTemporarilyUnavailable() const;
 
     /// Triggers a ping to the server to update state and
     /// connection status and errors.

--- a/src/libsync/connectionvalidator.cpp
+++ b/src/libsync/connectionvalidator.cpp
@@ -55,6 +55,8 @@ QString ConnectionValidator::statusString( Status stat )
         return QLatin1String("User canceled credentials");
     case ServiceUnavailable:
         return QLatin1String("Service unavailable");
+    case MaintenanceMode:
+        return QLatin1String("Maintenance mode");
     case Timeout:
         return QLatin1String("Timeout");
     }
@@ -127,6 +129,11 @@ void ConnectionValidator::slotStatusFound(const QUrl&url, const QVariantMap &inf
              << "(" << serverVersion << ")";
 
     if (!serverVersion.isEmpty() && !setAndCheckServerVersion(serverVersion)) {
+        return;
+    }
+
+    if (info["maintenance"].toBool()) {
+        reportResult( MaintenanceMode );
         return;
     }
 

--- a/src/libsync/connectionvalidator.h
+++ b/src/libsync/connectionvalidator.h
@@ -85,13 +85,13 @@ public:
         Undefined,
         Connected,
         NotConfigured,
-        ServerVersionMismatch,
-        CredentialsMissingOrWrong,
-        StatusNotFound,
-        UserCanceledCredentials,
-        ServiceUnavailable,
-        // actually also used for other errors on the authed request
-        Timeout
+        ServerVersionMismatch, // The server version is too old
+        CredentialsMissingOrWrong, // Credentials aren't ready or AuthenticationRequiredError
+        StatusNotFound, // Error retrieving status.php
+        UserCanceledCredentials, // checkAuthentication when credentials aren't ready
+        ServiceUnavailable, // 503 on authed request
+        MaintenanceMode, // maintenance enabled in status.php
+        Timeout // actually also used for other errors on the authed request
     };
 
     static QString statusString( Status );


### PR DESCRIPTION
When we first detect a 503 (probably from a PROPFIND) and enter the
ServiceUnavailable state, we new trigger a status.php query that will
switch the state to MaintenanceMode if necessary.