### PR TITLE
Selective sync: Skip excluded folders when reading db

### DIFF
--- a/src/libsync/syncjournaldb.h
+++ b/src/libsync/syncjournaldb.h
@@ -136,6 +136,14 @@ public:
     /**
      * Make sure that on the next sync, fileName is not read from the DB but uses the PROPFIND to
      * get the info from the server
+     *
+     * Specifically, this sets the md5 field of fileName and all its parents to _invalid_.
+     * That causes a metadata difference and a resulting discovery from the remote for the
+     * affected folders.
+     *
+     * Since folders in the selective sync list will not be rediscovered (csync_ftw,
+     * _csync_detect_update skip them), the _invalid_ marker will stay and it. And any
+     * child items in the db will be ignored when reading a remote tree from the database.
      */
     void avoidReadFromDbOnNextSync(const QString& fileName);
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -213,6 +213,49 @@ private slots:
         }
     }
 
+    void testSelectiveSyncBug() {
+        // issue owncloud/enterprise#1965: files from selective-sync ignored
+        // folders are uploaded anyway is some circumstances.
+        FakeFolder fakeFolder{FileInfo{ QString(), {
+            FileInfo { QStringLiteral("parentFolder"), {
+                FileInfo{ QStringLiteral("subFolder"), {
+                    { QStringLiteral("fileA.txt"), 400 },
+                    { QStringLiteral("fileB.txt"), 400, 'o' }
+                }}
+            }}
+        }}};
+
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        auto expectedServerState = fakeFolder.currentRemoteState();
+
+        // Remove subFolder with selectiveSync:
+        fakeFolder.syncEngine().journal()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList,
+                                                                {"parentFolder/subFolder/"});
+        fakeFolder.syncEngine().journal()->avoidReadFromDbOnNextSync("parentFolder/subFolder/");
+
+        // But touch a local file before the next sync, such that the local folder
+        // can't be removed
+        fakeFolder.localModifier().setContents("parentFolder/subFolder/fileB.txt", 'n');
+
+        // Several follow-up syncs don't change the state at all,
+        // in particular the remote state doesn't change and fileB.txt
+        // isn't uploaded.
+
+        for (int i = 0; i < 3; ++i) {
+            fakeFolder.syncOnce();
+
+            {
+                // Nothing changed on the server
+                QCOMPARE(fakeFolder.currentRemoteState(), expectedServerState);
+                // The local state should still have subFolderA
+                auto local = fakeFolder.currentLocalState();
+                QVERIFY(local.find("parentFolder/subFolder"));
+                QVERIFY(local.find("parentFolder/subFolder/fileA.txt"));
+                QVERIFY(local.find("parentFolder/subFolder/fileB.txt"));
+            }
+        }
+    }
+
     void abortAfterFailedMkdir() {
         QSKIP("Skip for 2.3");
         FakeFolder fakeFolder{FileInfo{}};


### PR DESCRIPTION
When a new folder becomes selective-sync excluded, we already mark it
and all its parent folders with _invalid_ etags to force rediscovery.

That's not enough however. Later calls to csync_statedb_get_below_path
could still pull data about the excluded files into the remote tree.

That lead to incorrect behavior, such as uploads happening for folders
that had been explicitly excluded from sync.

To fix the problem, statedb_get_below_path is adjusted to not read the
data about excluded folders from the database.

Currently we can't wipe this data from the database outright because we
need it to determine whether the files in the excluded folder can be
wiped away or not.

See owncloud/enterprise#1965