### PR TITLE
Add the account name and folder when starting the sync

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -865,7 +865,10 @@ void FolderMan::slotScheduleFolderByTime()
 
 void FolderMan::slotFolderSyncStarted( )
 {
-    qCInfo(lcFolderMan) << ">===================================== sync started for " << _currentSyncFolder->remoteUrl().toString();
+    qCInfo(lcFolderMan, ">========== Sync started for folder [%s] of account [%s] with remote [%s]",
+        qPrintable(_currentSyncFolder->shortGuiLocalPath()),
+        qPrintable(_currentSyncFolder->accountState()->account()->displayName()),
+        qPrintable(_currentSyncFolder->remoteUrl().toString()));
 }
 
 /*
@@ -876,7 +879,10 @@ void FolderMan::slotFolderSyncStarted( )
   */
 void FolderMan::slotFolderSyncFinished( const SyncResult& )
 {
-    qCInfo(lcFolderMan) << "<===================================== sync finished for " << _currentSyncFolder->remoteUrl().toString();
+    qCInfo(lcFolderMan, "<========== Sync finished for folder [%s] of account [%s] with remote [%s]",
+        qPrintable(_currentSyncFolder->shortGuiLocalPath()),
+        qPrintable(_currentSyncFolder->accountState()->account()->displayName()),
+        qPrintable(_currentSyncFolder->remoteUrl().toString()));
 
     _lastSyncFolder = _currentSyncFolder;
     _currentSyncFolder = 0;


### PR DESCRIPTION
This should help clearly delimiting them in the log for multi-account setups.
This information is already available elsewhere in the log in any case.

Issue #5672