### PR TITLE
Account: forget credentials on delete #5752

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -304,6 +304,8 @@ void AccountManager::deleteAccount(AccountState *account)
     auto copy = *it; // keep a reference to the shared pointer so it does not delete it just yet
     _accounts.erase(it);
 
+    // Forget account credentials, cookies
+    account->account()->credentials()->forgetSensitiveData();
     QFile::remove(account->account()->cookieJarPath());
 
     auto settings = Utility::settingsWithGroup(QLatin1String(accountsC));


### PR DESCRIPTION
@SamuAlfageme This should do it, I see the keychain-removal code being run on delete now. But I've had some trouble seeing the keychain entries. Testing would be appreciated.