### PR TITLE
Download: Retrigger folder discovery on 404

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -500,6 +500,11 @@ void PropagateDownloadFile::slotGetFinished()
         } else if (fileNotFound) {
             job->setErrorString(tr("File was deleted from server"));
             job->setErrorStatus(SyncFileItem::SoftError);
+
+            // As a precaution against bugs that cause our database and the
+            // reality on the server to diverge, rediscover this folder on the
+            // next sync run.
+            propagator()->_journal->avoidReadFromDbOnNextSync(_item->_file);
         }
 
         SyncFileItem::Status status = job->errorStatus();


### PR DESCRIPTION
See owncloud/enterprise#1966

If the server and the client's database go out of sync, there could be
persistent 404 errors. This change ensures that the problem corrects
itself eventually by triggering a remote discovery of the file's
parent folders.

It does not address the root cause that might have lead to the
divergence.