### PR TITLE
OAuth: cleanup debug messages

### DIFF
--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -21,8 +21,9 @@
 #include <QJsonDocument>
 #include "theme.h"
 
-
 namespace OCC {
+
+Q_LOGGING_CATEGORY(lcOauth, "sync.credentials.oauth", QtInfoMsg)
 
 OAuth::~OAuth()
 {
@@ -89,7 +90,7 @@ void OAuth::start()
                     if (reply->error() != QNetworkReply::NoError || jsonParseError.error != QJsonParseError::NoError
                         || json.isEmpty() || refreshToken.isEmpty() || accessToken.isEmpty()
                         || json["token_type"].toString() != QLatin1String("Bearer")) {
-                        qDebug() << "Error when getting the accessToken" << reply->error() << json << jsonParseError.errorString();
+                        qCWarning(lcOauth) << "Error when getting the accessToken" << reply->error() << json << jsonParseError.errorString();
                         emit result(Error);
                         return;
                     }

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -152,10 +152,12 @@ void AbstractNetworkJob::slotFinished()
     }
 
     if (_reply->error() != QNetworkReply::NoError) {
-        qCWarning(lcNetworkJob) << _reply->error() << errorString()
-                                << _reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
-        if (_reply->error() == QNetworkReply::ProxyAuthenticationRequiredError) {
-            qCWarning(lcNetworkJob) << _reply->rawHeader("Proxy-Authenticate");
+        if (!_ignoreCredentialFailure || _reply->error() != QNetworkReply::AuthenticationRequiredError) {
+            qCWarning(lcNetworkJob) << _reply->error() << errorString()
+                                    << _reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+            if (_reply->error() == QNetworkReply::ProxyAuthenticationRequiredError) {
+                qCWarning(lcNetworkJob) << _reply->rawHeader("Proxy-Authenticate");
+            }
         }
         emit networkError(_reply);
     }

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -181,7 +181,6 @@ void HttpCredentials::fetchFromKeychain()
         addSettingsToJob(_account, job);
         job->setInsecureFallback(false);
         job->setKey(kck);
-        qCDebug(lcHttpCredentials) << "-------- ----->" << _clientSslCertificate << _clientSslKey;
 
         connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotReadClientCertPEMJobDone(QKeychain::Job *)));
         job->start();
@@ -310,10 +309,10 @@ void HttpCredentials::refreshAccessToken()
         QString accessToken = json["access_token"].toString();
         if (reply->error() != QNetworkReply::NoError || jsonParseError.error != QJsonParseError::NoError || json.isEmpty()) {
             // Network error maybe?
-            qDebug() << "Error while refreshing the token" << reply->errorString() << jsonData << jsonParseError.errorString();
+            qCWarning(lcHttpCredentials) << "Error while refreshing the token" << reply->errorString() << jsonData << jsonParseError.errorString();
         } else if (accessToken.isEmpty()) {
             // The token is no longer valid.
-            qDebug() << "Expired refresh token. Logging out";
+            qCDebug(lcHttpCredentials) << "Expired refresh token. Logging out";
             _refreshToken.clear();
         } else {
             _ready = true;


### PR DESCRIPTION
- Add category to the all messages (they did not have it was merged right after
the patch to add category everywhere, but this code did not have it.)

- Make sure there is no warnings in the normal flow. (The wizard does a request
without authentication to determine the auth type)