### PR TITLE
Classify chunked items correctly. Issue #5850

### DIFF
--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -53,9 +53,10 @@ struct SyncOptions
     /** If a confirmation should be asked for external storages */
     bool _confirmExternalStorage;
 
-    /** The initial un-adjusted chunk size in bytes for chunked uploads
+    /** The initial un-adjusted chunk size in bytes for chunked uploads, both
+     * for old and new chunking algorithm, which classifies the item to be chunked
      *
-     * When dynamic chunk size adjustments are done, this is the
+     * In chunkingNG, when dynamic chunk size adjustments are done, this is the
      * starting value and is then gradually adjusted within the
      * minChunkSize / maxChunkSize bounds.
      */

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -379,7 +379,8 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
             return job;
         } else {
             PropagateUploadFileCommon *job = 0;
-            if (item->_size > _chunkSize && account()->capabilities().chunkingNg()) {
+            if (item->_size > syncOptions()._initialChunkSize && account()->capabilities().chunkingNg()) {
+                // Item is above _initialChunkSize, thus will be classified as to be chunked
                 job = new PropagateUploadFileNG(this, item);
             } else {
                 job = new PropagateUploadFileV1(this, item);

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -307,7 +307,11 @@ private:
     int _chunkCount; /// Total number of chunks for this file
     int _transferId; /// transfer id (part of the url)
 
-    quint64 chunkSize() const { return propagator()->syncOptions()._initialChunkSize; }
+    quint64 chunkSize() const {
+        // Old chunking does not use dynamic chunking algorithm, and does not adjusts the chunk size respectively,
+        // thus this value should be used as the one classifing item to be chunked
+        return propagator()->syncOptions()._initialChunkSize;
+    }
 
 
 public:

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -400,6 +400,7 @@ void PropagateUploadFileNG::slotPutFinished()
         // the chunk sizes a bit.
         quint64 targetSize = (propagator()->_chunkSize + predictedGoodSize) / 2;
 
+        // Adjust the dynamic chunk size _chunkSize used for sizing of the item's chunks to be send
         propagator()->_chunkSize = qBound(
             propagator()->syncOptions()._minChunkSize,
             targetSize,


### PR DESCRIPTION
This should solve https://github.com/owncloud/client/issues/5850. 

Please note: we cannot set chunk size of PUT V1 to _chunkSize which is dynamic because PUT V1 will not adjust dynamic chunk size. If we want it, we need to make code adjusting dynamic chunk size both for V1 and NG. 