### PR TITLE
Blacklist: Don't let errors become warnings #5516

### DIFF
--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -186,7 +186,8 @@ QTreeWidgetItem *ProtocolWidget::createCompletedTreewidgetItem(const QString &fo
 
     QIcon icon;
     if (item._status == SyncFileItem::NormalError
-        || item._status == SyncFileItem::FatalError) {
+        || item._status == SyncFileItem::FatalError
+        || item._status == SyncFileItem::BlacklistedError) {
         icon = Theme::instance()->syncStateIcon(SyncResult::Error);
     } else if (Progress::isWarningKind(item._status)) {
         icon = Theme::instance()->syncStateIcon(SyncResult::Problem);

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -195,8 +195,7 @@ static void blacklistUpdate(SyncJournalDb *journal, SyncFileItem &item)
     // An ignoreDuration of 0 mean we're tracking the error, but not actively
     // suppressing it.
     if (item._hasBlacklistEntry && newEntry._ignoreDuration > 0) {
-        item._status = SyncFileItem::FileIgnored;
-        item._errorString.prepend(PropagateItemJob::tr("Continue blacklisting:") + " ");
+        item._status = SyncFileItem::BlacklistedError;
 
         qCInfo(lcPropagator) << "blacklisting " << item._file
                              << " for " << newEntry._ignoreDuration
@@ -260,6 +259,7 @@ void PropagateItemJob::done(SyncFileItem::Status statusArg, const QString &error
     case SyncFileItem::Conflict:
     case SyncFileItem::FileIgnored:
     case SyncFileItem::NoStatus:
+    case SyncFileItem::BlacklistedError:
         // nothing
         break;
     }

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -90,7 +90,8 @@ bool Progress::isWarningKind(SyncFileItem::Status kind)
 {
     return kind == SyncFileItem::SoftError || kind == SyncFileItem::NormalError
         || kind == SyncFileItem::FatalError || kind == SyncFileItem::FileIgnored
-        || kind == SyncFileItem::Conflict || kind == SyncFileItem::Restoration;
+        || kind == SyncFileItem::Conflict || kind == SyncFileItem::Restoration
+        || kind == SyncFileItem::BlacklistedError;
 }
 
 bool Progress::isIgnoredKind(SyncFileItem::Status kind)

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -53,7 +53,7 @@ public:
         SoftLink = CSYNC_FTW_TYPE_SLINK
     };
 
-    enum Status {
+    enum Status { // stored in 4 bits
         NoStatus,
 
         FatalError, ///< Error that causes the sync to stop
@@ -63,7 +63,16 @@ public:
         Success, ///< The file was properly synced
         Conflict, ///< The file was properly synced, but a conflict was created
         FileIgnored, ///< The file is in the ignored list (or blacklisted with no retries left)
-        Restoration ///< The file was restored because what should have been done was not allowed
+        Restoration, ///< The file was restored because what should have been done was not allowed
+
+        /** For files whose errors were blacklisted.
+         *
+         * If _instruction == IGNORE, the file wasn't even reattempted.
+         *
+         * These errors should usually be shown as NormalErrors, but not be as loud
+         * as them.
+         */
+        BlacklistedError
     };
 
     SyncFileItem()

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -65,6 +65,7 @@ static inline bool showErrorInSocketApi(const SyncFileItem &item)
     return item._instruction == CSYNC_INSTRUCTION_ERROR
         || status == SyncFileItem::NormalError
         || status == SyncFileItem::FatalError
+        || status == SyncFileItem::BlacklistedError
         || item._hasBlacklistEntry;
 }
 


### PR DESCRIPTION
Before, blacklisted errors were set to FileIgnored status and hence
displayed as warnings. Now, they have their own BlacklistedError
category which allows them to appear as errors in the issues list and in
the shell integration icons.