### PR TITLE
Update central.owncloud.org link (#5862)

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,7 +2,7 @@
 Please try to only report a bug if it happens with the latest version
 The latest version can be seen by checking the ChangeLog: https://owncloud.org/changelog/desktop/
 
-For support try: https://central.owncloud.org/c/help/desktop-file-sync
+For support try: https://central.owncloud.org/c/desktop-client
 --->
 
 

--- a/src/libsync/owncloudtheme.cpp
+++ b/src/libsync/owncloudtheme.cpp
@@ -44,7 +44,7 @@ QString ownCloudTheme::about() const
 {
     QString devString;
     devString = trUtf8("<p>Version %2. For more information visit <a href=\"%3\">https://%4</a></p>"
-                       "<p>For known issues and help, please visit: <a href=\"https://central.owncloud.org/c/help/desktop-file-sync\">https://central.owncloud.org</a></p>"
+                       "<p>For known issues and help, please visit: <a href=\"https://central.owncloud.org/c/desktop-client\">https://central.owncloud.org</a></p>"
                        "<p><small>By Klaas Freitag, Daniel Molkentin, Olivier Goffart, Markus Götz, "
                        " Jan-Christoph Borchardt, and others.</small></p>"
                        "<p>Copyright ownCloud GmbH</p>"


### PR DESCRIPTION
Desktop client category was renamed, old link was 404 - see: https://central.owncloud.org/t/new-central-categories-you-decide