### PR TITLE
main.cpp: Fix a compiler warning

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
     // the updater is triggered
     Updater *updater = Updater::instance();
     if (updater && updater->handleStartup()) {
-        return true;
+        return 1;
     }
 
     // if the application is already running, notify it.


### PR DESCRIPTION
 src/gui/main.cpp:112:9: warning: bool literal returned from 'main' [-Wmain]

Used 1 to keep previous behaviour. I supposed the code was meant
to return success (0), but it does not really matter anyway.