### PR TITLE
IssuesTab: Hide folder and account filters if they aren't useful

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -141,6 +141,7 @@ int FolderMan::unloadAndDeleteAllFolders()
     _lastSyncFolder = 0;
     _currentSyncFolder = 0;
     _scheduledFolders.clear();
+    emit folderListChanged(_folderMap);
     emit scheduleQueueChanged();
 
     return cnt;
@@ -1038,6 +1039,8 @@ void FolderMan::removeFolder(Folder *f)
     } else {
         delete f;
     }
+
+    emit folderListChanged(_folderMap);
 }
 
 QString FolderMan::getBackupName(QString fullPathName) const

--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -69,6 +69,7 @@ private slots:
     void slotAccountRemoved(AccountState *account);
 
 private:
+    void updateAccountChoiceVisibility();
     AccountState *currentAccountFilter() const;
     QString currentFolderFilter() const;
     bool shouldBeVisible(QTreeWidgetItem *item, AccountState *filterAccount,

--- a/src/gui/issueswidget.ui
+++ b/src/gui/issueswidget.ui
@@ -27,9 +27,9 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <layout class="QFormLayout" name="formLayout">
+      <layout class="QFormLayout" name="accountFolderLayout">
        <item row="0" column="0">
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="accountLabel">
          <property name="text">
           <string>Account</string>
          </property>
@@ -45,7 +45,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="folderLabel">
          <property name="text">
           <string>Folder</string>
          </property>


### PR DESCRIPTION
And also select the obvious entry if there's only a single possible choice.