### PR TITLE
PropagateUpload: Model of remote quota, avoid some uploads #5537

### DIFF
--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -150,6 +150,7 @@ QTreeWidgetItem *ProtocolWidget::createCompletedTreewidgetItem(const QString &fo
     QIcon icon;
     if (item._status == SyncFileItem::NormalError
         || item._status == SyncFileItem::FatalError
+        || item._status == SyncFileItem::DetailError
         || item._status == SyncFileItem::BlacklistedError) {
         icon = Theme::instance()->syncStateIcon(SyncResult::Error);
     } else if (Progress::isWarningKind(item._status)) {

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -43,6 +43,7 @@ struct SyncOptions
         , _minChunkSize(1 * 1000 * 1000) // 1 MB
         , _maxChunkSize(100 * 1000 * 1000) // 100 MB
         , _targetChunkUploadDuration(60 * 1000) // 1 minute
+        , _parallelNetworkJobs(true)
     {
     }
 
@@ -73,6 +74,9 @@ struct SyncOptions
      * Set to 0 it will disable dynamic chunk sizing.
      */
     quint64 _targetChunkUploadDuration;
+
+    /** Whether parallel network jobs are allowed. */
+    bool _parallelNetworkJobs;
 };
 
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -80,7 +80,9 @@ OwncloudPropagator::~OwncloudPropagator()
 
 int OwncloudPropagator::maximumActiveTransferJob()
 {
-    if (_downloadLimit.fetchAndAddAcquire(0) != 0 || _uploadLimit.fetchAndAddAcquire(0) != 0) {
+    if (_downloadLimit.fetchAndAddAcquire(0) != 0
+        || _uploadLimit.fetchAndAddAcquire(0) != 0
+        || !_syncOptions._parallelNetworkJobs) {
         // disable parallelism when there is a network limit.
         return 1;
     }
@@ -90,6 +92,8 @@ int OwncloudPropagator::maximumActiveTransferJob()
 /* The maximum number of active jobs in parallel  */
 int OwncloudPropagator::hardMaximumActiveJob()
 {
+    if (!_syncOptions._parallelNetworkJobs)
+        return 1;
     static int max = qgetenv("OWNCLOUD_MAX_PARALLEL").toUInt();
     if (max)
         return max;

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -351,6 +351,19 @@ public:
     /** We detected that another sync is required after this one */
     bool _anotherSyncNeeded;
 
+    /** Per-folder quota guesses.
+     *
+     * This starts out empty. When an upload in a folder fails due to insufficent
+     * remote quota, the quota guess is updated to be attempted_size-1 at maximum.
+     *
+     * Note that it will usually just an upper limit for the actual quota - but
+     * since the quota on the server might change at any time it can sometimes be
+     * wrong in the other direction as well.
+     *
+     * This allows skipping of uploads that have a very high likelihood of failure.
+     */
+    QHash<QString, quint64> _folderQuota;
+
     /* the maximum number of jobs using bandwidth (uploads or downloads, in parallel) */
     int maximumActiveTransferJob();
 

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -91,7 +91,7 @@ bool Progress::isWarningKind(SyncFileItem::Status kind)
     return kind == SyncFileItem::SoftError || kind == SyncFileItem::NormalError
         || kind == SyncFileItem::FatalError || kind == SyncFileItem::FileIgnored
         || kind == SyncFileItem::Conflict || kind == SyncFileItem::Restoration
-        || kind == SyncFileItem::BlacklistedError;
+        || kind == SyncFileItem::DetailError || kind == SyncFileItem::BlacklistedError;
 }
 
 bool Progress::isIgnoredKind(SyncFileItem::Status kind)

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -429,10 +429,10 @@ void PropagateDownloadFile::startDownload()
     const auto diskSpaceResult = propagator()->diskSpaceCheck();
     if (diskSpaceResult != OwncloudPropagator::DiskSpaceOk) {
         if (diskSpaceResult == OwncloudPropagator::DiskSpaceFailure) {
-            // Using BlacklistedError here will make the error not pop up in the account
+            // Using DetailError here will make the error not pop up in the account
             // tab: instead we'll generate a general "disk space low" message and show
             // these detail errors only in the error view.
-            done(SyncFileItem::BlacklistedError,
+            done(SyncFileItem::DetailError,
                 tr("The download would reduce free local disk space below the limit"));
             emit propagator()->insufficientLocalStorage();
         } else if (diskSpaceResult == OwncloudPropagator::DiskSpaceCritical) {

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -524,8 +524,7 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
 
     if (_item->_httpErrorCode == 507) {
         // Insufficient remote storage.
-        _item->_errorMayBeBlacklisted = true;
-        status = SyncFileItem::BlacklistedError;
+        status = SyncFileItem::DetailError;
         errorString = tr("Upload of %1 exceeds the quota for the folder").arg(Utility::octetsToString(_item->_size));
         emit propagator()->insufficientRemoteStorage();
     }

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -72,12 +72,24 @@ public:
         FileIgnored, ///< The file is in the ignored list (or blacklisted with no retries left)
         Restoration, ///< The file was restored because what should have been done was not allowed
 
-        /** For files whose errors were blacklisted.
+        /** For errors that should only appear in the error view.
          *
-         * If _instruction == IGNORE, the file wasn't even reattempted.
+         * Some errors also produce a summary message. Usually displaying that message is
+         * sufficient, but the individual errors should still appear in the issues tab.
          *
-         * These errors should usually be shown as NormalErrors, but not be as loud
-         * as them.
+         * These errors do cause the sync to fail.
+         *
+         * A NormalError that isn't as prominent.
+         */
+        DetailError,
+
+        /** For files whose errors were blacklisted
+         *
+         * If an file is blacklisted due to an error it isn't even reattempted. These
+         * errors should appear in the issues tab, but not on the account settings and
+         * should not cause the sync run to fail.
+         *
+         * A DetailError that doesn't cause sync failure.
          */
         BlacklistedError
     };

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -65,6 +65,7 @@ static inline bool showErrorInSocketApi(const SyncFileItem &item)
     return item._instruction == CSYNC_INSTRUCTION_ERROR
         || status == SyncFileItem::NormalError
         || status == SyncFileItem::FatalError
+        || status == SyncFileItem::DetailError
         || status == SyncFileItem::BlacklistedError
         || item._hasBlacklistEntry;
 }


### PR DESCRIPTION
When we see a 507 error, assume that quota is < uploaded size.
