### PR TITLE
OAuth: Better message when loggin in with the wrong username

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -23,6 +23,7 @@
 #include "theme.h"
 #include "account.h"
 #include <QMessageBox>
+#include "asserts.h"
 
 using namespace QKeychain;
 
@@ -40,6 +41,7 @@ void HttpCredentialsGui::askFromUser()
         if (reply->rawHeader("WWW-Authenticate").contains("Bearer ")) {
             // OAuth
             _asyncAuth.reset(new OAuth(_account, this));
+            _asyncAuth->_expectedUser = _user;
             connect(_asyncAuth.data(), &OAuth::result,
                 this, &HttpCredentialsGui::asyncAuthResult);
             connect(_asyncAuth.data(), &OAuth::destroyed,
@@ -74,11 +76,8 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
         break;
     }
 
-    if (_user != user) {
-        QMessageBox::warning(nullptr, tr("Login Error"), tr("You must sign in as user %1").arg(_user));
-        _asyncAuth->openBrowser();
-        return;
-    }
+    ASSERT(_user == user); // ensured by _asyncAuth
+
     _password = token;
     _refreshToken = refreshToken;
     _ready = true;

--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -116,6 +116,18 @@ void OAuth::start()
                         emit result(Error);
                         return;
                     }
+                    if (!_expectedUser.isNull() && user != _expectedUser) {
+                        // Connected with the wrong user
+                        QString message = tr("<h1>Wrong user</h1>"
+                                             "<p>You logged-in with user <em>%1</em>, but must login with user <em>%2</em>.<br>"
+                                             "Please log out of %3 in another tab, then <a href='%4'>click here</a> "
+                                             "and log in as user %2</p>")
+                                              .arg(user, _expectedUser, Theme::instance()->appNameGUI(),
+                                                  authorisationLink().toString(QUrl::FullyEncoded));
+                        httpReplyAndClose(socket, "200 OK", message.toUtf8().constData());
+                        // We are still listening on the socket so we will get the new connection
+                        return;
+                    }
                     const char *loginSuccessfullHtml = "<h1>Login Successful</h1><p>You can close this window.</p>";
                     if (messageUrl.isValid()) {
                         httpReplyAndClose(socket, "303 See Other", loginSuccessfullHtml,

--- a/src/gui/creds/oauth.h
+++ b/src/gui/creds/oauth.h
@@ -66,6 +66,9 @@ signals:
 private:
     Account *_account;
     QTcpServer _server;
+
+public:
+    QString _expectedUser;
 };
 
 


### PR DESCRIPTION
Since the user is already in the browser, put the error message in the
browser with a message to log out and then log in as the right user.

Issue #5895