### PR TITLE
PropagateUpload: Remove the Qt workaround against data corruption

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -35,12 +35,6 @@
 #include <cmath>
 #include <cstring>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 4, 2)
-namespace {
-const char owncloudShouldSoftCancelPropertyName[] = "owncloud-should-soft-cancel";
-}
-#endif
-
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcPutJob, "sync.networkjob.put", QtInfoMsg)
@@ -91,26 +85,9 @@ void PUTFileJob::start()
 
     connect(reply(), SIGNAL(uploadProgress(qint64, qint64)), this, SIGNAL(uploadProgress(qint64, qint64)));
     connect(this, SIGNAL(networkActivity()), account().data(), SIGNAL(propagatorNetworkActivity()));
-
-// For Qt versions not including https://codereview.qt-project.org/110150
-// Also do the runtime check if compiled with an old Qt but running with fixed one.
-// (workaround disabled on windows and mac because the binaries we ship have patched qt)
-#if QT_VERSION < QT_VERSION_CHECK(5, 4, 2) && !defined Q_OS_WIN && !defined Q_OS_MAC
-    if (QLatin1String(qVersion()) < QLatin1String("5.4.2"))
-        connect(_device, SIGNAL(wasReset()), this, SLOT(slotSoftAbort()));
-#endif
-
     _requestTimer.start();
     AbstractNetworkJob::start();
 }
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 4, 2)
-void PUTFileJob::slotSoftAbort()
-{
-    reply()->setProperty(owncloudShouldSoftCancelPropertyName, true);
-    reply()->abort();
-}
-#endif
 
 void PollJob::start()
 {

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -154,10 +154,6 @@ signals:
     void finishedSignal();
     void uploadProgress(qint64, qint64);
 
-private slots:
-#if QT_VERSION < 0x050402
-    void slotSoftAbort();
-#endif
 };
 
 /**


### PR DESCRIPTION
This was only for Qt <= 5.4, which we don't really support anymore.
And even then, the data corruption is happens very seldomly anyway.