### PR TITLE
OAuth: Fix refresh of token after expiration

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -120,6 +120,7 @@ void HttpCredentialsGui::showDialog()
     bool ok = dialog.exec();
     if (ok) {
         _password = dialog.textValue();
+        _refreshToken.clear();
         _ready = true;
         persist();
     }

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -397,6 +397,7 @@ void HttpCredentials::persist()
 
     _account->setCredentialSetting(QLatin1String(userC), _user);
     _account->setCredentialSetting(QLatin1String(isOAuthC), isUsingOAuth());
+    _account->wantsAccountSaved(_account);
 
     // write cert
     WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -46,8 +46,8 @@ namespace OCC {
 
    1) First, AccountState will attempt to load the certificate from the keychain
 
-   ---->  fetchFromKeychain  ------------------------> shortcut to refreshAccessToken if the cached
-                |                           }                            information is still valid
+   ---->  fetchFromKeychain
+                |                           }
                 v                            }
           slotReadClientCertPEMJobDone       }     There are first 3 QtKeychain jobs to fetch
                 |                             }   the TLS client keys, if any, and the password
@@ -92,7 +92,10 @@ public:
     QString fetchUser();
     virtual bool sslIsTrusted() { return false; }
 
-    void refreshAccessToken();
+    /* If we still have a valid refresh token, try to refresh it assynchronously and emit fetched()
+     * otherwise return false
+     */
+    bool refreshAccessToken();
 
     // To fetch the user name as early as possible
     void setAccount(Account *account) Q_DECL_OVERRIDE;


### PR DESCRIPTION
Before commit d3b00532b1dd9f44cc606e6738b53345c37582cf,
fetchFromKeychain was called everytime we detect that the creds are
invalid (in AccountState::slotInvalidCredentials)
But since that commit, AccountState was calling askFromUser directly,
breaking the refresh of the token.

So I made sure AccountState::slotInvalidCredentials still calls
refreshAccessToken.

Another change that was made was too be sure to clear the cookies
in HttpCredentials::invalidateToken even when we are only clearing the
access_token. That's because the session with a cookie may stay valid
longer than the access_token