### PR TITLE
Splitt off Abstract Folder class from Folder

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -48,6 +48,8 @@ set(client_SRCS
     accountsettings.cpp
     application.cpp
     folder.cpp
+    abstractfolder.cpp
+    folderdefinition.cpp
     folderman.cpp
     folderstatusmodel.cpp
     folderstatusdelegate.cpp

--- a/src/gui/abstractfolder.cpp
+++ b/src/gui/abstractfolder.cpp
@@ -265,8 +265,8 @@ void AbstractFolder::showSyncResultPopup()
             _syncResult.numRenamedItems(), _syncResult.firstItemRenamed()->_renameTarget);
     }
 
-    if (_syncResult.firstConflictItem()) {
-        createGuiLog(_syncResult.firstConflictItem()->_file, LogStatusConflict, _syncResult.numConflictItems());
+    if (_syncResult.firstNewConflictItem()) {
+        createGuiLog(_syncResult.firstNewConflictItem()->_file, LogStatusConflict, _syncResult.numNewConflictItems());
     }
     if (int errorCount = _syncResult.numErrorItems()) {
         createGuiLog(_syncResult.firstItemError()->_file, LogStatusError, errorCount);

--- a/src/gui/abstractfolder.cpp
+++ b/src/gui/abstractfolder.cpp
@@ -47,8 +47,8 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcAbstractFolder, "gui.abstractfolder", QtInfoMsg)
 
 AbstractFolder::AbstractFolder(const FolderDefinition &definition,
-    AccountState *accountState,
-    QObject *parent)
+                               AccountState *accountState,
+                               QObject *parent)
     : QObject(parent)
     , _accountState(accountState)
     , _definition(definition)
@@ -83,7 +83,7 @@ AbstractFolder::AbstractFolder(const FolderDefinition &definition,
 
     connect(_engine.data(), SIGNAL(started()), SLOT(slotSyncStarted()), Qt::QueuedConnection);
     connect(_engine.data(), SIGNAL(finished(bool)), SLOT(slotSyncFinished(bool)), Qt::QueuedConnection);
-    connect(_engine.data(), SIGNAL(folderDiscovered(bool, QString)), this, SLOT(slotFolderDiscovered(bool, QString)));
+    // connect(_engine.data(), SIGNAL(folderDiscovered(bool, QString)), this, SLOT(slotFolderDiscovered(bool, QString)));
     connect(_engine.data(), SIGNAL(transmissionProgress(ProgressInfo)), this, SLOT(slotTransmissionProgress(ProgressInfo)));
     connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
             this, SLOT(slotItemCompleted(const SyncFileItemPtr &)));

--- a/src/gui/abstractfolder.h
+++ b/src/gui/abstractfolder.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) by Daniel Molkentin <danimo@owncloud.com>
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef ABSTRACTFOLDER_H
+#define ABSTRACTFOLDER_H
+
+#include "syncresult.h"
+#include "progressdispatcher.h"
+#include "syncjournaldb.h"
+#include "clientproxy.h"
+#include "networkjobs.h"
+#include "folderdefinition.h"
+
+
+#include <QObject>
+#include <QStringList>
+
+class QThread;
+class QSettings;
+
+namespace OCC {
+
+class SyncEngine;
+class AccountState;
+class SyncRunFileLog;
+
+/**
+ * @brief The Folder class
+ * @ingroup gui
+ */
+class AbstractFolder : public QObject
+{
+    Q_OBJECT
+
+public:
+    AbstractFolder(const FolderDefinition &definition, AccountState *accountState, QObject *parent = 0L);
+
+    ~AbstractFolder();
+
+    typedef QMap<QString, AbstractFolder *> Map;
+    typedef QMapIterator<QString, AbstractFolder *> MapIterator;
+
+    /**
+     * The account the folder is configured on.
+     */
+    AccountState *accountState() const { return _accountState.data(); }
+
+    /**
+     * alias or nickname
+     */
+    QString alias() const;
+    QString shortGuiRemotePathOrAppName() const; // since 2.0 we don't want to show aliases anymore, show the path instead
+
+    /**
+     * short local path to display on the GUI  (native separators)
+     */
+    QString shortGuiLocalPath() const;
+
+    /**
+     * canonical local folder path, always ends with /
+     */
+    QString path() const;
+
+    /**
+     * cleaned canonical folder path, like path() but never ends with a /
+     *
+     * Wrapper for QDir::cleanPath(path()) except for "Z:/",
+     * where it returns "Z:" instead of "Z:/".
+     */
+    QString cleanPath() const;
+
+    /**
+     * remote folder path
+     */
+    QString remotePath() const;
+
+    /**
+     * remote folder path with server url
+     */
+    QUrl remoteUrl() const;
+
+    /**
+     * switch sync on or off
+     */
+    void setSyncPaused(bool);
+
+    bool syncPaused() const;
+
+    /**
+     * Returns true when the folder may sync.
+     */
+    bool canSync() const;
+
+    void prepareToSync();
+
+    /**
+     * True if the folder is busy and can't initiate
+     * a synchronization
+     */
+    virtual bool isBusy() const;
+
+    /**
+     * return the last sync result with error message and status
+     */
+    SyncResult syncResult() const;
+
+    /**
+      * set the config file name.
+      */
+    // FIXME: Can probably be removed!
+    void setConfigFile(const QString &);
+    QString configFile();
+
+    /**
+      * This is called if the sync folder definition is removed. Do cleanups here.
+      */
+    virtual void wipe();
+
+    void setSyncState(SyncResult::Status state);
+
+    void setDirtyNetworkLimits();
+
+    // Used by the Socket API
+    SyncJournalDb *journalDb() { return &_journal; }
+    SyncEngine &syncEngine() { return *_engine; }
+
+    qint64 msecSinceLastSync() const { return _timeSinceLastSyncDone.elapsed(); }
+    qint64 msecLastSyncDuration() const { return _lastSyncDuration; }
+    int consecutiveFollowUpSyncs() const { return _consecutiveFollowUpSyncs; }
+    int consecutiveFailingSyncs() const { return _consecutiveFailingSyncs; }
+
+    /// Saves the folder data in the account's settings.
+    void saveToSettings() const;
+    /// Removes the folder from the account's settings.
+    void removeFromSettings() const;
+
+    /** Calls schedules this folder on the FolderMan after a short delay.
+      *
+      * This should be used in situations where a sync should be triggered
+      * because a local file was modified. Syncs don't upload files that were
+      * modified too recently, and this delay ensures the modification is
+      * far enough in the past.
+      *
+      * The delay doesn't reset with subsequent calls.
+      */
+    void scheduleThisFolderSoon();
+
+    /**
+      * Migration: When this flag is true, this folder will save to
+      * the backwards-compatible 'Folders' section in the config file.
+      */
+    void setSaveBackwardsCompatible(bool save);
+
+    /**
+     * @brief etagJob
+     * If the folder uses an ETag job to look for changes, it is returned by
+     * this method. Reimplemented in the normal folder.
+     */
+    virtual RequestEtagJob *etagJob() { return nullptr; }
+
+    /**
+      * Are hidden files ignored in the synchronization by default?
+      *
+      * This should be a per-folder setting, but currently it is not in the client.
+      */
+    virtual bool ignoreHiddenFiles() { return false; }
+    virtual void setIgnoreHiddenFiles(bool ignore) { Q_UNUSED(ignore) } // default does nothing, FIXME
+
+    // Exclude handling, FIXME: Think again!
+    virtual bool isFileExcludedRelative( const QString& ) { return false; } // nothing excluded by default.
+    virtual bool isFileExcludedAbsolute( const QString& ) { return false; } // nothing excluded by default.
+
+signals:
+    void syncStateChange();
+    void syncStarted();
+    void syncFinished(const SyncResult &result);
+    void progressInfo(const ProgressInfo &progress);
+    void syncPausedChanged(AbstractFolder *, bool paused);
+    void canSyncChanged();
+
+    /**
+     * Fires for each change inside this folder that wasn't caused
+     * by sync activity.
+     */
+    void watchedFileChangedExternally(const QString &path);
+
+public slots:
+
+    /**
+       * terminate the current sync run
+       */
+    void slotTerminateSync();
+
+    /**
+      * Starts a sync operation
+      *
+      * If the list of changed files is known, it is passed.
+      */
+    void startSync(const QStringList &pathList = QStringList());
+
+    void setProxyDirty(bool value);
+    bool proxyDirty();
+
+    int slotDiscardDownloadProgress();
+    int downloadInfoCount();
+    int slotWipeErrorBlacklist();
+    int errorBlackListEntryCount();
+
+    /**
+       * Triggered by the folder watcher when a file/dir in this folder
+       * changes. Needs to check whether this change should trigger a new
+       * sync run to be scheduled.
+       */
+    void slotWatchedPathChanged(const QString &path);
+
+private slots:
+    void slotSyncStarted();
+    void slotSyncError(const QString &);
+    void slotSyncFinished(bool);
+
+    void slotFolderDiscovered(bool local, QString folderName);
+    void slotTransmissionProgress(const ProgressInfo &pi);
+    void slotItemCompleted(const SyncFileItemPtr &);
+
+    void slotEmitFinishedDelayed();
+
+    void slotLogPropagationStart();
+
+    /** Adds this folder to the list of scheduled folders in the
+     *  FolderMan.
+     */
+protected slots:
+    void slotScheduleThisFolder();
+
+protected:
+    // FIXME: This should be empty
+    AccountStatePtr _accountState;
+    FolderDefinition _definition;
+    QScopedPointer<SyncEngine> _engine;
+
+private:
+    void showSyncResultPopup();
+
+    void checkLocalPath();
+
+    void setSyncOptions();
+
+    enum LogStatus {
+        LogStatusRemove,
+        LogStatusRename,
+        LogStatusMove,
+        LogStatusNew,
+        LogStatusError,
+        LogStatusConflict,
+        LogStatusUpdated
+    };
+
+    void createGuiLog(const QString &filename, LogStatus status, int count,
+        const QString &renameTarget = QString::null);
+
+
+    QString _canonicalLocalPath; // As returned with QFileInfo:canonicalFilePath.  Always ends with "/"
+
+    SyncResult _syncResult;
+    bool _proxyDirty;
+    QElapsedTimer _timeSinceLastSyncDone;
+    QElapsedTimer _timeSinceLastSyncStart;
+    qint64 _lastSyncDuration;
+
+    /// The number of syncs that failed in a row.
+    /// Reset when a sync is successful.
+    int _consecutiveFailingSyncs;
+
+    /// The number of requested follow-up syncs.
+    /// Reset when no follow-up is requested.
+    int _consecutiveFollowUpSyncs;
+
+    SyncJournalDb _journal;
+
+    ClientProxy _clientProxy;
+
+    QScopedPointer<SyncRunFileLog> _fileLog;
+
+    QTimer _scheduleSelfTimer;
+
+    /**
+     * When the same local path is synced to multiple accounts, only one
+     * of them can be stored in the settings in a way that's compatible
+     * with old clients that don't support it. This flag marks folders
+     * that shall be written in a backwards-compatible way, by being set
+     * on the *first* Folder instance that was configured for each local
+     * path.
+     */
+    bool _saveBackwardsCompatible;
+};
+}
+
+#endif

--- a/src/gui/abstractfolder.h
+++ b/src/gui/abstractfolder.h
@@ -179,8 +179,8 @@ public:
     virtual void setIgnoreHiddenFiles(bool ignore) { Q_UNUSED(ignore) } // default does nothing, FIXME
 
     // Exclude handling, FIXME: Think again!
-    virtual bool isFileExcludedRelative( const QString& ) { return false; } // nothing excluded by default.
-    virtual bool isFileExcludedAbsolute( const QString& ) { return false; } // nothing excluded by default.
+    virtual bool isFileExcludedRelative( const QString& ) const { return false; } // nothing excluded by default.
+    virtual bool isFileExcludedAbsolute( const QString& ) const { return false; } // nothing excluded by default.
 
 signals:
     void syncStateChange();

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -172,7 +172,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(ui->bigFolderSyncAll, SIGNAL(clicked(bool)), _model, SLOT(slotSyncAllPendingBigFolders()));
     connect(ui->bigFolderSyncNone, SIGNAL(clicked(bool)), _model, SLOT(slotSyncNoPendingBigFolders()));
 
-    connect(FolderMan::instance(), SIGNAL(folderListChanged(Folder::Map)), _model, SLOT(resetFolders()));
+    connect(FolderMan::instance(), &FolderMan::folderListChanged, _model, &FolderStatusModel::resetFolders);
     connect(this, SIGNAL(folderChanged()), _model, SLOT(resetFolders()));
 
 
@@ -513,7 +513,7 @@ void AccountSettings::slotEnableCurrentFolder()
         bool currentlyPaused = false;
 
         // this sets the folder status to disabled but does not interrupt it.
-        Folder *f = folderMan->folder(alias);
+        auto *f = folderMan->folder(alias);
         if (!f) {
             return;
         }
@@ -577,7 +577,7 @@ void AccountSettings::slotForceSyncCurrentFolder()
     FolderMan *folderMan = FolderMan::instance();
     if (auto selectedFolder = folderMan->folder(selectedFolderAlias())) {
         // Terminate and reschedule any running sync
-        if (Folder *current = folderMan->currentSyncFolder()) {
+        if (auto *current = folderMan->currentSyncFolder()) {
             folderMan->terminateSyncProcess();
             folderMan->scheduleFolder(current);
         }
@@ -632,7 +632,7 @@ void AccountSettings::slotAccountStateChanged()
         QUrl safeUrl(account->url());
         safeUrl.setPassword(QString()); // Remove the password from the URL to avoid showing it in the UI
         FolderMan *folderMan = FolderMan::instance();
-        foreach (Folder *folder, folderMan->map().values()) {
+        foreach (AbstractFolder *folder, folderMan->map().values()) {
             _model->slotUpdateFolderState(folder);
         }
 
@@ -714,7 +714,7 @@ void AccountSettings::slotLinkActivated(const QString &link)
             myFolder.chop(1);
 
         // Make sure the folder itself is expanded
-        Folder *f = FolderMan::instance()->folder(alias);
+        auto *f = FolderMan::instance()->folder(alias);
         QModelIndex folderIndx = _model->indexForPath(f, QString());
         if (!ui->_folderList->isExpanded(folderIndx)) {
             ui->_folderList->setExpanded(folderIndx, true);
@@ -748,7 +748,7 @@ void AccountSettings::refreshSelectiveSyncStatus()
 
     QString msg;
     int cnt = 0;
-    foreach (Folder *folder, FolderMan::instance()->map().values()) {
+    foreach (AbstractFolder *folder, FolderMan::instance()->map().values()) {
         if (folder->accountState() != _accountState) {
             continue;
         }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -408,7 +408,7 @@ void AccountSettings::slotFolderWizardAccepted()
 
     folderMan->setSyncEnabled(true);
 
-    Folder *f = folderMan->addFolder(_accountState, definition);
+    auto *f = folderMan->addFolder(_accountState, definition);
     if (f) {
         f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, selectiveSyncBlackList);
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -142,40 +142,6 @@ void Folder::etagRetreivedFromSyncEngine(const QString &etag)
     _lastEtag = etag;
 }
 
-void Folder::showSyncResultPopup()
-{
-    if (_syncResult.firstItemNew()) {
-        createGuiLog(_syncResult.firstItemNew()->_file, LogStatusNew, _syncResult.numNewItems());
-    }
-    if (_syncResult.firstItemDeleted()) {
-        createGuiLog(_syncResult.firstItemDeleted()->_file, LogStatusRemove, _syncResult.numRemovedItems());
-    }
-    if (_syncResult.firstItemUpdated()) {
-        createGuiLog(_syncResult.firstItemUpdated()->_file, LogStatusUpdated, _syncResult.numUpdatedItems());
-    }
-
-    if (_syncResult.firstItemRenamed()) {
-        LogStatus status(LogStatusRename);
-        // if the path changes it's rather a move
-        QDir renTarget = QFileInfo(_syncResult.firstItemRenamed()->_renameTarget).dir();
-        QDir renSource = QFileInfo(_syncResult.firstItemRenamed()->_file).dir();
-        if (renTarget != renSource) {
-            status = LogStatusMove;
-        }
-        createGuiLog(_syncResult.firstItemRenamed()->_originalFile, status,
-            _syncResult.numRenamedItems(), _syncResult.firstItemRenamed()->_renameTarget);
-    }
-
-    if (_syncResult.firstNewConflictItem()) {
-        createGuiLog(_syncResult.firstNewConflictItem()->_file, LogStatusConflict, _syncResult.numNewConflictItems());
-    }
-    if (int errorCount = _syncResult.numErrorItems()) {
-        createGuiLog(_syncResult.firstItemError()->_file, LogStatusError, errorCount);
-    }
-
-    qCInfo(lcFolder) << "Folder sync result: " << int(_syncResult.status());
-}
-
 bool Folder::isFileExcludedRelative(const QString &relativePath) const
 {
     return _engine->excludedFiles().isExcluded(path() + relativePath, path(), _definition.ignoreHiddenFiles);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -147,6 +147,11 @@ bool Folder::isFileExcludedRelative(const QString &relativePath) const
     return _engine->excludedFiles().isExcluded(path() + relativePath, path(), _definition.ignoreHiddenFiles);
 }
 
+bool Folder::isFileExcludedAbsolute(const QString& fullPath) const
+{
+    return _engine->excludedFiles().isExcluded(fullPath, path(), _definition.ignoreHiddenFiles);
+}
+
 bool Folder::setIgnoredFiles()
 {
     // Note: Doing this on each sync run and on Folder construction is

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -51,141 +51,37 @@ Q_LOGGING_CATEGORY(lcFolder, "gui.folder", QtInfoMsg)
 Folder::Folder(const FolderDefinition &definition,
     AccountState *accountState,
     QObject *parent)
-    : QObject(parent)
-    , _accountState(accountState)
-    , _definition(definition)
+    : AbstractFolder(definition, accountState, parent)
     , _csyncUnavail(false)
-    , _proxyDirty(true)
-    , _lastSyncDuration(0)
-    , _consecutiveFailingSyncs(0)
-    , _consecutiveFollowUpSyncs(0)
-    , _journal(_definition.absoluteJournalPath())
-    , _fileLog(new SyncRunFileLog)
-    , _saveBackwardsCompatible(false)
 {
-    _timeSinceLastSyncStart.start();
-    _timeSinceLastSyncDone.start();
+    // FIXME: Engine is initialized in the AbstractFolder constructor.
+    // Change that to have a method initializeSyncEngine(SyncEngine) in the AbstractFolder
+    // that needs to be called by the Folder class, to let the Folder instanciate its own
+    // SyncEngine. For that, we need an Abstract Sync Engine as well.
+    _engine->setIgnoreHiddenFiles(definition.ignoreHiddenFiles);
 
-    SyncResult::Status status = SyncResult::NotYetStarted;
-    if (definition.paused) {
-        status = SyncResult::Paused;
-    }
-    _syncResult.setStatus(status);
-
-    // check if the local path exists
-    checkLocalPath();
-
-    _syncResult.setFolder(_definition.alias);
-
-    _engine.reset(new SyncEngine(_accountState->account(), path(), remotePath(), &_journal));
-    // pass the setting if hidden files are to be ignored, will be read in csync_update
-    _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
-
-    if (!setIgnoredFiles())
+    if (!setIgnoredFiles()) {
         qCWarning(lcFolder, "Could not read system exclude file");
+    }
 
-    connect(_accountState.data(), SIGNAL(isConnectedChanged()), this, SIGNAL(canSyncChanged()));
+    connect(accountState, SIGNAL(isConnectedChanged()), this, SIGNAL(canSyncChanged()));
     connect(_engine.data(), SIGNAL(rootEtag(QString)), this, SLOT(etagRetreivedFromSyncEngine(QString)));
 
-    connect(_engine.data(), SIGNAL(started()), SLOT(slotSyncStarted()), Qt::QueuedConnection);
-    connect(_engine.data(), SIGNAL(finished(bool)), SLOT(slotSyncFinished(bool)), Qt::QueuedConnection);
     connect(_engine.data(), SIGNAL(csyncUnavailable()), SLOT(slotCsyncUnavailable()), Qt::QueuedConnection);
 
     //direct connection so the message box is blocking the sync.
     connect(_engine.data(), SIGNAL(aboutToRemoveAllFiles(SyncFileItem::Direction, bool *)),
-        SLOT(slotAboutToRemoveAllFiles(SyncFileItem::Direction, bool *)));
+            SLOT(slotAboutToRemoveAllFiles(SyncFileItem::Direction, bool *)));
     connect(_engine.data(), SIGNAL(aboutToRestoreBackup(bool *)),
-        SLOT(slotAboutToRestoreBackup(bool *)));
-    connect(_engine.data(), SIGNAL(transmissionProgress(ProgressInfo)), this, SLOT(slotTransmissionProgress(ProgressInfo)));
-    connect(_engine.data(), SIGNAL(itemCompleted(const SyncFileItemPtr &)),
-        this, SLOT(slotItemCompleted(const SyncFileItemPtr &)));
+            SLOT(slotAboutToRestoreBackup(bool *)));
     connect(_engine.data(), SIGNAL(newBigFolder(QString, bool)),
-        this, SLOT(slotNewBigFolderDiscovered(QString, bool)));
-    connect(_engine.data(), SIGNAL(seenLockedFile(QString)), FolderMan::instance(), SLOT(slotSyncOnceFileUnlocks(QString)));
-    connect(_engine.data(), SIGNAL(aboutToPropagate(SyncFileItemVector &)),
-        SLOT(slotLogPropagationStart()));
-    connect(_engine.data(), &SyncEngine::syncError, this, &Folder::slotSyncError);
-
-    _scheduleSelfTimer.setSingleShot(true);
-    _scheduleSelfTimer.setInterval(SyncEngine::minimumFileAgeForUpload);
-    connect(&_scheduleSelfTimer, SIGNAL(timeout()),
-        SLOT(slotScheduleThisFolder()));
+            this, SLOT(slotNewBigFolderDiscovered(QString, bool)));
 }
 
 Folder::~Folder()
 {
-    // Reset then engine first as it will abort and try to access members of the Folder
-    _engine.reset();
+
 }
-
-
-void Folder::checkLocalPath()
-{
-    const QFileInfo fi(_definition.localPath);
-    _canonicalLocalPath = fi.canonicalFilePath();
-    if (_canonicalLocalPath.isEmpty()) {
-        qCWarning(lcFolder) << "Broken symlink:" << _definition.localPath;
-        _canonicalLocalPath = _definition.localPath;
-    } else if (!_canonicalLocalPath.endsWith('/')) {
-        _canonicalLocalPath.append('/');
-    }
-
-    if (fi.isDir() && fi.isReadable()) {
-        qCDebug(lcFolder) << "Checked local path ok";
-    } else {
-        // Check directory again
-        if (!FileSystem::fileExists(_definition.localPath, fi)) {
-            _syncResult.appendErrorString(tr("Local folder %1 does not exist.").arg(_definition.localPath));
-            _syncResult.setStatus(SyncResult::SetupError);
-        } else if (!fi.isDir()) {
-            _syncResult.appendErrorString(tr("%1 should be a folder but is not.").arg(_definition.localPath));
-            _syncResult.setStatus(SyncResult::SetupError);
-        } else if (!fi.isReadable()) {
-            _syncResult.appendErrorString(tr("%1 is not readable.").arg(_definition.localPath));
-            _syncResult.setStatus(SyncResult::SetupError);
-        }
-    }
-}
-
-QString Folder::shortGuiRemotePathOrAppName() const
-{
-    if (remotePath().length() > 0 && remotePath() != QLatin1String("/")) {
-        QString a = QFile(remotePath()).fileName();
-        if (a.startsWith('/')) {
-            a = a.remove(0, 1);
-        }
-        return a;
-    } else {
-        return Theme::instance()->appNameGUI();
-    }
-}
-
-QString Folder::alias() const
-{
-    return _definition.alias;
-}
-
-QString Folder::path() const
-{
-    return _canonicalLocalPath;
-}
-
-QString Folder::shortGuiLocalPath() const
-{
-    QString p = _definition.localPath;
-    QString home = QDir::homePath();
-    if (!home.endsWith('/')) {
-        home.append('/');
-    }
-    if (p.startsWith(home)) {
-        p = p.mid(home.length());
-    }
-    if (p.length() > 1 && p.endsWith('/')) {
-        p.chop(1);
-    }
-    return QDir::toNativeSeparators(p);
-}
-
 
 bool Folder::ignoreHiddenFiles()
 {
@@ -198,79 +94,9 @@ void Folder::setIgnoreHiddenFiles(bool ignore)
     _definition.ignoreHiddenFiles = ignore;
 }
 
-QString Folder::cleanPath() const
-{
-    QString cleanedPath = QDir::cleanPath(_canonicalLocalPath);
-
-    if (cleanedPath.length() == 3 && cleanedPath.endsWith(":/"))
-        cleanedPath.remove(2, 1);
-
-    return cleanedPath;
-}
-
-bool Folder::isBusy() const
-{
-    return _engine->isSyncRunning();
-}
-
-QString Folder::remotePath() const
-{
-    return _definition.targetPath;
-}
-
-QUrl Folder::remoteUrl() const
-{
-    return Utility::concatUrlPath(_accountState->account()->davUrl(), remotePath());
-}
-
-bool Folder::syncPaused() const
-{
-    return _definition.paused;
-}
-
-bool Folder::canSync() const
-{
-    return !syncPaused() && accountState()->isConnected();
-}
-
-void Folder::setSyncPaused(bool paused)
-{
-    if (paused == _definition.paused) {
-        return;
-    }
-
-    _definition.paused = paused;
-    saveToSettings();
-
-    if (!paused) {
-        setSyncState(SyncResult::NotYetStarted);
-    } else {
-        setSyncState(SyncResult::Paused);
-    }
-    emit syncPausedChanged(this, paused);
-    emit syncStateChange();
-    emit canSyncChanged();
-}
-
-void Folder::setSyncState(SyncResult::Status state)
-{
-    _syncResult.setStatus(state);
-}
-
-SyncResult Folder::syncResult() const
-{
-    return _syncResult;
-}
-
-void Folder::prepareToSync()
-{
-    _syncResult.reset();
-    _syncResult.setStatus(SyncResult::NotYetStarted);
-}
-
 void Folder::slotRunEtagJob()
 {
-    qCInfo(lcFolder) << "Trying to check" << remoteUrl().toString() << "for changes via ETag check. (time since last sync:" << (_timeSinceLastSyncDone.elapsed() / 1000) << "s)";
+    qCInfo(lcFolder) << "Trying to check" << remoteUrl().toString() << "for changes via ETag check.";
 
     AccountPtr account = _accountState->account();
 
@@ -316,7 +142,6 @@ void Folder::etagRetreivedFromSyncEngine(const QString &etag)
     _lastEtag = etag;
 }
 
-
 void Folder::showSyncResultPopup()
 {
     if (_syncResult.firstItemNew()) {
@@ -351,238 +176,9 @@ void Folder::showSyncResultPopup()
     qCInfo(lcFolder) << "Folder sync result: " << int(_syncResult.status());
 }
 
-void Folder::createGuiLog(const QString &filename, LogStatus status, int count,
-    const QString &renameTarget)
-{
-    if (count > 0) {
-        Logger *logger = Logger::instance();
-
-        QString file = QDir::toNativeSeparators(filename);
-        QString text;
-
-        switch (status) {
-        case LogStatusRemove:
-            if (count > 1) {
-                text = tr("%1 and %n other file(s) have been removed.", "", count - 1).arg(file);
-            } else {
-                text = tr("%1 has been removed.", "%1 names a file.").arg(file);
-            }
-            break;
-        case LogStatusNew:
-            if (count > 1) {
-                text = tr("%1 and %n other file(s) have been downloaded.", "", count - 1).arg(file);
-            } else {
-                text = tr("%1 has been downloaded.", "%1 names a file.").arg(file);
-            }
-            break;
-        case LogStatusUpdated:
-            if (count > 1) {
-                text = tr("%1 and %n other file(s) have been updated.", "", count - 1).arg(file);
-            } else {
-                text = tr("%1 has been updated.", "%1 names a file.").arg(file);
-            }
-            break;
-        case LogStatusRename:
-            if (count > 1) {
-                text = tr("%1 has been renamed to %2 and %n other file(s) have been renamed.", "", count - 1).arg(file, renameTarget);
-            } else {
-                text = tr("%1 has been renamed to %2.", "%1 and %2 name files.").arg(file, renameTarget);
-            }
-            break;
-        case LogStatusMove:
-            if (count > 1) {
-                text = tr("%1 has been moved to %2 and %n other file(s) have been moved.", "", count - 1).arg(file, renameTarget);
-            } else {
-                text = tr("%1 has been moved to %2.").arg(file, renameTarget);
-            }
-            break;
-        case LogStatusConflict:
-            if (count > 1) {
-                text = tr("%1 has and %n other file(s) have sync conflicts.", "", count - 1).arg(file);
-            } else {
-                text = tr("%1 has a sync conflict. Please check the conflict file!").arg(file);
-            }
-            break;
-        case LogStatusError:
-            if (count > 1) {
-                text = tr("%1 and %n other file(s) could not be synced due to errors. See the log for details.", "", count - 1).arg(file);
-            } else {
-                text = tr("%1 could not be synced due to an error. See the log for details.").arg(file);
-            }
-            break;
-        }
-
-        if (!text.isEmpty()) {
-            logger->postOptionalGuiLog(tr("Sync Activity"), text);
-        }
-    }
-}
-
-int Folder::slotDiscardDownloadProgress()
-{
-    // Delete from journal and from filesystem.
-    QDir folderpath(_definition.localPath);
-    QSet<QString> keep_nothing;
-    const QVector<SyncJournalDb::DownloadInfo> deleted_infos =
-        _journal.getAndDeleteStaleDownloadInfos(keep_nothing);
-    foreach (const SyncJournalDb::DownloadInfo &deleted_info, deleted_infos) {
-        const QString tmppath = folderpath.filePath(deleted_info._tmpfile);
-        qCInfo(lcFolder) << "Deleting temporary file: " << tmppath;
-        FileSystem::remove(tmppath);
-    }
-    return deleted_infos.size();
-}
-
-int Folder::downloadInfoCount()
-{
-    return _journal.downloadInfoCount();
-}
-
-int Folder::errorBlackListEntryCount()
-{
-    return _journal.errorBlackListEntryCount();
-}
-
-int Folder::slotWipeErrorBlacklist()
-{
-    return _journal.wipeErrorBlacklist();
-}
-
-void Folder::slotWatchedPathChanged(const QString &path)
-{
-// The folder watcher fires a lot of bogus notifications during
-// a sync operation, both for actual user files and the database
-// and log. Therefore we check notifications against operations
-// the sync is doing to filter out our own changes.
-#ifdef Q_OS_MAC
-    Q_UNUSED(path)
-// On OSX the folder watcher does not report changes done by our
-// own process. Therefore nothing needs to be done here!
-#else
-    // Use the path to figure out whether it was our own change
-    const auto maxNotificationDelay = 15 * 1000;
-    qint64 time = _engine->timeSinceFileTouched(path);
-    if (time != -1 && time < maxNotificationDelay) {
-        return;
-    }
-#endif
-
-    // Check that the mtime actually changed.
-    if (path.startsWith(this->path())) {
-        auto relativePath = path.mid(this->path().size());
-        auto record = _journal.getFileRecord(relativePath);
-        if (record.isValid() && !FileSystem::fileChanged(path, record._fileSize, Utility::qDateTimeToTime_t(record._modtime))) {
-            qCInfo(lcFolder) << "Ignoring spurious notification for file" << relativePath;
-            return; // probably a spurious notification
-        }
-    }
-
-    emit watchedFileChangedExternally(path);
-
-    // Also schedule this folder for a sync, but only after some delay:
-    // The sync will not upload files that were changed too recently.
-    scheduleThisFolderSoon();
-}
-
-void Folder::saveToSettings() const
-{
-    // Remove first to make sure we don't get duplicates
-    removeFromSettings();
-
-    auto settings = _accountState->settings();
-
-    // The folder is saved to backwards-compatible "Folders"
-    // section only if it has the migrate flag set (i.e. was in
-    // there before) or if the folder is the only one for the
-    // given target path.
-    // This ensures that older clients will not read a configuration
-    // where two folders for different accounts point at the same
-    // local folders.
-    bool oneAccountOnly = true;
-    foreach (Folder *other, FolderMan::instance()->map()) {
-        if (other != this && other->cleanPath() == this->cleanPath()) {
-            oneAccountOnly = false;
-            break;
-        }
-    }
-
-    bool compatible = _saveBackwardsCompatible || oneAccountOnly;
-
-    if (compatible) {
-        settings->beginGroup(QLatin1String("Folders"));
-    } else {
-        settings->beginGroup(QLatin1String("Multifolders"));
-    }
-    FolderDefinition::save(*settings, _definition);
-
-    settings->sync();
-    qCInfo(lcFolder) << "Saved folder" << _definition.alias << "to settings, status" << settings->status();
-}
-
-void Folder::removeFromSettings() const
-{
-    auto settings = _accountState->settings();
-    settings->beginGroup(QLatin1String("Folders"));
-    settings->remove(FolderMan::escapeAlias(_definition.alias));
-    settings->endGroup();
-    settings->beginGroup(QLatin1String("Multifolders"));
-    settings->remove(FolderMan::escapeAlias(_definition.alias));
-}
-
-bool Folder::isFileExcludedAbsolute(const QString &fullPath) const
-{
-    return _engine->excludedFiles().isExcluded(fullPath, path(), _definition.ignoreHiddenFiles);
-}
-
 bool Folder::isFileExcludedRelative(const QString &relativePath) const
 {
     return _engine->excludedFiles().isExcluded(path() + relativePath, path(), _definition.ignoreHiddenFiles);
-}
-
-void Folder::slotTerminateSync()
-{
-    qCInfo(lcFolder) << "folder " << alias() << " Terminating!";
-
-    if (_engine->isSyncRunning()) {
-        _engine->abort();
-
-        setSyncState(SyncResult::SyncAbortRequested);
-    }
-}
-
-// This removes the csync File database
-// This is needed to provide a clean startup again in case another
-// local folder is synced to the same ownCloud.
-void Folder::wipe()
-{
-    QString stateDbFile = _engine->journal()->databaseFilePath();
-
-    // Delete files that have been partially downloaded.
-    slotDiscardDownloadProgress();
-
-    //Unregister the socket API so it does not keep the ._sync_journal file open
-    FolderMan::instance()->socketApi()->slotUnregisterPath(alias());
-    _journal.close(); // close the sync journal
-
-    QFile file(stateDbFile);
-    if (file.exists()) {
-        if (!file.remove()) {
-            qCWarning(lcFolder) << "Failed to remove existing csync StateDB " << stateDbFile;
-        } else {
-            qCInfo(lcFolder) << "wipe: Removed csync StateDB " << stateDbFile;
-        }
-    } else {
-        qCWarning(lcFolder) << "statedb is empty, can not remove.";
-    }
-
-    // Also remove other db related files
-    QFile::remove(stateDbFile + ".ctmp");
-    QFile::remove(stateDbFile + "-shm");
-    QFile::remove(stateDbFile + "-wal");
-    QFile::remove(stateDbFile + "-journal");
-
-    if (canSync())
-        FolderMan::instance()->socketApi()->slotRegisterPath(alias());
 }
 
 bool Folder::setIgnoredFiles()
@@ -605,246 +201,10 @@ bool Folder::setIgnoredFiles()
     return _engine->excludedFiles().reloadExcludes();
 }
 
-void Folder::setProxyDirty(bool value)
-{
-    _proxyDirty = value;
-}
-
-bool Folder::proxyDirty()
-{
-    return _proxyDirty;
-}
-
-void Folder::startSync(const QStringList &pathList)
-{
-    Q_UNUSED(pathList)
-    if (proxyDirty()) {
-        setProxyDirty(false);
-    }
-
-    if (isBusy()) {
-        qCCritical(lcFolder) << "ERROR csync is still running and new sync requested.";
-        return;
-    }
-    _csyncUnavail = false;
-
-    _timeSinceLastSyncStart.start();
-    _syncResult.setStatus(SyncResult::SyncPrepare);
-    emit syncStateChange();
-
-    qCInfo(lcFolder) << "*** Start syncing " << remoteUrl().toString() << " - client version"
-                     << qPrintable(Theme::instance()->version());
-
-    _fileLog->start(path());
-
-    if (!setIgnoredFiles()) {
-        slotSyncError(tr("Could not read system exclude file"));
-        QMetaObject::invokeMethod(this, "slotSyncFinished", Qt::QueuedConnection, Q_ARG(bool, false));
-        return;
-    }
-
-    setDirtyNetworkLimits();
-    setSyncOptions();
-
-    _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
-
-    QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
-
-    emit syncStarted();
-}
-
-void Folder::setSyncOptions()
-{
-    SyncOptions opt;
-    ConfigFile cfgFile;
-
-    auto newFolderLimit = cfgFile.newBigFolderSizeLimit();
-    opt._newBigFolderSizeLimit = newFolderLimit.first ? newFolderLimit.second * 1000LL * 1000LL : -1; // convert from MB to B
-    opt._confirmExternalStorage = cfgFile.confirmExternalStorage();
-
-    QByteArray chunkSizeEnv = qgetenv("OWNCLOUD_CHUNK_SIZE");
-    if (!chunkSizeEnv.isEmpty()) {
-        opt._initialChunkSize = chunkSizeEnv.toUInt();
-    } else {
-        opt._initialChunkSize = cfgFile.chunkSize();
-    }
-    QByteArray minChunkSizeEnv = qgetenv("OWNCLOUD_MIN_CHUNK_SIZE");
-    if (!minChunkSizeEnv.isEmpty()) {
-        opt._minChunkSize = minChunkSizeEnv.toUInt();
-    } else {
-        opt._minChunkSize = cfgFile.minChunkSize();
-    }
-    QByteArray maxChunkSizeEnv = qgetenv("OWNCLOUD_MAX_CHUNK_SIZE");
-    if (!maxChunkSizeEnv.isEmpty()) {
-        opt._maxChunkSize = maxChunkSizeEnv.toUInt();
-    } else {
-        opt._maxChunkSize = cfgFile.maxChunkSize();
-    }
-
-    // Previously min/max chunk size values didn't exist, so users might
-    // have setups where the chunk size exceeds the new min/max default
-    // values. To cope with this, adjust min/max to always include the
-    // initial chunk size value.
-    opt._minChunkSize = qMin(opt._minChunkSize, opt._initialChunkSize);
-    opt._maxChunkSize = qMax(opt._maxChunkSize, opt._initialChunkSize);
-
-    QByteArray targetChunkUploadDurationEnv = qgetenv("OWNCLOUD_TARGET_CHUNK_UPLOAD_DURATION");
-    if (!targetChunkUploadDurationEnv.isEmpty()) {
-        opt._targetChunkUploadDuration = targetChunkUploadDurationEnv.toUInt();
-    } else {
-        opt._targetChunkUploadDuration = cfgFile.targetChunkUploadDuration();
-    }
-
-    _engine->setSyncOptions(opt);
-}
-
-void Folder::setDirtyNetworkLimits()
-{
-    ConfigFile cfg;
-    int downloadLimit = -75; // 75%
-    int useDownLimit = cfg.useDownloadLimit();
-    if (useDownLimit >= 1) {
-        downloadLimit = cfg.downloadLimit() * 1000;
-    } else if (useDownLimit == 0) {
-        downloadLimit = 0;
-    }
-
-    int uploadLimit = -75; // 75%
-    int useUpLimit = cfg.useUploadLimit();
-    if (useUpLimit >= 1) {
-        uploadLimit = cfg.uploadLimit() * 1000;
-    } else if (useUpLimit == 0) {
-        uploadLimit = 0;
-    }
-
-    _engine->setNetworkLimits(uploadLimit, downloadLimit);
-}
-
-void Folder::slotSyncError(const QString &message, ErrorCategory category)
-{
-    _syncResult.appendErrorString(message);
-    emit ProgressDispatcher::instance()->syncError(alias(), message, category);
-}
-
-void Folder::slotSyncStarted()
-{
-    qCInfo(lcFolder) << "#### Propagation start ####################################################";
-    _syncResult.setStatus(SyncResult::SyncRunning);
-    emit syncStateChange();
-}
 
 void Folder::slotCsyncUnavailable()
 {
     _csyncUnavail = true;
-}
-
-void Folder::slotSyncFinished(bool success)
-{
-    qCInfo(lcFolder) << "Client version" << qPrintable(Theme::instance()->version())
-                     << " Qt" << qVersion()
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-                     << " SSL " << QSslSocket::sslLibraryVersionString().toUtf8().data()
-#endif
-        ;
-
-    bool syncError = !_syncResult.errorStrings().isEmpty();
-    if (syncError) {
-        qCWarning(lcFolder) << "SyncEngine finished with ERROR";
-    } else {
-        qCInfo(lcFolder) << "SyncEngine finished without problem.";
-    }
-    _fileLog->finish();
-    showSyncResultPopup();
-
-    auto anotherSyncNeeded = _engine->isAnotherSyncNeeded();
-
-    if (syncError) {
-        _syncResult.setStatus(SyncResult::Error);
-    } else if (_csyncUnavail) {
-        _syncResult.setStatus(SyncResult::Error);
-        qCWarning(lcFolder) << "csync not available.";
-    } else if (_syncResult.foundFilesNotSynced()) {
-        _syncResult.setStatus(SyncResult::Problem);
-    } else if (_definition.paused) {
-        // Maybe the sync was terminated because the user paused the folder
-        _syncResult.setStatus(SyncResult::Paused);
-    } else {
-        _syncResult.setStatus(SyncResult::Success);
-    }
-
-    // Count the number of syncs that have failed in a row.
-    if (_syncResult.status() == SyncResult::Success
-        || _syncResult.status() == SyncResult::Problem) {
-        _consecutiveFailingSyncs = 0;
-    } else {
-        _consecutiveFailingSyncs++;
-        qCInfo(lcFolder) << "the last" << _consecutiveFailingSyncs << "syncs failed";
-    }
-
-    if (_syncResult.status() == SyncResult::Success && success) {
-        // Clear the white list as all the folders that should be on that list are sync-ed
-        journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, QStringList());
-    }
-
-    emit syncStateChange();
-
-    // The syncFinished result that is to be triggered here makes the folderman
-    // clear the current running sync folder marker.
-    // Lets wait a bit to do that because, as long as this marker is not cleared,
-    // file system change notifications are ignored for that folder. And it takes
-    // some time under certain conditions to make the file system notifications
-    // all come in.
-    QTimer::singleShot(200, this, SLOT(slotEmitFinishedDelayed()));
-
-    _lastSyncDuration = _timeSinceLastSyncStart.elapsed();
-    _timeSinceLastSyncDone.start();
-
-    // Increment the follow-up sync counter if necessary.
-    if (anotherSyncNeeded == ImmediateFollowUp) {
-        _consecutiveFollowUpSyncs++;
-        qCInfo(lcFolder) << "another sync was requested by the finished sync, this has"
-                         << "happened" << _consecutiveFollowUpSyncs << "times";
-    } else {
-        _consecutiveFollowUpSyncs = 0;
-    }
-
-    // Maybe force a follow-up sync to take place, but only a couple of times.
-    if (anotherSyncNeeded == ImmediateFollowUp && _consecutiveFollowUpSyncs <= 3) {
-        // Sometimes another sync is requested because a local file is still
-        // changing, so wait at least a small amount of time before syncing
-        // the folder again.
-        scheduleThisFolderSoon();
-    }
-}
-
-void Folder::slotEmitFinishedDelayed()
-{
-    emit syncFinished(_syncResult);
-}
-
-// the progress comes without a folder and the valid path set. Add that here
-// and hand the result over to the progress dispatcher.
-void Folder::slotTransmissionProgress(const ProgressInfo &pi)
-{
-    emit progressInfo(pi);
-    ProgressDispatcher::instance()->setProgressInfo(alias(), pi);
-}
-
-// a item is completed: count the errors and forward to the ProgressDispatcher
-void Folder::slotItemCompleted(const SyncFileItemPtr &item)
-{
-    // add new directories or remove gone away dirs to the watcher
-    if (item->_isDirectory && item->_instruction == CSYNC_INSTRUCTION_NEW) {
-        FolderMan::instance()->addMonitorPath(alias(), path() + item->_file);
-    }
-    if (item->_isDirectory && item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
-        FolderMan::instance()->removeMonitorPath(alias(), path() + item->_file);
-    }
-
-    _syncResult.processCompletedItem(item);
-
-    _fileLog->logItem(*item);
-    emit ProgressDispatcher::instance()->itemCompleted(alias(), item);
 }
 
 void Folder::slotNewBigFolderDiscovered(const QString &newF, bool isExternal)
@@ -881,28 +241,6 @@ void Folder::slotNewBigFolderDiscovered(const QString &newF, bool isExternal)
         auto logger = Logger::instance();
         logger->postOptionalGuiLog(Theme::instance()->appNameGUI(), message);
     }
-}
-
-void Folder::slotLogPropagationStart()
-{
-    _fileLog->logLap("Propagation starts");
-}
-
-void Folder::slotScheduleThisFolder()
-{
-    FolderMan::instance()->scheduleFolder(this);
-}
-
-void Folder::scheduleThisFolderSoon()
-{
-    if (!_scheduleSelfTimer.isActive()) {
-        _scheduleSelfTimer.start();
-    }
-}
-
-void Folder::setSaveBackwardsCompatible(bool save)
-{
-    _saveBackwardsCompatible = save;
 }
 
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, bool *cancel)
@@ -959,7 +297,10 @@ void Folder::slotAboutToRestoreBackup(bool *restore)
     *restore = msgBox.clickedButton() == keepBtn;
 }
 
+void Folder::startSync(const QStringList &pathList){
 
+    _csyncUnavail = false;
+    AbstractFolder::startSync(pathList);
 }
 
 } // namespace OCC

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -82,6 +82,7 @@ public slots:
     void startSync(const QStringList &pathList = QStringList());
 
 private slots:
+    void slotCsyncUnavailable();
     void slotRunEtagJob();
     void etagRetreived(const QString &);
     void etagRetreivedFromSyncEngine(const QString &);

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -22,6 +22,7 @@
 #include "syncjournaldb.h"
 #include "clientproxy.h"
 #include "networkjobs.h"
+#include "abstractfolder.h"
 
 #include <csync.h>
 
@@ -35,59 +36,13 @@ namespace OCC {
 
 class SyncEngine;
 class AccountState;
-class SyncRunFileLog;
-
-/**
- * @brief The FolderDefinition class
- * @ingroup gui
- */
-class FolderDefinition
-{
-public:
-    FolderDefinition()
-        : paused(false)
-        , ignoreHiddenFiles(true)
-    {
-    }
-
-    /// The name of the folder in the ui and internally
-    QString alias;
-    /// path on local machine
-    QString localPath;
-    /// path to the journal, usually relative to localPath
-    QString journalPath;
-    /// path on remote
-    QString targetPath;
-    /// whether the folder is paused
-    bool paused;
-    /// whether the folder syncs hidden files
-    bool ignoreHiddenFiles;
-
-    /// Saves the folder definition, creating a new settings group.
-    static void save(QSettings &settings, const FolderDefinition &folder);
-
-    /// Reads a folder definition from a settings group with the name 'alias'.
-    static bool load(QSettings &settings, const QString &alias,
-        FolderDefinition *folder);
-
-    /// Ensure / as separator and trailing /.
-    static QString prepareLocalPath(const QString &path);
-
-    /// Ensure starting / and no ending /.
-    static QString prepareTargetPath(const QString &path);
-
-    /// journalPath relative to localPath.
-    QString absoluteJournalPath() const;
-
-    /// Returns the relative journal path that's appropriate for this folder and account.
-    QString defaultJournalPath(AccountPtr account);
-};
+class FolderDefinition;
 
 /**
  * @brief The Folder class
  * @ingroup gui
  */
-class Folder : public QObject
+class Folder : public AbstractFolder
 {
     Q_OBJECT
 
@@ -96,109 +51,14 @@ public:
 
     ~Folder();
 
-    typedef QMap<QString, Folder *> Map;
-    typedef QMapIterator<QString, Folder *> MapIterator;
-
-    /**
-     * The account the folder is configured on.
-     */
-    AccountState *accountState() const { return _accountState.data(); }
-
-    /**
-     * alias or nickname
-     */
-    QString alias() const;
-    QString shortGuiRemotePathOrAppName() const; // since 2.0 we don't want to show aliases anymore, show the path instead
-
-    /**
-     * short local path to display on the GUI  (native separators)
-     */
-    QString shortGuiLocalPath() const;
-
-    /**
-     * canonical local folder path, always ends with /
-     */
-    QString path() const;
-
-    /**
-     * cleaned canonical folder path, like path() but never ends with a /
-     *
-     * Wrapper for QDir::cleanPath(path()) except for "Z:/",
-     * where it returns "Z:" instead of "Z:/".
-     */
-    QString cleanPath() const;
-
-    /**
-     * remote folder path
-     */
-    QString remotePath() const;
-
-    /**
-     * remote folder path with server url
-     */
-    QUrl remoteUrl() const;
-
-    /**
-     * switch sync on or off
-     */
-    void setSyncPaused(bool);
-
-    bool syncPaused() const;
-
-    /**
-     * Returns true when the folder may sync.
-     */
-    bool canSync() const;
-
-    void prepareToSync();
-
-    /**
-     * True if the folder is busy and can't initiate
-     * a synchronization
-     */
-    virtual bool isBusy() const;
-
-    /**
-     * return the last sync result with error message and status
-     */
-    SyncResult syncResult() const;
-
-    /**
-      * set the config file name.
-      */
-    void setConfigFile(const QString &);
-    QString configFile();
-
-    /**
-      * This is called if the sync folder definition is removed. Do cleanups here.
-      */
-    virtual void wipe();
-
-    void setSyncState(SyncResult::Status state);
-
-    void setDirtyNetworkLimits();
-
-    /**
+     /**
       * Ignore syncing of hidden files or not. This is defined in the
       * folder definition
       */
     bool ignoreHiddenFiles();
     void setIgnoreHiddenFiles(bool ignore);
 
-    // Used by the Socket API
-    SyncJournalDb *journalDb() { return &_journal; }
-    SyncEngine &syncEngine() { return *_engine; }
-
     RequestEtagJob *etagJob() { return _requestEtagJob; }
-    qint64 msecSinceLastSync() const { return _timeSinceLastSyncDone.elapsed(); }
-    qint64 msecLastSyncDuration() const { return _lastSyncDuration; }
-    int consecutiveFollowUpSyncs() const { return _consecutiveFollowUpSyncs; }
-    int consecutiveFailingSyncs() const { return _consecutiveFailingSyncs; }
-
-    /// Saves the folder data in the account's settings.
-    void saveToSettings() const;
-    /// Removes the folder from the account's settings.
-    void removeFromSettings() const;
 
     /**
       * Returns whether a file inside this folder should be excluded.
@@ -210,161 +70,30 @@ public:
       */
     bool isFileExcludedRelative(const QString &relativePath) const;
 
-    /** Calls schedules this folder on the FolderMan after a short delay.
-      *
-      * This should be used in situations where a sync should be triggered
-      * because a local file was modified. Syncs don't upload files that were
-      * modified too recently, and this delay ensures the modification is
-      * far enough in the past.
-      *
-      * The delay doesn't reset with subsequent calls.
-      */
-    void scheduleThisFolderSoon();
-
-    /**
-      * Migration: When this flag is true, this folder will save to
-      * the backwards-compatible 'Folders' section in the config file.
-      */
-    void setSaveBackwardsCompatible(bool save);
-
 signals:
-    void syncStateChange();
-    void syncStarted();
-    void syncFinished(const SyncResult &result);
-    void progressInfo(const ProgressInfo &progress);
     void newBigFolderDiscovered(const QString &); // A new folder bigger than the threshold was discovered
-    void syncPausedChanged(Folder *, bool paused);
-    void canSyncChanged();
-
-    /**
-     * Fires for each change inside this folder that wasn't caused
-     * by sync activity.
-     */
-    void watchedFileChangedExternally(const QString &path);
 
 public slots:
-
-    /**
-       * terminate the current sync run
-       */
-    void slotTerminateSync();
 
     // connected to the corresponding signals in the SyncEngine
     void slotAboutToRemoveAllFiles(SyncFileItem::Direction, bool *);
     void slotAboutToRestoreBackup(bool *);
 
-
-    /**
-      * Starts a sync operation
-      *
-      * If the list of changed files is known, it is passed.
-      */
     void startSync(const QStringList &pathList = QStringList());
 
-    void setProxyDirty(bool value);
-    bool proxyDirty();
-
-    int slotDiscardDownloadProgress();
-    int downloadInfoCount();
-    int slotWipeErrorBlacklist();
-    int errorBlackListEntryCount();
-
-    /**
-       * Triggered by the folder watcher when a file/dir in this folder
-       * changes. Needs to check whether this change should trigger a new
-       * sync run to be scheduled.
-       */
-    void slotWatchedPathChanged(const QString &path);
-
 private slots:
-    void slotSyncStarted();
-    void slotSyncFinished(bool);
-
-    /** Adds a error message that's not tied to a specific item.
-     */
-    void slotSyncError(const QString &message, ErrorCategory category = ErrorCategory::Normal);
-
-    void slotCsyncUnavailable();
-
-    void slotTransmissionProgress(const ProgressInfo &pi);
-    void slotItemCompleted(const SyncFileItemPtr &);
-
     void slotRunEtagJob();
     void etagRetreived(const QString &);
     void etagRetreivedFromSyncEngine(const QString &);
 
-    void slotEmitFinishedDelayed();
-
     void slotNewBigFolderDiscovered(const QString &, bool isExternal);
-
-    void slotLogPropagationStart();
-
-    /** Adds this folder to the list of scheduled folders in the
-     *  FolderMan.
-     */
-    void slotScheduleThisFolder();
 
 private:
     bool setIgnoredFiles();
 
-    void showSyncResultPopup();
-
-    void checkLocalPath();
-
-    void setSyncOptions();
-
-    enum LogStatus {
-        LogStatusRemove,
-        LogStatusRename,
-        LogStatusMove,
-        LogStatusNew,
-        LogStatusError,
-        LogStatusConflict,
-        LogStatusUpdated
-    };
-
-    void createGuiLog(const QString &filename, LogStatus status, int count,
-        const QString &renameTarget = QString::null);
-
-    AccountStatePtr _accountState;
-    FolderDefinition _definition;
-    QString _canonicalLocalPath; // As returned with QFileInfo:canonicalFilePath.  Always ends with "/"
-
-    SyncResult _syncResult;
-    QScopedPointer<SyncEngine> _engine;
     bool _csyncUnavail;
-    bool _proxyDirty;
     QPointer<RequestEtagJob> _requestEtagJob;
     QString _lastEtag;
-    QElapsedTimer _timeSinceLastSyncDone;
-    QElapsedTimer _timeSinceLastSyncStart;
-    qint64 _lastSyncDuration;
-
-    /// The number of syncs that failed in a row.
-    /// Reset when a sync is successful.
-    int _consecutiveFailingSyncs;
-
-    /// The number of requested follow-up syncs.
-    /// Reset when no follow-up is requested.
-    int _consecutiveFollowUpSyncs;
-
-    SyncJournalDb _journal;
-
-    ClientProxy _clientProxy;
-
-    QScopedPointer<SyncRunFileLog> _fileLog;
-
-    QTimer _scheduleSelfTimer;
-
-    /**
-     * When the same local path is synced to multiple accounts, only one
-     * of them can be stored in the settings in a way that's compatible
-     * with old clients that don't support it. This flag marks folders
-     * that shall be written in a backwards-compatible way, by being set
-     * on the *first* Folder instance that was configured for each local
-     * path.
-     */
-    bool _saveBackwardsCompatible;
 };
 }
 

--- a/src/gui/folderdefinition.cpp
+++ b/src/gui/folderdefinition.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+#include "config.h"
+#include "logger.h"
+
+#include "folderman.h"
+#include "account.h"
+#include "accountstate.h"
+
+#include "folderdefinition.h"
+
+#include <QSettings>
+#include <QDir>
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcFolderDef, "gui.folderdefinition", QtInfoMsg)
+
+
+void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
+{
+    settings.beginGroup(FolderMan::escapeAlias(folder.alias));
+    settings.setValue(QLatin1String("localPath"), folder.localPath);
+    settings.setValue(QLatin1String("journalPath"), folder.journalPath);
+    settings.setValue(QLatin1String("targetPath"), folder.targetPath);
+    settings.setValue(QLatin1String("paused"), folder.paused);
+    settings.setValue(QLatin1String("ignoreHiddenFiles"), folder.ignoreHiddenFiles);
+    settings.endGroup();
+}
+
+bool FolderDefinition::load(QSettings &settings, const QString &alias,
+    FolderDefinition *folder)
+{
+    settings.beginGroup(alias);
+    folder->alias = FolderMan::unescapeAlias(alias);
+    folder->localPath = settings.value(QLatin1String("localPath")).toString();
+    folder->journalPath = settings.value(QLatin1String("journalPath")).toString();
+    folder->targetPath = settings.value(QLatin1String("targetPath")).toString();
+    folder->paused = settings.value(QLatin1String("paused")).toBool();
+    folder->ignoreHiddenFiles = settings.value(QLatin1String("ignoreHiddenFiles"), QVariant(true)).toBool();
+    folder->cryptoContainerPath = settings.value(QLatin1String("cryptoContainerPath")).toString();
+    settings.endGroup();
+
+    // Old settings can contain paths with native separators. In the rest of the
+    // code we assum /, so clean it up now.
+    folder->localPath = prepareLocalPath(folder->localPath);
+
+    // Target paths also have a convention
+    folder->targetPath = prepareTargetPath(folder->targetPath);
+
+    return true;
+}
+
+QString FolderDefinition::prepareLocalPath(const QString &path)
+{
+    QString p = QDir::fromNativeSeparators(path);
+    if (!p.endsWith(QLatin1Char('/'))) {
+        p.append(QLatin1Char('/'));
+    }
+    return p;
+}
+
+QString FolderDefinition::prepareTargetPath(const QString &path)
+{
+    QString p = path;
+    if (p.endsWith(QLatin1Char('/'))) {
+        p.chop(1);
+    }
+    // Doing this second ensures the empty string or "/" come
+    // out as "/".
+    if (!p.startsWith(QLatin1Char('/'))) {
+        p.prepend(QLatin1Char('/'));
+    }
+    return p;
+}
+
+QString FolderDefinition::absoluteJournalPath() const
+{
+    return QDir(localPath).filePath(journalPath);
+}
+
+QString FolderDefinition::defaultJournalPath(AccountPtr account)
+{
+    return SyncJournalDb::makeDbName(localPath, account->url(), targetPath, account->credentials()->user());
+}
+
+} // namespace OCC

--- a/src/gui/folderdefinition.h
+++ b/src/gui/folderdefinition.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef FOLDERDEFINITION_H
+#define FOLDERDEFINITION_H
+
+#include <QObject>
+#include <QStringList>
+
+class AccountPtr;
+class QSettings;
+
+namespace OCC {
+
+/**
+ * @brief The FolderDefinition class
+ * @ingroup gui
+ */
+class FolderDefinition
+{
+public:
+    FolderDefinition()
+        : paused(false)
+        , ignoreHiddenFiles(true)
+    {
+    }
+
+    /// The name of the folder in the ui and internally
+    QString alias;
+    /// path on local machine
+    QString localPath;
+    /// path to the journal, usually relative to localPath
+    QString journalPath;
+    /// path on remote
+    QString targetPath;
+    /// whether the folder is paused
+    bool paused;
+    /// whether the folder syncs hidden files
+    bool ignoreHiddenFiles;
+    /// path to the crypto container if the folder is an encrypted one
+    QString cryptoContainerPath;
+
+    /// Saves the folder definition, creating a new settings group.
+    static void save(QSettings &settings, const FolderDefinition &folder);
+
+    /// Reads a folder definition from a settings group with the name 'alias'.
+    static bool load(QSettings &settings, const QString &alias,
+        FolderDefinition *folder);
+
+    /// Ensure / as separator and trailing /.
+    static QString prepareLocalPath(const QString &path);
+
+    /// Ensure starting / and no ending /.
+    static QString prepareTargetPath(const QString &path);
+
+    /// journalPath relative to localPath.
+    QString absoluteJournalPath() const;
+
+    /// Returns the relative journal path that's appropriate for this folder and account.
+    QString defaultJournalPath(AccountPtr account);
+};
+
+}
+
+#endif

--- a/src/gui/folderdefinition.h
+++ b/src/gui/folderdefinition.h
@@ -18,7 +18,8 @@
 #include <QObject>
 #include <QStringList>
 
-class AccountPtr;
+#include "account.h"
+
 class QSettings;
 
 namespace OCC {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -263,7 +263,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 SyncJournalDb::maybeMigrateDb(folderDefinition.localPath, folderDefinition.absoluteJournalPath());
             }
 
-            Folder *f = addFolderInternal(std::move(folderDefinition), account.data());
+            auto *f = addFolderInternal(std::move(folderDefinition), account.data());
             if (f) {
                 // Migration: Mark folders that shall be saved in a backwards-compatible way
                 if (backwardsCompatible) {
@@ -292,7 +292,7 @@ int FolderMan::setupFoldersMigration()
     // Normally there should be only one account when migrating.
     AccountState *accountState = AccountManager::instance()->accounts().value(0).data();
     foreach (const QString &alias, list) {
-        Folder *f = setupFolderFromOldConfigFile(alias, accountState);
+        auto *f = setupFolderFromOldConfigFile(alias, accountState);
         if (f) {
             scheduleFolder(f);
             emit folderSyncStateChange(f);
@@ -383,9 +383,9 @@ QString FolderMan::unescapeAlias(const QString &alias)
 // filename is the name of the file only, it does not include
 // the configuration directory path
 // WARNING: Do not remove this code, it is used for predefined/automated deployments (2016)
-Folder *FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountState *accountState)
+AbstractFolder *FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountState *accountState)
 {
-    Folder *folder = 0;
+    AbstractFolder *folder = 0;
 
     qCInfo(lcFolderMan) << "  ` -> setting up:" << file;
     QString escapedAlias(file);
@@ -481,7 +481,7 @@ void FolderMan::slotFolderSyncPaused(AbstractFolder *f, bool paused)
 
 void FolderMan::slotFolderCanSyncChanged()
 {
-    Folder *f = qobject_cast<Folder *>(sender());
+    auto *f = qobject_cast<AbstractFolder *>(sender());
     ASSERT(f);
     if (f->canSync()) {
         _socketApi->slotRegisterPath(f->alias());
@@ -806,7 +806,7 @@ void FolderMan::slotRemoveFoldersForAccount(AccountState *accountState)
 
 void FolderMan::slotForwardFolderSyncStateChange()
 {
-    if (Folder *f = qobject_cast<Folder *>(sender())) {
+    if (auto *f = qobject_cast<AbstractFolder *>(sender())) {
         emit folderSyncStateChange(f);
     }
 }
@@ -907,7 +907,7 @@ void FolderMan::slotFolderSyncFinished(const SyncResult &)
     startScheduledSyncSoon();
 }
 
-Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition &folderDefinition)
+AbstractFolder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition &folderDefinition)
 {
     // Choose a db filename
     auto definition = folderDefinition;
@@ -938,7 +938,7 @@ Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition 
     return folder;
 }
 
-Folder *FolderMan::addFolderInternal(FolderDefinition folderDefinition,
+AbstractFolder *FolderMan::addFolderInternal(FolderDefinition folderDefinition,
     AccountState *accountState)
 {
     auto alias = folderDefinition.alias;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -75,10 +75,10 @@ public:
     Folder *addFolder(AccountState *accountState, const FolderDefinition &folderDefinition);
 
     /** Removes a folder */
-    void removeFolder(Folder *);
+    void removeFolder(AbstractFolder *);
 
     /** Returns the folder which the file or directory stored in path is in */
-    Folder *folderForPath(const QString &path);
+    AbstractFolder *folderForPath(const QString &path);
 
     /**
       * returns a list of local files that exist on the local harddisk for an
@@ -88,7 +88,7 @@ public:
     QStringList findFileInLocalFolders(const QString &relPath, const AccountPtr acc);
 
     /** Returns the folder by alias or NULL if no folder with the alias exists. */
-    Folder *folder(const QString &);
+    AbstractFolder *folder(const QString &);
 
     /**
      * Migrate accounts from owncloud < 2.0
@@ -108,7 +108,7 @@ public:
 
     QString statusToString(SyncResult::Status, bool paused) const;
 
-    static SyncResult accountStatus(const QList<Folder *> &folders);
+    static SyncResult accountStatus(const QList<AbstractFolder *> &folders);
 
     void removeMonitorPath(const QString &alias, const QString &path);
     void addMonitorPath(const QString &alias, const QString &path);
@@ -155,12 +155,12 @@ public:
     /**
      * Access to the current queue of scheduled folders.
      */
-    QQueue<Folder *> scheduleQueue() const;
+    QQueue<AbstractFolder *> scheduleQueue() const;
 
     /**
      * Access to the currently syncing folder.
      */
-    Folder *currentSyncFolder() const;
+    AbstractFolder *currentSyncFolder() const;
 
     /** Removes all folders */
     int unloadAndDeleteAllFolders();
@@ -172,10 +172,10 @@ public:
     void setSyncEnabled(bool);
 
     /** Queues a folder for syncing. */
-    void scheduleFolder(Folder *);
+    void scheduleFolder(AbstractFolder *);
 
     /** Puts a folder in the very front of the queue. */
-    void scheduleFolderNext(Folder *);
+    void scheduleFolderNext(AbstractFolder*);
 
     /** Queues all folders for syncing. */
     void scheduleAllFolders();
@@ -196,7 +196,7 @@ signals:
       *
       * Attention: The folder may be zero. Do a general update of the state then.
       */
-    void folderSyncStateChange(Folder *);
+    void folderSyncStateChange(AbstractFolder *);
 
     /**
      * Indicates when the schedule queue changes.
@@ -206,7 +206,7 @@ signals:
     /**
      * Emitted whenever the list of configured folders changes.
      */
-    void folderListChanged(const Folder::Map &);
+    void folderListChanged(const AbstractFolder::Map &);
 
 public slots:
 
@@ -233,7 +233,7 @@ public slots:
     void slotScheduleETagJob(const QString &alias, RequestEtagJob *job);
 
 private slots:
-    void slotFolderSyncPaused(Folder *, bool paused);
+    void slotFolderSyncPaused(AbstractFolder *, bool paused);
     void slotFolderCanSyncChanged();
     void slotFolderSyncStarted();
     void slotFolderSyncFinished(const SyncResult &);
@@ -277,7 +277,7 @@ private:
         AccountState *accountState);
 
     /* unloads a folder object, does not delete it */
-    void unloadFolder(Folder *);
+    void unloadFolder(AbstractFolder *);
 
     /** Will start a sync after a bit of delay. */
     void startScheduledSyncSoon();
@@ -285,18 +285,18 @@ private:
     // finds all folder configuration files
     // and create the folders
     QString getBackupName(QString fullPathName) const;
-    void registerFolderMonitor(Folder *folder);
+    void registerFolderMonitor(AbstractFolder *folder);
 
     // restarts the application (Linux only)
     void restartApplication();
 
     void setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool backwardsCompatible);
 
-    QSet<Folder *> _disabledFolders;
-    Folder::Map _folderMap;
+    QSet<AbstractFolder *> _disabledFolders;
+    AbstractFolder::Map _folderMap;
     QString _folderConfigPath;
-    Folder *_currentSyncFolder;
-    QPointer<Folder> _lastSyncFolder;
+    AbstractFolder *_currentSyncFolder;
+    QPointer<AbstractFolder> _lastSyncFolder;
     bool _syncEnabled;
 
     /// Watching for file changes in folders
@@ -314,7 +314,7 @@ private:
     QTimer _timeScheduler;
 
     /// Scheduled folders that should be synced as soon as possible
-    QQueue<Folder *> _scheduledFolders;
+    QQueue<AbstractFolder *> _scheduledFolders;
 
     /// Picks the next scheduled folder and starts the sync
     QTimer _startScheduledSyncTimer;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -72,7 +72,7 @@ public:
 
     /** Adds a folder for an account, ensures the journal is gone and saves it in the settings.
       */
-    Folder *addFolder(AccountState *accountState, const FolderDefinition &folderDefinition);
+    AbstractFolder *addFolder(AccountState *accountState, const FolderDefinition &folderDefinition);
 
     /** Removes a folder */
     void removeFolder(AbstractFolder *);
@@ -94,7 +94,7 @@ public:
      * Migrate accounts from owncloud < 2.0
      * Creates a folder for a specific configuration, identified by alias.
      */
-    Folder *setupFolderFromOldConfigFile(const QString &, AccountState *account);
+    AbstractFolder *setupFolderFromOldConfigFile(const QString &, AccountState *account);
 
     /**
      * Ensures that a given directory does not contain a sync journal file.
@@ -273,7 +273,7 @@ private:
     /** Adds a new folder, does not add it to the account settings and
      *  does not set an account on the new folder.
       */
-    Folder *addFolderInternal(FolderDefinition folderDefinition,
+    AbstractFolder *addFolderInternal(FolderDefinition folderDefinition,
         AccountState *accountState);
 
     /* unloads a folder object, does not delete it */

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -872,7 +872,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
         return; // for https://github.com/owncloud/client/issues/2648#issuecomment-71377909
     }
 
-    Folder *f = qobject_cast<Folder *>(sender());
+    AbstractFolder *f = qobject_cast<AbstractFolder *>(sender());
     if (!f) {
         return;
     }
@@ -1187,8 +1187,8 @@ void FolderStatusModel::slotSyncNoPendingBigFolders()
 
 void FolderStatusModel::slotNewBigFolder()
 {
-    auto f = qobject_cast<Folder *>(sender());
-    ASSERT(f);
+    auto *f = qobject_cast<Folder *>(sender());
+    ASSERT(f);  // FIXME: If this ASSERT fires, the cast before should probably be AbstractFolder
 
     int folderIndex = -1;
     for (int i = 0; i < _folders.count(); ++i) {

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -68,10 +68,10 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
     _folders.clear();
     _accountState = accountState;
 
-    connect(FolderMan::instance(), SIGNAL(folderSyncStateChange(Folder *)),
-        SLOT(slotFolderSyncStateChange(Folder *)), Qt::UniqueConnection);
-    connect(FolderMan::instance(), SIGNAL(scheduleQueueChanged()),
-        SLOT(slotFolderScheduleQueueChanged()), Qt::UniqueConnection);
+    connect(FolderMan::instance(), &FolderMan::folderSyncStateChange,
+        this, &FolderStatusModel::slotFolderSyncStateChange, Qt::UniqueConnection);
+    connect(FolderMan::instance(), &FolderMan::scheduleQueueChanged,
+        this, &FolderStatusModel::slotFolderScheduleQueueChanged, Qt::UniqueConnection);
 
     auto folders = FolderMan::instance()->map();
     foreach (auto f, folders) {
@@ -415,7 +415,7 @@ FolderStatusModel::SubFolderInfo *FolderStatusModel::infoForIndex(const QModelIn
     }
 }
 
-QModelIndex FolderStatusModel::indexForPath(Folder *f, const QString &path) const
+QModelIndex FolderStatusModel::indexForPath(AbstractFolder *f, const QString &path) const
 {
     if (!f) {
         return QModelIndex();
@@ -801,7 +801,7 @@ QStringList FolderStatusModel::createBlackList(FolderStatusModel::SubFolderInfo 
     return result;
 }
 
-void FolderStatusModel::slotUpdateFolderState(Folder *folder)
+void FolderStatusModel::slotUpdateFolderState(AbstractFolder *folder)
 {
     if (!folder)
         return;
@@ -1043,7 +1043,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
     emit dataChanged(index(folderIndex), index(folderIndex), roles);
 }
 
-void FolderStatusModel::slotFolderSyncStateChange(Folder *f)
+void FolderStatusModel::slotFolderSyncStateChange(AbstractFolder *f)
 {
     if (!f) {
         return;
@@ -1104,7 +1104,7 @@ void FolderStatusModel::slotFolderSyncStateChange(Folder *f)
 void FolderStatusModel::slotFolderScheduleQueueChanged()
 {
     // Update messages on waiting folders.
-    foreach (Folder *f, FolderMan::instance()->map()) {
+    foreach (auto *f, FolderMan::instance()->map()) {
         slotFolderSyncStateChange(f);
     }
 }

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -28,6 +28,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcFolderStatus)
 
 class Folder;
 class ProgressInfo;
+class AbstractFolder;
 
 /**
  * @brief The FolderStatusModel class
@@ -66,7 +67,7 @@ public:
             , _checked(Qt::Checked)
         {
         }
-        Folder *_folder;
+        AbstractFolder *_folder;
         QString _name;
         QString _path;
         QVector<int> _pathIdx;
@@ -126,10 +127,10 @@ public:
      * return a QModelIndex for the given path within the given folder.
      * Note: this method returns an invalid index if the path was not fetched from the server before
      */
-    QModelIndex indexForPath(Folder *f, const QString &path) const;
+    QModelIndex indexForPath(OCC::AbstractFolder *f, const QString &path) const;
 
 public slots:
-    void slotUpdateFolderState(Folder *);
+    void slotUpdateFolderState(OCC::AbstractFolder *);
     void slotApplySelectiveSync();
     void resetFolders();
     void slotSyncAllPendingBigFolders();
@@ -140,7 +141,7 @@ private slots:
     void slotUpdateDirectories(const QStringList &);
     void slotGatherPermissions(const QString &name, const QMap<QString, QString> &properties);
     void slotLscolFinishedWithError(QNetworkReply *r);
-    void slotFolderSyncStateChange(Folder *f);
+    void slotFolderSyncStateChange(AbstractFolder *f);
     void slotFolderScheduleQueueChanged();
     void slotNewBigFolder();
 

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -33,13 +33,13 @@
 #endif
 
 #include "excludedfiles.h"
-#include "folder.h"
+#include "abstractfolder.h"
 
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcFolderWatcher, "gui.folderwatcher", QtInfoMsg)
 
-FolderWatcher::FolderWatcher(const QString &root, Folder *folder)
+FolderWatcher::FolderWatcher(const QString &root, AbstractFolder *folder)
     : QObject(folder)
     , _folder(folder)
 {

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -34,7 +34,7 @@ namespace OCC {
 Q_DECLARE_LOGGING_CATEGORY(lcFolderWatcher)
 
 class FolderWatcherPrivate;
-class Folder;
+class AbstractFolder;
 
 /**
  * @brief Monitors a directory recursively for changes
@@ -58,7 +58,7 @@ public:
     /**
      * @param root Path of the root of the folder
      */
-    FolderWatcher(const QString &root, Folder *folder = 0L);
+    FolderWatcher(const QString &root, AbstractFolder *folder = 0L);
     virtual ~FolderWatcher();
 
     /**
@@ -92,7 +92,7 @@ private:
     QScopedPointer<FolderWatcherPrivate> _d;
     QTime _timer;
     QSet<QString> _lastPaths;
-    Folder *_folder;
+    AbstractFolder *_folder;
 
     friend class FolderWatcherPrivate;
 };

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -129,7 +129,7 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
     // We need to force a remote discovery after a change of the ignore list.
     // Otherwise we would not download the files/directories that are no longer
     // ignored (because the remote etag did not change)   (issue #3172)
-    foreach (Folder *folder, folderMan->map()) {
+    foreach (auto *folder, folderMan->map()) {
         folder->journalDb()->forceRemoteDiscoveryNextSync();
         folderMan->scheduleFolder(folder);
     }

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -69,7 +69,7 @@ IssuesWidget::IssuesWidget(QWidget *parent)
         SLOT(slotAccountAdded(AccountState *)));
     connect(AccountManager::instance(), SIGNAL(accountRemoved(AccountState *)),
         SLOT(slotAccountRemoved(AccountState *)));
-    connect(FolderMan::instance(), SIGNAL(folderListChanged(Folder::Map)),
+    connect(FolderMan::instance(), SIGNAL(folderListChanged(AbstractFolder::Map)),
         SLOT(slotUpdateFolderFilters()));
 
 

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -164,7 +164,7 @@ void IssuesWidget::slotOpenFile(QTreeWidgetItem *item, int)
     QString folderName = item->data(2, Qt::UserRole).toString();
     QString fileName = item->text(1);
 
-    Folder *folder = FolderMan::instance()->folder(folderName);
+    auto *folder = FolderMan::instance()->folder(folderName);
     if (folder) {
         // folder->path() always comes back with trailing path
         QString fullPath = folder->path() + fileName;

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -29,7 +29,7 @@
 
 namespace OCC {
 
-class Folder;
+class AbstractFolder;
 
 class SettingsDialog;
 class SettingsDialogMac;
@@ -77,7 +77,7 @@ public slots:
     void slotShowSettings();
     void slotShowSyncProtocol();
     void slotShutdown();
-    void slotSyncStateChange(Folder *);
+    void slotSyncStateChange(OCC::AbstractFolder *);
     void slotTrayClicked(QSystemTrayIcon::ActivationReason reason);
     void slotToggleLogBrowser();
     void slotOpenOwnCloud();

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -114,7 +114,7 @@ void ProtocolWidget::slotOpenFile(QTreeWidgetItem *item, int)
     QString folderName = item->data(2, Qt::UserRole).toString();
     QString fileName = item->text(1);
 
-    Folder *folder = FolderMan::instance()->folder(folderName);
+    auto *folder = FolderMan::instance()->folder(folderName);
     if (folder) {
         // folder->path() always comes back with trailing path
         QString fullPath = folder->path() + fileName;

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -549,7 +549,7 @@ QString SocketApi::buildRegisterPathMessage(const QString &path)
 
 QUrl SocketApi::getPrivateLinkUrl(const QString &localFile) const
 {
-    Folder *shareFolder = FolderMan::instance()->folderForPath(localFile);
+    auto *shareFolder = FolderMan::instance()->folderForPath(localFile);
     if (!shareFolder) {
         qCWarning(lcSocketApi) << "Unknown path" << localFile;
         return QUrl();

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -34,7 +34,7 @@ class QStringList;
 namespace OCC {
 
 class SyncFileStatus;
-class Folder;
+class AbstractFolder;
 class SocketListener;
 
 /**
@@ -50,7 +50,7 @@ public:
     virtual ~SocketApi();
 
 public slots:
-    void slotUpdateFolderView(Folder *f);
+    void slotUpdateFolderView(OCC::AbstractFolder *f);
     void slotUnregisterPath(const QString &alias);
     void slotRegisterPath(const QString &alias);
 

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -271,7 +271,7 @@ class OWNCLOUDSYNC_EXPORT ProgressDispatcher : public QObject
 {
     Q_OBJECT
 
-    friend class Folder; // only allow Folder class to access the setting slots.
+    friend class AbstractFolder; // only allow Folder class to access the setting slots.
 public:
     static ProgressDispatcher *instance();
     ~ProgressDispatcher();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,8 @@ owncloud_add_benchmark(LargeSync "syncenginetestutils.h")
 
 SET(FolderMan_SRC ../src/gui/folderman.cpp)
 list(APPEND FolderMan_SRC ../src/gui/folder.cpp )
+list(APPEND FolderMan_SRC ../src/gui/abstractfolder.cpp )
+list(APPEND FolderMan_SRC ../src/gui/folderdefinition.cpp )
 list(APPEND FolderMan_SRC ../src/gui/socketapi.cpp )
 list(APPEND FolderMan_SRC ../src/gui/accountstate.cpp )
 list(APPEND FolderMan_SRC ../src/gui/syncrunfilelog.cpp )


### PR DESCRIPTION
Please consider this (large) patch. I splits off an abstract class for folders, providing the integration with the application by managing the interfaces with GUI, socketapi, scheduling and such. The folder class now only still contains things specific to this (the old, common) type  of sync folder. 

However, with the new structure we will be able to develop other folder types, such as folders that are actually containers containing a file folder structure, which require special handling in the client code.

A long term goal is that folders can even have different sync engines.

I am looking forward to hearing your comments.  