### PR TITLE
AccountState: reset _waitingForNewCredentials when signin in

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -153,6 +153,7 @@ void AccountState::signOutByUi()
 void AccountState::signIn()
 {
     if (_state == SignedOut) {
+        _waitingForNewCredentials = false;
         setState(Disconnected);
     }
 }


### PR DESCRIPTION
Just to force the logic to re-ask the credenticals, in case we were
already asking them when singin off.

Issue: https://github.com/owncloud/client/issues/5893#issuecomment-316949686