### PR TITLE
FolderWizard: fix crash in FolderWizardRemotePath::slotHandleLsColNetworkError

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -22,6 +22,7 @@
 #include "accountstate.h"
 #include "creds/abstractcredentials.h"
 #include "wizard/owncloudwizard.h"
+#include "asserts.h"
 
 #include <QDesktopServices>
 #include <QDir>
@@ -229,7 +230,8 @@ void FolderWizardRemotePath::slotHandleMkdirNetworkError(QNetworkReply *reply)
 
 void FolderWizardRemotePath::slotHandleLsColNetworkError(QNetworkReply * /*reply*/)
 {
-    auto job = qobject_cast<MkColJob *>(sender());
+    auto job = qobject_cast<LsColJob *>(sender());
+    ASSERT(job);
     showWarn(tr("Failed to list a folder. Error: %1")
                  .arg(job->errorStringParsingBody()));
 }


### PR DESCRIPTION
The Job is a LsColJob, not a MkColJob!

Reproduce by entering a name with invalid character that cause an error 400
in the folder wizard's remote path line edit.

(Relates issue #5924)