### PR TITLE
Windows: Use the application icon for the sidebar

### DIFF
--- a/csync/src/csync_exclude.c
+++ b/csync/src/csync_exclude.c
@@ -293,6 +293,13 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(c_strlist_t *excludes, const ch
     }
 #endif
 
+    /* We create a desktop.ini on Windows for the sidebar icon, make sure we don't sync them. */
+    rc = csync_fnmatch("Desktop.ini", bname, 0);
+    if (rc == 0) {
+        match = CSYNC_FILE_SILENTLY_EXCLUDED;
+        goto out;
+    }
+
     rc = csync_fnmatch(".owncloudsync.log*", bname, 0);
     if (rc == 0) {
         match = CSYNC_FILE_SILENTLY_EXCLUDED;

--- a/src/libsync/utility_win.cpp
+++ b/src/libsync/utility_win.cpp
@@ -28,8 +28,20 @@ namespace OCC {
 
 static void setupFavLink_private(const QString &folder)
 {
-    // Windows Explorer: Place under "Favorites" (Links)
+    // First create a Desktop.ini so that the folder and favorite link show our application's icon.
+    QFile desktopIni(folder + QLatin1String("/Desktop.ini"));
+    if (desktopIni.exists()) {
+        qCWarning(lcUtility) << desktopIni.fileName() << "already exists, not overwriting it to set the folder icon.";
+    } else {
+        qCInfo(lcUtility) << "Creating" << desktopIni.fileName() << "to set a folder icon in Explorer.";
+        desktopIni.open(QFile::WriteOnly);
+        desktopIni.write("[.ShellClassInfo]\r\nIconResource=");
+        desktopIni.write(QDir::toNativeSeparators(qApp->applicationFilePath()).toUtf8());
+        desktopIni.write(",0\r\n");
+        desktopIni.close();
+    }
 
+    // Windows Explorer: Place under "Favorites" (Links)
     QString linkName;
     QDir folderDir(QDir::fromNativeSeparators(folder));
 
@@ -41,7 +53,7 @@ static void setupFavLink_private(const QString &folder)
         linkName = QDir(links).filePath(folderDir.dirName() + QLatin1String(".lnk"));
         CoTaskMemFree(path);
     }
-    qCDebug(lcUtility) << " creating link from " << linkName << " to " << folder;
+    qCInfo(lcUtility) << "Creating favorite link from" << folder << "to" << linkName;
     if (!QFile::link(folder, linkName))
         qCWarning(lcUtility) << "linking" << folder << "to" << linkName << "failed!";
 }

--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -8,7 +8,6 @@
 ].ds_store
 ._*
 ]Thumbs.db
-desktop.ini
 System Volume Information
 
 .*.sw?


### PR DESCRIPTION
By setting the icon in Desktop.ini of the root folder, this adds the icon
both when browsing the folder directly and to the sidebar shortcut.

To avoid overwriting any user setting that could exist in Desktop.ini,
only do this if the file doesn't exist. Editing .ini files on Windows
isn't trivial and isn't worth it given that this file won't exist most
of the time.

Fixes #2446