### PR TITLE
fix branded nemo and caja shell integration

### DIFF
--- a/shell_integration/icons/CMakeLists.txt
+++ b/shell_integration/icons/CMakeLists.txt
@@ -7,7 +7,7 @@ if( UNIX AND NOT APPLE )
 	FOREACH( file ${files} )
 	    # the GLOB returns a absolute path. Make it relative by replacing the current src dir by nothing
 	    STRING(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/${size}/" "" shortFile ${file})
-	    STRING(REPLACE "oC" ${APPLICATION_NAME} brandedName ${shortFile})
+	    STRING(REPLACE "oC" ${APPLICATION_SHORTNAME} brandedName ${shortFile})
 	    install(FILES ${file} DESTINATION ${ICON_DIR}/${size}/apps RENAME ${brandedName})
 	ENDFOREACH(file)
     ENDFOREACH(size)

--- a/shell_integration/nautilus/CMakeLists.txt
+++ b/shell_integration/nautilus/CMakeLists.txt
@@ -3,8 +3,6 @@
 if( UNIX AND NOT APPLE )
 
     configure_file(syncstate.py syncstate.py COPYONLY)
-    configure_file(syncstate.py syncstate_nemo.py COPYONLY)
-    configure_file(syncstate.py syncstate_caja.py COPYONLY)
 
     # Call the setupappname.sh script to set the custom app name.
     set (cmd "${CMAKE_CURRENT_SOURCE_DIR}/setappname.sh")

--- a/shell_integration/nautilus/createcajaplugin.sh
+++ b/shell_integration/nautilus/createcajaplugin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # this script creates a plugin for caja, just by replacing
-# all occurences of Nautilus with Caja (case sensitive).
+# all occurences of Nautilus with Caja (case sensitive).X
 
 sed -i.org -e 's/Nautilus/Caja/g' syncstate_caja.py
 sed -i.org -e 's/nautilus/caja/g' syncstate_caja.py

--- a/shell_integration/nautilus/createcajaplugin.sh
+++ b/shell_integration/nautilus/createcajaplugin.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # this script creates a plugin for caja, just by replacing
-# all occurences of Nautilus with Caja (case sensitive).X
+# all occurences of Nautilus with Caja (case sensitive).
 
+cp syncstate.py syncstate_caja.py
 sed -i.org -e 's/Nautilus/Caja/g' syncstate_caja.py
 sed -i.org -e 's/nautilus/caja/g' syncstate_caja.py

--- a/shell_integration/nautilus/createnemoplugin.sh
+++ b/shell_integration/nautilus/createnemoplugin.sh
@@ -3,4 +3,5 @@
 # this script creates a plugin for nemo, just be replacing
 # all occurences of Nautilus with Nemo.
 
+cp syncstate.py syncstate_nemo.py
 sed -i.org -e 's/autilus/emo/g' syncstate_nemo.py


### PR DESCRIPTION
The APPLICATION_SHORTNAME only made it into the nautilus copy of syncstate.py so far.
Now caja and nemo also recieve a branded copy. Correct branding is important for a nemo plugin, because this is part of the socket name that we need for connecting.