### PR TITLE
Documentation improvement for #5969

### DIFF
--- a/doc/navigating.rst
+++ b/doc/navigating.rst
@@ -190,7 +190,9 @@ The Activity window contains the log of your recent activities, organized over
 three tabs: **Server Activities**, which includes new shares and files 
 downloaded and deleted, **Sync Protocol**, which displays local activities such 
 as which local folders your files went into, and **Not Synced** shows errors 
-such as files not synced. 
+such as files not synced. Double clicking an entry pointing to an existing
+file in **Server Activities** or **Sync Protocol** will open the folder containing
+the file and highlight it.
 
 .. figure:: images/client-8.png
    :alt: Activity windows logs all server and client activities.


### PR DESCRIPTION
Refs: Issue #5969 (Documentation improvement)

Adding text describing in navigation.rst section Activity Window that you can double click an item to open the corresponding folder.