### PR TITLE
Add 2.3.3 System Requirements to client repo

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -25,6 +25,20 @@ KWallet, so that the sync client can login automatically.
 You will also find links to source code archives and older versions on the 
 download page.
 
+System Requirements (Version 2.3.3)
+----------------------------------
+
+- Windows 7+
+- Mac OS X 10.7+ (**64-bit only**)
+- CentOS 6 & 7 (64-bit only)
+- Debian 7.0 & 8.0 & 9.0
+- Fedora 24 & 25 & 26
+- Ubuntu 16.04 & 16.10 & 17.04
+- openSUSE Leap 42.1 & 42.2 & 42.3
+
+.. note::
+   For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous `LTS`_.
+
 Installation Wizard
 -------------------
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -25,7 +25,7 @@ KWallet, so that the sync client can login automatically.
 You will also find links to source code archives and older versions on the 
 download page.
 
-System Requirements (Version 2.3.3)
+System Requirements
 ----------------------------------
 
 - Windows 7+


### PR DESCRIPTION
I would like to maintain the System Requirements in the client repo. (Switch planned for 2.4.0 release).

[documentation/admin_manual/installation/system_requirements.rst](https://github.com/owncloud/documentation/blob/master/admin_manual/installation/system_requirements.rst) > [client/doc/installing.rst](https://github.com/owncloud/client/blob/master/doc/installing.rst)

@guruz @settermjd @SamuAlfageme What do you think?