### PR TITLE
Http credentials: Fix behavior for bad password #5989

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -31,6 +31,14 @@ namespace OCC {
 
 void HttpCredentialsGui::askFromUser()
 {
+    // Unfortunately there's a bug that doesn't allow us to send the "is this
+    // OAuth2 or Basic auth?" GET request directly. Scheduling it for the event
+    // loop works though. See #5989.
+    QMetaObject::invokeMethod(this, "askFromUserAsync", Qt::QueuedConnection);
+}
+
+void HttpCredentialsGui::askFromUserAsync()
+{
     _password = QString(); // So our QNAM does not add any auth
 
     // First, we will send a call to the webdav endpoint to check what kind of auth we need.

--- a/src/gui/creds/httpcredentialsgui.h
+++ b/src/gui/creds/httpcredentialsgui.h
@@ -48,7 +48,7 @@ public:
      * This will query the server and either uses OAuth via _asyncAuth->start()
      * or call showDialog to ask the password
      */
-    Q_INVOKABLE void askFromUser() Q_DECL_OVERRIDE;
+    void askFromUser() Q_DECL_OVERRIDE;
     /**
      * In case of oauth, return an URL to the link to open the browser.
      * An invalid URL otherwise
@@ -65,6 +65,8 @@ signals:
     void authorisationLinkChanged();
 
 private:
+    Q_INVOKABLE void askFromUserAsync();
+
     QScopedPointer<OAuth, QScopedPointerObjectDeleteLater<OAuth>> _asyncAuth;
 };
 


### PR DESCRIPTION
When the GET request from askFromUser is scheduled on the QNAM inside
the slot that handles the QNetworkReply::finished signal, it seems to
not get processed at all.

This workaround moves the sending of the new GET to the event loop,
sidestepping the problem.