### PR TITLE
Update server url in case of permanent redirection #5972

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -196,13 +196,10 @@ void OwncloudSetupWizard::slotOwnCloudFoundAuth(const QUrl &url, const QJsonObje
     // https://github.com/owncloud/core/pull/27473/files
     _ocWizard->account()->setServerVersion(serverVersion);
 
-    QString p = url.path();
-    if (p.endsWith("/status.php")) {
+    if (url != _ocWizard->account()->url()) {
         // We might be redirected, update the account
-        QUrl redirectedUrl = url;
-        redirectedUrl.setPath(url.path().left(url.path().length() - 11));
-        _ocWizard->account()->setUrl(redirectedUrl);
-        qCInfo(lcWizard) << " was redirected to" << redirectedUrl.toString();
+        _ocWizard->account()->setUrl(url);
+        qCInfo(lcWizard) << " was redirected to" << url.toString();
     }
 
     DetermineAuthTypeJob *job = new DetermineAuthTypeJob(_ocWizard->account(), this);

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -34,25 +34,6 @@ class AccountState;
 class OwncloudWizard;
 
 /**
- * @brief The DetermineAuthTypeJob class
- * @ingroup gui
- */
-class DetermineAuthTypeJob : public AbstractNetworkJob
-{
-    Q_OBJECT
-public:
-    explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
-signals:
-    void authType(WizardCommon::AuthType);
-private slots:
-    bool finished() Q_DECL_OVERRIDE;
-
-private:
-    int _redirects;
-};
-
-/**
  * @brief The OwncloudSetupWizard class
  * @ingroup gui
  */

--- a/src/gui/wizard/owncloudoauthcredspage.cpp
+++ b/src/gui/wizard/owncloudoauthcredspage.cpp
@@ -76,7 +76,7 @@ void OwncloudOAuthCredsPage::asyncAuthResult(OAuth::Result r, const QString &use
         /* OAuth not supported (can't open browser), fallback to HTTP credentials */
         OwncloudWizard *ocWizard = qobject_cast<OwncloudWizard *>(wizard());
         ocWizard->back();
-        ocWizard->setAuthType(WizardCommon::HttpCreds);
+        ocWizard->setAuthType(DetermineAuthTypeJob::Basic);
         break;
     }
     case OAuth::Error:

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -40,7 +40,7 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     , _ocUser()
     , _authTypeKnown(false)
     , _checking(false)
-    , _authType(WizardCommon::HttpCreds)
+    , _authType(DetermineAuthTypeJob::Basic)
     , _progressIndi(new QProgressIndicator(this))
 {
     _ui.setupUi(this);
@@ -201,9 +201,9 @@ bool OwncloudSetupPage::urlHasChanged()
 
 int OwncloudSetupPage::nextId() const
 {
-    if (_authType == WizardCommon::HttpCreds) {
+    if (_authType == DetermineAuthTypeJob::Basic) {
         return WizardCommon::Page_HttpCreds;
-    } else if (_authType == WizardCommon::OAuth) {
+    } else if (_authType == DetermineAuthTypeJob::OAuth) {
         return WizardCommon::Page_OAuthCreds;
     } else {
         return WizardCommon::Page_ShibbolethCreds;
@@ -235,7 +235,7 @@ bool OwncloudSetupPage::validatePage()
     }
 }
 
-void OwncloudSetupPage::setAuthType(WizardCommon::AuthType type)
+void OwncloudSetupPage::setAuthType(DetermineAuthTypeJob::AuthType type)
 {
     _authTypeKnown = true;
     _authType = type;

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -53,7 +53,7 @@ public:
     QString localFolder() const;
     void setRemoteFolder(const QString &remoteFolder);
     void setMultipleFoldersExist(bool exist);
-    void setAuthType(WizardCommon::AuthType type);
+    void setAuthType(DetermineAuthTypeJob::AuthType type);
 
 public slots:
     void setErrorString(const QString &, bool retryHTTPonly);
@@ -80,7 +80,7 @@ private:
     bool _authTypeKnown;
     bool _checking;
     bool _multipleFoldersExist;
-    WizardCommon::AuthType _authType;
+    DetermineAuthTypeJob::AuthType _authType;
 
     QProgressIndicator *_progressIndi;
     QButtonGroup *_selectiveSyncButtons;

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -167,17 +167,17 @@ void OwncloudWizard::successfulStep()
     next();
 }
 
-void OwncloudWizard::setAuthType(WizardCommon::AuthType type)
+void OwncloudWizard::setAuthType(DetermineAuthTypeJob::AuthType type)
 {
     _setupPage->setAuthType(type);
 #ifndef NO_SHIBBOLETH
-    if (type == WizardCommon::Shibboleth) {
+    if (type == DetermineAuthTypeJob::Shibboleth) {
         _credentialsPage = _shibbolethCredsPage;
     } else
 #endif
-        if (type == WizardCommon::OAuth) {
+        if (type == DetermineAuthTypeJob::OAuth) {
         _credentialsPage = _browserCredsPage;
-    } else {
+    } else { // try Basic auth even for "Unknown"
         _credentialsPage = _httpCredsPage;
     }
     next();

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -21,6 +21,7 @@
 #include <QSslKey>
 #include <QSslCertificate>
 
+#include "networkjobs.h"
 #include "wizard/owncloudwizardcommon.h"
 #include "accountfwd.h"
 
@@ -75,7 +76,7 @@ public:
     QSslCertificate _clientSslCertificate;
 
 public slots:
-    void setAuthType(WizardCommon::AuthType type);
+    void setAuthType(DetermineAuthTypeJob::AuthType type);
     void setRemoteFolder(const QString &);
     void appendToConfigurationLog(const QString &msg, LogType type = LogParagraph);
     void slotCurrentPageChanged(int);

--- a/src/gui/wizard/owncloudwizardcommon.h
+++ b/src/gui/wizard/owncloudwizardcommon.h
@@ -28,12 +28,6 @@ namespace WizardCommon {
     QString subTitleTemplate();
     void initErrorLabel(QLabel *errorLabel);
 
-    enum AuthType {
-        HttpCreds,
-        Shibboleth,
-        OAuth
-    };
-
     enum SyncMode {
         SelectiveMode,
         BoxMode

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -182,6 +182,8 @@ void AbstractNetworkJob::slotFinished()
         } else if (verb.isEmpty()) {
             qCWarning(lcNetworkJob) << this << "cannot redirect request: could not detect original verb";
         } else {
+            emit redirected(_reply, redirectUrl, _redirectCount - 1);
+
             // Create the redirected request and send it
             qCInfo(lcNetworkJob) << "Redirecting" << verb << requestedUrl << redirectUrl;
             resetTimeout();

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -98,6 +98,14 @@ signals:
     void networkError(QNetworkReply *reply);
     void networkActivity();
 
+    /** Emitted when a redirect is followed.
+     *
+     * \a reply The "please redirect" reply
+     * \a targetUrl Where to redirect to
+     * \a redirectCount Counts redirect hops, first is 0.
+     */
+    void redirected(QNetworkReply *reply, const QUrl &targetUrl, int redirectCount);
+
 protected:
     void setupConnections(QNetworkReply *reply);
 

--- a/src/libsync/connectionvalidator.cpp
+++ b/src/libsync/connectionvalidator.cpp
@@ -135,6 +135,13 @@ void ConnectionValidator::slotStatusFound(const QUrl &url, const QJsonObject &in
                                   << CheckServerJob::versionString(info)
                                   << "(" << serverVersion << ")";
 
+    // Update server url in case of redirection
+    if (_account->url() != url) {
+        qCInfo(lcConnectionValidator()) << "status.php was redirected to" << url.toString();
+        _account->setUrl(url);
+        _account->wantsAccountSaved(_account.data());
+    }
+
     if (!serverVersion.isEmpty() && !setAndCheckServerVersion(serverVersion)) {
         return;
     }

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -19,6 +19,7 @@
 #include <QMap>
 #include <QSslCertificate>
 #include <QSslKey>
+#include <QNetworkRequest>
 #include "creds/abstractcredentials.h"
 
 class QNetworkReply;
@@ -75,6 +76,9 @@ class OWNCLOUDSYNC_EXPORT HttpCredentials : public AbstractCredentials
     friend class HttpCredentialsAccessManager;
 
 public:
+    /// Don't add credentials if this is set on a QNetworkRequest
+    static constexpr QNetworkRequest::Attribute DontAddCredentialsAttribute = QNetworkRequest::User;
+
     explicit HttpCredentials();
     HttpCredentials(const QString &user, const QString &password, const QSslCertificate &certificate = QSslCertificate(), const QSslKey &key = QSslKey());
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -241,6 +241,11 @@ public:
     static bool installed(const QJsonObject &info);
 
 signals:
+    /** Emitted when a status.php was successfully read.
+     *
+     * \a url see _serverStatusUrl (does not include "/status.php")
+     * \a info The status.php reply information
+     */
     void instanceFound(const QUrl &url, const QJsonObject &info);
 
     /** Emitted on invalid status.php reply.
@@ -248,6 +253,11 @@ signals:
      * \a reply is never null
      */
     void instanceNotFound(QNetworkReply *reply);
+
+    /** A timeout occurred.
+     *
+     * \a url The specific url where the timeout happened.
+     */
     void timeout(const QUrl &url);
 
 private:
@@ -256,9 +266,20 @@ private:
 private slots:
     virtual void metaDataChangedSlot();
     virtual void encryptedSlot();
+    void slotRedirected(QNetworkReply *reply, const QUrl &targetUrl, int redirectCount);
 
 private:
     bool _subdirFallback;
+
+    /** The permanent-redirect adjusted account url.
+     *
+     * Note that temporary redirects or a permanent redirect behind a temporary
+     * one do not affect this url.
+     */
+    QUrl _serverUrl;
+
+    /** Keep track of how many permanent redirect were applied. */
+    int _permanentRedirects;
 };
 
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -330,6 +330,32 @@ private:
     QList<QPair<QString, QString>> _additionalParams;
 };
 
+/**
+ * @brief Checks with auth type to use for a server
+ * @ingroup libsync
+ */
+class OWNCLOUDSYNC_EXPORT DetermineAuthTypeJob : public AbstractNetworkJob
+{
+    Q_OBJECT
+public:
+    enum AuthType {
+        Unknown,
+        Basic,
+        OAuth,
+        Shibboleth
+    };
+
+    explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = 0);
+    void start() Q_DECL_OVERRIDE;
+signals:
+    void authType(AuthType);
+private slots:
+    bool finished() Q_DECL_OVERRIDE;
+private:
+    void send(const QUrl &url);
+    int _redirects;
+};
+
 } // namespace OCC
 
 #endif // NETWORKJOBS_H


### PR DESCRIPTION
This is the first time the account url may update outside of
account setup.

Summary of redirection handling:
1. During account setup (wizard) - fixes #5954
   - status.php gets permanently redirected -> adjust url 
   - authed PROPFIND gets *any* redirection -> adjust url
2. During connectivity ping (ConnectionValidator)
   - status.php gets permanently redirected -> adjust url (new!)

All other redirections should be followed transparently and
don't update the account url in the settings.

See #5972 