### PR TITLE
Wizard: Handle url-shortener redirects

### DIFF
--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -91,6 +91,7 @@ void OAuth::start()
                 requestBody->setData(arguments.query(QUrl::FullyEncoded).toLatin1());
 
                 auto job = _account->sendRequest("POST", requestToken, req, requestBody);
+                job->setTimeout(qMin(30 * 1000ll, job->timeoutMsec()));
                 QObject::connect(job, &SimpleNetworkJob::finishedSignal, this, [this, socket](QNetworkReply *reply) {
                     auto jsonData = reply->readAll();
                     QJsonParseError jsonParseError;

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -180,6 +180,10 @@ void OwncloudSetupWizard::slotContinueDetermineAuth()
     // redirect subpaths.
     auto redirectCheckJob = account->sendRequest("GET", account->url());
 
+    // Use a significantly reduced timeout for this redirect check:
+    // the 5-minute default is inappropriate.
+    redirectCheckJob->setTimeout(qMin(2000ll, redirectCheckJob->timeoutMsec()));
+
     // Grab the chain of permanent redirects and adjust the account url
     // accordingly
     auto permanentRedirects = std::make_shared<int>(0);

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -173,6 +173,10 @@ void AbstractNetworkJob::slotFinished()
     if (_followRedirects && !redirectUrl.isEmpty()) {
         _redirectCount++;
 
+        // Redirects may be relative
+        if (redirectUrl.isRelative())
+            redirectUrl = requestedUrl.resolved(redirectUrl);
+
         // For POST requests where the target url has query arguments, Qt automatically
         // moves these arguments to the body if no explicit body is specified.
         // This can cause problems with redirected requests, because the redirect url

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -356,6 +356,7 @@ bool HttpCredentials::refreshAccessToken()
     requestBody->setData(arguments.query(QUrl::FullyEncoded).toLatin1());
 
     auto job = _account->sendRequest("POST", requestToken, req, requestBody);
+    job->setTimeout(qMin(30 * 1000ll, job->timeoutMsec()));
     QObject::connect(job, &SimpleNetworkJob::finishedSignal, this, [this](QNetworkReply *reply) {
         auto jsonData = reply->readAll();
         QJsonParseError jsonParseError;


### PR DESCRIPTION
Grab any permanent redirects from the base url the user entered before attempting to connect to a modified url (with status.php added).

Solves #5954 
Depends on #6016 (for SimpleNetworkJob), only the last commit is new