### PR TITLE
Windows: Make sure that the folder and Desktop.ini have the right attributes

### DIFF
--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -43,6 +43,12 @@ static void setupFavLink_private(const QString &folder)
         desktopIni.write(QDir::toNativeSeparators(qApp->applicationFilePath()).toUtf8());
         desktopIni.write(",0\r\n");
         desktopIni.close();
+
+        // Set the folder as system and Desktop.ini as hidden+system for explorer to pick it.
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/cc144102
+        DWORD folderAttrs = GetFileAttributesW((wchar_t *)folder.utf16());
+        SetFileAttributesW((wchar_t *)folder.utf16(), folderAttrs | FILE_ATTRIBUTE_SYSTEM);
+        SetFileAttributesW((wchar_t *)desktopIni.fileName().utf16(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM);
     }
 
     // Windows Explorer: Place under "Favorites" (Links)


### PR DESCRIPTION
When created from scratch, the owncloud icon won't be picked-up by
explorer unless the right attributes are set on both the sync root and the
Desktop.ini file.

Issue #2446