### PR TITLE
Credentials: Use per-account keychain entries #5830

### DIFF
--- a/src/gui/creds/shibbolethcredentials.h
+++ b/src/gui/creds/shibbolethcredentials.h
@@ -84,6 +84,10 @@ private:
     void storeShibCookie(const QNetworkCookie &cookie);
     void removeShibCookie();
     void addToCookieJar(const QNetworkCookie &cookie);
+
+    /// Reads data from keychain, progressing to slotReadJobDone
+    void fetchFromKeychainHelper();
+
     QUrl _url;
     QByteArray prepareCookieData() const;
 
@@ -92,6 +96,7 @@ private:
     QPointer<ShibbolethWebView> _browser;
     QNetworkCookie _shibCookie;
     QString _user;
+    bool _keychainMigration;
 };
 
 } // namespace OCC

--- a/src/libsync/creds/abstractcredentials.cpp
+++ b/src/libsync/creds/abstractcredentials.cpp
@@ -34,7 +34,7 @@ void AbstractCredentials::setAccount(Account *account)
     _account = account;
 }
 
-QString AbstractCredentials::keychainKey(const QString &url, const QString &user)
+QString AbstractCredentials::keychainKey(const QString &url, const QString &user, const QString &accountId)
 {
     QString u(url);
     if (u.isEmpty()) {
@@ -51,6 +51,9 @@ QString AbstractCredentials::keychainKey(const QString &url, const QString &user
     }
 
     QString key = user + QLatin1Char(':') + u;
+    if (!accountId.isEmpty()) {
+        key += QLatin1Char(':') + accountId;
+    }
     return key;
 }
 } // namespace OCC

--- a/src/libsync/creds/abstractcredentials.h
+++ b/src/libsync/creds/abstractcredentials.h
@@ -85,7 +85,7 @@ public:
      */
     virtual void forgetSensitiveData() = 0;
 
-    static QString keychainKey(const QString &url, const QString &user);
+    static QString keychainKey(const QString &url, const QString &user, const QString &accountId);
 
 Q_SIGNALS:
     /** Emitted when fetchFromKeychain() is done.

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -411,14 +411,6 @@ void HttpCredentials::invalidateToken()
     job->setKey(kck);
     job->start();
 
-    // Also ensure the password is deleted from the deprecated place
-    // otherwise we'd possibly read and use it again and again.
-    DeletePasswordJob *job2 = new DeletePasswordJob(Theme::instance()->appName());
-    // no job2->setSettings() call here, to make it use the deprecated location.
-    job2->setInsecureFallback(true);
-    job2->setKey(kck);
-    job2->start();
-
     // let QNAM forget about the password
     // This needs to be done later in the event loop because we might be called (directly or
     // indirectly) from QNetworkAccessManagerPrivate::authenticationRequired, which itself

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -119,6 +119,18 @@ private Q_SLOTS:
     void slotWriteJobDone(QKeychain::Job *);
 
 protected:
+    /** Reads data from keychain locations
+     *
+     * Goes through
+     *   slotReadClientCertPEMJobDone to
+     *   slotReadClientCertPEMJobDone to
+     *   slotReadJobDone
+     */
+    void fetchFromKeychainHelper();
+
+    /// Wipes legacy keychain locations
+    void deleteOldKeychainEntries();
+
     QString _user;
     QString _password; // user's password, or access_token for OAuth
     QString _refreshToken; // OAuth _refreshToken, set if OAuth is used.
@@ -128,6 +140,7 @@ protected:
     bool _ready;
     QSslKey _clientSslKey;
     QSslCertificate _clientSslCertificate;
+    bool _keychainMigration;
 };
 
 


### PR DESCRIPTION
This requires a lot of migration code: the old entries need to be read,
saved to the new locations and then deleted.

See #5830. It's potentially breaking, so please review carefully.

Known side effects of this patch:
* If you go back from 2.4 to 2.3, you'll have to enter the keychain data for your accounts again.
* If you have several accounts pointing to the same url+user, one of them might not have credentials set up on the first start of 2.4.

While working on this I had an idea about an alternate approach: What if we added a "what's the keychain base id" entry to the settings? Then we could add the new account identifier to new accounts and old accounts would work without losing keychain data even when switching between 2.3 and 2.4. The drawback is that we'd never migrate old accounts.