### PR TITLE
Excludes: Allow escaping # #6012

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -84,6 +84,7 @@ static const char *csync_exclude_expand_escapes(const char * input)
             case '"': out[o++] = '"'; break;
             case '?': out[o++] = '?'; break;
             case '\\': out[o++] = '\\'; break;
+            case '#': out[o++] = '#'; break;
             case 'a': out[o++] = '\a'; break;
             case 'b': out[o++] = '\b'; break;
             case 'f': out[o++] = '\f'; break;

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -107,6 +107,8 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
                 QByteArray prepend;
                 if (deletableItem->checkState() == Qt::Checked) {
                     prepend = "]";
+                } else if (patternItem->text().startsWith('#')) {
+                    prepend = "\\";
                 }
                 ignores.write(prepend + patternItem->text().toUtf8() + '\n');
             }

--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -1,3 +1,5 @@
+# This file contains fixed global exclude patterns
+
 *~
 ~$*
 .~lock.*

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -387,9 +387,9 @@ static void check_csync_exclude_expand_escapes(void **state)
     (void)state;
 
     const char *str = csync_exclude_expand_escapes(
-            "keep \\' \\\" \\? \\\\ \\a \\b \\f \\n \\r \\t \\v \\z");
+            "keep \\' \\\" \\? \\\\ \\a \\b \\f \\n \\r \\t \\v \\z \\#");
     assert_true(0 == strcmp(
-            str, "keep ' \" ? \\ \a \b \f \n \r \t \v \\z"));
+            str, "keep ' \" ? \\ \a \b \f \n \r \t \v \\z #"));
     SAFE_FREE(str);
 
     str = csync_exclude_expand_escapes("");


### PR DESCRIPTION
Otherwise adding patterns that start with # are impossible to add, since
they get treated as comments. Also add this escaping for patterns added
in the ui.

See #6012