### PR TITLE
Gui: Allow to add multiple sync folder connection of the same folder

### DIFF
--- a/doc/navigating.rst
+++ b/doc/navigating.rst
@@ -87,8 +87,7 @@ have the following features:
   **Log Out**, and **Remove**.
 * Used and available space on the server.
 * Current synchronization status.
-* **Add Folder Sync Connection** button, which is active only when you have 
-  removed synchronization on an account (see **Remove Sync** below).
+* **Add Folder Sync Connection** button.
 
 The little button with three dots (the overflow menu) that sits to the right of 
 the sync status bar offers four additional options:

--- a/doc/visualtour.rst
+++ b/doc/visualtour.rst
@@ -80,11 +80,6 @@ Adding a Folder Sync Connection
 Adding a new sync is initiated by clicking ``Add Folder Sync Connection`` in
 the ``Account`` settings.
 
-..note:: To add a folder, you must not already sync a folder that contains this
-        folder. By default, the wizard sets up the root folder of the ownCloud
-        server to sync all of your ownCloud account. In consequence, you will
-        first need to remove this folder prior to specifying new syncs.
-
 .. image:: images/folderwizard_local.png
    :scale: 50 %
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -113,12 +113,6 @@ Qt::ItemFlags FolderStatusModel::flags(const QModelIndex &index) const
         ret = Qt::ItemNeverHasChildren;
         if (!_accountState->isConnected()) {
             return ret;
-        } else if (_folders.count() == 1) {
-            auto remotePath = _folders.at(0)._folder->remotePath();
-            // special case when syncing the entire owncloud: disable the add folder button (#3438)
-            if (remotePath.isEmpty() || remotePath == QLatin1String("/")) {
-                return ret;
-            }
         }
         return Qt::ItemIsEnabled | ret;
     }
@@ -147,15 +141,6 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
         } else if (role == Qt::ToolTipRole) {
             if (!_accountState->isConnected()) {
                 return tr("You need to be connected to add a folder");
-            }
-            if (_folders.count() == 1) {
-                auto remotePath = _folders.at(0)._folder->remotePath();
-                if (remotePath.isEmpty() || remotePath == QLatin1String("/")) {
-                    // Syncing the entire owncloud: disable the add folder button (#3438)
-                    return tr("Adding folder is disabled because you are already syncing all your files. "
-                              "If you want to sync multiple folders, please remove the currently "
-                              "configured root folder.");
-                }
             }
             return tr("Click this button to add a folder to synchronize.");
         }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -445,16 +445,10 @@ bool FolderWizardRemotePath::isComplete() const
         } else if (dir.startsWith(curDir + QLatin1Char('/'))) {
             warnStrings.append(tr("You are already syncing <i>%1</i>, which is a parent folder of <i>%2</i>.").arg(Utility::escape(curDir), Utility::escape(dir)));
         }
-
-        if (curDir == QLatin1String("/")) {
-            warnStrings.append(tr("You are already syncing all your files. Syncing another folder is <b>not</b> supported. "
-                                  "If you want to sync multiple folders, please remove the currently configured "
-                                  "root folder sync."));
-        }
     }
 
     showWarn(formatWarnings(warnStrings));
-    return warnStrings.isEmpty();
+    return true;
 }
 
 void FolderWizardRemotePath::cleanupPage()


### PR DESCRIPTION
... or child folders

There is also no real reason to forbid the user from syncing the same
folder to multiple location on its hardrive.
A real use case is when the user uncheck a big directory using "choose
what to sync", but would still like to sync a folder within this disabled
tree. The user can now do this with the "add folder" feature

Since 2.3, we even support syncing the same local folder to multiple
remote folder, so why not allow syncing the same remote folder several
times?

Relates to issue #3645