### PR TITLE
Private links: Retrieve link through propfind property #6020

### DIFF
--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -37,7 +37,7 @@ class OCSYNC_EXPORT SyncJournalFileRecord
 public:
     SyncJournalFileRecord();
 
-    bool isValid()
+    bool isValid() const
     {
         return !_path.isEmpty();
     }

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -49,8 +49,8 @@ public:
 
 private slots:
     void done(int r);
-    void slotMaxSharingPermissionsReceived(const QVariantMap &result);
-    void slotMaxSharingPermissionsError();
+    void slotPropfindReceived(const QVariantMap &result);
+    void slotPropfindError();
     void slotThumbnailFetched(const int &statusCode, const QByteArray &reply);
     void slotAccountStateChanged(int state);
 
@@ -63,6 +63,7 @@ private:
     QString _localPath;
     SharePermissions _maxSharingPermissions;
     QByteArray _numericFileId;
+    QString _privateLinkUrl;
 
     ShareLinkWidget *_linkWidget;
     ShareUserGroupWidget *_userGroupWidget;

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -48,7 +48,7 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
     const QString &sharePath,
     const QString &localPath,
     SharePermissions maxSharingPermissions,
-    const QByteArray &numericFileId,
+    const QString &privateLinkUrl,
     QWidget *parent)
     : QWidget(parent)
     , _ui(new Ui::ShareUserGroupWidget)
@@ -56,7 +56,7 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
     , _sharePath(sharePath)
     , _localPath(localPath)
     , _maxSharingPermissions(maxSharingPermissions)
-    , _numericFileId(numericFileId)
+    , _privateLinkUrl(privateLinkUrl)
     , _disableCompleterActivated(false)
 {
     setAttribute(Qt::WA_DeleteOnClose);
@@ -323,19 +323,19 @@ void ShareUserGroupWidget::displayError(int code, const QString &message)
 
 void ShareUserGroupWidget::slotPrivateLinkOpenBrowser()
 {
-    Utility::openBrowser(_account->filePermalinkUrl(_numericFileId), this);
+    Utility::openBrowser(_privateLinkUrl, this);
 }
 
 void ShareUserGroupWidget::slotPrivateLinkCopy()
 {
-    QApplication::clipboard()->setText(_account->filePermalinkUrl(_numericFileId).toString());
+    QApplication::clipboard()->setText(_privateLinkUrl);
 }
 
 void ShareUserGroupWidget::slotPrivateLinkEmail()
 {
     Utility::openEmailComposer(
         tr("I shared something with you"),
-        _account->filePermalinkUrl(_numericFileId).toString(),
+        _privateLinkUrl,
         this);
 }
 

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -57,7 +57,7 @@ public:
         const QString &sharePath,
         const QString &localPath,
         SharePermissions maxSharingPermissions,
-        const QByteArray &numericFileId,
+        const QString &privateLinkUrl,
         QWidget *parent = 0);
     ~ShareUserGroupWidget();
 
@@ -89,7 +89,7 @@ private:
     QString _sharePath;
     QString _localPath;
     SharePermissions _maxSharingPermissions;
-    QByteArray _numericFileId;
+    QString _privateLinkUrl;
 
     QCompleter *_completer;
     ShareeModel *_completerModel;

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -491,23 +491,70 @@ void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listen
     listener->sendMessage(QLatin1String("SHARE_MENU_TITLE:") + tr("Share with %1", "parameter is ownCloud").arg(Theme::instance()->appNameGUI()));
 }
 
+// Fetches the private link url asynchronously and then calls the target slot
+void fetchPrivateLinkUrl(const QString &localFile, SocketApi *target, void (SocketApi::*targetFun)(const QString &url) const)
+{
+    Folder *shareFolder = FolderMan::instance()->folderForPath(localFile);
+    if (!shareFolder) {
+        qCWarning(lcSocketApi) << "Unknown path" << localFile;
+        return;
+    }
+
+    const QString localFileClean = QDir::cleanPath(localFile);
+    const QString file = localFileClean.mid(shareFolder->cleanPath().length() + 1);
+
+    // Generate private link ourselves: used as a fallback
+    const SyncJournalFileRecord rec = shareFolder->journalDb()->getFileRecord(file);
+    if (!rec.isValid())
+        return;
+    const QString oldUrl =
+        shareFolder->accountState()->account()->deprecatedPrivateLinkUrl(rec.numericFileId()).toString(QUrl::FullyEncoded);
+
+    // If the server doesn't have the property, use the old url directly.
+    if (!shareFolder->accountState()->account()->capabilities().privateLinkPropertyAvailable()) {
+        (target->*targetFun)(oldUrl);
+        return;
+    }
+
+    // Retrieve the new link by PROPFIND
+    PropfindJob *job = new PropfindJob(shareFolder->accountState()->account(), file, target);
+    job->setProperties(QList<QByteArray>() << "http://owncloud.org/ns:privatelink");
+    job->setTimeout(10 * 1000);
+    QObject::connect(job, &PropfindJob::result, target, [=](const QVariantMap &result) {
+        auto privateLinkUrl = result["privatelink"].toString();
+        if (!privateLinkUrl.isEmpty()) {
+            (target->*targetFun)(privateLinkUrl);
+        } else {
+            (target->*targetFun)(oldUrl);
+        }
+    });
+    QObject::connect(job, &PropfindJob::finishedWithError, target, [=](QNetworkReply *) {
+        (target->*targetFun)(oldUrl);
+    });
+    job->start();
+}
+
 void SocketApi::command_COPY_PRIVATE_LINK(const QString &localFile, SocketListener *)
 {
-    auto url = getPrivateLinkUrl(localFile);
-    if (!url.isEmpty()) {
-        QApplication::clipboard()->setText(url.toString());
-    }
+    fetchPrivateLinkUrl(localFile, this, &SocketApi::copyPrivateLinkToClipboard);
 }
 
 void SocketApi::command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *)
 {
-    auto url = getPrivateLinkUrl(localFile);
-    if (!url.isEmpty()) {
-        Utility::openEmailComposer(
-            tr("I shared something with you"),
-            url.toString(QUrl::FullyEncoded),
-            0);
-    }
+    fetchPrivateLinkUrl(localFile, this, &SocketApi::emailPrivateLink);
+}
+
+void SocketApi::copyPrivateLinkToClipboard(const QString &link) const
+{
+    QApplication::clipboard()->setText(link);
+}
+
+void SocketApi::emailPrivateLink(const QString &link) const
+{
+    Utility::openEmailComposer(
+        tr("I shared something with you"),
+        link,
+        0);
 }
 
 void SocketApi::command_GET_STRINGS(const QString &, SocketListener *listener)
@@ -531,24 +578,6 @@ QString SocketApi::buildRegisterPathMessage(const QString &path)
     QString message = QLatin1String("REGISTER_PATH:");
     message.append(QDir::toNativeSeparators(fi.absoluteFilePath()));
     return message;
-}
-
-QUrl SocketApi::getPrivateLinkUrl(const QString &localFile) const
-{
-    Folder *shareFolder = FolderMan::instance()->folderForPath(localFile);
-    if (!shareFolder) {
-        qCWarning(lcSocketApi) << "Unknown path" << localFile;
-        return QUrl();
-    }
-
-    const QString localFileClean = QDir::cleanPath(localFile);
-    const QString file = localFileClean.mid(shareFolder->cleanPath().length() + 1);
-
-    SyncJournalFileRecord rec = shareFolder->journalDb()->getFileRecord(file);
-    if (rec.isValid()) {
-        return shareFolder->accountState()->account()->filePermalinkUrl(rec.numericFileId());
-    }
-    return QUrl();
 }
 
 } // namespace OCC

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -64,6 +64,9 @@ private slots:
     void slotReadSocket();
     void broadcastStatusPushMessage(const QString &systemPath, SyncFileStatus fileStatus);
 
+    void copyPrivateLinkToClipboard(const QString &link) const;
+    void emailPrivateLink(const QString &link) const;
+
 private:
     void broadcastMessage(const QString &msg, bool doWait = false);
 
@@ -84,7 +87,6 @@ private:
     Q_INVOKABLE void command_GET_STRINGS(const QString &argument, SocketListener *listener);
 
     QString buildRegisterPathMessage(const QString &path);
-    QUrl getPrivateLinkUrl(const QString &localFile) const;
 
     QSet<QString> _registeredAliases;
     QList<SocketListener> _listeners;

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -162,7 +162,7 @@ QUrl Account::davUrl() const
     return Utility::concatUrlPath(url(), davPath());
 }
 
-QUrl Account::filePermalinkUrl(const QByteArray &numericFileId) const
+QUrl Account::deprecatedPrivateLinkUrl(const QByteArray &numericFileId) const
 {
     return Utility::concatUrlPath(url(),
         QLatin1String("/index.php/f/") + QUrl::toPercentEncoding(QString::fromLatin1(numericFileId)));

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -108,8 +108,12 @@ public:
     /** Returns webdav entry URL, based on url() */
     QUrl davUrl() const;
 
-    /** Returns a permalink url for a file */
-    QUrl filePermalinkUrl(const QByteArray &numericFileId) const;
+    /** Returns the legacy permalink url for a file.
+     *
+     * This uses the old way of manually building the url. New code should
+     * use the "privatelink" property accessible via PROPFIND.
+     */
+    QUrl deprecatedPrivateLinkUrl(const QByteArray &numericFileId) const;
 
     /** Holds the accounts credentials */
     AbstractCredentials *credentials() const;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -132,6 +132,11 @@ bool Capabilities::chunkingParallelUploadDisabled() const
     return _capabilities["dav"].toMap()["chunkingParallelUploadDisabled"].toBool();
 }
 
+bool Capabilities::privateLinkPropertyAvailable() const
+{
+    return _capabilities["files"].toMap()["privateLinks"].toBool();
+}
+
 QList<int> Capabilities::httpErrorCodesThatResetFailingChunkedUploads() const
 {
     QList<int> list;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -47,6 +47,9 @@ public:
     /// disable parallel upload in chunking
     bool chunkingParallelUploadDisabled() const;
 
+    /// Whether the "privatelink" DAV property is available
+    bool privateLinkPropertyAvailable() const;
+
     /// returns true if the capabilities report notifications
     bool notificationsAvailable() const;
 


### PR DESCRIPTION
* The sharing ui does a propfind anyway: use that to query the new
property as well!
* For the socket api, asynchronously query the server for the right url
when an action that needs it is triggered.

The old, manually generated URL will be used as fallback in case the
server doesn't support the new property or the property can't be
retrieved for some reason.

Depends on owncloud/core#29021
For #6020