### PR TITLE
Conflicts: Upload them files if env variable says so

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -175,6 +175,18 @@ namespace Utility {
     /**  Returns a new settings pre-set in a specific group.  The Settings will be created
          with the given parent. If no parent is specified, the caller must destroy the settings */
     OCSYNC_EXPORT std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = 0);
+
+    /** Returns whether a file name indicates a conflict file
+     *
+     * See FileSystem::makeConflictFileName.
+     */
+    OCSYNC_EXPORT bool isConflictFile(const char *name);
+
+    /** Returns whether conflict files should be uploaded.
+     *
+     * Experimental! Real feature planned for 2.5.
+     */
+    OCSYNC_EXPORT bool shouldUploadConflictFiles();
 }
 /** @} */ // \addtogroup
 

--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -46,6 +46,8 @@
 #include "csync_log.h"
 #include "csync_rename.h"
 
+#include "common/utility.h"
+
 // Needed for PRIu64 on MinGW in C++ mode.
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -371,6 +373,15 @@ out:
       && fs->type != CSYNC_FTW_TYPE_DIR) {
     fs->child_modified = true;
   }
+
+  // If conflict files are uploaded, they won't be marked as IGNORE / CSYNC_FILE_EXCLUDE_CONFLICT
+  // but we still want them marked!
+  if (OCC::Utility::shouldUploadConflictFiles()) {
+      if (OCC::Utility::isConflictFile(fs->path.constData())) {
+          fs->error_status = CSYNC_STATUS_INDIVIDUAL_IS_CONFLICT_FILE;
+      }
+  }
+
   ctx->current_fs = fs.get();
 
   CSYNC_LOG(CSYNC_LOG_PRIORITY_INFO, "file: %s, instruction: %s <<=", fs->path.constData(),


### PR DESCRIPTION
Set OWNCLOUD_UPLOAD_CONFLICT_FILES=1 to trigger this behavior.

Note that this is experimental and unsupported. The real feature is
likely to end up in 2.5.

Uploading conflict files is simply done by removing the pattern from
csync_exclude. The rest here deals with making the conflict notification
ui approximately work.

There are still some concerns about where an uploaded conflict file
appears in the sync protocol and issues list (it should be in both, but
is only in one of them currently!).

See #4557.