### PR TITLE
RemotePermissions: Store in a class rather than in a QByteArray to save memory

### DIFF
--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -8,4 +8,5 @@ set(common_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/syncjournaldb.cpp
     ${CMAKE_CURRENT_LIST_DIR}/syncjournalfilerecord.cpp
     ${CMAKE_CURRENT_LIST_DIR}/utility.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/remotepermissions.cpp
 )

--- a/src/common/remotepermissions.cpp
+++ b/src/common/remotepermissions.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "remotepermissions.h"
+#include <cstring>
+
+namespace OCC {
+
+static const char letters[] = " WDNVCKRSMm";
+
+
+template <typename Char>
+void RemotePermissions::fromArray(const Char *p)
+{
+    _value = p ? notNullMask : 0;
+    if (!p)
+        return;
+    while (*p) {
+        if (auto res = std::strchr(letters, static_cast<char>(*p)))
+            _value |= (1 << (res - letters));
+        ++p;
+    }
+}
+
+RemotePermissions::RemotePermissions(const char *p)
+{
+    fromArray(p);
+}
+
+RemotePermissions::RemotePermissions(const QString &s)
+{
+    fromArray(s.isEmpty() ? nullptr : s.utf16());
+}
+
+QByteArray RemotePermissions::toString() const
+{
+    QByteArray result;
+    if (isNull())
+        return result;
+    result.reserve(PermissionsCount);
+    for (uint i = 1; i <= PermissionsCount; ++i) {
+        if (_value & (1 << i))
+            result.append(letters[i]);
+    }
+    if (result.isEmpty()) {
+        // Make sure it is not empty so we can differentiate null and empty permissions
+        result.append(' ');
+    }
+    return result;
+}
+
+} // namespace OCC

--- a/src/common/remotepermissions.h
+++ b/src/common/remotepermissions.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <QString>
+#include <QMetaType>
+#include "ocsynclib.h"
+
+namespace OCC {
+
+/**
+ * Class that store in a memory efficient way the remote permission
+ */
+class OCSYNC_EXPORT RemotePermissions
+{
+private:
+    // The first bit tells if the value is set or not
+    // The remaining bits correspond to know if the value is set
+    quint16 _value = 0;
+    static constexpr int notNullMask = 0x1;
+
+    template <typename Char> // can be 'char' or 'ushort' if conversion from QString
+    void fromArray(const Char *p);
+
+public:
+    enum Permissions {
+        CanWrite = 1,             // W
+        CanDelete = 2,            // D
+        CanRename = 3,            // N
+        CanMove = 4,              // V
+        CanAddFile = 5,           // C
+        CanAddSubDirectories = 6, // K
+        CanReshare = 7,           // R
+        // Note: on the server, this means SharedWithMe, but in discoveryphase.cpp we also set
+        // this permission when the server reports the any "share-types"
+        IsShared = 8,             // S
+        IsMounted = 9,            // M
+        IsMountedSub = 10,        // m (internal: set if the parent dir has IsMounted)
+
+        // Note: when adding support for more permissions, we need to invalid the cache in the database.
+        // (by setting forceRemoteDiscovery in SyncJournalDb::checkConnect)
+        PermissionsCount = IsMountedSub
+    };
+    RemotePermissions() = default;
+    explicit RemotePermissions(const char *);
+    explicit RemotePermissions(const QString &);
+
+    QByteArray toString() const;
+    bool hasPermission(Permissions p) const
+    {
+        return _value & (1 << static_cast<int>(p));
+    }
+    void setPermission(Permissions p)
+    {
+        _value |= (1 << static_cast<int>(p)) | notNullMask;
+    }
+    void unsetPermission(Permissions p)
+    {
+        _value &= ~(1 << static_cast<int>(p));
+    }
+
+    bool isNull() const { return !(_value & notNullMask); }
+    friend bool operator==(RemotePermissions a, RemotePermissions b)
+    {
+        return a._value == b._value;
+    }
+    friend bool operator!=(RemotePermissions a, RemotePermissions b)
+    {
+        return !(a == b);
+    }
+};
+
+
+} // namespace OCC
+
+Q_DECLARE_METATYPE(OCC::RemotePermissions)

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -894,7 +894,7 @@ bool SyncJournalDb::setFileRecord(const SyncJournalFileRecord &_record)
 
     qCInfo(lcDb) << "Updating file record for path:" << record._path << "inode:" << record._inode
                  << "modtime:" << record._modtime << "type:" << record._type
-                 << "etag:" << record._etag << "fileId:" << record._fileId << "remotePerm:" << record._remotePerm
+                 << "etag:" << record._etag << "fileId:" << record._fileId << "remotePerm:" << record._remotePerm.toString()
                  << "fileSize:" << record._fileSize << "checksum:" << record._checksumHeader;
 
     qlonglong phash = getPHash(record._path);
@@ -908,9 +908,7 @@ bool SyncJournalDb::setFileRecord(const SyncJournalFileRecord &_record)
         QString fileId(record._fileId);
         if (fileId.isEmpty())
             fileId = "";
-        QString remotePerm(record._remotePerm);
-        if (remotePerm.isEmpty())
-            remotePerm = QString(); // have NULL in DB (vs empty)
+        QByteArray remotePerm = record._remotePerm.toString();
         QByteArray checksumType, checksum;
         parseChecksumHeader(record._checksumHeader, &checksumType, &checksum);
         int contentChecksumTypeId = mapChecksumType(checksumType);
@@ -1001,7 +999,7 @@ SyncJournalFileRecord SyncJournalDb::getFileRecord(const QString &filename)
             rec._type = _getFileRecordQuery->intValue(6);
             rec._etag = _getFileRecordQuery->baValue(7);
             rec._fileId = _getFileRecordQuery->baValue(8);
-            rec._remotePerm = _getFileRecordQuery->baValue(9);
+            rec._remotePerm = RemotePermissions(_getFileRecordQuery->baValue(9).constData());
             rec._fileSize = _getFileRecordQuery->int64Value(10);
             rec._serverHasIgnoredFiles = (_getFileRecordQuery->intValue(11) > 0);
             rec._checksumHeader = _getFileRecordQuery->baValue(12);

--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -23,6 +23,7 @@
 #include <QDateTime>
 
 #include "ocsynclib.h"
+#include "remotepermissions.h"
 
 namespace OCC {
 
@@ -57,7 +58,7 @@ public:
     QByteArray _etag;
     QByteArray _fileId;
     qint64 _fileSize;
-    QByteArray _remotePerm;
+    RemotePermissions _remotePerm;
     bool _serverHasIgnoredFiles;
     QByteArray _checksumHeader;
 };

--- a/src/csync/csync.h
+++ b/src/csync/csync.h
@@ -41,6 +41,7 @@
 #include <config_csync.h>
 #include <memory>
 #include <QByteArray>
+#include "common/remotepermissions.h"
 
 #if defined(Q_CC_GNU) && !defined(Q_CC_INTEL) && !defined(Q_CC_CLANG) && (__GNUC__ * 100 + __GNUC_MINOR__ < 408)
 // openSuse 12.3 didn't like enum bitfields.
@@ -163,6 +164,8 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   time_t modtime;
   int64_t size;
   uint64_t inode;
+
+  OCC::RemotePermissions remotePerm;
   enum csync_ftw_type_e type BITFIELD(4);
   bool child_modified BITFIELD(1);
   bool has_ignored_files BITFIELD(1); // Specify that a directory, or child directory contains ignored files.
@@ -174,7 +177,6 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   QByteArray file_id;
   QByteArray directDownloadUrl;
   QByteArray directDownloadCookies;
-  QByteArray remotePerm;
   QByteArray original_path; // only set if locale conversion fails
 
   // In the local tree, this can hold a checksum and its type if it is

--- a/src/csync/csync_private.h
+++ b/src/csync/csync_private.h
@@ -86,7 +86,7 @@ struct OCSYNC_EXPORT csync_s {
 
       /* hooks for checking the white list (uses the update_callback_userdata) */
       int (*checkSelectiveSyncBlackListHook)(void*, const QByteArray &) = nullptr;
-      int (*checkSelectiveSyncNewFolderHook)(void*, const QByteArray &/* path */, const QByteArray &/* remotePerm */) = nullptr;
+      int (*checkSelectiveSyncNewFolderHook)(void *, const QByteArray & /* path */, OCC::RemotePermissions) = nullptr;
 
 
       csync_vio_opendir_hook remote_opendir_hook = nullptr;
@@ -126,7 +126,7 @@ struct OCSYNC_EXPORT csync_s {
   struct {
     FileMap files;
     bool read_from_db = false;
-    QByteArray root_perms; /* Permission of the root folder. (Since the root folder is not in the db tree, we need to keep a separate entry.) */
+    OCC::RemotePermissions root_perms; /* Permission of the root folder. (Since the root folder is not in the db tree, we need to keep a separate entry.) */
   } remote;
 
   /* replica we are currently walking */

--- a/src/csync/csync_statedb.cpp
+++ b/src/csync/csync_statedb.cpp
@@ -264,7 +264,10 @@ static int _csync_file_stat_from_metadata_table( std::unique_ptr<csync_file_stat
         st->type = static_cast<enum csync_ftw_type_e>(sqlite3_column_int(stmt, 3));
         st->etag = (char*)sqlite3_column_text(stmt, 4);
         st->file_id = (char*)sqlite3_column_text(stmt, 5);
-        st->remotePerm = (char*)sqlite3_column_text(stmt, 6);
+        const char *permStr = (char *)sqlite3_column_text(stmt, 6);
+        // If permStr is empty, construct a null RemotePermissions.  We make sure that non-null
+        // permissions are never empty in RemotePermissions.toString()
+        st->remotePerm = permStr && *permStr ? OCC::RemotePermissions(permStr) : OCC::RemotePermissions();
         st->size = sqlite3_column_int64(stmt, 7);
         st->has_ignored_files = sqlite3_column_int(stmt, 8);
         st->checksumHeader = (char *)sqlite3_column_text(stmt, 9);

--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -183,10 +183,10 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
       /* we have an update! */
       CSYNC_LOG(CSYNC_LOG_PRIORITY_INFO, "Database entry found, compare: %" PRId64 " <-> %" PRId64
                                           ", etag: %s <-> %s, inode: %" PRId64 " <-> %" PRId64
-                                          ", size: %" PRId64 " <-> %" PRId64 ", perms: %s <-> %s, ignore: %d",
+                                          ", size: %" PRId64 " <-> %" PRId64 ", perms: %x <-> %x, ignore: %d",
                 ((int64_t) fs->modtime), ((int64_t) tmp->modtime),
                 fs->etag.constData(), tmp->etag.constData(), (uint64_t) fs->inode, (uint64_t) tmp->inode,
-                (uint64_t) fs->size, (uint64_t) tmp->size, fs->remotePerm.constData(), tmp->remotePerm.constData(), tmp->has_ignored_files );
+                (uint64_t) fs->size, (uint64_t) tmp->size, *reinterpret_cast<short*>(&fs->remotePerm), *reinterpret_cast<short*>(&tmp->remotePerm), tmp->has_ignored_files );
       if (ctx->current == REMOTE_REPLICA && fs->etag != tmp->etag) {
           fs->instruction = CSYNC_INSTRUCTION_EVAL;
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1007,7 +1007,7 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
     bool resharingAllowed = true; // lets assume the good
     if (fileRecord.isValid()) {
         // check the permission: Is resharing allowed?
-        if (!fileRecord._remotePerm.contains('R')) {
+        if (!fileRecord._remotePerm.isNull() && !fileRecord._remotePerm.hasPermission(RemotePermissions::CanReshare)) {
             resharingAllowed = false;
         }
     }

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -113,7 +113,7 @@ public:
 
     // This is not actually a network job, it is just a job
 signals:
-    void firstDirectoryPermissions(const QString &);
+    void firstDirectoryPermissions(RemotePermissions);
     void etagConcatenation(const QString &);
     void etag(const QString &);
     void finishedWithResult();
@@ -178,7 +178,7 @@ public slots:
     // From Job:
     void singleDirectoryJobResultSlot();
     void singleDirectoryJobFinishedWithErrorSlot(int csyncErrnoCode, const QString &msg);
-    void singleDirectoryJobFirstDirectoryPermissionsSlot(const QString &);
+    void singleDirectoryJobFirstDirectoryPermissionsSlot(RemotePermissions);
 
     void slotGetSizeFinishedWithError();
     void slotGetSizeResult(const QVariantMap &);
@@ -212,8 +212,8 @@ class DiscoveryJob : public QObject
      */
     bool isInSelectiveSyncBlackList(const QByteArray &path) const;
     static int isInSelectiveSyncBlackListCallback(void *, const QByteArray &);
-    bool checkSelectiveSyncNewFolder(const QString &path, const QByteArray &remotePerm);
-    static int checkSelectiveSyncNewFolderCallback(void *data, const QByteArray &path, const QByteArray &remotePerm);
+    bool checkSelectiveSyncNewFolder(const QString &path, RemotePermissions rp);
+    static int checkSelectiveSyncNewFolderCallback(void *data, const QByteArray &path, RemotePermissions rm);
 
     // Just for progress
     static void update_job_update_callback(bool local,

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -235,7 +235,7 @@ private:
      * to recover
      */
     void checkForPermission(SyncFileItemVector &syncItems);
-    QByteArray getPermissions(const QString &file) const;
+    RemotePermissions getPermissions(const QString &file) const;
 
     /**
      * Instead of downloading files from the server, upload the files to the server

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -215,6 +215,7 @@ public:
     Status _status BITFIELD(4);
     bool _isRestoration BITFIELD(1); // The original operation was forbidden, and this is a restoration
     quint16 _httpErrorCode;
+    RemotePermissions _remotePerm;
     QString _errorString; // Contains a string only in case of error
     QByteArray _responseTimeStamp;
     quint32 _affectedItems; // the number of affected items by the operation on this item.
@@ -228,7 +229,6 @@ public:
     quint64 _size;
     quint64 _inode;
     QByteArray _fileId;
-    QByteArray _remotePerm;
 
     // This is the value for the 'new' side, matching with _size and _modtime.
     //

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -147,7 +147,7 @@ SyncFileStatus SyncFileStatusTracker::fileStatus(const QString &relativePath)
     // First look it up in the database to know if it's shared
     SyncJournalFileRecord rec = _syncEngine->journal()->getFileRecord(relativePath);
     if (rec.isValid()) {
-        return resolveSyncAndErrorStatus(relativePath, rec._remotePerm.contains("S") ? Shared : NotShared);
+        return resolveSyncAndErrorStatus(relativePath, rec._remotePerm.hasPermission(RemotePermissions::IsShared) ? Shared : NotShared);
     }
 
     // Must be a new file not yet in the database, check if it's syncing or has an error.
@@ -226,7 +226,7 @@ void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector &items)
             _syncProblems[item->_file] = SyncFileStatus::StatusWarning;
         }
 
-        SharedFlag sharedFlag = item->_remotePerm.contains("S") ? Shared : NotShared;
+        SharedFlag sharedFlag = item->_remotePerm.hasPermission(RemotePermissions::IsShared) ? Shared : NotShared;
         if (item->_instruction != CSYNC_INSTRUCTION_NONE
             && item->_instruction != CSYNC_INSTRUCTION_UPDATE_METADATA
             && item->_instruction != CSYNC_INSTRUCTION_IGNORE
@@ -272,7 +272,7 @@ void SyncFileStatusTracker::slotItemCompleted(const SyncFileItemPtr &item)
         _syncProblems.erase(item->_file);
     }
 
-    SharedFlag sharedFlag = item->_remotePerm.contains("S") ? Shared : NotShared;
+    SharedFlag sharedFlag = item->_remotePerm.hasPermission(RemotePermissions::IsShared) ? Shared : NotShared;
     if (item->_instruction != CSYNC_INSTRUCTION_NONE
         && item->_instruction != CSYNC_INSTRUCTION_UPDATE_METADATA
         && item->_instruction != CSYNC_INSTRUCTION_IGNORE

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -54,7 +54,7 @@ private slots:
         record._type = 5;
         record._etag = "789789";
         record._fileId = "abcd";
-        record._remotePerm = "744";
+        record._remotePerm = RemotePermissions("RW");
         record._fileSize = 213089055;
         record._checksumHeader = "MD5:mychecksum";
         QVERIFY(_db.setFileRecord(record));
@@ -74,7 +74,7 @@ private slots:
         record._type = 7;
         record._etag = "789FFF";
         record._fileId = "efg";
-        record._remotePerm = "777";
+        record._remotePerm = RemotePermissions("NV");
         record._fileSize = 289055;
         _db.setFileRecordMetadata(record);
         storedRecord = _db.getFileRecord("foo");
@@ -91,7 +91,7 @@ private slots:
         {
             SyncJournalFileRecord record;
             record._path = "foo-checksum";
-            record._remotePerm = "744";
+            record._remotePerm = RemotePermissions("RW");
             record._checksumHeader = "MD5:mychecksum";
             record._modtime = QDateTime::currentDateTimeUtc();
             QVERIFY(_db.setFileRecord(record));
@@ -111,7 +111,7 @@ private slots:
         {
             SyncJournalFileRecord record;
             record._path = "foo-nochecksum";
-            record._remotePerm = "744";
+            record._remotePerm = RemotePermissions("RWN");
 	    record._modtime = QDateTime::currentDateTimeUtc();
 
             QVERIFY(_db.setFileRecord(record));


### PR DESCRIPTION
Create a specific type that parses the permissions so we can store
it in a short rather than in a QByteArray



(Note: since most files have the same permissions, i was also wondering if we could not try to "internate" the QByteArray  (storing it into a QSet so they can all be shared.)  But this is Good enough I think.
The other advantage is that we keep all these letters in a centralized place.