### PR TITLE
Use the Qt5 connection syntax

### DIFF
--- a/src/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -101,7 +101,7 @@ bool QtLocalPeer::isClient()
     bool res = server->listen(socketName);
     if (!res)
         qWarning("QtSingleCoreApplication: listen on local socket failed, %s", qPrintable(server->errorString()));
-    QObject::connect(server, SIGNAL(newConnection()), SLOT(receiveConnection()));
+    QObject::connect(server, &QLocalServer::newConnection, this, &QtLocalPeer::receiveConnection);
     return false;
 }
 

--- a/src/3rdparty/qtsingleapplication/qtsingleapplication.cpp
+++ b/src/3rdparty/qtsingleapplication/qtsingleapplication.cpp
@@ -95,7 +95,7 @@ QtSingleApplication::QtSingleApplication(const QString &appId, int &argc, char *
     *pids = 0;
     pidPeer = new QtLocalPeer(this, appId + QLatin1Char('-') +
                               QString::number(QCoreApplication::applicationPid()));
-    connect(pidPeer, SIGNAL(messageReceived(QString,QObject*)), SIGNAL(messageReceived(QString,QObject*)));
+    connect(pidPeer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::messageReceived);
     pidPeer->isClient();
     lockfile.unlock();
 }
@@ -169,9 +169,9 @@ void QtSingleApplication::setActivationWindow(QWidget *aw, bool activateOnMessag
     if (!pidPeer)
         return;
     if (activateOnMessage)
-        connect(pidPeer, SIGNAL(messageReceived(QString,QObject*)), this, SLOT(activateWindow()));
+        connect(pidPeer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow);
     else
-        disconnect(pidPeer, SIGNAL(messageReceived(QString,QObject*)), this, SLOT(activateWindow()));
+        disconnect(pidPeer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow);
 }
 
 

--- a/src/3rdparty/qtsingleapplication/qtsinglecoreapplication.cpp
+++ b/src/3rdparty/qtsingleapplication/qtsinglecoreapplication.cpp
@@ -37,7 +37,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(int &argc, char **argv)
 {
     peer = new QtLocalPeer(this);
     block = false;
-    connect(peer, SIGNAL(messageReceived(QString)), SIGNAL(messageReceived(QString)));
+    connect(peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived);
 }
 
 
@@ -45,7 +45,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(const QString &appId, int &argc
     : QCoreApplication(argc, argv)
 {
     peer = new QtLocalPeer(this, appId);
-    connect(peer, SIGNAL(messageReceived(QString)), SIGNAL(messageReceived(QString)));
+    connect(peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived);
 }
 
 

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -512,7 +512,7 @@ restart_sync:
     engine.setNetworkLimits(options.uplimit, options.downlimit);
     QObject::connect(&engine, &SyncEngine::finished,
         [&app](bool result) { app.exit(result ? EXIT_SUCCESS : EXIT_FAILURE); });
-    QObject::connect(&engine, SIGNAL(transmissionProgress(ProgressInfo)), &cmd, SLOT(transmissionProgressSlot()));
+    QObject::connect(&engine, &SyncEngine::transmissionProgress, &cmd, &Cmd::transmissionProgressSlot);
 
 
     // Exclude lists

--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -151,8 +151,8 @@ QByteArray ComputeChecksum::checksumType() const
 void ComputeChecksum::start(const QString &filePath)
 {
     // Calculate the checksum in a different thread first.
-    connect(&_watcher, SIGNAL(finished()),
-        this, SLOT(slotCalculationDone()),
+    connect(&_watcher, &QFutureWatcherBase::finished,
+        this, &ComputeChecksum::slotCalculationDone,
         Qt::UniqueConnection);
     _watcher.setFuture(QtConcurrent::run(ComputeChecksum::computeNow, filePath, checksumType()));
 }
@@ -208,8 +208,8 @@ void ValidateChecksumHeader::start(const QString &filePath, const QByteArray &ch
 
     auto calculator = new ComputeChecksum(this);
     calculator->setChecksumType(_expectedChecksumType);
-    connect(calculator, SIGNAL(done(QByteArray, QByteArray)),
-        SLOT(slotChecksumCalculated(QByteArray, QByteArray)));
+    connect(calculator, &ComputeChecksum::done,
+        this, &ValidateChecksumHeader::slotChecksumCalculated);
     calculator->start(filePath);
 }
 

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -319,8 +319,8 @@ AccountPtr AccountManager::createAccount()
 {
     AccountPtr acc = Account::create();
     acc->setSslErrorHandler(new SslDialogErrorHandler);
-    connect(acc.data(), SIGNAL(proxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)),
-        ProxyAuthHandler::instance(), SLOT(handleProxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)));
+    connect(acc.data(), &Account::proxyAuthenticationRequired,
+        ProxyAuthHandler::instance(), &ProxyAuthHandler::handleProxyAuthenticationRequired);
     return acc;
 }
 
@@ -359,8 +359,8 @@ QString AccountManager::generateFreeAccountId() const
 void AccountManager::addAccountState(AccountState *accountState)
 {
     QObject::connect(accountState->account().data(),
-        SIGNAL(wantsAccountSaved(Account *)),
-        SLOT(saveAccount(Account *)));
+        &Account::wantsAccountSaved,
+        this, &AccountManager::saveAccount);
 
     AccountStatePtr ptr(accountState);
     _accounts << ptr;

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -139,41 +139,41 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     ui->_folderList->installEventFilter(mouseCursorChanger);
 
     createAccountToolbox();
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState *)),
-        SLOT(slotAccountAdded(AccountState *)));
-    connect(ui->_folderList, SIGNAL(customContextMenuRequested(QPoint)),
-        this, SLOT(slotCustomContextMenuRequested(QPoint)));
-    connect(ui->_folderList, SIGNAL(clicked(const QModelIndex &)),
-        this, SLOT(slotFolderListClicked(const QModelIndex &)));
-    connect(ui->_folderList, SIGNAL(expanded(QModelIndex)), this, SLOT(refreshSelectiveSyncStatus()));
-    connect(ui->_folderList, SIGNAL(collapsed(QModelIndex)), this, SLOT(refreshSelectiveSyncStatus()));
-    connect(ui->selectiveSyncNotification, SIGNAL(linkActivated(QString)),
-        this, SLOT(slotLinkActivated(QString)));
-    connect(_model, SIGNAL(suggestExpand(QModelIndex)), ui->_folderList, SLOT(expand(QModelIndex)));
-    connect(_model, SIGNAL(dirtyChanged()), this, SLOT(refreshSelectiveSyncStatus()));
+    connect(AccountManager::instance(), &AccountManager::accountAdded,
+        this, &AccountSettings::slotAccountAdded);
+    connect(ui->_folderList, &QWidget::customContextMenuRequested,
+        this, &AccountSettings::slotCustomContextMenuRequested);
+    connect(ui->_folderList, &QAbstractItemView::clicked,
+        this, &AccountSettings::slotFolderListClicked);
+    connect(ui->_folderList, &QTreeView::expanded, this, &AccountSettings::refreshSelectiveSyncStatus);
+    connect(ui->_folderList, &QTreeView::collapsed, this, &AccountSettings::refreshSelectiveSyncStatus);
+    connect(ui->selectiveSyncNotification, &QLabel::linkActivated,
+        this, &AccountSettings::slotLinkActivated);
+    connect(_model, &FolderStatusModel::suggestExpand, ui->_folderList, &QTreeView::expand);
+    connect(_model, &FolderStatusModel::dirtyChanged, this, &AccountSettings::refreshSelectiveSyncStatus);
     refreshSelectiveSyncStatus();
-    connect(_model, SIGNAL(rowsInserted(QModelIndex, int, int)),
-        this, SLOT(refreshSelectiveSyncStatus()));
+    connect(_model, &QAbstractItemModel::rowsInserted,
+        this, &AccountSettings::refreshSelectiveSyncStatus);
 
     QAction *syncNowAction = new QAction(this);
     syncNowAction->setShortcut(QKeySequence(Qt::Key_F6));
-    connect(syncNowAction, SIGNAL(triggered()), SLOT(slotScheduleCurrentFolder()));
+    connect(syncNowAction, &QAction::triggered, this, &AccountSettings::slotScheduleCurrentFolder);
     addAction(syncNowAction);
 
     QAction *syncNowWithRemoteDiscovery = new QAction(this);
     syncNowWithRemoteDiscovery->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F6));
-    connect(syncNowWithRemoteDiscovery, SIGNAL(triggered()), SLOT(slotScheduleCurrentFolderForceRemoteDiscovery()));
+    connect(syncNowWithRemoteDiscovery, &QAction::triggered, this, &AccountSettings::slotScheduleCurrentFolderForceRemoteDiscovery);
     addAction(syncNowWithRemoteDiscovery);
 
 
-    connect(ui->selectiveSyncApply, SIGNAL(clicked()), _model, SLOT(slotApplySelectiveSync()));
-    connect(ui->selectiveSyncCancel, SIGNAL(clicked()), _model, SLOT(resetFolders()));
-    connect(ui->bigFolderApply, SIGNAL(clicked(bool)), _model, SLOT(slotApplySelectiveSync()));
-    connect(ui->bigFolderSyncAll, SIGNAL(clicked(bool)), _model, SLOT(slotSyncAllPendingBigFolders()));
-    connect(ui->bigFolderSyncNone, SIGNAL(clicked(bool)), _model, SLOT(slotSyncNoPendingBigFolders()));
+    connect(ui->selectiveSyncApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
+    connect(ui->selectiveSyncCancel, &QAbstractButton::clicked, _model, &FolderStatusModel::resetFolders);
+    connect(ui->bigFolderApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
+    connect(ui->bigFolderSyncAll, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncAllPendingBigFolders);
+    connect(ui->bigFolderSyncNone, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncNoPendingBigFolders);
 
-    connect(FolderMan::instance(), SIGNAL(folderListChanged(Folder::Map)), _model, SLOT(resetFolders()));
-    connect(this, SIGNAL(folderChanged()), _model, SLOT(resetFolders()));
+    connect(FolderMan::instance(), &FolderMan::folderListChanged, _model, &FolderStatusModel::resetFolders);
+    connect(this, &AccountSettings::folderChanged, _model, &FolderStatusModel::resetFolders);
 
 
     QColor color = palette().highlight().color();
@@ -184,8 +184,8 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(_accountState, &AccountState::stateChanged, this, &AccountSettings::slotAccountStateChanged);
     slotAccountStateChanged();
 
-    connect(&_quotaInfo, SIGNAL(quotaUpdated(qint64, qint64)),
-        this, SLOT(slotUpdateQuota(qint64, qint64)));
+    connect(&_quotaInfo, &QuotaInfo::quotaUpdated,
+        this, &AccountSettings::slotUpdateQuota);
 }
 
 
@@ -194,15 +194,15 @@ void AccountSettings::createAccountToolbox()
     QMenu *menu = new QMenu();
     _addAccountAction = new QAction(tr("Add new"), this);
     menu->addAction(_addAccountAction);
-    connect(_addAccountAction, SIGNAL(triggered(bool)), SLOT(slotOpenAccountWizard()));
+    connect(_addAccountAction, &QAction::triggered, this, &AccountSettings::slotOpenAccountWizard);
 
     _toggleSignInOutAction = new QAction(tr("Log out"), this);
-    connect(_toggleSignInOutAction, SIGNAL(triggered(bool)), SLOT(slotToggleSignInState()));
+    connect(_toggleSignInOutAction, &QAction::triggered, this, &AccountSettings::slotToggleSignInState);
     menu->addAction(_toggleSignInOutAction);
 
     QAction *action = new QAction(tr("Remove"), this);
     menu->addAction(action);
-    connect(action, SIGNAL(triggered(bool)), SLOT(slotDeleteAccount()));
+    connect(action, &QAction::triggered, this, &AccountSettings::slotDeleteAccount);
 
     ui->_accountToolbox->setText(tr("Account") + QLatin1Char(' '));
     ui->_accountToolbox->setMenu(menu);
@@ -268,7 +268,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
         menu->setAttribute(Qt::WA_DeleteOnClose);
 
         QAction *ac = menu->addAction(tr("Open folder"));
-        connect(ac, SIGNAL(triggered(bool)), this, SLOT(slotOpenCurrentLocalSubFolder()));
+        connect(ac, &QAction::triggered, this, &AccountSettings::slotOpenCurrentLocalSubFolder);
 
         QString fileName = _model->data(index, FolderStatusDelegate::FolderPathRole).toString();
         if (!QFile::exists(fileName)) {
@@ -294,12 +294,12 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     menu->setAttribute(Qt::WA_DeleteOnClose);
 
     QAction *ac = menu->addAction(tr("Open folder"));
-    connect(ac, SIGNAL(triggered(bool)), this, SLOT(slotOpenCurrentFolder()));
+    connect(ac, &QAction::triggered, this, &AccountSettings::slotOpenCurrentFolder);
 
     if (!ui->_folderList->isExpanded(index)) {
         ac = menu->addAction(tr("Choose what to sync"));
         ac->setEnabled(folderConnected);
-        connect(ac, SIGNAL(triggered(bool)), this, SLOT(doExpand()));
+        connect(ac, &QAction::triggered, this, &AccountSettings::doExpand);
     }
 
     if (!folderPaused) {
@@ -308,14 +308,14 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
             ac->setText(tr("Restart sync"));
         }
         ac->setEnabled(folderConnected);
-        connect(ac, SIGNAL(triggered(bool)), this, SLOT(slotForceSyncCurrentFolder()));
+        connect(ac, &QAction::triggered, this, &AccountSettings::slotForceSyncCurrentFolder);
     }
 
     ac = menu->addAction(folderPaused ? tr("Resume sync") : tr("Pause sync"));
-    connect(ac, SIGNAL(triggered(bool)), this, SLOT(slotEnableCurrentFolder()));
+    connect(ac, &QAction::triggered, this, &AccountSettings::slotEnableCurrentFolder);
 
     ac = menu->addAction(tr("Remove folder sync connection"));
-    connect(ac, SIGNAL(triggered(bool)), this, SLOT(slotRemoveCurrentFolder()));
+    connect(ac, &QAction::triggered, this, &AccountSettings::slotRemoveCurrentFolder);
     menu->exec(tv->mapToGlobal(pos));
 }
 
@@ -361,8 +361,8 @@ void AccountSettings::slotAddFolder()
 
     FolderWizard *folderWizard = new FolderWizard(_accountState->account(), this);
 
-    connect(folderWizard, SIGNAL(accepted()), SLOT(slotFolderWizardAccepted()));
-    connect(folderWizard, SIGNAL(rejected()), SLOT(slotFolderWizardRejected()));
+    connect(folderWizard, &QDialog::accepted, this, &AccountSettings::slotFolderWizardAccepted);
+    connect(folderWizard, &QDialog::rejected, this, &AccountSettings::slotFolderWizardRejected);
     folderWizard->open();
 }
 

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -201,8 +201,8 @@ void AccountState::checkConnectivity()
 
     ConnectionValidator *conValidator = new ConnectionValidator(account());
     _connectionValidator = conValidator;
-    connect(conValidator, SIGNAL(connectionResult(ConnectionValidator::Status, QStringList)),
-        SLOT(slotConnectionValidatorResult(ConnectionValidator::Status, QStringList)));
+    connect(conValidator, &ConnectionValidator::connectionResult,
+        this, &AccountState::slotConnectionValidatorResult);
     if (isConnected()) {
         // Use a small authed propfind as a minimal ping when we're
         // already connected.

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -38,12 +38,12 @@ AccountState::AccountState(AccountPtr account)
 {
     qRegisterMetaType<AccountState *>("AccountState*");
 
-    connect(account.data(), SIGNAL(invalidCredentials()),
-        SLOT(slotInvalidCredentials()));
-    connect(account.data(), SIGNAL(credentialsFetched(AbstractCredentials *)),
-        SLOT(slotCredentialsFetched(AbstractCredentials *)));
-    connect(account.data(), SIGNAL(credentialsAsked(AbstractCredentials *)),
-        SLOT(slotCredentialsAsked(AbstractCredentials *)));
+    connect(account.data(), &Account::invalidCredentials,
+        this, &AccountState::slotInvalidCredentials);
+    connect(account.data(), &Account::credentialsFetched,
+        this, &AccountState::slotCredentialsFetched);
+    connect(account.data(), &Account::credentialsAsked,
+        this, &AccountState::slotCredentialsAsked);
     _timeSinceLastETagCheck.invalidate();
 }
 
@@ -242,7 +242,7 @@ void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status sta
             qCInfo(lcAccountState) << "AccountState reconnection: delaying for"
                                    << _maintenanceToConnectedDelay << "ms";
             _timeSinceMaintenanceOver.start();
-            QTimer::singleShot(_maintenanceToConnectedDelay + 100, this, SLOT(checkConnectivity()));
+            QTimer::singleShot(_maintenanceToConnectedDelay + 100, this, &AccountState::checkConnectivity);
             return;
         } else if (_timeSinceMaintenanceOver.elapsed() < _maintenanceToConnectedDelay) {
             qCInfo(lcAccountState) << "AccountState reconnection: only"

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -124,8 +124,8 @@ void ActivityListModel::startFetchJob(AccountState *s)
         return;
     }
     JsonApiJob *job = new JsonApiJob(s->account(), QLatin1String("ocs/v1.php/cloud/activity"), this);
-    QObject::connect(job, SIGNAL(jsonReceived(QJsonDocument, int)),
-        this, SLOT(slotActivitiesReceived(QJsonDocument, int)));
+    QObject::connect(job, &JsonApiJob::jsonReceived,
+        this, &ActivityListModel::slotActivitiesReceived);
     job->setProperty("AccountStatePtr", QVariant::fromValue<QPointer<AccountState>>(s));
 
     QList<QPair<QString, QString>> params;

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -81,19 +81,19 @@ ActivityWidget::ActivityWidget(QWidget *parent)
 
     showLabels();
 
-    connect(_model, SIGNAL(activityJobStatusCode(AccountState *, int)),
-        this, SLOT(slotAccountActivityStatus(AccountState *, int)));
+    connect(_model, &ActivityListModel::activityJobStatusCode,
+        this, &ActivityWidget::slotAccountActivityStatus);
 
     _copyBtn = _ui->_dialogButtonBox->addButton(tr("Copy"), QDialogButtonBox::ActionRole);
     _copyBtn->setToolTip(tr("Copy the activity list to the clipboard."));
-    connect(_copyBtn, SIGNAL(clicked()), SIGNAL(copyToClipboard()));
+    connect(_copyBtn, &QAbstractButton::clicked, this, &ActivityWidget::copyToClipboard);
 
-    connect(_model, SIGNAL(rowsInserted(QModelIndex, int, int)), SIGNAL(rowsInserted()));
+    connect(_model, &QAbstractItemModel::rowsInserted, this, &ActivityWidget::rowsInserted);
 
     connect(_ui->_activityList, SIGNAL(activated(QModelIndex)), this,
         SLOT(slotOpenFile(QModelIndex)));
 
-    connect(&_removeTimer, SIGNAL(timeout()), this, SLOT(slotCheckToCleanWidgets()));
+    connect(&_removeTimer, &QTimer::timeout, this, &ActivityWidget::slotCheckToCleanWidgets);
     _removeTimer.setInterval(1000);
 }
 
@@ -260,10 +260,10 @@ void ActivityWidget::slotBuildNotificationDisplay(const ActivityList &list)
             widget = _widgetForNotifId[activity.ident()];
         } else {
             widget = new NotificationWidget(this);
-            connect(widget, SIGNAL(sendNotificationRequest(QString, QString, QByteArray)),
-                this, SLOT(slotSendNotificationRequest(QString, QString, QByteArray)));
-            connect(widget, SIGNAL(requestCleanupAndBlacklist(Activity)),
-                this, SLOT(slotRequestCleanupAndBlacklist(Activity)));
+            connect(widget, &NotificationWidget::sendNotificationRequest,
+                this, &ActivityWidget::slotSendNotificationRequest);
+            connect(widget, &NotificationWidget::requestCleanupAndBlacklist,
+                this, &ActivityWidget::slotRequestCleanupAndBlacklist);
 
             _notificationsLayout->addWidget(widget);
 // _ui->_notifyScroll->setMinimumHeight( widget->height());
@@ -386,8 +386,8 @@ void ActivityWidget::slotSendNotificationRequest(const QString &accountName, con
             QUrl l(link);
             job->setLinkAndVerb(l, verb);
             job->setWidget(theSender);
-            connect(job, SIGNAL(networkError(QNetworkReply *)),
-                this, SLOT(slotNotifyNetworkError(QNetworkReply *)));
+            connect(job, &AbstractNetworkJob::networkError,
+                this, &ActivityWidget::slotNotifyNetworkError);
             connect(job, SIGNAL(jobFinished(QString, int)),
                 this, SLOT(slotNotifyServerFinished(QString, int)));
             job->start();
@@ -515,32 +515,32 @@ ActivitySettings::ActivitySettings(QWidget *parent)
     hbox->addWidget(_tab);
     _activityWidget = new ActivityWidget(this);
     _activityTabId = _tab->addTab(_activityWidget, Theme::instance()->applicationIcon(), tr("Server Activity"));
-    connect(_activityWidget, SIGNAL(copyToClipboard()), this, SLOT(slotCopyToClipboard()));
-    connect(_activityWidget, SIGNAL(hideActivityTab(bool)), this, SLOT(setActivityTabHidden(bool)));
-    connect(_activityWidget, SIGNAL(guiLog(QString, QString)), this, SIGNAL(guiLog(QString, QString)));
-    connect(_activityWidget, SIGNAL(newNotification()), SLOT(slotShowActivityTab()));
+    connect(_activityWidget, &ActivityWidget::copyToClipboard, this, &ActivitySettings::slotCopyToClipboard);
+    connect(_activityWidget, &ActivityWidget::hideActivityTab, this, &ActivitySettings::setActivityTabHidden);
+    connect(_activityWidget, &ActivityWidget::guiLog, this, &ActivitySettings::guiLog);
+    connect(_activityWidget, &ActivityWidget::newNotification, this, &ActivitySettings::slotShowActivityTab);
 
     _protocolWidget = new ProtocolWidget(this);
     _protocolTabId = _tab->addTab(_protocolWidget, Theme::instance()->syncStateIcon(SyncResult::Success), tr("Sync Protocol"));
-    connect(_protocolWidget, SIGNAL(copyToClipboard()), this, SLOT(slotCopyToClipboard()));
+    connect(_protocolWidget, &ProtocolWidget::copyToClipboard, this, &ActivitySettings::slotCopyToClipboard);
 
     _issuesWidget = new IssuesWidget(this);
     _syncIssueTabId = _tab->addTab(_issuesWidget, Theme::instance()->syncStateIcon(SyncResult::Problem), QString());
     slotShowIssueItemCount(0); // to display the label.
-    connect(_issuesWidget, SIGNAL(issueCountUpdated(int)),
-        this, SLOT(slotShowIssueItemCount(int)));
-    connect(_issuesWidget, SIGNAL(copyToClipboard()),
-        this, SLOT(slotCopyToClipboard()));
+    connect(_issuesWidget, &IssuesWidget::issueCountUpdated,
+        this, &ActivitySettings::slotShowIssueItemCount);
+    connect(_issuesWidget, &IssuesWidget::copyToClipboard,
+        this, &ActivitySettings::slotCopyToClipboard);
 
     // Add a progress indicator to spin if the acitivity list is updated.
     _progressIndicator = new QProgressIndicator(this);
     _tab->setCornerWidget(_progressIndicator);
 
-    connect(&_notificationCheckTimer, SIGNAL(timeout()),
-        this, SLOT(slotRegularNotificationCheck()));
+    connect(&_notificationCheckTimer, &QTimer::timeout,
+        this, &ActivitySettings::slotRegularNotificationCheck);
 
     // connect a model signal to stop the animation.
-    connect(_activityWidget, SIGNAL(rowsInserted()), _progressIndicator, SLOT(stopAnimation()));
+    connect(_activityWidget, &ActivityWidget::rowsInserted, _progressIndicator, &QProgressIndicator::stopAnimation);
 
     // We want the protocol be the default
     _tab->setCurrentIndex(1);

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -90,8 +90,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
 
     connect(_model, &QAbstractItemModel::rowsInserted, this, &ActivityWidget::rowsInserted);
 
-    connect(_ui->_activityList, SIGNAL(activated(QModelIndex)), this,
-        SLOT(slotOpenFile(QModelIndex)));
+    connect(_ui->_activityList, &QListView::activated, this, &ActivityWidget::slotOpenFile);
 
     connect(&_removeTimer, &QTimer::timeout, this, &ActivityWidget::slotCheckToCleanWidgets);
     _removeTimer.setInterval(1000);
@@ -113,8 +112,8 @@ void ActivityWidget::slotRefreshNotifications(AccountState *ptr)
     // are running
     if (_notificationRequestsRunning == 0) {
         ServerNotificationHandler *snh = new ServerNotificationHandler;
-        connect(snh, SIGNAL(newNotificationList(ActivityList)), this,
-            SLOT(slotBuildNotificationDisplay(ActivityList)));
+        connect(snh, &ServerNotificationHandler::newNotificationList,
+            this, &ActivityWidget::slotBuildNotificationDisplay);
 
         snh->slotFetchNotifications(ptr);
     } else {
@@ -388,8 +387,8 @@ void ActivityWidget::slotSendNotificationRequest(const QString &accountName, con
             job->setWidget(theSender);
             connect(job, &AbstractNetworkJob::networkError,
                 this, &ActivityWidget::slotNotifyNetworkError);
-            connect(job, SIGNAL(jobFinished(QString, int)),
-                this, SLOT(slotNotifyServerFinished(QString, int)));
+            connect(job, &NotificationConfirmJob::jobFinished,
+                this, &ActivityWidget::slotNotifyServerFinished);
             job->start();
 
             // count the number of running notification requests. If this member var

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -208,8 +208,8 @@ Application::Application(int &argc, char **argv)
     QTimer::singleShot(0, this, &Application::slotCheckConnection);
 
     // Can't use onlineStateChanged because it is always true on modern systems because of many interfaces
-    connect(&_networkConfigurationManager, SIGNAL(configurationChanged(QNetworkConfiguration)),
-        this, SLOT(slotSystemOnlineConfigurationChanged(QNetworkConfiguration)));
+    connect(&_networkConfigurationManager, &QNetworkConfigurationManager::configurationChanged,
+        this, &Application::slotSystemOnlineConfigurationChanged);
 
     // Update checks
     UpdaterScheduler *updaterScheduler = new UpdaterScheduler(this);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -71,6 +71,7 @@ public:
 public slots:
     // TODO: this should not be public
     void slotownCloudWizardDone(int);
+    void slotCrash();
 
 protected:
     void parseOptions(const QStringList &);
@@ -90,7 +91,6 @@ protected slots:
     void slotCleanup();
     void slotAccountStateAdded(AccountState *accountState);
     void slotAccountStateRemoved(AccountState *accountState);
-    void slotCrash();
     void slotSystemOnlineConfigurationChanged(QNetworkConfiguration);
 
 private:

--- a/src/gui/authenticationdialog.cpp
+++ b/src/gui/authenticationdialog.cpp
@@ -40,8 +40,8 @@ AuthenticationDialog::AuthenticationDialog(const QString &realm, const QString &
     _password->setEchoMode(QLineEdit::Password);
 
     QDialogButtonBox *box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal);
-    connect(box, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(box, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(box, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(box, &QDialogButtonBox::rejected, this, &QDialog::reject);
     lay->addWidget(box);
 }
 

--- a/src/gui/creds/shibboleth/shibbolethuserjob.cpp
+++ b/src/gui/creds/shibboleth/shibbolethuserjob.cpp
@@ -27,7 +27,7 @@ ShibbolethUserJob::ShibbolethUserJob(AccountPtr account, QObject *parent)
     : JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"), parent)
 {
     setIgnoreCredentialFailure(true);
-    connect(this, SIGNAL(jsonReceived(QJsonDocument, int)), this, SLOT(slotJsonReceived(QJsonDocument, int)));
+    connect(this, &JsonApiJob::jsonReceived, this, &ShibbolethUserJob::slotJsonReceived);
 }
 
 void ShibbolethUserJob::slotJsonReceived(const QJsonDocument &json, int statusCode)

--- a/src/gui/creds/shibboleth/shibbolethwebview.cpp
+++ b/src/gui/creds/shibboleth/shibbolethwebview.cpp
@@ -63,10 +63,10 @@ ShibbolethWebView::ShibbolethWebView(AccountPtr account, QWidget *parent)
     setAttribute(Qt::WA_DeleteOnClose);
 
     QWebPage *page = new UserAgentWebPage(this);
-    connect(page, SIGNAL(loadStarted()),
-        this, SLOT(slotLoadStarted()));
-    connect(page, SIGNAL(loadFinished(bool)),
-        this, SLOT(slotLoadFinished(bool)));
+    connect(page, &QWebPage::loadStarted,
+        this, &ShibbolethWebView::slotLoadStarted);
+    connect(page, &QWebPage::loadFinished,
+        this, &ShibbolethWebView::slotLoadFinished);
 
     // Make sure to accept the same SSL certificate issues as the regular QNAM we use for syncing
     QObject::connect(page->networkAccessManager(), SIGNAL(sslErrors(QNetworkReply *, QList<QSslError>)),

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -117,8 +117,8 @@ void FolderMan::unloadFolder(Folder *f)
         this, &FolderMan::slotForwardFolderSyncStateChange);
     disconnect(f, &Folder::syncPausedChanged,
         this, &FolderMan::slotFolderSyncPaused);
-    disconnect(&f->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
-        _socketApi.data(), SLOT(broadcastStatusPushMessage(const QString &, SyncFileStatus)));
+    disconnect(&f->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::fileStatusChanged,
+        _socketApi.data(), &SocketApi::broadcastStatusPushMessage);
     disconnect(f, &Folder::watchedFileChangedExternally,
         &f->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::slotPathTouched);
 }
@@ -959,8 +959,8 @@ Folder *FolderMan::addFolderInternal(FolderDefinition folderDefinition,
     connect(folder, &Folder::syncStateChange, this, &FolderMan::slotForwardFolderSyncStateChange);
     connect(folder, &Folder::syncPausedChanged, this, &FolderMan::slotFolderSyncPaused);
     connect(folder, &Folder::canSyncChanged, this, &FolderMan::slotFolderCanSyncChanged);
-    connect(&folder->syncEngine().syncFileStatusTracker(), SIGNAL(fileStatusChanged(const QString &, SyncFileStatus)),
-        _socketApi.data(), SLOT(broadcastStatusPushMessage(const QString &, SyncFileStatus)));
+    connect(&folder->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::fileStatusChanged,
+        _socketApi.data(), &SocketApi::broadcastStatusPushMessage);
     connect(folder, &Folder::watchedFileChangedExternally,
         &folder->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::slotPathTouched);
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -24,7 +24,6 @@
 #include "folderwatcher.h"
 #include "syncfileitem.h"
 
-class QSignalMapper;
 class TestFolderMan;
 
 namespace OCC {

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -34,7 +34,7 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
     _fd = inotify_init();
     if (_fd != -1) {
         _socket.reset(new QSocketNotifier(_fd, QSocketNotifier::Read));
-        connect(_socket.data(), SIGNAL(activated(int)), SLOT(slotReceivedNotification(int)));
+        connect(_socket.data(), &QSocketNotifier::activated, this, &FolderWatcherPrivate::slotReceivedNotification);
     } else {
         qCWarning(lcFolderWatcher) << "notify_init() failed: " << strerror(errno);
     }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -62,7 +62,7 @@ FolderWizardLocalPath::FolderWizardLocalPath(const AccountPtr &account)
 {
     _ui.setupUi(this);
     registerField(QLatin1String("sourceFolder*"), _ui.localFolderLineEdit);
-    connect(_ui.localFolderChooseBtn, SIGNAL(clicked()), this, SLOT(slotChooseLocalFolder()));
+    connect(_ui.localFolderChooseBtn, &QAbstractButton::clicked, this, &FolderWizardLocalPath::slotChooseLocalFolder);
     _ui.localFolderChooseBtn->setToolTip(tr("Click to select a local folder to sync."));
 
     QString defaultPath = QDir::homePath() + QLatin1Char('/') + Theme::instance()->appName();
@@ -151,15 +151,15 @@ FolderWizardRemotePath::FolderWizardRemotePath(const AccountPtr &account)
     _ui.folderTreeWidget->setSortingEnabled(true);
     _ui.folderTreeWidget->sortByColumn(0, Qt::AscendingOrder);
 
-    connect(_ui.addFolderButton, SIGNAL(clicked()), SLOT(slotAddRemoteFolder()));
-    connect(_ui.refreshButton, SIGNAL(clicked()), SLOT(slotRefreshFolders()));
-    connect(_ui.folderTreeWidget, SIGNAL(itemExpanded(QTreeWidgetItem *)), SLOT(slotItemExpanded(QTreeWidgetItem *)));
-    connect(_ui.folderTreeWidget, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), SLOT(slotCurrentItemChanged(QTreeWidgetItem *)));
-    connect(_ui.folderEntry, SIGNAL(textEdited(QString)), SLOT(slotFolderEntryEdited(QString)));
+    connect(_ui.addFolderButton, &QAbstractButton::clicked, this, &FolderWizardRemotePath::slotAddRemoteFolder);
+    connect(_ui.refreshButton, &QAbstractButton::clicked, this, &FolderWizardRemotePath::slotRefreshFolders);
+    connect(_ui.folderTreeWidget, &QTreeWidget::itemExpanded, this, &FolderWizardRemotePath::slotItemExpanded);
+    connect(_ui.folderTreeWidget, &QTreeWidget::currentItemChanged, this, &FolderWizardRemotePath::slotCurrentItemChanged);
+    connect(_ui.folderEntry, &QLineEdit::textEdited, this, &FolderWizardRemotePath::slotFolderEntryEdited);
 
     _lscolTimer.setInterval(500);
     _lscolTimer.setSingleShot(true);
-    connect(&_lscolTimer, SIGNAL(timeout()), SLOT(slotLsColFolderEntry()));
+    connect(&_lscolTimer, &QTimer::timeout, this, &FolderWizardRemotePath::slotLsColFolderEntry);
 
     _ui.folderTreeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     // Make sure that there will be a scrollbar when the contents is too wide
@@ -200,7 +200,7 @@ void FolderWizardRemotePath::slotCreateRemoteFolder(const QString &folder)
     /* check the owncloud configuration file and query the ownCloud */
     connect(job, SIGNAL(finished(QNetworkReply::NetworkError)),
         SLOT(slotCreateRemoteFolderFinished(QNetworkReply::NetworkError)));
-    connect(job, SIGNAL(networkError(QNetworkReply *)), SLOT(slotHandleMkdirNetworkError(QNetworkReply *)));
+    connect(job, &AbstractNetworkJob::networkError, this, &FolderWizardRemotePath::slotHandleMkdirNetworkError);
     job->start();
 }
 
@@ -373,10 +373,10 @@ void FolderWizardRemotePath::slotLsColFolderEntry()
     // No error handling, no updating, we do this manually
     // because of extra logic in the typed-path case.
     disconnect(job, 0, this, 0);
-    connect(job, SIGNAL(finishedWithError(QNetworkReply *)),
-        SLOT(slotTypedPathError(QNetworkReply *)));
-    connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
-        SLOT(slotTypedPathFound(QStringList)));
+    connect(job, &LsColJob::finishedWithError,
+        this, &FolderWizardRemotePath::slotTypedPathError);
+    connect(job, &LsColJob::directoryListingSubfolders,
+        this, &FolderWizardRemotePath::slotTypedPathFound);
 }
 
 void FolderWizardRemotePath::slotTypedPathFound(const QStringList &subpaths)
@@ -404,10 +404,10 @@ LsColJob *FolderWizardRemotePath::runLsColJob(const QString &path)
 {
     LsColJob *job = new LsColJob(_account, path, this);
     job->setProperties(QList<QByteArray>() << "resourcetype");
-    connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
-        SLOT(slotUpdateDirectories(QStringList)));
-    connect(job, SIGNAL(finishedWithError(QNetworkReply *)),
-        SLOT(slotHandleLsColNetworkError(QNetworkReply *)));
+    connect(job, &LsColJob::directoryListingSubfolders,
+        this, &FolderWizardRemotePath::slotUpdateDirectories);
+    connect(job, &LsColJob::finishedWithError,
+        this, &FolderWizardRemotePath::slotHandleLsColNetworkError);
     job->start();
 
     return job;

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -198,8 +198,8 @@ void FolderWizardRemotePath::slotCreateRemoteFolder(const QString &folder)
 
     MkColJob *job = new MkColJob(_account, fullPath, this);
     /* check the owncloud configuration file and query the ownCloud */
-    connect(job, SIGNAL(finished(QNetworkReply::NetworkError)),
-        SLOT(slotCreateRemoteFolderFinished(QNetworkReply::NetworkError)));
+    connect(job, static_cast<void (MkColJob::*)(QNetworkReply::NetworkError)>(&MkColJob::finished),
+        this, &FolderWizardRemotePath::slotCreateRemoteFolderFinished);
     connect(job, &AbstractNetworkJob::networkError, this, &FolderWizardRemotePath::slotHandleMkdirNetworkError);
     job->start();
 }

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -66,7 +66,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     connect(_ui->monoIconsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->crashreporterCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newFolderLimitCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
-    connect(_ui->newFolderLimitSpinBox, SIGNAL(valueChanged(int)), SLOT(saveMiscSettings()));
+    connect(_ui->newFolderLimitSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newExternalStorage, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
 
 #ifndef WITH_CRASHREPORTER
@@ -126,7 +126,7 @@ void GeneralSettings::slotUpdateInfo()
     if (updater) {
         connect(updater, &OCUpdater::downloadStateChanged, this, &GeneralSettings::slotUpdateInfo, Qt::UniqueConnection);
         connect(_ui->restartButton, &QAbstractButton::clicked, updater, &OCUpdater::slotStartInstaller, Qt::UniqueConnection);
-        connect(_ui->restartButton, SIGNAL(clicked()), qApp, SLOT(quit()), Qt::UniqueConnection);
+        connect(_ui->restartButton, &QAbstractButton::clicked, qApp, &QApplication::quit, Qt::UniqueConnection);
         _ui->updateStateLabel->setText(updater->statusString());
         _ui->restartButton->setVisible(updater->downloadState() == OCUpdater::DownloadComplete);
     } else {

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -42,11 +42,11 @@ GeneralSettings::GeneralSettings(QWidget *parent)
 {
     _ui->setupUi(this);
 
-    connect(_ui->desktopNotificationsCheckBox, SIGNAL(toggled(bool)),
-        SLOT(slotToggleOptionalDesktopNotifications(bool)));
+    connect(_ui->desktopNotificationsCheckBox, &QAbstractButton::toggled,
+        this, &GeneralSettings::slotToggleOptionalDesktopNotifications);
 
     _ui->autostartCheckBox->setChecked(Utility::hasLaunchOnStartup(Theme::instance()->appName()));
-    connect(_ui->autostartCheckBox, SIGNAL(toggled(bool)), SLOT(slotToggleLaunchOnStartup(bool)));
+    connect(_ui->autostartCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleLaunchOnStartup);
 
     // setup about section
     QString about = Theme::instance()->about();
@@ -63,11 +63,11 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     slotUpdateInfo();
 
     // misc
-    connect(_ui->monoIconsCheckBox, SIGNAL(toggled(bool)), SLOT(saveMiscSettings()));
-    connect(_ui->crashreporterCheckBox, SIGNAL(toggled(bool)), SLOT(saveMiscSettings()));
-    connect(_ui->newFolderLimitCheckBox, SIGNAL(toggled(bool)), SLOT(saveMiscSettings()));
+    connect(_ui->monoIconsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
+    connect(_ui->crashreporterCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
+    connect(_ui->newFolderLimitCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newFolderLimitSpinBox, SIGNAL(valueChanged(int)), SLOT(saveMiscSettings()));
-    connect(_ui->newExternalStorage, SIGNAL(toggled(bool)), SLOT(saveMiscSettings()));
+    connect(_ui->newExternalStorage, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
 
 #ifndef WITH_CRASHREPORTER
     _ui->crashreporterCheckBox->setVisible(false);
@@ -84,10 +84,10 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     // is no point in offering an option
     _ui->monoIconsCheckBox->setVisible(Theme::instance()->monoIconsAvailable());
 
-    connect(_ui->ignoredFilesButton, SIGNAL(clicked()), SLOT(slotIgnoreFilesEditor()));
+    connect(_ui->ignoredFilesButton, &QAbstractButton::clicked, this, &GeneralSettings::slotIgnoreFilesEditor);
 
     // accountAdded means the wizard was finished and the wizard might change some options.
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState *)), this, SLOT(loadMiscSettings()));
+    connect(AccountManager::instance(), &AccountManager::accountAdded, this, &GeneralSettings::loadMiscSettings);
 }
 
 GeneralSettings::~GeneralSettings()
@@ -124,8 +124,8 @@ void GeneralSettings::slotUpdateInfo()
     }
 
     if (updater) {
-        connect(updater, SIGNAL(downloadStateChanged()), SLOT(slotUpdateInfo()), Qt::UniqueConnection);
-        connect(_ui->restartButton, SIGNAL(clicked()), updater, SLOT(slotStartInstaller()), Qt::UniqueConnection);
+        connect(updater, &OCUpdater::downloadStateChanged, this, &GeneralSettings::slotUpdateInfo, Qt::UniqueConnection);
+        connect(_ui->restartButton, &QAbstractButton::clicked, updater, &OCUpdater::slotStartInstaller, Qt::UniqueConnection);
         connect(_ui->restartButton, SIGNAL(clicked()), qApp, SLOT(quit()), Qt::UniqueConnection);
         _ui->updateStateLabel->setText(updater->statusString());
         _ui->restartButton->setVisible(updater->downloadState() == OCUpdater::DownloadComplete);

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -54,11 +54,11 @@ IgnoreListEditor::IgnoreListEditor(QWidget *parent)
     readIgnoreFile(cfgFile.excludeFile(ConfigFile::SystemScope), true);
     readIgnoreFile(cfgFile.excludeFile(ConfigFile::UserScope), false);
 
-    connect(this, SIGNAL(accepted()), SLOT(slotUpdateLocalIgnoreList()));
+    connect(this, &QDialog::accepted, this, &IgnoreListEditor::slotUpdateLocalIgnoreList);
     ui->removePushButton->setEnabled(false);
-    connect(ui->tableWidget, SIGNAL(itemSelectionChanged()), SLOT(slotItemSelectionChanged()));
-    connect(ui->removePushButton, SIGNAL(clicked()), SLOT(slotRemoveCurrentItem()));
-    connect(ui->addPushButton, SIGNAL(clicked()), SLOT(slotAddPattern()));
+    connect(ui->tableWidget, &QTableWidget::itemSelectionChanged, this, &IgnoreListEditor::slotItemSelectionChanged);
+    connect(ui->removePushButton, &QAbstractButton::clicked, this, &IgnoreListEditor::slotRemoveCurrentItem);
+    connect(ui->addPushButton, &QAbstractButton::clicked, this, &IgnoreListEditor::slotAddPattern);
 
     ui->tableWidget->resizeColumnsToContents();
     ui->tableWidget->horizontalHeader()->setResizeMode(patternCol, QHeaderView::Stretch);

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -56,9 +56,9 @@ IssuesWidget::IssuesWidget(QWidget *parent)
 
     connect(_ui->showIgnores, &QAbstractButton::toggled, this, &IssuesWidget::slotRefreshIssues);
     connect(_ui->showWarnings, &QAbstractButton::toggled, this, &IssuesWidget::slotRefreshIssues);
-    connect(_ui->filterAccount, SIGNAL(currentIndexChanged(int)), SLOT(slotRefreshIssues()));
-    connect(_ui->filterAccount, SIGNAL(currentIndexChanged(int)), SLOT(slotUpdateFolderFilters()));
-    connect(_ui->filterFolder, SIGNAL(currentIndexChanged(int)), SLOT(slotRefreshIssues()));
+    connect(_ui->filterAccount, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &IssuesWidget::slotRefreshIssues);
+    connect(_ui->filterAccount, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &IssuesWidget::slotUpdateFolderFilters);
+    connect(_ui->filterFolder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &IssuesWidget::slotRefreshIssues);
     for (auto account : AccountManager::instance()->accounts()) {
         slotAccountAdded(account.data());
     }

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -44,30 +44,30 @@ IssuesWidget::IssuesWidget(QWidget *parent)
 {
     _ui->setupUi(this);
 
-    connect(ProgressDispatcher::instance(), SIGNAL(progressInfo(QString, ProgressInfo)),
-        this, SLOT(slotProgressInfo(QString, ProgressInfo)));
-    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString, SyncFileItemPtr)),
-        this, SLOT(slotItemCompleted(QString, SyncFileItemPtr)));
+    connect(ProgressDispatcher::instance(), &ProgressDispatcher::progressInfo,
+        this, &IssuesWidget::slotProgressInfo);
+    connect(ProgressDispatcher::instance(), &ProgressDispatcher::itemCompleted,
+        this, &IssuesWidget::slotItemCompleted);
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::syncError,
         this, &IssuesWidget::addError);
 
-    connect(_ui->_treeWidget, SIGNAL(itemActivated(QTreeWidgetItem *, int)), SLOT(slotOpenFile(QTreeWidgetItem *, int)));
-    connect(_ui->copyIssuesButton, SIGNAL(clicked()), SIGNAL(copyToClipboard()));
+    connect(_ui->_treeWidget, &QTreeWidget::itemActivated, this, &IssuesWidget::slotOpenFile);
+    connect(_ui->copyIssuesButton, &QAbstractButton::clicked, this, &IssuesWidget::copyToClipboard);
 
-    connect(_ui->showIgnores, SIGNAL(toggled(bool)), SLOT(slotRefreshIssues()));
-    connect(_ui->showWarnings, SIGNAL(toggled(bool)), SLOT(slotRefreshIssues()));
+    connect(_ui->showIgnores, &QAbstractButton::toggled, this, &IssuesWidget::slotRefreshIssues);
+    connect(_ui->showWarnings, &QAbstractButton::toggled, this, &IssuesWidget::slotRefreshIssues);
     connect(_ui->filterAccount, SIGNAL(currentIndexChanged(int)), SLOT(slotRefreshIssues()));
     connect(_ui->filterAccount, SIGNAL(currentIndexChanged(int)), SLOT(slotUpdateFolderFilters()));
     connect(_ui->filterFolder, SIGNAL(currentIndexChanged(int)), SLOT(slotRefreshIssues()));
     for (auto account : AccountManager::instance()->accounts()) {
         slotAccountAdded(account.data());
     }
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState *)),
-        SLOT(slotAccountAdded(AccountState *)));
-    connect(AccountManager::instance(), SIGNAL(accountRemoved(AccountState *)),
-        SLOT(slotAccountRemoved(AccountState *)));
-    connect(FolderMan::instance(), SIGNAL(folderListChanged(Folder::Map)),
-        SLOT(slotUpdateFolderFilters()));
+    connect(AccountManager::instance(), &AccountManager::accountAdded,
+        this, &IssuesWidget::slotAccountAdded);
+    connect(AccountManager::instance(), &AccountManager::accountRemoved,
+        this, &IssuesWidget::slotAccountRemoved);
+    connect(FolderMan::instance(), &FolderMan::folderListChanged,
+        this, &IssuesWidget::slotUpdateFolderFilters);
 
 
     // Adjust copyToClipboard() when making changes here!

--- a/src/gui/lockwatcher.cpp
+++ b/src/gui/lockwatcher.cpp
@@ -27,8 +27,8 @@ static const int check_frequency = 20 * 1000; // ms
 LockWatcher::LockWatcher(QObject *parent)
     : QObject(parent)
 {
-    connect(&_timer, SIGNAL(timeout()),
-        SLOT(checkFiles()));
+    connect(&_timer, &QTimer::timeout,
+        this, &LockWatcher::checkFiles);
     _timer.start(check_frequency);
 }
 

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -76,7 +76,7 @@ LogBrowser::LogBrowser(QWidget *parent)
     // find button
     QPushButton *findBtn = new QPushButton;
     findBtn->setText(tr("&Find"));
-    connect(findBtn, SIGNAL(clicked()), this, SLOT(slotFind()));
+    connect(findBtn, &QAbstractButton::clicked, this, &LogBrowser::slotFind);
     toolLayout->addWidget(findBtn);
 
     // stretch
@@ -87,12 +87,12 @@ LogBrowser::LogBrowser(QWidget *parent)
 
     // Debug logging
     _logDebugCheckBox = new QCheckBox(tr("&Capture debug messages") + " ");
-    connect(_logDebugCheckBox, SIGNAL(stateChanged(int)), SLOT(slotDebugCheckStateChanged(int)));
+    connect(_logDebugCheckBox, &QCheckBox::stateChanged, this, &LogBrowser::slotDebugCheckStateChanged);
     toolLayout->addWidget(_logDebugCheckBox);
 
     QDialogButtonBox *btnbox = new QDialogButtonBox;
     QPushButton *closeBtn = btnbox->addButton(QDialogButtonBox::Close);
-    connect(closeBtn, SIGNAL(clicked()), this, SLOT(close()));
+    connect(closeBtn, &QAbstractButton::clicked, this, &QWidget::close);
 
     mainLayout->addWidget(btnbox);
 
@@ -101,14 +101,14 @@ LogBrowser::LogBrowser(QWidget *parent)
     _clearBtn->setText(tr("Clear"));
     _clearBtn->setToolTip(tr("Clear the log display."));
     btnbox->addButton(_clearBtn, QDialogButtonBox::ActionRole);
-    connect(_clearBtn, SIGNAL(clicked()), this, SLOT(slotClearLog()));
+    connect(_clearBtn, &QAbstractButton::clicked, this, &LogBrowser::slotClearLog);
 
     // save Button
     _saveBtn = new QPushButton;
     _saveBtn->setText(tr("S&ave"));
     _saveBtn->setToolTip(tr("Save the log file to a file on disk for debugging."));
     btnbox->addButton(_saveBtn, QDialogButtonBox::ActionRole);
-    connect(_saveBtn, SIGNAL(clicked()), this, SLOT(slotSave()));
+    connect(_saveBtn, &QAbstractButton::clicked, this, &LogBrowser::slotSave);
 
     setLayout(mainLayout);
 
@@ -116,11 +116,11 @@ LogBrowser::LogBrowser(QWidget *parent)
 
     Logger::instance()->setLogWindowActivated(true);
     // Direct connection for log coming from this thread, and queued for the one in a different thread
-    connect(Logger::instance(), SIGNAL(logWindowLog(QString)), this, SLOT(slotNewLog(QString)), Qt::AutoConnection);
+    connect(Logger::instance(), &Logger::logWindowLog, this, &LogBrowser::slotNewLog, Qt::AutoConnection);
 
     QAction *showLogWindow = new QAction(this);
     showLogWindow->setShortcut(QKeySequence("F12"));
-    connect(showLogWindow, SIGNAL(triggered()), SLOT(close()));
+    connect(showLogWindow, &QAction::triggered, this, &QWidget::close);
     addAction(showLogWindow);
 
     ConfigFile cfg;

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -57,8 +57,8 @@ NetworkSettings::NetworkSettings(QWidget *parent)
     loadBWLimitSettings();
 
     // proxy
-    connect(_ui->typeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(saveProxySettings()));
-    connect(_ui->proxyButtonGroup, SIGNAL(buttonClicked(int)), SLOT(saveProxySettings()));
+    connect(_ui->typeComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &NetworkSettings::saveProxySettings);
+    connect(_ui->proxyButtonGroup, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked), this, &NetworkSettings::saveProxySettings);
     connect(_ui->hostLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
     connect(_ui->userLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
     connect(_ui->passwordLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
@@ -71,8 +71,8 @@ NetworkSettings::NetworkSettings(QWidget *parent)
     connect(_ui->downloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
     connect(_ui->noDownloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
     connect(_ui->autoDownloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
-    connect(_ui->downloadSpinBox, SIGNAL(valueChanged(int)), SLOT(saveBWLimitSettings()));
-    connect(_ui->uploadSpinBox, SIGNAL(valueChanged(int)), SLOT(saveBWLimitSettings()));
+    connect(_ui->downloadSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->uploadSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &NetworkSettings::saveBWLimitSettings);
 }
 
 NetworkSettings::~NetworkSettings()

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -45,13 +45,13 @@ NetworkSettings::NetworkSettings(QWidget *parent)
     _ui->userLineEdit->setEnabled(true);
     _ui->passwordLineEdit->setEnabled(true);
     _ui->authWidgets->setEnabled(_ui->authRequiredcheckBox->isChecked());
-    connect(_ui->authRequiredcheckBox, SIGNAL(toggled(bool)),
-        _ui->authWidgets, SLOT(setEnabled(bool)));
+    connect(_ui->authRequiredcheckBox, &QAbstractButton::toggled,
+        _ui->authWidgets, &QWidget::setEnabled);
 
-    connect(_ui->manualProxyRadioButton, SIGNAL(toggled(bool)),
-        _ui->manualSettings, SLOT(setEnabled(bool)));
-    connect(_ui->manualProxyRadioButton, SIGNAL(toggled(bool)),
-        _ui->typeComboBox, SLOT(setEnabled(bool)));
+    connect(_ui->manualProxyRadioButton, &QAbstractButton::toggled,
+        _ui->manualSettings, &QWidget::setEnabled);
+    connect(_ui->manualProxyRadioButton, &QAbstractButton::toggled,
+        _ui->typeComboBox, &QWidget::setEnabled);
 
     loadProxySettings();
     loadBWLimitSettings();
@@ -59,18 +59,18 @@ NetworkSettings::NetworkSettings(QWidget *parent)
     // proxy
     connect(_ui->typeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(saveProxySettings()));
     connect(_ui->proxyButtonGroup, SIGNAL(buttonClicked(int)), SLOT(saveProxySettings()));
-    connect(_ui->hostLineEdit, SIGNAL(editingFinished()), SLOT(saveProxySettings()));
-    connect(_ui->userLineEdit, SIGNAL(editingFinished()), SLOT(saveProxySettings()));
-    connect(_ui->passwordLineEdit, SIGNAL(editingFinished()), SLOT(saveProxySettings()));
-    connect(_ui->portSpinBox, SIGNAL(editingFinished()), SLOT(saveProxySettings()));
-    connect(_ui->authRequiredcheckBox, SIGNAL(toggled(bool)), SLOT(saveProxySettings()));
+    connect(_ui->hostLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
+    connect(_ui->userLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
+    connect(_ui->passwordLineEdit, &QLineEdit::editingFinished, this, &NetworkSettings::saveProxySettings);
+    connect(_ui->portSpinBox, &QAbstractSpinBox::editingFinished, this, &NetworkSettings::saveProxySettings);
+    connect(_ui->authRequiredcheckBox, &QAbstractButton::toggled, this, &NetworkSettings::saveProxySettings);
 
-    connect(_ui->uploadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
-    connect(_ui->noUploadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
-    connect(_ui->autoUploadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
-    connect(_ui->downloadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
-    connect(_ui->noDownloadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
-    connect(_ui->autoDownloadLimitRadioButton, SIGNAL(clicked()), SLOT(saveBWLimitSettings()));
+    connect(_ui->uploadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->noUploadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->autoUploadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->downloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->noDownloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
+    connect(_ui->autoDownloadLimitRadioButton, &QAbstractButton::clicked, this, &NetworkSettings::saveBWLimitSettings);
     connect(_ui->downloadSpinBox, SIGNAL(valueChanged(int)), SLOT(saveBWLimitSettings()));
     connect(_ui->uploadSpinBox, SIGNAL(valueChanged(int)), SLOT(saveBWLimitSettings()));
 }

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -66,13 +66,13 @@ void NotificationWidget::setActivity(const Activity &activity)
         // in case there is no action defined, do a close button.
         QPushButton *b = _ui._buttonBox->addButton(QDialogButtonBox::Close);
         b->setDefault(true);
-        connect(b, SIGNAL(clicked()), this, SLOT(slotButtonClicked()));
+        connect(b, &QAbstractButton::clicked, this, &NotificationWidget::slotButtonClicked);
         _buttons.append(b);
     } else {
         foreach (auto link, activity._links) {
             QPushButton *b = _ui._buttonBox->addButton(link._label, QDialogButtonBox::AcceptRole);
             b->setDefault(link._isPrimary);
-            connect(b, SIGNAL(clicked()), this, SLOT(slotButtonClicked()));
+            connect(b, &QAbstractButton::clicked, this, &NotificationWidget::slotButtonClicked);
             _buttons.append(b);
         }
     }

--- a/src/gui/ocsshareejob.cpp
+++ b/src/gui/ocsshareejob.cpp
@@ -20,7 +20,7 @@ OcsShareeJob::OcsShareeJob(AccountPtr account)
     : OcsJob(account)
 {
     setPath("ocs/v1.php/apps/files_sharing/api/v1/sharees");
-    connect(this, SIGNAL(jobFinished(QJsonDocument)), SLOT(jobDone(QJsonDocument)));
+    connect(this, &OcsJob::jobFinished, this, &OcsShareeJob::jobDone);
 }
 
 void OcsShareeJob::getSharees(const QString &search,

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -25,7 +25,7 @@ OcsShareJob::OcsShareJob(AccountPtr account)
     : OcsJob(account)
 {
     setPath("ocs/v1.php/apps/files_sharing/api/v1/shares");
-    connect(this, SIGNAL(jobFinished(QJsonDocument)), this, SLOT(jobDone(QJsonDocument)));
+    connect(this, &OcsJob::jobFinished, this, &OcsShareJob::jobDone);
 }
 
 void OcsShareJob::getShares(const QString &path)

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -70,8 +70,8 @@ ownCloudGui::ownCloudGui(Application *parent)
     // for the beginning, set the offline icon until the account was verified
     _tray->setIcon(Theme::instance()->folderOfflineIcon(/*systray?*/ true, /*currently visible?*/ false));
 
-    connect(_tray.data(), SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
-        SLOT(slotTrayClicked(QSystemTrayIcon::ActivationReason)));
+    connect(_tray.data(), &QSystemTrayIcon::activated,
+        this, &ownCloudGui::slotTrayClicked);
 
     setupActions();
     setupContextMenu();
@@ -79,24 +79,24 @@ ownCloudGui::ownCloudGui(Application *parent)
     _tray->show();
 
     ProgressDispatcher *pd = ProgressDispatcher::instance();
-    connect(pd, SIGNAL(progressInfo(QString, ProgressInfo)), this,
-        SLOT(slotUpdateProgress(QString, ProgressInfo)));
+    connect(pd, &ProgressDispatcher::progressInfo, this,
+        &ownCloudGui::slotUpdateProgress);
 
     FolderMan *folderMan = FolderMan::instance();
-    connect(folderMan, SIGNAL(folderSyncStateChange(Folder *)),
-        this, SLOT(slotSyncStateChange(Folder *)));
+    connect(folderMan, &FolderMan::folderSyncStateChange,
+        this, &ownCloudGui::slotSyncStateChange);
 
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState *)),
-        SLOT(updateContextMenuNeeded()));
-    connect(AccountManager::instance(), SIGNAL(accountRemoved(AccountState *)),
-        SLOT(updateContextMenuNeeded()));
+    connect(AccountManager::instance(), &AccountManager::accountAdded,
+        this, &ownCloudGui::updateContextMenuNeeded);
+    connect(AccountManager::instance(), &AccountManager::accountRemoved,
+        this, &ownCloudGui::updateContextMenuNeeded);
 
-    connect(Logger::instance(), SIGNAL(guiLog(QString, QString)),
-        SLOT(slotShowTrayMessage(QString, QString)));
-    connect(Logger::instance(), SIGNAL(optionalGuiLog(QString, QString)),
-        SLOT(slotShowOptionalTrayMessage(QString, QString)));
-    connect(Logger::instance(), SIGNAL(guiMessage(QString, QString)),
-        SLOT(slotShowGuiMessage(QString, QString)));
+    connect(Logger::instance(), &Logger::guiLog,
+        this, &ownCloudGui::slotShowTrayMessage);
+    connect(Logger::instance(), &Logger::optionalGuiLog,
+        this, &ownCloudGui::slotShowOptionalTrayMessage);
+    connect(Logger::instance(), &Logger::guiMessage,
+        this, &ownCloudGui::slotShowGuiMessage);
 }
 
 // This should rather be in application.... or rather in ConfigFile?
@@ -302,7 +302,7 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
     }
     auto actionOpenoC = menu->addAction(browserOpen);
     actionOpenoC->setProperty(propertyAccountC, QVariant::fromValue(accountState->account()));
-    QObject::connect(actionOpenoC, SIGNAL(triggered(bool)), SLOT(slotOpenOwnCloud()));
+    QObject::connect(actionOpenoC, &QAction::triggered, this, &ownCloudGui::slotOpenOwnCloud);
 
     FolderMan *folderMan = FolderMan::instance();
     bool firstFolder = true;
@@ -336,22 +336,22 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
         if (onePaused) {
             QAction *enable = menu->addAction(tr("Unpause all folders"));
             enable->setProperty(propertyAccountC, QVariant::fromValue(accountState));
-            connect(enable, SIGNAL(triggered(bool)), SLOT(slotUnpauseAllFolders()));
+            connect(enable, &QAction::triggered, this, &ownCloudGui::slotUnpauseAllFolders);
         }
         if (!allPaused) {
             QAction *enable = menu->addAction(tr("Pause all folders"));
             enable->setProperty(propertyAccountC, QVariant::fromValue(accountState));
-            connect(enable, SIGNAL(triggered(bool)), SLOT(slotPauseAllFolders()));
+            connect(enable, &QAction::triggered, this, &ownCloudGui::slotPauseAllFolders);
         }
 
         if (accountState->isSignedOut()) {
             QAction *signin = menu->addAction(tr("Log in..."));
             signin->setProperty(propertyAccountC, QVariant::fromValue(accountState));
-            connect(signin, SIGNAL(triggered()), this, SLOT(slotLogin()));
+            connect(signin, &QAction::triggered, this, &ownCloudGui::slotLogin);
         } else {
             QAction *signout = menu->addAction(tr("Log out"));
             signout->setProperty(propertyAccountC, QVariant::fromValue(accountState));
-            connect(signout, SIGNAL(triggered()), this, SLOT(slotLogout()));
+            connect(signout, &QAction::triggered, this, &ownCloudGui::slotLogout);
         }
     }
 }
@@ -462,7 +462,7 @@ void ownCloudGui::setupContextMenu()
     // When the qdbusmenuWorkaround is necessary, we can't do on-demand updates
     // because the workaround is to hide and show the tray icon.
     if (_qdbusmenuWorkaround) {
-        connect(&_workaroundBatchTrayUpdate, SIGNAL(timeout()), SLOT(updateContextMenu()));
+        connect(&_workaroundBatchTrayUpdate, &QTimer::timeout, this, &ownCloudGui::updateContextMenu);
         _workaroundBatchTrayUpdate.setInterval(30 * 1000);
         _workaroundBatchTrayUpdate.setSingleShot(true);
     } else {
@@ -473,7 +473,7 @@ void ownCloudGui::setupContextMenu()
         connect(_contextMenu.data(), SIGNAL(aboutToShow()), SLOT(slotContextMenuAboutToShow()));
         connect(_contextMenu.data(), SIGNAL(aboutToHide()), SLOT(slotContextMenuAboutToHide()));
 #else
-        connect(_contextMenu.data(), SIGNAL(aboutToShow()), SLOT(updateContextMenu()));
+        connect(_contextMenu.data(), &QMenu::aboutToShow, this, &ownCloudGui::updateContextMenu);
 #endif
     }
 
@@ -576,7 +576,7 @@ void ownCloudGui::updateContextMenu()
             text = tr("Unpause synchronization");
         }
         QAction *action = _contextMenu->addAction(text);
-        connect(action, SIGNAL(triggered(bool)), SLOT(slotUnpauseAllFolders()));
+        connect(action, &QAction::triggered, this, &ownCloudGui::slotUnpauseAllFolders);
     }
     if (atLeastOneNotPaused) {
         QString text;
@@ -586,7 +586,7 @@ void ownCloudGui::updateContextMenu()
             text = tr("Pause synchronization");
         }
         QAction *action = _contextMenu->addAction(text);
-        connect(action, SIGNAL(triggered(bool)), SLOT(slotPauseAllFolders()));
+        connect(action, &QAction::triggered, this, &ownCloudGui::slotPauseAllFolders);
     }
     if (atLeastOneSignedIn) {
         if (accountList.count() > 1) {
@@ -686,18 +686,18 @@ void ownCloudGui::setupActions()
     _actionRecent = new QAction(tr("Details..."), this);
     _actionRecent->setEnabled(true);
 
-    QObject::connect(_actionRecent, SIGNAL(triggered(bool)), SLOT(slotShowSyncProtocol()));
-    QObject::connect(_actionSettings, SIGNAL(triggered(bool)), SLOT(slotShowSettings()));
-    QObject::connect(_actionNewAccountWizard, SIGNAL(triggered(bool)), SLOT(slotNewAccountWizard()));
+    QObject::connect(_actionRecent, &QAction::triggered, this, &ownCloudGui::slotShowSyncProtocol);
+    QObject::connect(_actionSettings, &QAction::triggered, this, &ownCloudGui::slotShowSettings);
+    QObject::connect(_actionNewAccountWizard, &QAction::triggered, this, &ownCloudGui::slotNewAccountWizard);
     _actionHelp = new QAction(tr("Help"), this);
-    QObject::connect(_actionHelp, SIGNAL(triggered(bool)), SLOT(slotHelp()));
+    QObject::connect(_actionHelp, &QAction::triggered, this, &ownCloudGui::slotHelp);
     _actionQuit = new QAction(tr("Quit %1").arg(Theme::instance()->appNameGUI()), this);
     QObject::connect(_actionQuit, SIGNAL(triggered(bool)), _app, SLOT(quit()));
 
     _actionLogin = new QAction(tr("Log in..."), this);
-    connect(_actionLogin, SIGNAL(triggered()), this, SLOT(slotLogin()));
+    connect(_actionLogin, &QAction::triggered, this, &ownCloudGui::slotLogin);
     _actionLogout = new QAction(tr("Log out"), this);
-    connect(_actionLogout, SIGNAL(triggered()), this, SLOT(slotLogout()));
+    connect(_actionLogout, &QAction::triggered, this, &ownCloudGui::slotLogout);
 
     if (_app->debugMode()) {
         _actionCrash = new QAction(tr("Crash now", "Only shows in debug mode to allow testing the crash handler"), this);
@@ -742,7 +742,7 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const ProgressInfo &
                                        .arg(progress._currentDiscoveredFolder));
         }
     } else if (progress.status() == ProgressInfo::Done) {
-        QTimer::singleShot(2000, this, SLOT(slotDisplayIdle()));
+        QTimer::singleShot(2000, this, &ownCloudGui::slotDisplayIdle);
     }
     if (progress.status() != ProgressInfo::Propagation) {
         return;
@@ -1036,7 +1036,7 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         w->setAttribute(Qt::WA_DeleteOnClose, true);
 
         _shareDialogs[localPath] = w;
-        connect(w, SIGNAL(destroyed(QObject *)), SLOT(slotRemoveDestroyedShareDialogs()));
+        connect(w, &QObject::destroyed, this, &ownCloudGui::slotRemoveDestroyedShareDialogs);
     }
     raiseDialog(w);
 }

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -701,7 +701,7 @@ void ownCloudGui::setupActions()
 
     if (_app->debugMode()) {
         _actionCrash = new QAction(tr("Crash now", "Only shows in debug mode to allow testing the crash handler"), this);
-        connect(_actionCrash, SIGNAL(triggered()), _app, SLOT(slotCrash()));
+        connect(_actionCrash, &QAction::triggered, _app, &Application::slotCrash);
     } else {
         _actionCrash = 0;
     }

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -23,7 +23,6 @@
 #include <QPointer>
 #include <QAction>
 #include <QMenu>
-#include <QSignalMapper>
 #include <QSize>
 #include <QTimer>
 
@@ -144,10 +143,6 @@ private:
     QAction *_actionCrash;
 
     QList<QAction *> _recentItemsActions;
-
-    QSignalMapper *_folderOpenActionMapper;
-    QSignalMapper *_recentItemsMapper;
-
     Application *_app;
 };
 

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -38,10 +38,10 @@ ProtocolWidget::ProtocolWidget(QWidget *parent)
 {
     _ui->setupUi(this);
 
-    connect(ProgressDispatcher::instance(), SIGNAL(itemCompleted(QString, SyncFileItemPtr)),
-        this, SLOT(slotItemCompleted(QString, SyncFileItemPtr)));
+    connect(ProgressDispatcher::instance(), &ProgressDispatcher::itemCompleted,
+        this, &ProtocolWidget::slotItemCompleted);
 
-    connect(_ui->_treeWidget, SIGNAL(itemActivated(QTreeWidgetItem *, int)), SLOT(slotOpenFile(QTreeWidgetItem *, int)));
+    connect(_ui->_treeWidget, &QTreeWidget::itemActivated, this, &ProtocolWidget::slotOpenFile);
 
     // Adjust copyToClipboard() when making changes here!
     QStringList header;
@@ -74,7 +74,7 @@ ProtocolWidget::ProtocolWidget(QWidget *parent)
     QPushButton *copyBtn = _ui->_dialogButtonBox->addButton(tr("Copy"), QDialogButtonBox::ActionRole);
     copyBtn->setToolTip(tr("Copy the activity list to the clipboard."));
     copyBtn->setEnabled(true);
-    connect(copyBtn, SIGNAL(clicked()), SIGNAL(copyToClipboard()));
+    connect(copyBtn, &QAbstractButton::clicked, this, &ProtocolWidget::copyToClipboard);
 }
 
 ProtocolWidget::~ProtocolWidget()

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -131,8 +131,8 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
     sending_qnam = qnam_alive.data();
     if (sending_qnam) {
         _gaveCredentialsTo.insert(sending_qnam);
-        connect(sending_qnam, SIGNAL(destroyed(QObject *)),
-            SLOT(slotSenderDestroyed(QObject *)));
+        connect(sending_qnam, &QObject::destroyed,
+            this, &ProxyAuthHandler::slotSenderDestroyed);
     }
 }
 
@@ -194,8 +194,8 @@ bool ProxyAuthHandler::getCredsFromKeychain()
         _readPasswordJob->setInsecureFallback(false);
         _readPasswordJob->setKey(keychainPasswordKey());
         _readPasswordJob->setAutoDelete(false);
-        connect(_readPasswordJob.data(), SIGNAL(finished(QKeychain::Job *)),
-            SLOT(slotKeychainJobDone()));
+        connect(_readPasswordJob.data(), &QKeychain::Job::finished,
+            this, &ProxyAuthHandler::slotKeychainJobDone);
         _keychainJobRunning = true;
         _readPasswordJob->start();
     }
@@ -242,7 +242,7 @@ void ProxyAuthHandler::storeCredsInKeychain()
     job->setKey(keychainPasswordKey());
     job->setTextData(_password);
     job->setAutoDelete(false);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotKeychainJobDone()));
+    connect(job, &QKeychain::Job::finished, this, &ProxyAuthHandler::slotKeychainJobDone);
     _keychainJobRunning = true;
     job->start();
 

--- a/src/gui/quotainfo.cpp
+++ b/src/gui/quotainfo.cpp
@@ -36,9 +36,9 @@ QuotaInfo::QuotaInfo(AccountState *accountState, QObject *parent)
     , _lastQuotaUsedBytes(0)
     , _active(false)
 {
-    connect(accountState, SIGNAL(stateChanged(int)),
-        SLOT(slotAccountStateChanged()));
-    connect(&_jobRestartTimer, SIGNAL(timeout()), SLOT(slotCheckQuota()));
+    connect(accountState, &AccountState::stateChanged,
+        this, &QuotaInfo::slotAccountStateChanged);
+    connect(&_jobRestartTimer, &QTimer::timeout, this, &QuotaInfo::slotCheckQuota);
     _jobRestartTimer.setSingleShot(true);
 }
 
@@ -101,8 +101,8 @@ void QuotaInfo::slotCheckQuota()
     _job = new PropfindJob(account, quotaBaseFolder(), this);
     _job->setProperties(QList<QByteArray>() << "quota-available-bytes"
                                             << "quota-used-bytes");
-    connect(_job, SIGNAL(result(QVariantMap)), SLOT(slotUpdateLastQuota(QVariantMap)));
-    connect(_job, SIGNAL(networkError(QNetworkReply *)), SLOT(slotRequestFailed()));
+    connect(_job.data(), &PropfindJob::result, this, &QuotaInfo::slotUpdateLastQuota);
+    connect(_job.data(), &AbstractNetworkJob::networkError, this, &QuotaInfo::slotRequestFailed);
     _job->start();
 }
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -83,10 +83,10 @@ SelectiveSyncWidget::SelectiveSyncWidget(AccountPtr account, QWidget *parent)
 
     layout->addWidget(_folderTree);
 
-    connect(_folderTree, SIGNAL(itemExpanded(QTreeWidgetItem *)),
-        SLOT(slotItemExpanded(QTreeWidgetItem *)));
-    connect(_folderTree, SIGNAL(itemChanged(QTreeWidgetItem *, int)),
-        SLOT(slotItemChanged(QTreeWidgetItem *, int)));
+    connect(_folderTree, &QTreeWidget::itemExpanded,
+        this, &SelectiveSyncWidget::slotItemExpanded);
+    connect(_folderTree, &QTreeWidget::itemChanged,
+        this, &SelectiveSyncWidget::slotItemChanged);
     _folderTree->setSortingEnabled(true);
     _folderTree->sortByColumn(0, Qt::AscendingOrder);
     _folderTree->setColumnCount(2);
@@ -107,10 +107,10 @@ void SelectiveSyncWidget::refreshFolders()
     LsColJob *job = new LsColJob(_account, _folderPath, this);
     job->setProperties(QList<QByteArray>() << "resourcetype"
                                            << "http://owncloud.org/ns:size");
-    connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
-        this, SLOT(slotUpdateDirectories(QStringList)));
-    connect(job, SIGNAL(finishedWithError(QNetworkReply *)),
-        this, SLOT(slotLscolFinishedWithError(QNetworkReply *)));
+    connect(job, &LsColJob::directoryListingSubfolders,
+        this, &SelectiveSyncWidget::slotUpdateDirectories);
+    connect(job, &LsColJob::finishedWithError,
+        this, &SelectiveSyncWidget::slotLscolFinishedWithError);
     job->start();
     _folderTree->clear();
     _loading->show();
@@ -291,8 +291,8 @@ void SelectiveSyncWidget::slotItemExpanded(QTreeWidgetItem *item)
     LsColJob *job = new LsColJob(_account, prefix + dir, this);
     job->setProperties(QList<QByteArray>() << "resourcetype"
                                            << "http://owncloud.org/ns:size");
-    connect(job, SIGNAL(directoryListingSubfolders(QStringList)),
-        SLOT(slotUpdateDirectories(QStringList)));
+    connect(job, &LsColJob::directoryListingSubfolders,
+        this, &SelectiveSyncWidget::slotUpdateDirectories);
     job->start();
 }
 
@@ -440,7 +440,7 @@ SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, Folder *folder, QWi
         _okButton->setEnabled(false);
     }
     // Make sure we don't get crashes if the folder is destroyed while we are still open
-    connect(_folder, SIGNAL(destroyed(QObject *)), this, SLOT(deleteLater()));
+    connect(_folder, &QObject::destroyed, this, &QObject::deleteLater);
 }
 
 SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, const QString &folder,
@@ -463,7 +463,7 @@ void SelectiveSyncDialog::init(const AccountPtr &account)
     connect(_okButton, SIGNAL(clicked()), this, SLOT(accept()));
     QPushButton *button;
     button = buttonBox->addButton(QDialogButtonBox::Cancel);
-    connect(button, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(button, &QAbstractButton::clicked, this, &QDialog::reject);
     layout->addWidget(buttonBox);
 }
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -460,7 +460,7 @@ void SelectiveSyncDialog::init(const AccountPtr &account)
     layout->addWidget(_selectiveSync);
     QDialogButtonBox *buttonBox = new QDialogButtonBox(Qt::Horizontal);
     _okButton = buttonBox->addButton(QDialogButtonBox::Ok);
-    connect(_okButton, SIGNAL(clicked()), this, SLOT(accept()));
+    connect(_okButton, &QPushButton::clicked, this, &SelectiveSyncDialog::accept);
     QPushButton *button;
     button = buttonBox->addButton(QDialogButtonBox::Cancel);
     connect(button, &QAbstractButton::clicked, this, &QDialog::reject);

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -48,8 +48,8 @@ void ServerNotificationHandler::slotFetchNotifications(AccountState *ptr)
 
     // if the previous notification job has finished, start next.
     _notificationJob = new JsonApiJob(ptr->account(), QLatin1String("ocs/v2.php/apps/notifications/api/v1/notifications"), this);
-    QObject::connect(_notificationJob.data(), SIGNAL(jsonReceived(QJsonDocument, int)),
-        this, SLOT(slotNotificationsReceived(QJsonDocument, int)));
+    QObject::connect(_notificationJob.data(), &JsonApiJob::jsonReceived,
+        this, &ServerNotificationHandler::slotNotificationsReceived);
     _notificationJob->setProperty("AccountStatePtr", QVariant::fromValue<AccountState *>(ptr));
 
     _notificationJob->start();

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -109,8 +109,8 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _toolBar->addAction(_activityAction);
     _activitySettings = new ActivitySettings;
     _ui->stack->addWidget(_activitySettings);
-    connect(_activitySettings, SIGNAL(guiLog(QString, QString)), _gui,
-        SLOT(slotShowOptionalTrayMessage(QString, QString)));
+    connect(_activitySettings, &ActivitySettings::guiLog, _gui,
+        &ownCloudGui::slotShowOptionalTrayMessage);
     _activitySettings->setNotificationRefreshInterval(cfg.notificationRefreshInterval());
 
     QAction *generalAction = createColorAwareAction(QLatin1String(":/client/resources/settings.png"), tr("General"));
@@ -129,24 +129,24 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 
-    connect(_actionGroup, SIGNAL(triggered(QAction *)), SLOT(slotSwitchPage(QAction *)));
+    connect(_actionGroup, &QActionGroup::triggered, this, &SettingsDialog::slotSwitchPage);
 
-    connect(AccountManager::instance(), SIGNAL(accountAdded(AccountState *)),
-        this, SLOT(accountAdded(AccountState *)));
-    connect(AccountManager::instance(), SIGNAL(accountRemoved(AccountState *)),
-        this, SLOT(accountRemoved(AccountState *)));
+    connect(AccountManager::instance(), &AccountManager::accountAdded,
+        this, &SettingsDialog::accountAdded);
+    connect(AccountManager::instance(), &AccountManager::accountRemoved,
+        this, &SettingsDialog::accountRemoved);
     foreach (auto ai, AccountManager::instance()->accounts()) {
         accountAdded(ai.data());
     }
 
-    QTimer::singleShot(1, this, SLOT(showFirstPage()));
+    QTimer::singleShot(1, this, &SettingsDialog::showFirstPage);
 
     QPushButton *closeButton = _ui->buttonBox->button(QDialogButtonBox::Close);
     connect(closeButton, SIGNAL(clicked()), SLOT(accept()));
 
     QAction *showLogWindow = new QAction(this);
     showLogWindow->setShortcut(QKeySequence("F12"));
-    connect(showLogWindow, SIGNAL(triggered()), gui, SLOT(slotToggleLogBrowser()));
+    connect(showLogWindow, &QAction::triggered, gui, &ownCloudGui::slotToggleLogBrowser);
     addAction(showLogWindow);
 
     customizeStyle();
@@ -245,11 +245,11 @@ void SettingsDialog::accountAdded(AccountState *s)
     _actionGroupWidgets.insert(accountAction, accountSettings);
     _actionForAccount.insert(s->account().data(), accountAction);
 
-    connect(accountSettings, SIGNAL(folderChanged()), _gui, SLOT(slotFoldersChanged()));
-    connect(accountSettings, SIGNAL(openFolderAlias(const QString &)),
-        _gui, SLOT(slotFolderOpenAction(QString)));
-    connect(accountSettings, SIGNAL(showIssuesList(QString)), SLOT(showIssuesList(QString)));
-    connect(s->account().data(), SIGNAL(accountChangedAvatar()), SLOT(slotAccountAvatarChanged()));
+    connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotFoldersChanged);
+    connect(accountSettings, &AccountSettings::openFolderAlias,
+        _gui, &ownCloudGui::slotFolderOpenAction);
+    connect(accountSettings, &AccountSettings::showIssuesList, this, &SettingsDialog::showIssuesList);
+    connect(s->account().data(), &Account::accountChangedAvatar, this, &SettingsDialog::slotAccountAvatarChanged);
 
     slotRefreshActivity(s);
 }

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -93,7 +93,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     // People perceive this as a Window, so also make Ctrl+W work
     QAction *closeWindowAction = new QAction(this);
     closeWindowAction->setShortcut(QKeySequence("Ctrl+W"));
-    connect(closeWindowAction, SIGNAL(triggered()), SLOT(accept()));
+    connect(closeWindowAction, &QAction::triggered, this, &SettingsDialog::accept);
     addAction(closeWindowAction);
 
     setObjectName("Settings"); // required as group for saveGeometry call

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -58,10 +58,10 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     _ui->setupUi(this);
 
     QPushButton *closeButton = _ui->buttonBox->button(QDialogButtonBox::Close);
-    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
+    connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
 
     // We want to act on account state changes
-    connect(_accountState, SIGNAL(stateChanged(int)), SLOT(slotAccountStateChanged(int)));
+    connect(_accountState.data(), &AccountState::stateChanged, this, &ShareDialog::slotAccountStateChanged);
 
     // Because people press enter in the dialog and we don't want to close for that
     closeButton->setDefault(false);
@@ -118,7 +118,7 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
 
     if (QFileInfo(_localPath).isFile()) {
         ThumbnailJob *job = new ThumbnailJob(_sharePath, _accountState->account(), this);
-        connect(job, SIGNAL(jobFinished(int, QByteArray)), SLOT(slotThumbnailFetched(int, QByteArray)));
+        connect(job, &ThumbnailJob::jobFinished, this, &ShareDialog::slotThumbnailFetched);
         job->start();
     }
 
@@ -135,8 +135,8 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
         << "http://open-collaboration-services.org/ns:share-permissions"
         << "http://owncloud.org/ns:privatelink");
     job->setTimeout(10 * 1000);
-    connect(job, SIGNAL(result(QVariantMap)), SLOT(slotPropfindReceived(QVariantMap)));
-    connect(job, SIGNAL(finishedWithError(QNetworkReply *)), SLOT(slotPropfindError()));
+    connect(job, &PropfindJob::result, this, &ShareDialog::slotPropfindReceived);
+    connect(job, &PropfindJob::finishedWithError, this, &ShareDialog::slotPropfindError);
     job->start();
 }
 

--- a/src/gui/sharee.cpp
+++ b/src/gui/sharee.cpp
@@ -72,8 +72,8 @@ void ShareeModel::fetch(const QString &search, const ShareeSet &blacklist)
     _search = search;
     _shareeBlacklist = blacklist;
     OcsShareeJob *job = new OcsShareeJob(_account);
-    connect(job, SIGNAL(shareeJobFinished(QJsonDocument)), SLOT(shareesFetched(QJsonDocument)));
-    connect(job, SIGNAL(ocsError(int, QString)), SIGNAL(displayErrorMessage(int, QString)));
+    connect(job, &OcsShareeJob::shareeJobFinished, this, &ShareeModel::shareesFetched);
+    connect(job, &OcsJob::ocsError, this, &ShareeModel::displayErrorMessage);
     job->getSharees(_search, _type, 1, 50);
 }
 

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -170,7 +170,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     if (sharingPossible) {
         _manager = new ShareManager(_account, this);
         connect(_manager, &ShareManager::sharesFetched, this, &ShareLinkWidget::slotSharesFetched);
-        connect(_manager, SIGNAL(linkShareCreated(QSharedPointer<LinkShare>)), SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
+        connect(_manager, &ShareManager::linkShareCreated, this, &ShareLinkWidget::slotCreateShareFetched);
         connect(_manager, &ShareManager::linkShareRequiresPassword, this, &ShareLinkWidget::slotCreateShareRequiresPassword);
         connect(_manager, &ShareManager::serverError, this, &ShareLinkWidget::slotServerError);
     }
@@ -436,7 +436,7 @@ void ShareLinkWidget::slotDeleteShareFetched()
     getShares();
 }
 
-void ShareLinkWidget::slotCreateShareFetched(const QSharedPointer<LinkShare> share)
+void ShareLinkWidget::slotCreateShareFetched(const QSharedPointer<LinkShare> &share)
 {
     _pi_create->stopAnimation();
     _pi_password->stopAnimation();

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -71,18 +71,18 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     _ui->layout_editing->addWidget(_pi_editing, 0, 2);
     _ui->horizontalLayout_expire->insertWidget(_ui->horizontalLayout_expire->count() - 1, _pi_date);
 
-    connect(_ui->nameLineEdit, SIGNAL(returnPressed()), SLOT(slotShareNameEntered()));
-    connect(_ui->createShareButton, SIGNAL(clicked(bool)), SLOT(slotShareNameEntered()));
-    connect(_ui->linkShares, SIGNAL(itemSelectionChanged()), SLOT(slotShareSelectionChanged()));
-    connect(_ui->linkShares, SIGNAL(itemChanged(QTableWidgetItem *)), SLOT(slotNameEdited(QTableWidgetItem *)));
-    connect(_ui->checkBox_password, SIGNAL(clicked()), this, SLOT(slotCheckBoxPasswordClicked()));
-    connect(_ui->lineEdit_password, SIGNAL(returnPressed()), this, SLOT(slotPasswordReturnPressed()));
-    connect(_ui->lineEdit_password, SIGNAL(textChanged(QString)), this, SLOT(slotPasswordChanged(QString)));
-    connect(_ui->pushButton_setPassword, SIGNAL(clicked(bool)), SLOT(slotPasswordReturnPressed()));
-    connect(_ui->checkBox_expire, SIGNAL(clicked()), this, SLOT(slotCheckBoxExpireClicked()));
-    connect(_ui->calendar, SIGNAL(dateChanged(QDate)), SLOT(slotExpireDateChanged(QDate)));
-    connect(_ui->checkBox_editing, SIGNAL(clicked()), this, SLOT(slotPermissionsCheckboxClicked()));
-    connect(_ui->checkBox_fileListing, SIGNAL(clicked(bool)), this, SLOT(slotPermissionsCheckboxClicked()));
+    connect(_ui->nameLineEdit, &QLineEdit::returnPressed, this, &ShareLinkWidget::slotShareNameEntered);
+    connect(_ui->createShareButton, &QAbstractButton::clicked, this, &ShareLinkWidget::slotShareNameEntered);
+    connect(_ui->linkShares, &QTableWidget::itemSelectionChanged, this, &ShareLinkWidget::slotShareSelectionChanged);
+    connect(_ui->linkShares, &QTableWidget::itemChanged, this, &ShareLinkWidget::slotNameEdited);
+    connect(_ui->checkBox_password, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCheckBoxPasswordClicked);
+    connect(_ui->lineEdit_password, &QLineEdit::returnPressed, this, &ShareLinkWidget::slotPasswordReturnPressed);
+    connect(_ui->lineEdit_password, &QLineEdit::textChanged, this, &ShareLinkWidget::slotPasswordChanged);
+    connect(_ui->pushButton_setPassword, &QAbstractButton::clicked, this, &ShareLinkWidget::slotPasswordReturnPressed);
+    connect(_ui->checkBox_expire, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCheckBoxExpireClicked);
+    connect(_ui->calendar, &QDateTimeEdit::dateChanged, this, &ShareLinkWidget::slotExpireDateChanged);
+    connect(_ui->checkBox_editing, &QAbstractButton::clicked, this, &ShareLinkWidget::slotPermissionsCheckboxClicked);
+    connect(_ui->checkBox_fileListing, &QAbstractButton::clicked, this, &ShareLinkWidget::slotPermissionsCheckboxClicked);
 
     _ui->errorLabel->hide();
 
@@ -156,8 +156,8 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     // Prepare sharing menu
 
     _shareLinkMenu = new QMenu(this);
-    connect(_shareLinkMenu, SIGNAL(triggered(QAction *)),
-        SLOT(slotShareLinkActionTriggered(QAction *)));
+    connect(_shareLinkMenu, &QMenu::triggered,
+        this, &ShareLinkWidget::slotShareLinkActionTriggered);
     _openLinkAction = _shareLinkMenu->addAction(tr("Open link in browser"));
     _copyLinkAction = _shareLinkMenu->addAction(tr("Copy link to clipboard"));
     _copyDirectLinkAction = _shareLinkMenu->addAction(tr("Copy link to clipboard (direct download)"));
@@ -169,10 +169,10 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
      */
     if (sharingPossible) {
         _manager = new ShareManager(_account, this);
-        connect(_manager, SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
+        connect(_manager, &ShareManager::sharesFetched, this, &ShareLinkWidget::slotSharesFetched);
         connect(_manager, SIGNAL(linkShareCreated(QSharedPointer<LinkShare>)), SLOT(slotCreateShareFetched(const QSharedPointer<LinkShare>)));
-        connect(_manager, SIGNAL(linkShareRequiresPassword(QString)), SLOT(slotCreateShareRequiresPassword(QString)));
-        connect(_manager, SIGNAL(serverError(int, QString)), SLOT(slotServerError(int, QString)));
+        connect(_manager, &ShareManager::linkShareRequiresPassword, this, &ShareLinkWidget::slotCreateShareRequiresPassword);
+        connect(_manager, &ShareManager::serverError, this, &ShareLinkWidget::slotServerError);
     }
 }
 
@@ -218,13 +218,13 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         auto linkShare = qSharedPointerDynamicCast<LinkShare>(share);
 
         // Connect all shares signals to gui slots
-        connect(share.data(), SIGNAL(serverError(int, QString)), SLOT(slotServerError(int, QString)));
-        connect(share.data(), SIGNAL(shareDeleted()), SLOT(slotDeleteShareFetched()));
+        connect(share.data(), &Share::serverError, this, &ShareLinkWidget::slotServerError);
+        connect(share.data(), &Share::shareDeleted, this, &ShareLinkWidget::slotDeleteShareFetched);
         connect(share.data(), SIGNAL(expireDateSet()), SLOT(slotExpireSet()));
         connect(share.data(), SIGNAL(publicUploadSet()), SLOT(slotPermissionsSet()));
         connect(share.data(), SIGNAL(passwordSet()), SLOT(slotPasswordSet()));
         connect(share.data(), SIGNAL(passwordSetError(int, QString)), SLOT(slotPasswordSetError(int, QString)));
-        connect(share.data(), SIGNAL(permissionsSet()), SLOT(slotPermissionsSet()));
+        connect(share.data(), &Share::permissionsSet, this, &ShareLinkWidget::slotPermissionsSet);
 
         // Build the table row
         auto row = table->rowCount();
@@ -247,13 +247,13 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         auto shareButton = new QToolButton;
         shareButton->setText("...");
         shareButton->setProperty(propertyShareC, QVariant::fromValue(linkShare));
-        connect(shareButton, SIGNAL(clicked(bool)), SLOT(slotShareLinkButtonClicked()));
+        connect(shareButton, &QAbstractButton::clicked, this, &ShareLinkWidget::slotShareLinkButtonClicked);
         table->setCellWidget(row, 1, shareButton);
 
         auto deleteButton = new QToolButton;
         deleteButton->setIcon(deleteIcon);
         deleteButton->setProperty(propertyShareC, QVariant::fromValue(linkShare));
-        connect(deleteButton, SIGNAL(clicked(bool)), SLOT(slotDeleteShareClicked()));
+        connect(deleteButton, &QAbstractButton::clicked, this, &ShareLinkWidget::slotDeleteShareClicked);
         table->setCellWidget(row, 2, deleteButton);
 
         // Reestablish the previous selection

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -74,7 +74,7 @@ private slots:
     void slotShareLinkActionTriggered(QAction *action);
 
     void slotDeleteShareFetched();
-    void slotCreateShareFetched(const QSharedPointer<LinkShare> share);
+    void slotCreateShareFetched(const QSharedPointer<LinkShare> &share);
     void slotCreateShareRequiresPassword(const QString &message);
     void slotPasswordSet();
     void slotExpireSet();

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -72,8 +72,8 @@ QSharedPointer<Sharee> Share::getShareWith() const
 void Share::setPermissions(Permissions permissions)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotPermissionsSet(QJsonDocument, QVariant)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &Share::slotPermissionsSet);
+    connect(job, &OcsJob::ocsError, this, &Share::slotOcsError);
     job->setPermissions(getId(), permissions);
 }
 
@@ -91,8 +91,8 @@ Share::Permissions Share::getPermissions() const
 void Share::deleteShare()
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotDeleted()));
-    connect(job, SIGNAL(ocsError(int, const QString &)), SLOT(slotOcsError(int, const QString &)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &Share::slotDeleted);
+    connect(job, &OcsJob::ocsError, this, &Share::slotOcsError);
     job->deleteShare(getId());
 }
 
@@ -164,8 +164,8 @@ QString LinkShare::getName() const
 void LinkShare::setName(const QString &name)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotNameSet(QJsonDocument, QVariant)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &LinkShare::slotNameSet);
+    connect(job, &OcsJob::ocsError, this, &LinkShare::slotOcsError);
     job->setName(getId(), name);
 }
 
@@ -177,8 +177,8 @@ QString LinkShare::getToken() const
 void LinkShare::setPassword(const QString &password)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotPasswordSet(QJsonDocument, QVariant)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotSetPasswordError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &LinkShare::slotPasswordSet);
+    connect(job, &OcsJob::ocsError, this, &LinkShare::slotSetPasswordError);
     job->setPassword(getId(), password);
 }
 
@@ -191,8 +191,8 @@ void LinkShare::slotPasswordSet(const QJsonDocument &, const QVariant &value)
 void LinkShare::setExpireDate(const QDate &date)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotExpireDateSet(QJsonDocument, QVariant)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &LinkShare::slotExpireDateSet);
+    connect(job, &OcsJob::ocsError, this, &LinkShare::slotOcsError);
     job->setExpireDate(getId(), date);
 }
 
@@ -234,8 +234,8 @@ void ShareManager::createLinkShare(const QString &path,
     const QString &password)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotLinkShareCreated(QJsonDocument)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &ShareManager::slotLinkShareCreated);
+    connect(job, &OcsJob::ocsError, this, &ShareManager::slotOcsError);
     job->createLinkShare(path, name, password);
 }
 
@@ -276,8 +276,8 @@ void ShareManager::createShare(const QString &path,
     continuation.permissions = permissions;
     _jobContinuation[job] = QVariant::fromValue(continuation);
 
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotCreateShare(QJsonDocument)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &ShareManager::slotCreateShare);
+    connect(job, &OcsJob::ocsError, this, &ShareManager::slotOcsError);
     job->getSharedWithMe();
 }
 
@@ -308,8 +308,8 @@ void ShareManager::slotCreateShare(const QJsonDocument &reply)
     }
 
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotShareCreated(QJsonDocument)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &ShareManager::slotShareCreated);
+    connect(job, &OcsJob::ocsError, this, &ShareManager::slotOcsError);
     job->createShare(cont.path, cont.shareType, cont.shareWith, cont.permissions);
 }
 
@@ -325,8 +325,8 @@ void ShareManager::slotShareCreated(const QJsonDocument &reply)
 void ShareManager::fetchShares(const QString &path)
 {
     OcsShareJob *job = new OcsShareJob(_account);
-    connect(job, SIGNAL(shareJobFinished(QJsonDocument, QVariant)), SLOT(slotSharesFetched(QJsonDocument)));
-    connect(job, SIGNAL(ocsError(int, QString)), SLOT(slotOcsError(int, QString)));
+    connect(job, &OcsShareJob::shareJobFinished, this, &ShareManager::slotSharesFetched);
+    connect(job, &OcsJob::ocsError, this, &ShareManager::slotOcsError);
     job->getShares(path);
 }
 

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -71,8 +71,8 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
     _completerModel = new ShareeModel(_account,
         _isFile ? QLatin1String("file") : QLatin1String("folder"),
         _completer);
-    connect(_completerModel, SIGNAL(shareesReady()), this, SLOT(slotShareesReady()));
-    connect(_completerModel, SIGNAL(displayErrorMessage(int, QString)), this, SLOT(displayError(int, QString)));
+    connect(_completerModel, &ShareeModel::shareesReady, this, &ShareUserGroupWidget::slotShareesReady);
+    connect(_completerModel, &ShareeModel::displayErrorMessage, this, &ShareUserGroupWidget::displayError);
 
     _completer->setModel(_completerModel);
     _completer->setCaseSensitivity(Qt::CaseInsensitive);
@@ -80,11 +80,11 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
     _ui->shareeLineEdit->setCompleter(_completer);
 
     _manager = new ShareManager(_account, this);
-    connect(_manager, SIGNAL(sharesFetched(QList<QSharedPointer<Share>>)), SLOT(slotSharesFetched(QList<QSharedPointer<Share>>)));
-    connect(_manager, SIGNAL(shareCreated(QSharedPointer<Share>)), SLOT(getShares()));
-    connect(_manager, SIGNAL(serverError(int, QString)), this, SLOT(displayError(int, QString)));
-    connect(_ui->shareeLineEdit, SIGNAL(returnPressed()), SLOT(slotLineEditReturn()));
-    connect(_ui->privateLinkText, SIGNAL(linkActivated(QString)), SLOT(slotPrivateLinkShare()));
+    connect(_manager, &ShareManager::sharesFetched, this, &ShareUserGroupWidget::slotSharesFetched);
+    connect(_manager, &ShareManager::shareCreated, this, &ShareUserGroupWidget::getShares);
+    connect(_manager, &ShareManager::serverError, this, &ShareUserGroupWidget::displayError);
+    connect(_ui->shareeLineEdit, &QLineEdit::returnPressed, this, &ShareUserGroupWidget::slotLineEditReturn);
+    connect(_ui->privateLinkText, &QLabel::linkActivated, this, &ShareUserGroupWidget::slotPrivateLinkShare);
 
     // By making the next two QueuedConnections we can override
     // the strings the completer sets on the line edit.
@@ -94,9 +94,9 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
         Qt::QueuedConnection);
 
     // Queued connection so this signal is recieved after textChanged
-    connect(_ui->shareeLineEdit, SIGNAL(textEdited(QString)),
-        this, SLOT(slotLineEditTextEdited(QString)), Qt::QueuedConnection);
-    connect(&_completionTimer, SIGNAL(timeout()), this, SLOT(searchForSharees()));
+    connect(_ui->shareeLineEdit, &QLineEdit::textEdited,
+        this, &ShareUserGroupWidget::slotLineEditTextEdited, Qt::QueuedConnection);
+    connect(&_completionTimer, &QTimer::timeout, this, &ShareUserGroupWidget::searchForSharees);
     _completionTimer.setSingleShot(true);
     _completionTimer.setInterval(600);
 
@@ -192,8 +192,8 @@ void ShareUserGroupWidget::slotSharesFetched(const QList<QSharedPointer<Share>> 
             }
 
             ShareUserLine *s = new ShareUserLine(share, _maxSharingPermissions, _isFile, _ui->scrollArea);
-            connect(s, SIGNAL(resizeRequested()), this, SLOT(slotAdjustScrollWidgetSize()));
-            connect(s, SIGNAL(visualDeletionDone()), this, SLOT(getShares()));
+            connect(s, &ShareUserLine::resizeRequested, this, &ShareUserGroupWidget::slotAdjustScrollWidgetSize);
+            connect(s, &ShareUserLine::visualDeletionDone, this, &ShareUserGroupWidget::getShares);
             layout->addWidget(s);
 
             x++;
@@ -390,11 +390,11 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
     _ui->permissionsEdit->setEnabled(maxSharingPermissions
         & (SharePermissionCreate | SharePermissionUpdate | SharePermissionDelete));
 
-    connect(_permissionUpdate, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
-    connect(_permissionCreate, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
-    connect(_permissionDelete, SIGNAL(triggered(bool)), SLOT(slotPermissionsChanged()));
-    connect(_ui->permissionShare, SIGNAL(clicked(bool)), SLOT(slotPermissionsChanged()));
-    connect(_ui->permissionsEdit, SIGNAL(clicked(bool)), SLOT(slotEditPermissionsChanged()));
+    connect(_permissionUpdate, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
+    connect(_permissionCreate, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
+    connect(_permissionDelete, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
+    connect(_ui->permissionShare, &QAbstractButton::clicked, this, &ShareUserLine::slotPermissionsChanged);
+    connect(_ui->permissionsEdit, &QAbstractButton::clicked, this, &ShareUserLine::slotEditPermissionsChanged);
 
     /*
      * We don't show permssion share for federated shares with server <9.1
@@ -407,8 +407,8 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
         _ui->permissionToolButton->setVisible(false);
     }
 
-    connect(share.data(), SIGNAL(permissionsSet()), SLOT(slotPermissionsSet()));
-    connect(share.data(), SIGNAL(shareDeleted()), SLOT(slotShareDeleted()));
+    connect(share.data(), &Share::permissionsSet, this, &ShareUserLine::slotPermissionsSet);
+    connect(share.data(), &Share::shareDeleted, this, &ShareUserLine::slotShareDeleted);
 
     _ui->deleteShareButton->setIcon(QIcon::fromTheme(QLatin1String("user-trash"),
         QIcon(QLatin1String(":/client/resources/delete.png"))));
@@ -509,8 +509,8 @@ void ShareUserLine::slotShareDeleted()
     animation->setStartValue(height());
     animation->setEndValue(0);
 
-    connect(animation, SIGNAL(finished()), SLOT(slotDeleteAnimationFinished()));
-    connect(animation, SIGNAL(valueChanged(QVariant)), this, SIGNAL(resizeRequested()));
+    connect(animation, &QAbstractAnimation::finished, this, &ShareUserLine::slotDeleteAnimationFinished);
+    connect(animation, &QVariantAnimation::valueChanged, this, &ShareUserLine::resizeRequested);
 
     animation->start();
 }

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -207,10 +207,10 @@ SocketApi::SocketApi(QObject *parent)
         qCInfo(lcSocketApi) << "server started, listening at " << socketPath;
     }
 
-    connect(&_localServer, SIGNAL(newConnection()), this, SLOT(slotNewConnection()));
+    connect(&_localServer, &QLocalServer::newConnection, this, &SocketApi::slotNewConnection);
 
     // folder watcher
-    connect(FolderMan::instance(), SIGNAL(folderSyncStateChange(Folder *)), this, SLOT(slotUpdateFolderView(Folder *)));
+    connect(FolderMan::instance(), &FolderMan::folderSyncStateChange, this, &SocketApi::slotUpdateFolderView);
 }
 
 SocketApi::~SocketApi()
@@ -230,9 +230,9 @@ void SocketApi::slotNewConnection()
         return;
     }
     qCInfo(lcSocketApi) << "New connection" << socket;
-    connect(socket, SIGNAL(readyRead()), this, SLOT(slotReadSocket()));
+    connect(socket, &QIODevice::readyRead, this, &SocketApi::slotReadSocket);
     connect(socket, SIGNAL(disconnected()), this, SLOT(onLostConnection()));
-    connect(socket, SIGNAL(destroyed(QObject *)), this, SLOT(slotSocketDestroyed(QObject *)));
+    connect(socket, &QObject::destroyed, this, &SocketApi::slotSocketDestroyed);
     ASSERT(socket->readAll().isEmpty());
 
     _listeners.append(SocketListener(socket));

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -53,6 +53,7 @@ public slots:
     void slotUpdateFolderView(Folder *f);
     void slotUnregisterPath(const QString &alias);
     void slotRegisterPath(const QString &alias);
+    void broadcastStatusPushMessage(const QString &systemPath, SyncFileStatus fileStatus);
 
 signals:
     void shareCommandReceived(const QString &sharePath, const QString &localPath);
@@ -62,7 +63,6 @@ private slots:
     void onLostConnection();
     void slotSocketDestroyed(QObject *obj);
     void slotReadSocket();
-    void broadcastStatusPushMessage(const QString &systemPath, SyncFileStatus fileStatus);
 
     void copyPrivateLinkToClipboard(const QString &link) const;
     void emailPrivateLink(const QString &link) const;

--- a/src/gui/sslbutton.cpp
+++ b/src/gui/sslbutton.cpp
@@ -35,8 +35,8 @@ SslButton::SslButton(QWidget *parent)
     setAutoRaise(true);
 
     _menu = new QMenu(this);
-    QObject::connect(_menu, SIGNAL(aboutToShow()),
-        this, SLOT(slotUpdateMenu()));
+    QObject::connect(_menu, &QMenu::aboutToShow,
+        this, &SslButton::slotUpdateMenu);
 }
 
 QString SslButton::protoToString(QSsl::SslProtocol proto)

--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -68,13 +68,13 @@ SslErrorDialog::SslErrorDialog(AccountPtr account, QWidget *parent)
     QPushButton *cancelButton =
         _ui->_dialogButtonBox->button(QDialogButtonBox::Cancel);
     okButton->setEnabled(false);
-    connect(_ui->_cbTrustConnect, SIGNAL(clicked(bool)),
-        okButton, SLOT(setEnabled(bool)));
+    connect(_ui->_cbTrustConnect, &QAbstractButton::clicked,
+        okButton, &QWidget::setEnabled);
 
     if (okButton) {
         okButton->setDefault(true);
-        connect(okButton, SIGNAL(clicked()), SLOT(accept()));
-        connect(cancelButton, SIGNAL(clicked()), SLOT(reject()));
+        connect(okButton, &QAbstractButton::clicked, this, &QDialog::accept);
+        connect(cancelButton, &QAbstractButton::clicked, this, &QDialog::reject);
     }
 }
 

--- a/src/gui/synclogdialog.cpp
+++ b/src/gui/synclogdialog.cpp
@@ -41,7 +41,7 @@ SyncLogDialog::SyncLogDialog(QWidget *parent, ProtocolWidget *protoWidget)
 
     QPushButton *closeButton = _ui->buttonBox->button(QDialogButtonBox::Close);
     if (closeButton) {
-        connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
+        connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
     }
 }
 

--- a/src/gui/tooltipupdater.cpp
+++ b/src/gui/tooltipupdater.cpp
@@ -24,8 +24,8 @@ ToolTipUpdater::ToolTipUpdater(QTreeView *treeView)
     : QObject(treeView)
     , _treeView(treeView)
 {
-    connect(_treeView->model(), SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)),
-        SLOT(dataChanged(QModelIndex, QModelIndex, QVector<int>)));
+    connect(_treeView->model(), &QAbstractItemModel::dataChanged,
+        this, &ToolTipUpdater::dataChanged);
     _treeView->viewport()->installEventFilter(this);
 }
 

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -39,18 +39,18 @@ static const char autoUpdateAttemptedC[] = "Updater/autoUpdateAttempted";
 UpdaterScheduler::UpdaterScheduler(QObject *parent)
     : QObject(parent)
 {
-    connect(&_updateCheckTimer, SIGNAL(timeout()),
-        this, SLOT(slotTimerFired()));
+    connect(&_updateCheckTimer, &QTimer::timeout,
+        this, &UpdaterScheduler::slotTimerFired);
 
     // Note: the sparkle-updater is not an OCUpdater
     if (OCUpdater *updater = qobject_cast<OCUpdater *>(Updater::instance())) {
-        connect(updater, SIGNAL(newUpdateAvailable(QString, QString)),
-            this, SIGNAL(updaterAnnouncement(QString, QString)));
-        connect(updater, SIGNAL(requestRestart()), SIGNAL(requestRestart()));
+        connect(updater, &OCUpdater::newUpdateAvailable,
+            this, &UpdaterScheduler::updaterAnnouncement);
+        connect(updater, &OCUpdater::requestRestart, this, &UpdaterScheduler::requestRestart);
     }
 
     // at startup, do a check in any case.
-    QTimer::singleShot(3000, this, SLOT(slotTimerFired()));
+    QTimer::singleShot(3000, this, &UpdaterScheduler::slotTimerFired);
 
     ConfigFile cfg;
     auto checkInterval = cfg.updateCheckInterval();
@@ -194,9 +194,9 @@ void OCUpdater::slotStartInstaller()
 void OCUpdater::checkForUpdate()
 {
     QNetworkReply *reply = _accessManager->get(QNetworkRequest(_updateUrl));
-    connect(_timeoutWatchdog, SIGNAL(timeout()), this, SLOT(slotTimedOut()));
+    connect(_timeoutWatchdog, &QTimer::timeout, this, &OCUpdater::slotTimedOut);
     _timeoutWatchdog->start(30 * 1000);
-    connect(reply, SIGNAL(finished()), this, SLOT(slotVersionInfoArrived()));
+    connect(reply, &QNetworkReply::finished, this, &OCUpdater::slotVersionInfoArrived);
 
     setDownloadState(CheckingServer);
 }
@@ -303,8 +303,8 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
                 setDownloadState(DownloadComplete);
             } else {
                 QNetworkReply *reply = qnam()->get(QNetworkRequest(QUrl(url)));
-                connect(reply, SIGNAL(readyRead()), SLOT(slotWriteFile()));
-                connect(reply, SIGNAL(finished()), SLOT(slotDownloadFinished()));
+                connect(reply, &QIODevice::readyRead, this, &NSISUpdater::slotWriteFile);
+                connect(reply, &QNetworkReply::finished, this, &NSISUpdater::slotDownloadFinished);
                 setDownloadState(Downloading);
                 _file.reset(new QTemporaryFile);
                 _file->setAutoRemove(true);
@@ -353,11 +353,11 @@ void NSISUpdater::showDialog(const UpdateInfo &info)
     QPushButton *reject = bb->addButton(tr("Skip this time"), QDialogButtonBox::AcceptRole);
     QPushButton *getupdate = bb->addButton(tr("Get update"), QDialogButtonBox::AcceptRole);
 
-    connect(skip, SIGNAL(clicked()), msgBox, SLOT(reject()));
-    connect(reject, SIGNAL(clicked()), msgBox, SLOT(reject()));
-    connect(getupdate, SIGNAL(clicked()), msgBox, SLOT(accept()));
+    connect(skip, &QAbstractButton::clicked, msgBox, &QDialog::reject);
+    connect(reject, &QAbstractButton::clicked, msgBox, &QDialog::reject);
+    connect(getupdate, &QAbstractButton::clicked, msgBox, &QDialog::accept);
 
-    connect(skip, SIGNAL(clicked()), SLOT(slotSetSeenVersion()));
+    connect(skip, &QAbstractButton::clicked, this, &NSISUpdater::slotSetSeenVersion);
     connect(getupdate, SIGNAL(clicked()), SLOT(slotOpenUpdateUrl()));
 
     layout->addWidget(bb);

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -54,12 +54,12 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage()
     stopSpinner();
     setupCustomization();
 
-    connect(_ui.pbSelectLocalFolder, SIGNAL(clicked()), SLOT(slotSelectFolder()));
+    connect(_ui.pbSelectLocalFolder, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectFolder);
     setButtonText(QWizard::NextButton, tr("Connect..."));
 
-    connect(_ui.rSyncEverything, SIGNAL(clicked()), SLOT(slotSyncEverythingClicked()));
-    connect(_ui.rSelectiveSync, SIGNAL(clicked()), SLOT(slotSelectiveSyncClicked()));
-    connect(_ui.bSelectiveSync, SIGNAL(clicked()), SLOT(slotSelectiveSyncClicked()));
+    connect(_ui.rSyncEverything, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSyncEverythingClicked);
+    connect(_ui.rSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
+    connect(_ui.bSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
 
     QIcon appIcon = theme->applicationIcon();
     _ui.lServerIcon->setText(QString());
@@ -120,13 +120,13 @@ void OwncloudAdvancedSetupPage::initializePage()
     auto quotaJob = new PropfindJob(acc, _remoteFolder, this);
     quotaJob->setProperties(QList<QByteArray>() << "http://owncloud.org/ns:size");
 
-    connect(quotaJob, SIGNAL(result(QVariantMap)), SLOT(slotQuotaRetrieved(QVariantMap)));
+    connect(quotaJob, &PropfindJob::result, this, &OwncloudAdvancedSetupPage::slotQuotaRetrieved);
     quotaJob->start();
 
 
     if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
         _selectiveSyncBlacklist = QStringList("/");
-        QTimer::singleShot(0, this, SLOT(slotSelectiveSyncClicked()));
+        QTimer::singleShot(0, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
     }
 
     ConfigFile cfgFile;

--- a/src/gui/wizard/owncloudconnectionmethoddialog.cpp
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.cpp
@@ -24,9 +24,9 @@ OwncloudConnectionMethodDialog::OwncloudConnectionMethodDialog(QWidget *parent)
 {
     ui->setupUi(this);
 
-    connect(ui->btnNoTLS, SIGNAL(clicked(bool)), this, SLOT(returnNoTLS()));
-    connect(ui->btnClientSideTLS, SIGNAL(clicked(bool)), this, SLOT(returnClientSideTLS()));
-    connect(ui->btnBack, SIGNAL(clicked(bool)), this, SLOT(returnBack()));
+    connect(ui->btnNoTLS, &QAbstractButton::clicked, this, &OwncloudConnectionMethodDialog::returnNoTLS);
+    connect(ui->btnClientSideTLS, &QAbstractButton::clicked, this, &OwncloudConnectionMethodDialog::returnClientSideTLS);
+    connect(ui->btnBack, &QAbstractButton::clicked, this, &OwncloudConnectionMethodDialog::returnBack);
 }
 
 void OwncloudConnectionMethodDialog::setUrl(const QUrl &url)

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -66,8 +66,8 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     setupCustomization();
 
     slotUrlChanged(QLatin1String("")); // don't jitter UI
-    connect(_ui.leUrl, SIGNAL(textChanged(QString)), SLOT(slotUrlChanged(QString)));
-    connect(_ui.leUrl, SIGNAL(editingFinished()), SLOT(slotUrlEditFinished()));
+    connect(_ui.leUrl, &QLineEdit::textChanged, this, &OwncloudSetupPage::slotUrlChanged);
+    connect(_ui.leUrl, &QLineEdit::editingFinished, this, &OwncloudSetupPage::slotUrlEditFinished);
 
     addCertDial = new AddCertificateDialog(this);
 }
@@ -268,7 +268,7 @@ void OwncloudSetupPage::setErrorString(const QString &err, bool retryHTTPonly)
                 } break;
                 case OwncloudConnectionMethodDialog::Client_Side_TLS:
                     addCertDial->show();
-                    connect(addCertDial, SIGNAL(accepted()), this, SLOT(slotCertificateAccepted()));
+                    connect(addCertDial, &QDialog::accepted, this, &OwncloudSetupPage::slotCertificateAccepted);
                     break;
                 case OwncloudConnectionMethodDialog::Closed:
                 case OwncloudConnectionMethodDialog::Back:

--- a/src/gui/wizard/owncloudshibbolethcredspage.cpp
+++ b/src/gui/wizard/owncloudshibbolethcredspage.cpp
@@ -49,10 +49,10 @@ void OwncloudShibbolethCredsPage::setupBrowser()
     qnam->setCookieJar(jar);
 
     _browser = new ShibbolethWebView(account);
-    connect(_browser, SIGNAL(shibbolethCookieReceived(const QNetworkCookie &)),
-        this, SLOT(slotShibbolethCookieReceived(const QNetworkCookie &)), Qt::QueuedConnection);
-    connect(_browser, SIGNAL(rejected()),
-        this, SLOT(slotBrowserRejected()));
+    connect(_browser.data(), &ShibbolethWebView::shibbolethCookieReceived,
+        this, &OwncloudShibbolethCredsPage::slotShibbolethCookieReceived, Qt::QueuedConnection);
+    connect(_browser.data(), &ShibbolethWebView::rejected,
+        this, &OwncloudShibbolethCredsPage::slotBrowserRejected);
 
     _browser->move(ocWizard->x(), ocWizard->y());
     _browser->show();

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -62,22 +62,22 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     setPage(WizardCommon::Page_AdvancedSetup, _advancedSetupPage);
     setPage(WizardCommon::Page_Result, _resultPage);
 
-    connect(this, SIGNAL(finished(int)), SIGNAL(basicSetupFinished(int)));
+    connect(this, &QDialog::finished, this, &OwncloudWizard::basicSetupFinished);
 
     // note: start Id is set by the calling class depending on if the
     // welcome text is to be shown or not.
     setWizardStyle(QWizard::ModernStyle);
 
-    connect(this, SIGNAL(currentIdChanged(int)), SLOT(slotCurrentPageChanged(int)));
-    connect(_setupPage, SIGNAL(determineAuthType(QString)), SIGNAL(determineAuthType(QString)));
-    connect(_httpCredsPage, SIGNAL(connectToOCUrl(QString)), SIGNAL(connectToOCUrl(QString)));
-    connect(_browserCredsPage, SIGNAL(connectToOCUrl(QString)), SIGNAL(connectToOCUrl(QString)));
+    connect(this, &QWizard::currentIdChanged, this, &OwncloudWizard::slotCurrentPageChanged);
+    connect(_setupPage, &OwncloudSetupPage::determineAuthType, this, &OwncloudWizard::determineAuthType);
+    connect(_httpCredsPage, &OwncloudHttpCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
+    connect(_browserCredsPage, &OwncloudOAuthCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
 #ifndef NO_SHIBBOLETH
-    connect(_shibbolethCredsPage, SIGNAL(connectToOCUrl(QString)), SIGNAL(connectToOCUrl(QString)));
+    connect(_shibbolethCredsPage, &OwncloudShibbolethCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
 #endif
-    connect(_advancedSetupPage, SIGNAL(createLocalAndRemoteFolders(QString, QString)),
-        SIGNAL(createLocalAndRemoteFolders(QString, QString)));
-    connect(this, SIGNAL(customButtonClicked(int)), this, SIGNAL(skipFolderConfiguration()));
+    connect(_advancedSetupPage, &OwncloudAdvancedSetupPage::createLocalAndRemoteFolders,
+        this, &OwncloudWizard::createLocalAndRemoteFolders);
+    connect(this, &QWizard::customButtonClicked, this, &OwncloudWizard::skipFolderConfiguration);
 
 
     Theme *theme = Theme::instance();
@@ -193,7 +193,7 @@ void OwncloudWizard::slotCurrentPageChanged(int id)
     }
 
     if (id == WizardCommon::Page_Result) {
-        disconnect(this, SIGNAL(finished(int)), this, SIGNAL(basicSetupFinished(int)));
+        disconnect(this, &QDialog::finished, this, &OwncloudWizard::basicSetupFinished);
         emit basicSetupFinished(QDialog::Accepted);
         appendToConfigurationLog(QString::null);
         // Immediately close on show, we currently don't want this page anymore

--- a/src/gui/wizard/owncloudwizardresultpage.cpp
+++ b/src/gui/wizard/owncloudwizardresultpage.cpp
@@ -41,7 +41,7 @@ OwncloudWizardResultPage::OwncloudWizardResultPage()
     _ui.pbOpenLocal->setIcon(QIcon(QLatin1String(":/client/resources/folder-sync.png")));
     _ui.pbOpenLocal->setIconSize(QSize(48, 48));
     _ui.pbOpenLocal->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    connect(_ui.pbOpenLocal, SIGNAL(clicked()), SLOT(slotOpenLocal()));
+    connect(_ui.pbOpenLocal, &QAbstractButton::clicked, this, &OwncloudWizardResultPage::slotOpenLocal);
 
     Theme *theme = Theme::instance();
     QIcon appIcon = theme->applicationIcon();
@@ -49,7 +49,7 @@ OwncloudWizardResultPage::OwncloudWizardResultPage()
     _ui.pbOpenServer->setIcon(appIcon.pixmap(48));
     _ui.pbOpenServer->setIconSize(QSize(48, 48));
     _ui.pbOpenServer->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    connect(_ui.pbOpenServer, SIGNAL(clicked()), SLOT(slotOpenServer()));
+    connect(_ui.pbOpenServer, &QAbstractButton::clicked, this, &OwncloudWizardResultPage::slotOpenServer);
     setupCustomization();
 }
 

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -26,6 +26,7 @@
 #include <QTimer>
 #include <QMutex>
 #include <QCoreApplication>
+#include <QAuthenticator>
 
 #include "networkjobs.h"
 #include "account.h"

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -32,6 +32,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QSslKey>
+#include <QAuthenticator>
 
 namespace OCC {
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -150,12 +150,12 @@ void Account::setCredentials(AbstractCredentials *cred)
     }
     connect(_am.data(), SIGNAL(sslErrors(QNetworkReply *, QList<QSslError>)),
         SLOT(slotHandleSslErrors(QNetworkReply *, QList<QSslError>)));
-    connect(_am.data(), SIGNAL(proxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)),
-        SIGNAL(proxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)));
-    connect(_credentials.data(), SIGNAL(fetched()),
-        SLOT(slotCredentialsFetched()));
-    connect(_credentials.data(), SIGNAL(asked()),
-        SLOT(slotCredentialsAsked()));
+    connect(_am.data(), &QNetworkAccessManager::proxyAuthenticationRequired,
+        this, &Account::proxyAuthenticationRequired);
+    connect(_credentials.data(), &AbstractCredentials::fetched,
+        this, &Account::slotCredentialsFetched);
+    connect(_credentials.data(), &AbstractCredentials::asked,
+        this, &Account::slotCredentialsAsked);
 }
 
 QUrl Account::davUrl() const
@@ -213,8 +213,8 @@ void Account::resetNetworkAccessManager()
     _am->setCookieJar(jar); // takes ownership of the old cookie jar
     connect(_am.data(), SIGNAL(sslErrors(QNetworkReply *, QList<QSslError>)),
         SLOT(slotHandleSslErrors(QNetworkReply *, QList<QSslError>)));
-    connect(_am.data(), SIGNAL(proxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)),
-        SIGNAL(proxyAuthenticationRequired(QNetworkProxy, QAuthenticator *)));
+    connect(_am.data(), &QNetworkAccessManager::proxyAuthenticationRequired,
+        this, &Account::proxyAuthenticationRequired);
 }
 
 QNetworkAccessManager *Account::networkAccessManager()

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -225,6 +225,7 @@ public:
 public slots:
     /// Used when forgetting credentials
     void clearQNAMCache();
+    void slotHandleSslErrors(QNetworkReply *, QList<QSslError>);
 
 signals:
     /// Emitted whenever there's network activity
@@ -247,7 +248,6 @@ signals:
     void accountChangedAvatar();
 
 protected Q_SLOTS:
-    void slotHandleSslErrors(QNetworkReply *, QList<QSslError>);
     void slotCredentialsFetched();
     void slotCredentialsAsked();
 

--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -56,34 +56,34 @@ BandwidthManager::BandwidthManager(OwncloudPropagator *p)
     _currentUploadLimit = _propagator->_uploadLimit.fetchAndAddAcquire(0);
     _currentDownloadLimit = _propagator->_downloadLimit.fetchAndAddAcquire(0);
 
-    QObject::connect(&_switchingTimer, SIGNAL(timeout()), this, SLOT(switchingTimerExpired()));
+    QObject::connect(&_switchingTimer, &QTimer::timeout, this, &BandwidthManager::switchingTimerExpired);
     _switchingTimer.setInterval(10 * 1000);
     _switchingTimer.start();
     QMetaObject::invokeMethod(this, "switchingTimerExpired", Qt::QueuedConnection);
 
     // absolute uploads/downloads
-    QObject::connect(&_absoluteLimitTimer, SIGNAL(timeout()), this, SLOT(absoluteLimitTimerExpired()));
+    QObject::connect(&_absoluteLimitTimer, &QTimer::timeout, this, &BandwidthManager::absoluteLimitTimerExpired);
     _absoluteLimitTimer.setInterval(1000);
     _absoluteLimitTimer.start();
 
     // Relative uploads
-    QObject::connect(&_relativeUploadMeasuringTimer, SIGNAL(timeout()),
-        this, SLOT(relativeUploadMeasuringTimerExpired()));
+    QObject::connect(&_relativeUploadMeasuringTimer, &QTimer::timeout,
+        this, &BandwidthManager::relativeUploadMeasuringTimerExpired);
     _relativeUploadMeasuringTimer.setInterval(relativeLimitMeasuringTimerIntervalMsec);
     _relativeUploadMeasuringTimer.start();
     _relativeUploadMeasuringTimer.setSingleShot(true); // will be restarted from the delay timer
-    QObject::connect(&_relativeUploadDelayTimer, SIGNAL(timeout()),
-        this, SLOT(relativeUploadDelayTimerExpired()));
+    QObject::connect(&_relativeUploadDelayTimer, &QTimer::timeout,
+        this, &BandwidthManager::relativeUploadDelayTimerExpired);
     _relativeUploadDelayTimer.setSingleShot(true); // will be restarted from the measuring timer
 
     // Relative downloads
-    QObject::connect(&_relativeDownloadMeasuringTimer, SIGNAL(timeout()),
-        this, SLOT(relativeDownloadMeasuringTimerExpired()));
+    QObject::connect(&_relativeDownloadMeasuringTimer, &QTimer::timeout,
+        this, &BandwidthManager::relativeDownloadMeasuringTimerExpired);
     _relativeDownloadMeasuringTimer.setInterval(relativeLimitMeasuringTimerIntervalMsec);
     _relativeDownloadMeasuringTimer.start();
     _relativeDownloadMeasuringTimer.setSingleShot(true); // will be restarted from the delay timer
-    QObject::connect(&_relativeDownloadDelayTimer, SIGNAL(timeout()),
-        this, SLOT(relativeDownloadDelayTimerExpired()));
+    QObject::connect(&_relativeDownloadDelayTimer, &QTimer::timeout,
+        this, &BandwidthManager::relativeDownloadDelayTimerExpired);
     _relativeDownloadDelayTimer.setSingleShot(true); // will be restarted from the measuring timer
 }
 

--- a/src/libsync/connectionvalidator.cpp
+++ b/src/libsync/connectionvalidator.cpp
@@ -116,9 +116,9 @@ void ConnectionValidator::slotCheckServerAndAuth()
     CheckServerJob *checkJob = new CheckServerJob(_account, this);
     checkJob->setTimeout(timeoutToUseMsec);
     checkJob->setIgnoreCredentialFailure(true);
-    connect(checkJob, SIGNAL(instanceFound(QUrl, QJsonObject)), SLOT(slotStatusFound(QUrl, QJsonObject)));
-    connect(checkJob, SIGNAL(instanceNotFound(QNetworkReply *)), SLOT(slotNoStatusFound(QNetworkReply *)));
-    connect(checkJob, SIGNAL(timeout(QUrl)), SLOT(slotJobTimeout(QUrl)));
+    connect(checkJob, &CheckServerJob::instanceFound, this, &ConnectionValidator::slotStatusFound);
+    connect(checkJob, &CheckServerJob::instanceNotFound, this, &ConnectionValidator::slotNoStatusFound);
+    connect(checkJob, &CheckServerJob::timeout, this, &ConnectionValidator::slotJobTimeout);
     checkJob->start();
 }
 
@@ -154,7 +154,7 @@ void ConnectionValidator::slotStatusFound(const QUrl &url, const QJsonObject &in
     }
 
     // now check the authentication
-    QTimer::singleShot( 0, this, SLOT( checkAuthentication() ));
+    QTimer::singleShot(0, this, &ConnectionValidator::checkAuthentication);
 }
 
 // status.php could not be loaded (network or server issue!).
@@ -201,8 +201,8 @@ void ConnectionValidator::checkAuthentication()
     PropfindJob *job = new PropfindJob(_account, "/", this);
     job->setTimeout(timeoutToUseMsec);
     job->setProperties(QList<QByteArray>() << "getlastmodified");
-    connect(job, SIGNAL(result(QVariantMap)), SLOT(slotAuthSuccess()));
-    connect(job, SIGNAL(finishedWithError(QNetworkReply *)), SLOT(slotAuthFailed(QNetworkReply *)));
+    connect(job, &PropfindJob::result, this, &ConnectionValidator::slotAuthSuccess);
+    connect(job, &PropfindJob::finishedWithError, this, &ConnectionValidator::slotAuthFailed);
     job->start();
 }
 
@@ -249,7 +249,7 @@ void ConnectionValidator::checkServerCapabilities()
 {
     JsonApiJob *job = new JsonApiJob(_account, QLatin1String("ocs/v1.php/cloud/capabilities"), this);
     job->setTimeout(timeoutToUseMsec);
-    QObject::connect(job, SIGNAL(jsonReceived(QJsonDocument, int)), this, SLOT(slotCapabilitiesRecieved(QJsonDocument)));
+    QObject::connect(job, &JsonApiJob::jsonReceived, this, &ConnectionValidator::slotCapabilitiesRecieved);
     job->start();
 }
 
@@ -272,7 +272,7 @@ void ConnectionValidator::fetchUser()
 {
     JsonApiJob *job = new JsonApiJob(_account, QLatin1String("ocs/v1.php/cloud/user"), this);
     job->setTimeout(timeoutToUseMsec);
-    QObject::connect(job, SIGNAL(jsonReceived(QJsonDocument, int)), this, SLOT(slotUserFetched(QJsonDocument)));
+    QObject::connect(job, &JsonApiJob::jsonReceived, this, &ConnectionValidator::slotUserFetched);
     job->start();
 }
 
@@ -312,7 +312,7 @@ void ConnectionValidator::slotUserFetched(const QJsonDocument &json)
 
         AvatarJob *job = new AvatarJob(_account, this);
         job->setTimeout(20 * 1000);
-        QObject::connect(job, SIGNAL(avatarPixmap(QImage)), this, SLOT(slotAvatarImage(QImage)));
+        QObject::connect(job, &AvatarJob::avatarPixmap, this, &ConnectionValidator::slotAvatarImage);
 
         job->start();
     }

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -31,6 +31,7 @@
 #include "syncengine.h"
 #include "creds/credentialscommon.h"
 #include "creds/httpcredentials.h"
+#include <QAuthenticator>
 
 using namespace QKeychain;
 

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -147,8 +147,8 @@ QNetworkAccessManager *HttpCredentials::createQNAM() const
 {
     AccessManager *qnam = new HttpCredentialsAccessManager(this);
 
-    connect(qnam, SIGNAL(authenticationRequired(QNetworkReply *, QAuthenticator *)),
-        this, SLOT(slotAuthentication(QNetworkReply *, QAuthenticator *)));
+    connect(qnam, &QNetworkAccessManager::authenticationRequired,
+        this, &HttpCredentials::slotAuthentication);
 
     return qnam;
 }
@@ -198,7 +198,7 @@ void HttpCredentials::fetchFromKeychainHelper()
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
     job->setKey(kck);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotReadClientCertPEMJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotReadClientCertPEMJobDone);
     job->start();
 }
 
@@ -238,7 +238,7 @@ void HttpCredentials::slotReadClientCertPEMJobDone(QKeychain::Job *incoming)
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
     job->setKey(kck);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotReadClientKeyPEMJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotReadClientKeyPEMJobDone);
     job->start();
 }
 
@@ -273,7 +273,7 @@ void HttpCredentials::slotReadClientKeyPEMJobDone(QKeychain::Job *incoming)
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
     job->setKey(kck);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotReadJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotReadJobDone);
     job->start();
 }
 
@@ -419,7 +419,7 @@ void HttpCredentials::invalidateToken()
     // indirectly) from QNetworkAccessManagerPrivate::authenticationRequired, which itself
     // is a called from a BlockingQueuedConnection from the Qt HTTP thread. And clearing the
     // cache needs to synchronize again with the HTTP thread.
-    QTimer::singleShot(0, _account, SLOT(clearQNAMCache()));
+    QTimer::singleShot(0, _account, &Account::clearQNAMCache);
 }
 
 void HttpCredentials::forgetSensitiveData()
@@ -446,7 +446,7 @@ void HttpCredentials::persist()
     WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotWriteClientCertPEMJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotWriteClientCertPEMJobDone);
     job->setKey(keychainKey(_account->url().toString(), _user + clientCertificatePEMC, _account->id()));
     job->setBinaryData(_clientSslCertificate.toPem());
     job->start();
@@ -459,7 +459,7 @@ void HttpCredentials::slotWriteClientCertPEMJobDone(Job *incomingJob)
     WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotWriteClientKeyPEMJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotWriteClientKeyPEMJobDone);
     job->setKey(keychainKey(_account->url().toString(), _user + clientKeyPEMC, _account->id()));
     job->setBinaryData(_clientSslKey.toPem());
     job->start();
@@ -471,7 +471,7 @@ void HttpCredentials::slotWriteClientKeyPEMJobDone(Job *incomingJob)
     WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());
     addSettingsToJob(_account, job);
     job->setInsecureFallback(false);
-    connect(job, SIGNAL(finished(QKeychain::Job *)), SLOT(slotWriteJobDone(QKeychain::Job *)));
+    connect(job, &Job::finished, this, &HttpCredentials::slotWriteJobDone);
     job->setKey(keychainKey(_account->url().toString(), _user, _account->id()));
     job->setTextData(isUsingOAuth() ? _refreshToken : _password);
     job->start();

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -282,10 +282,10 @@ void DiscoverySingleDirectoryJob::start()
 
     lsColJob->setProperties(props);
 
-    QObject::connect(lsColJob, SIGNAL(directoryListingIterated(QString, QMap<QString, QString>)),
-        this, SLOT(directoryListingIteratedSlot(QString, QMap<QString, QString>)));
-    QObject::connect(lsColJob, SIGNAL(finishedWithError(QNetworkReply *)), this, SLOT(lsJobFinishedWithErrorSlot(QNetworkReply *)));
-    QObject::connect(lsColJob, SIGNAL(finishedWithoutError()), this, SLOT(lsJobFinishedWithoutErrorSlot()));
+    QObject::connect(lsColJob, &LsColJob::directoryListingIterated,
+        this, &DiscoverySingleDirectoryJob::directoryListingIteratedSlot);
+    QObject::connect(lsColJob, &LsColJob::finishedWithError, this, &DiscoverySingleDirectoryJob::lsJobFinishedWithErrorSlot);
+    QObject::connect(lsColJob, &LsColJob::finishedWithoutError, this, &DiscoverySingleDirectoryJob::lsJobFinishedWithoutErrorSlot);
     lsColJob->start();
 
     _lsColJob = lsColJob;
@@ -469,11 +469,11 @@ void DiscoveryMainThread::setupHooks(DiscoveryJob *discoveryJob, const QString &
     _discoveryJob = discoveryJob;
     _pathPrefix = pathPrefix;
 
-    connect(discoveryJob, SIGNAL(doOpendirSignal(QString, DiscoveryDirectoryResult *)),
-        this, SLOT(doOpendirSlot(QString, DiscoveryDirectoryResult *)),
+    connect(discoveryJob, &DiscoveryJob::doOpendirSignal,
+        this, &DiscoveryMainThread::doOpendirSlot,
         Qt::QueuedConnection);
-    connect(discoveryJob, SIGNAL(doGetSizeSignal(QString, qint64 *)),
-        this, SLOT(doGetSizeSlot(QString, qint64 *)),
+    connect(discoveryJob, &DiscoveryJob::doGetSizeSignal,
+        this, &DiscoveryMainThread::doGetSizeSlot,
         Qt::QueuedConnection);
 }
 
@@ -499,16 +499,16 @@ void DiscoveryMainThread::doOpendirSlot(const QString &subPath, DiscoveryDirecto
 
     // Schedule the DiscoverySingleDirectoryJob
     _singleDirJob = new DiscoverySingleDirectoryJob(_account, fullPath, this);
-    QObject::connect(_singleDirJob, SIGNAL(finishedWithResult()),
-        this, SLOT(singleDirectoryJobResultSlot()));
-    QObject::connect(_singleDirJob, SIGNAL(finishedWithError(int, QString)),
-        this, SLOT(singleDirectoryJobFinishedWithErrorSlot(int, QString)));
-    QObject::connect(_singleDirJob, SIGNAL(firstDirectoryPermissions(QString)),
-        this, SLOT(singleDirectoryJobFirstDirectoryPermissionsSlot(QString)));
-    QObject::connect(_singleDirJob, SIGNAL(etagConcatenation(QString)),
-        this, SIGNAL(etagConcatenation(QString)));
-    QObject::connect(_singleDirJob, SIGNAL(etag(QString)),
-        this, SIGNAL(etag(QString)));
+    QObject::connect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::finishedWithResult,
+        this, &DiscoveryMainThread::singleDirectoryJobResultSlot);
+    QObject::connect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::finishedWithError,
+        this, &DiscoveryMainThread::singleDirectoryJobFinishedWithErrorSlot);
+    QObject::connect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::firstDirectoryPermissions,
+        this, &DiscoveryMainThread::singleDirectoryJobFirstDirectoryPermissionsSlot);
+    QObject::connect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::etagConcatenation,
+        this, &DiscoveryMainThread::etagConcatenation);
+    QObject::connect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::etag,
+        this, &DiscoveryMainThread::etag);
 
     if (!_firstFolderProcessed) {
         _singleDirJob->setIsRootPath();
@@ -584,10 +584,10 @@ void DiscoveryMainThread::doGetSizeSlot(const QString &path, qint64 *result)
     auto propfindJob = new PropfindJob(_account, fullPath, this);
     propfindJob->setProperties(QList<QByteArray>() << "resourcetype"
                                                    << "http://owncloud.org/ns:size");
-    QObject::connect(propfindJob, SIGNAL(finishedWithError()),
-        this, SLOT(slotGetSizeFinishedWithError()));
-    QObject::connect(propfindJob, SIGNAL(result(QVariantMap)),
-        this, SLOT(slotGetSizeResult(QVariantMap)));
+    QObject::connect(propfindJob, &PropfindJob::finishedWithError,
+        this, &DiscoveryMainThread::slotGetSizeFinishedWithError);
+    QObject::connect(propfindJob, &PropfindJob::result,
+        this, &DiscoveryMainThread::slotGetSizeResult);
     propfindJob->start();
 }
 

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -622,9 +622,9 @@ void DiscoveryMainThread::slotGetSizeResult(const QVariantMap &map)
 void DiscoveryMainThread::abort()
 {
     if (_singleDirJob) {
-        _singleDirJob->disconnect(SIGNAL(finishedWithError(int, QString)), this);
-        _singleDirJob->disconnect(SIGNAL(firstDirectoryPermissions(QString)), this);
-        _singleDirJob->disconnect(SIGNAL(finishedWithResult()), this);
+        disconnect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::finishedWithError, this, nullptr);
+        disconnect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::firstDirectoryPermissions, this, nullptr);
+        disconnect(_singleDirJob.data(), &DiscoverySingleDirectoryJob::finishedWithResult, this, nullptr);
         _singleDirJob->abort();
     }
     if (_currentDiscoveryDirectoryResult) {

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -362,14 +362,14 @@ bool LsColJob::finished()
     int httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     if (httpCode == 207 && contentType.contains("application/xml; charset=utf-8")) {
         LsColXMLParser parser;
-        connect(&parser, SIGNAL(directoryListingSubfolders(const QStringList &)),
-            this, SIGNAL(directoryListingSubfolders(const QStringList &)));
-        connect(&parser, SIGNAL(directoryListingIterated(const QString &, const QMap<QString, QString> &)),
-            this, SIGNAL(directoryListingIterated(const QString &, const QMap<QString, QString> &)));
-        connect(&parser, SIGNAL(finishedWithError(QNetworkReply *)),
-            this, SIGNAL(finishedWithError(QNetworkReply *)));
-        connect(&parser, SIGNAL(finishedWithoutError()),
-            this, SIGNAL(finishedWithoutError()));
+        connect(&parser, &LsColXMLParser::directoryListingSubfolders,
+            this, &LsColJob::directoryListingSubfolders);
+        connect(&parser, &LsColXMLParser::directoryListingIterated,
+            this, &LsColJob::directoryListingIterated);
+        connect(&parser, &LsColXMLParser::finishedWithError,
+            this, &LsColJob::finishedWithError);
+        connect(&parser, &LsColXMLParser::finishedWithoutError,
+            this, &LsColJob::finishedWithoutError);
 
         QString expectedPath = reply()->request().url().path(); // something like "/owncloud/remote.php/webdav/folder"
         if (!parser.parse(reply()->readAll(), &_sizes, expectedPath)) {
@@ -400,16 +400,16 @@ CheckServerJob::CheckServerJob(AccountPtr account, QObject *parent)
     , _permanentRedirects(0)
 {
     setIgnoreCredentialFailure(true);
-    connect(this, SIGNAL(redirected(QNetworkReply *, QUrl, int)),
-        SLOT(slotRedirected(QNetworkReply *, QUrl, int)));
+    connect(this, &AbstractNetworkJob::redirected,
+        this, &CheckServerJob::slotRedirected);
 }
 
 void CheckServerJob::start()
 {
     _serverUrl = account()->url();
     sendRequest("GET", Utility::concatUrlPath(_serverUrl, path()));
-    connect(reply(), SIGNAL(metaDataChanged()), this, SLOT(metaDataChangedSlot()));
-    connect(reply(), SIGNAL(encrypted()), this, SLOT(encryptedSlot()));
+    connect(reply(), &QNetworkReply::metaDataChanged, this, &CheckServerJob::metaDataChangedSlot);
+    connect(reply(), &QNetworkReply::encrypted, this, &CheckServerJob::encryptedSlot);
     AbstractNetworkJob::start();
 }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -331,8 +331,8 @@ bool PropagateItemJob::checkForProblemsWithShared(int httpStatusCode, const QStr
         if (newJob) {
             newJob->setRestoreJobMsg(msg);
             _restoreJob.reset(newJob);
-            connect(_restoreJob.data(), SIGNAL(finished(SyncFileItem::Status)),
-                this, SLOT(slotRestoreJobFinished(SyncFileItem::Status)));
+            connect(_restoreJob.data(), &PropagatorJob::finished,
+                this, &PropagateItemJob::slotRestoreJobFinished);
             QMetaObject::invokeMethod(newJob, "start");
         }
         return true;
@@ -521,7 +521,7 @@ void OwncloudPropagator::start(const SyncFileItemVector &items)
         _rootJob->appendJob(it);
     }
 
-    connect(_rootJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(emitFinished(SyncFileItem::Status)));
+    connect(_rootJob.data(), &PropagatorJob::finished, this, &OwncloudPropagator::emitFinished);
 
     scheduleNextJob();
 }
@@ -654,7 +654,7 @@ QString OwncloudPropagator::getFilePath(const QString &tmp_file_name) const
 
 void OwncloudPropagator::scheduleNextJob()
 {
-    QTimer::singleShot(0, this, SLOT(scheduleNextJobImpl()));
+    QTimer::singleShot(0, this, &OwncloudPropagator::scheduleNextJobImpl);
 }
 
 void OwncloudPropagator::scheduleNextJobImpl()
@@ -854,9 +854,9 @@ PropagateDirectory::PropagateDirectory(OwncloudPropagator *propagator, const Syn
     , _subJobs(propagator)
 {
     if (_firstJob) {
-        connect(_firstJob.data(), SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotFirstJobFinished(SyncFileItem::Status)));
+        connect(_firstJob.data(), &PropagatorJob::finished, this, &PropagateDirectory::slotFirstJobFinished);
     }
-    connect(&_subJobs, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobsFinished(SyncFileItem::Status)));
+    connect(&_subJobs, &PropagatorJob::finished, this, &PropagateDirectory::slotSubJobsFinished);
 }
 
 PropagatorJob::JobParallelism PropagateDirectory::parallelism()
@@ -968,7 +968,7 @@ void CleanupPollsJob::start()
     if (record.isValid()) {
         SyncFileItemPtr item = SyncFileItem::fromSyncJournalFileRecord(record);
         PollJob *job = new PollJob(_account, info._url, item, _journal, _localPath, this);
-        connect(job, SIGNAL(finishedSignal()), SLOT(slotPollFinished()));
+        connect(job, &PollJob::finishedSignal, this, &CleanupPollsJob::slotPollFinished);
         job->start();
     }
 }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -221,7 +221,7 @@ private slots:
     bool possiblyRunNextJob(PropagatorJob *next)
     {
         if (next->_state == NotYetStarted) {
-            connect(next, SIGNAL(finished(SyncFileItem::Status)), this, SLOT(slotSubJobFinished(SyncFileItem::Status)));
+            connect(next, &PropagatorJob::finished, this, &PropagatorCompositeJob::slotSubJobFinished);
         }
         return next->scheduleSelfOrChild();
     }

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -130,7 +130,7 @@ void ProgressDispatcher::setProgressInfo(const QString &folder, const ProgressIn
 
 ProgressInfo::ProgressInfo()
 {
-    connect(&_updateEstimatesTimer, SIGNAL(timeout()), SLOT(updateEstimates()));
+    connect(&_updateEstimatesTimer, &QTimer::timeout, this, &ProgressInfo::updateEstimates);
     reset();
 }
 

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -70,7 +70,7 @@ void PropagateRemoteDelete::start()
     _job = new DeleteJob(propagator()->account(),
         propagator()->_remoteFolder + _item->_file,
         this);
-    connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotDeleteJobFinished()));
+    connect(_job.data(), &DeleteJob::finishedSignal, this, &PropagateRemoteDelete::slotDeleteJobFinished);
     propagator()->_activeJobList.append(this);
     _job->start();
 }

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -111,8 +111,8 @@ void PropagateRemoteMkdir::slotMkcolJobFinished()
         auto propfindJob = new PropfindJob(_job->account(), _job->path(), this);
         propfindJob->setProperties(QList<QByteArray>() << "getetag"
                                                        << "http://owncloud.org/ns:id");
-        QObject::connect(propfindJob, SIGNAL(result(QVariantMap)), this, SLOT(propfindResult(QVariantMap)));
-        QObject::connect(propfindJob, SIGNAL(finishedWithError()), this, SLOT(propfindError()));
+        QObject::connect(propfindJob, &PropfindJob::result, this, &PropagateRemoteMkdir::propfindResult);
+        QObject::connect(propfindJob, &PropfindJob::finishedWithError, this, &PropagateRemoteMkdir::propfindError);
         propfindJob->start();
         _job = propfindJob;
         return;

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -112,7 +112,7 @@ void PropagateRemoteMove::start()
     _job = new MoveJob(propagator()->account(),
         propagator()->_remoteFolder + _item->_file,
         destination, this);
-    connect(_job, SIGNAL(finishedSignal()), this, SLOT(slotMoveJobFinished()));
+    connect(_job.data(), &MoveJob::finishedSignal, this, &PropagateRemoteMove::slotMoveJobFinished);
     propagator()->_activeJobList.append(this);
     _job->start();
 }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -126,10 +126,10 @@ void PropagateUploadFileV1::startNextChunk()
     // job takes ownership of device via a QScopedPointer. Job deletes itself when finishing
     PUTFileJob *job = new PUTFileJob(propagator()->account(), propagator()->_remoteFolder + path, device, headers, _currentChunk, this);
     _jobs.append(job);
-    connect(job, SIGNAL(finishedSignal()), this, SLOT(slotPutFinished()));
-    connect(job, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(slotUploadProgress(qint64, qint64)));
+    connect(job, &PUTFileJob::finishedSignal, this, &PropagateUploadFileV1::slotPutFinished);
+    connect(job, &PUTFileJob::uploadProgress, this, &PropagateUploadFileV1::slotUploadProgress);
     connect(job, SIGNAL(uploadProgress(qint64, qint64)), device, SLOT(slotJobUploadProgress(qint64, qint64)));
-    connect(job, SIGNAL(destroyed(QObject *)), this, SLOT(slotJobDestroyed(QObject *)));
+    connect(job, &QObject::destroyed, this, &PropagateUploadFileCommon::slotJobDestroyed);
     job->start();
     propagator()->_activeJobList.append(this);
     _currentChunk++;

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -111,13 +111,13 @@ static inline bool showWarningInSocketApi(const SyncFileItem &item)
 SyncFileStatusTracker::SyncFileStatusTracker(SyncEngine *syncEngine)
     : _syncEngine(syncEngine)
 {
-    connect(syncEngine, SIGNAL(aboutToPropagate(SyncFileItemVector &)),
-        SLOT(slotAboutToPropagate(SyncFileItemVector &)));
-    connect(syncEngine, SIGNAL(itemCompleted(const SyncFileItemPtr &)),
-        SLOT(slotItemCompleted(const SyncFileItemPtr &)));
-    connect(syncEngine, SIGNAL(finished(bool)), SLOT(slotSyncFinished()));
-    connect(syncEngine, SIGNAL(started()), SLOT(slotSyncEngineRunningChanged()));
-    connect(syncEngine, SIGNAL(finished(bool)), SLOT(slotSyncEngineRunningChanged()));
+    connect(syncEngine, &SyncEngine::aboutToPropagate,
+        this, &SyncFileStatusTracker::slotAboutToPropagate);
+    connect(syncEngine, &SyncEngine::itemCompleted,
+        this, &SyncFileStatusTracker::slotItemCompleted);
+    connect(syncEngine, &SyncEngine::finished, this, &SyncFileStatusTracker::slotSyncFinished);
+    connect(syncEngine, &SyncEngine::started, this, &SyncFileStatusTracker::slotSyncEngineRunningChanged);
+    connect(syncEngine, &SyncEngine::finished, this, &SyncFileStatusTracker::slotSyncEngineRunningChanged);
 }
 
 SyncFileStatus SyncFileStatusTracker::fileStatus(const QString &relativePath)

--- a/test/stub.cpp
+++ b/test/stub.cpp
@@ -1,5 +1,7 @@
 // stub to prevent linker error
 #include "accountmanager.h"
-OCC::AccountManager *OCC::AccountManager::instance() { return 0; }
+OCC::AccountManager *OCC::AccountManager::instance() { return static_cast<AccountManager *>(new QObject); }
 void OCC::AccountManager::saveAccountState(AccountState *) { }
 void OCC::AccountManager::save(bool saveCredentials) { Q_UNUSED(saveCredentials); }
+void OCC::AccountManager::accountRemoved(OCC::AccountState*) { }
+const QMetaObject OCC::AccountManager::staticMetaObject = QObject::staticMetaObject;


### PR DESCRIPTION
This is motivated by the fact that QMetaObject::noralizeSignature takes 7.35%
CPU of the LargeSyncBench. (Mostly from ABstractNetworkJob::setupConnections and
PropagateUploadFileV1::startNextChunk). It could be fixed by using normalized
signature in the connection statement, but i tought it was a good oportunity
to modernize the code.

One commit is done automatically,  then i started doing the the rest is manually, altough not everything has been converted.
