### PR TITLE
csync_vio_local_stat: Try to avoid expensive call to c_utf8_path_to_locale

### DIFF
--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -565,16 +565,10 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
       continue;
     }
 
-    fullpath = uri;
-    if (!fullpath.isEmpty())
-        fullpath += '/';
-    fullpath += filename;
-    /* Only for the local replica we have to stat(), for the remote one we have all data already */
-    if (ctx->current == LOCAL_REPLICA) {
-        if (csync_vio_stat(ctx, fullpath, dirent.get()) != 0) {
-            // Will get excluded by _csync_detect_update.
-            dirent->type = CSYNC_FTW_TYPE_SKIP;
-        }
+    if (uri[0] == '\0') {
+        fullpath = filename;
+    } else {
+        fullpath = QByteArray() % uri % '/' % filename;
     }
 
     /* if the filename starts with a . we consider it a hidden file

--- a/src/csync/vio/csync_vio.cpp
+++ b/src/csync/vio/csync_vio.cpp
@@ -24,7 +24,6 @@
 
 #include <errno.h>
 #include <stdio.h>
-#include <QLoggingCategory>
 #include "common/asserts.h"
 
 #include "csync_private.h"
@@ -33,8 +32,6 @@
 #include "vio/csync_vio_local.h"
 #include "csync_statedb.h"
 #include "common/c_jhash.h"
-
-Q_LOGGING_CATEGORY(lcVio, "sync.csync.vio", QtInfoMsg)
 
 csync_vio_handle_t *csync_vio_opendir(CSYNC *ctx, const char *name) {
   switch(ctx->current) {
@@ -92,17 +89,6 @@ std::unique_ptr<csync_file_stat_t> csync_vio_readdir(CSYNC *ctx, csync_vio_handl
   }
 
   return NULL;
-}
-
-int csync_vio_stat(CSYNC *ctx, const char *uri, csync_file_stat_t *buf) {
-  int rc = -1;
-
-    ASSERT(ctx->current == LOCAL_REPLICA);
-    rc = csync_vio_local_stat(uri, buf);
-    if (rc < 0)
-        qCWarning(lcVio, "Local stat failed, errno %d for %s", errno, uri);
-
-  return rc;
 }
 
 char *csync_vio_get_status_string(CSYNC *ctx) {

--- a/src/csync/vio/csync_vio.h
+++ b/src/csync/vio/csync_vio.h
@@ -36,8 +36,6 @@ csync_vio_handle_t *csync_vio_opendir(CSYNC *ctx, const char *name);
 int csync_vio_closedir(CSYNC *ctx, csync_vio_handle_t *dhandle);
 std::unique_ptr<csync_file_stat_t> csync_vio_readdir(CSYNC *ctx, csync_vio_handle_t *dhandle);
 
-int csync_vio_stat(CSYNC *ctx, const char *uri, csync_file_stat_t *buf);
-
 char *csync_vio_get_status_string(CSYNC *ctx);
 
 


### PR DESCRIPTION
Keep the value stored in the original_path
Saves 15% of the CPU time for csync_update