### PR TITLE
Only use $(MAKE) in doc target if make is used as generator

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,7 +39,13 @@ if(SPHINX_FOUND)
 				     -D latex_logo=${LATEX_LOGO}
 				     ${CMAKE_CURRENT_SOURCE_DIR}
 				     ${SPHINX_PDF_DIR} )
-        add_custom_target(doc-pdf $(MAKE) -C ${SPHINX_PDF_DIR} all-pdf
+
+        set(MAKE "make" CACHE FILEPATH "make to be used for documentation generation if not using make as generator anyway")
+        if(CMAKE_GENERATOR MATCHES "Makefiles")
+            set(MAKE "$(MAKE)")
+        endif()
+
+        add_custom_target(doc-pdf ${MAKE} -C ${SPHINX_PDF_DIR} all-pdf
 		                  DEPENDS doc-latex )
         add_dependencies(doc doc-pdf)
     endif(PDFLATEX_FOUND)


### PR DESCRIPTION
The old behavior broke builds with other CMake generators like Ninja as it obviously has no concept of $(MAKE)