### PR TITLE
Fix double slash in URL

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -148,7 +148,10 @@ QString HttpCredentialsGui::requestAppPasswordText(const Account *account)
         return QString();
     }
 
+    auto baseUrl = account->url().toString();
+    if (baseUrl.endsWith('/'))
+        baseUrl.chop(1);
     return tr("<a href=\"%1\">Click here</a> to request an app password from the web interface.")
-        .arg(account->url().toString() + path);
+        .arg(baseUrl + path);
 }
 } // namespace OCC

--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -76,7 +76,7 @@ void OAuth::start()
 
                 QString code = rx.cap(1); // The 'code' is the first capture of the regexp
 
-                QUrl requestToken(_account->url().toString() + QLatin1String("/index.php/apps/oauth2/api/v1/token"));
+                QUrl requestToken = Utility::concatUrlPath(_account->url().toString(), QLatin1String("/index.php/apps/oauth2/api/v1/token"));
                 QNetworkRequest req;
                 req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
@@ -154,10 +154,10 @@ void OAuth::start()
 QUrl OAuth::authorisationLink() const
 {
     Q_ASSERT(_server.isListening());
-    QUrl url = QUrl(_account->url().toString()
-        + QLatin1String("/index.php/apps/oauth2/authorize?response_type=code&client_id=")
-        + Theme::instance()->oauthClientId()
-        + QLatin1String("&redirect_uri=http://localhost:") + QString::number(_server.serverPort()));
+    QUrl url = Utility::concatUrlPath(_account->url(), QLatin1String("/index.php/apps/oauth2/authorize"),
+        { { QLatin1String("response_type"), QLatin1String("code") },
+            { QLatin1String("client_id"), Theme::instance()->oauthClientId() },
+            { QLatin1String("redirect_uri"), QLatin1String("http://localhost:") + QString::number(_server.serverPort()) } });
     if (!_expectedUser.isNull())
         url.addQueryItem("user", _expectedUser);
     return url;

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -344,7 +344,7 @@ bool HttpCredentials::refreshAccessToken()
     if (_refreshToken.isEmpty())
         return false;
 
-    QUrl requestToken(_account->url().toString() + QLatin1String("/index.php/apps/oauth2/api/v1/token"));
+    QUrl requestToken = Utility::concatUrlPath(_account->url(), QLatin1String("/index.php/apps/oauth2/api/v1/token"));
     QNetworkRequest req;
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 


### PR DESCRIPTION
We need to use concatPath to avoid possible double '/' in the URLs if the
account url() ends with '/'.

This has become even more of a problem since commit
d1b8370a4ad21c741da507f64a5dbfe82a3fad05 which was resolving the url after
a redirect where most server actually add a '/' if the url is a folder

CC/ @DeepDiver1975 