### PR TITLE
bandwidthmanager: Fix unregistering devices on delete

### DIFF
--- a/src/libsync/bandwidthmanager.h
+++ b/src/libsync/bandwidthmanager.h
@@ -45,11 +45,9 @@ public:
 
 public slots:
     void registerUploadDevice(UploadDevice *);
-    void unregisterUploadDevice(UploadDevice *);
     void unregisterUploadDevice(QObject *);
 
     void registerDownloadJob(GETFileJob *);
-    void unregisterDownloadJob(GETFileJob *);
     void unregisterDownloadJob(QObject *);
 
     void absoluteLimitTimerExpired();


### PR DESCRIPTION
from the destroyed signal, qobject_cast won't work because the object
is already destroyed. One must use reinterpret_cast then