### PR TITLE
Rename detection: File size must be equal

### DIFF
--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -265,8 +265,8 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
           fs->instruction = CSYNC_INSTRUCTION_NEW;
 
           bool isRename =
-              base.isValid() && base._inode == fs->inode && base._type == fs->type
-                  && (base._modtime == fs->modtime || fs->type == CSYNC_FTW_TYPE_DIR)
+              base.isValid() && base._type == fs->type
+                  && ((base._modtime == fs->modtime && base._fileSize == fs->size) || fs->type == CSYNC_FTW_TYPE_DIR)
 #ifdef NO_RENAME_EXTENSION
                   && _csync_sameextension(base._path, fs->path)
 #endif


### PR DESCRIPTION
Comparison of file sizes for potential conflicts was added in
0eb9401c624f20a128b46f8eb1fa5a984f9ef61e, but did not extend to checking
the file size in case of potential local moves.

This commit adds this check and adds tests for various move+change
scenarios.