### PR TITLE
Context menu: More detailed status messages

### DIFF
--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -98,7 +98,6 @@ public slots:
     void slotRemoveDestroyedShareDialogs();
 
 private slots:
-    void slotDisplayIdle();
     void slotLogin();
     void slotLogout();
     void slotUnpauseAllFolders();


### PR DESCRIPTION
Previously it could only display synchronization progress or "up to
date". Now it also communicates the same overall state that the icon
shows.

See owncloud/enterprise#2134