### PR TITLE
Speed up local discovery by not doing it

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -27,6 +27,8 @@ Some interesting values that can be set on the configuration file are:
 +---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
 | ``forceSyncInterval``           | ``7200000``   | The duration of no activity after which a synchronization run shall be triggered automatically.        |
 +---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
+| ``fullLocalDiscoveryInterval``  | ``3600000``   | The interval after which the next synchronization will perform a full local discovery.                 |
++---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
 | ``notificationRefreshInterval`` | ``300000``    | Specifies the default interval of checking for new server notifications in milliseconds.               |
 +---------------------------------+---------------+--------------------------------------------------------------------------------------------------------+
 

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -244,6 +244,7 @@ private:
     QScopedPointer<SqlQuery> _getFileRecordQueryByInode;
     QScopedPointer<SqlQuery> _getFileRecordQueryByFileId;
     QScopedPointer<SqlQuery> _getFilesBelowPathQuery;
+    QScopedPointer<SqlQuery> _getAllFilesQuery;
     QScopedPointer<SqlQuery> _setFileRecordQuery;
     QScopedPointer<SqlQuery> _setFileRecordChecksumQuery;
     QScopedPointer<SqlQuery> _setFileRecordLocalMetadataQuery;

--- a/src/csync/csync.cpp
+++ b/src/csync/csync.cpp
@@ -314,6 +314,9 @@ int csync_s::reinitialize() {
   local.files.clear();
   remote.files.clear();
 
+  local_discovery_style = LocalDiscoveryStyle::FilesystemOnly;
+  locally_touched_dirs.clear();
+
   status = CSYNC_STATUS_INIT;
   SAFE_FREE(error_string);
 

--- a/src/csync/csync_private.h
+++ b/src/csync/csync_private.h
@@ -38,6 +38,7 @@
 #include <stdbool.h>
 #include <sqlite3.h>
 #include <map>
+#include <set>
 
 #include "common/syncjournaldb.h"
 #include "config_csync.h"
@@ -68,6 +69,11 @@
 enum csync_replica_e {
   LOCAL_REPLICA,
   REMOTE_REPLICA
+};
+
+enum class LocalDiscoveryStyle {
+    FilesystemOnly, //< read all local data from the filesystem
+    DatabaseAndFilesystem, //< read from the db, except for listed paths
 };
 
 
@@ -189,6 +195,16 @@ struct OCSYNC_EXPORT csync_s {
    * Specify if it is allowed to read the remote tree from the DB (default to enabled)
    */
   bool read_remote_from_db = false;
+
+  LocalDiscoveryStyle local_discovery_style = LocalDiscoveryStyle::FilesystemOnly;
+
+  /**
+   * List of folder-relative directory paths that should be scanned on the
+   * filesystem if the local_discovery_style suggests it.
+   *
+   * Their parents will be scanned too. The paths don't start with a /.
+   */
+  std::set<QByteArray> locally_touched_dirs;
 
   bool ignore_hidden_files = true;
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -448,12 +448,26 @@ int Folder::slotWipeErrorBlacklist()
 
 void Folder::slotWatchedPathChanged(const QString &path)
 {
+    if (!path.startsWith(this->path())) {
+        qCDebug(lcFolder) << "Changed path is not contained in folder, ignoring:" << path;
+        return;
+    }
+
+    auto relativePath = path.midRef(this->path().size());
+
+    // Add to list of locally modified paths
+    //
+    // We do this before checking for our own sync-related changes to make
+    // extra sure to not miss relevant changes.
+    auto relativePathBytes = relativePath.toUtf8();
+    _localDiscoveryPaths.insert(relativePathBytes);
+    qCDebug(lcFolder) << "local discovery: inserted" << relativePath << "due to file watcher";
+
 // The folder watcher fires a lot of bogus notifications during
 // a sync operation, both for actual user files and the database
 // and log. Therefore we check notifications against operations
 // the sync is doing to filter out our own changes.
 #ifdef Q_OS_MAC
-    Q_UNUSED(path)
 // On OSX the folder watcher does not report changes done by our
 // own process. Therefore nothing needs to be done here!
 #else
@@ -465,15 +479,12 @@ void Folder::slotWatchedPathChanged(const QString &path)
 #endif
 
     // Check that the mtime actually changed.
-    if (path.startsWith(this->path())) {
-        auto relativePath = path.mid(this->path().size());
-        SyncJournalFileRecord record;
-        if (_journal.getFileRecord(relativePath, &record)
-            && record.isValid()
-            && !FileSystem::fileChanged(path, record._fileSize, record._modtime)) {
-            qCInfo(lcFolder) << "Ignoring spurious notification for file" << relativePath;
-            return; // probably a spurious notification
-        }
+    SyncJournalFileRecord record;
+    if (_journal.getFileRecord(relativePathBytes, &record)
+        && record.isValid()
+        && !FileSystem::fileChanged(path, record._fileSize, record._modtime)) {
+        qCInfo(lcFolder) << "Ignoring spurious notification for file" << relativePath;
+        return; // probably a spurious notification
     }
 
     emit watchedFileChangedExternally(path);
@@ -645,6 +656,36 @@ void Folder::startSync(const QStringList &pathList)
     setDirtyNetworkLimits();
     setSyncOptions();
 
+    static qint64 fullLocalDiscoveryInterval = []() {
+        auto interval = ConfigFile().fullLocalDiscoveryInterval();
+        QByteArray env = qgetenv("OWNCLOUD_FULL_LOCAL_DISCOVERY_INTERVAL");
+        if (!env.isEmpty()) {
+            interval = env.toLongLong();
+        }
+        return interval;
+    }();
+    if (_folderWatcher && _folderWatcher->isReliable()
+        && _timeSinceLastFullLocalDiscovery.isValid()
+        && (fullLocalDiscoveryInterval < 0
+               || _timeSinceLastFullLocalDiscovery.elapsed() < fullLocalDiscoveryInterval)) {
+        qCInfo(lcFolder) << "Allowing local discovery to read from the database";
+        _engine->setLocalDiscoveryOptions(LocalDiscoveryStyle::DatabaseAndFilesystem, _localDiscoveryPaths);
+
+        if (lcFolder().isDebugEnabled()) {
+            QByteArrayList paths;
+            for (auto &path : _localDiscoveryPaths)
+                paths.append(path);
+            qCDebug(lcFolder) << "local discovery paths: " << paths;
+        }
+
+        _previousLocalDiscoveryPaths = std::move(_localDiscoveryPaths);
+    } else {
+        qCInfo(lcFolder) << "Forbidding local discovery to read from the database";
+        _engine->setLocalDiscoveryOptions(LocalDiscoveryStyle::FilesystemOnly);
+        _previousLocalDiscoveryPaths.clear();
+    }
+    _localDiscoveryPaths.clear();
+
     _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
 
     QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
@@ -783,6 +824,24 @@ void Folder::slotSyncFinished(bool success)
         journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, QStringList());
     }
 
+    // bug: This function uses many different criteria for "sync was successful" - investigate!
+    if ((_syncResult.status() == SyncResult::Success
+            || _syncResult.status() == SyncResult::Problem)
+        && success) {
+        if (_engine->lastLocalDiscoveryStyle() == LocalDiscoveryStyle::FilesystemOnly) {
+            _timeSinceLastFullLocalDiscovery.start();
+        }
+        qCDebug(lcFolder) << "Sync success, forgetting last sync's local discovery path list";
+    } else {
+        // On overall-failure we can't forget about last sync's local discovery
+        // paths yet, reuse them for the next sync again.
+        // C++17: Could use std::set::merge().
+        _localDiscoveryPaths.insert(
+            _previousLocalDiscoveryPaths.begin(), _previousLocalDiscoveryPaths.end());
+        qCDebug(lcFolder) << "Sync failed, keeping last sync's local discovery path list";
+    }
+    _previousLocalDiscoveryPaths.clear();
+
     emit syncStateChange();
 
     // The syncFinished result that is to be triggered here makes the folderman
@@ -851,6 +910,25 @@ void Folder::slotItemCompleted(const SyncFileItemPtr &item)
             _folderWatcher->removePath(path() + item->_file);
     }
 
+    // Success and failure of sync items adjust what the next sync is
+    // supposed to do.
+    //
+    // For successes, we want to wipe the file from the list to ensure we don't
+    // rediscover it even if this overall sync fails.
+    //
+    // For failures, we want to add the file to the list so the next sync
+    // will be able to retry it.
+    if (item->_status == SyncFileItem::Success
+        || item->_status == SyncFileItem::FileIgnored
+        || item->_status == SyncFileItem::Restoration
+        || item->_status == SyncFileItem::Conflict) {
+        if (_previousLocalDiscoveryPaths.erase(item->_file.toUtf8()))
+            qCDebug(lcFolder) << "local discovery: wiped" << item->_file;
+    } else {
+        _localDiscoveryPaths.insert(item->_file.toUtf8());
+        qCDebug(lcFolder) << "local discovery: inserted" << item->_file << "due to sync failure";
+    }
+
     _syncResult.processCompletedItem(item);
 
     _fileLog->logItem(*item);
@@ -903,6 +981,11 @@ void Folder::slotScheduleThisFolder()
     FolderMan::instance()->scheduleFolder(this);
 }
 
+void Folder::slotNextSyncFullLocalDiscovery()
+{
+    _timeSinceLastFullLocalDiscovery.invalidate();
+}
+
 void Folder::scheduleThisFolderSoon()
 {
     if (!_scheduleSelfTimer.isActive()) {
@@ -925,6 +1008,8 @@ void Folder::registerFolderWatcher()
     _folderWatcher.reset(new FolderWatcher(path(), this));
     connect(_folderWatcher.data(), &FolderWatcher::pathChanged,
         this, &Folder::slotWatchedPathChanged);
+    connect(_folderWatcher.data(), &FolderWatcher::lostChanges,
+        this, &Folder::slotNextSyncFullLocalDiscovery);
 }
 
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, bool *cancel)

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -27,6 +27,7 @@
 
 #include <QObject>
 #include <QStringList>
+#include <set>
 
 class QThread;
 class QSettings;
@@ -312,6 +313,9 @@ private slots:
      */
     void slotScheduleThisFolder();
 
+    /** Ensures that the next sync performs a full local discovery. */
+    void slotNextSyncFullLocalDiscovery();
+
 private:
     bool setIgnoredFiles();
 
@@ -346,6 +350,7 @@ private:
     QString _lastEtag;
     QElapsedTimer _timeSinceLastSyncDone;
     QElapsedTimer _timeSinceLastSyncStart;
+    QElapsedTimer _timeSinceLastFullLocalDiscovery;
     qint64 _lastSyncDuration;
 
     /// The number of syncs that failed in a row.
@@ -380,6 +385,22 @@ private:
      * Created by registerFolderWatcher(), triggers slotWatchedPathChanged()
      */
     QScopedPointer<FolderWatcher> _folderWatcher;
+
+    /**
+     * The paths that should be checked by the next local discovery.
+     *
+     * Mostly a collection of files the filewatchers have reported as touched.
+     * Also includes files that have had errors in the last sync run.
+     */
+    std::set<QByteArray> _localDiscoveryPaths;
+
+    /**
+     * The paths that the current sync run used for local discovery.
+     *
+     * For failing syncs, this list will be merged into _localDiscoveryPaths
+     * again when the sync is done to make sure everything is retried.
+     */
+    std::set<QByteArray> _previousLocalDiscoveryPaths;
 };
 }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -36,6 +36,7 @@ namespace OCC {
 class SyncEngine;
 class AccountState;
 class SyncRunFileLog;
+class FolderWatcher;
 
 /**
  * @brief The FolderDefinition class
@@ -227,6 +228,13 @@ public:
       */
     void setSaveBackwardsCompatible(bool save);
 
+    /**
+     * Sets up this folder's folderWatcher if possible.
+     *
+     * May be called several times.
+     */
+    void registerFolderWatcher();
+
 signals:
     void syncStateChange();
     void syncStarted();
@@ -365,6 +373,13 @@ private:
      * path.
      */
     bool _saveBackwardsCompatible;
+
+    /**
+     * Watches this folder's local directory for changes.
+     *
+     * Created by registerFolderWatcher(), triggers slotWatchedPathChanged()
+     */
+    QScopedPointer<FolderWatcher> _folderWatcher;
 };
 }
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -104,9 +104,6 @@ void FolderMan::unloadFolder(Folder *f)
 
     _socketApi->slotUnregisterPath(f->alias());
 
-    if (_folderWatchers.contains(f->alias())) {
-        _folderWatchers.remove(f->alias());
-    }
     _folderMap.remove(f->alias());
 
     disconnect(f, &Folder::syncStarted,
@@ -147,52 +144,16 @@ int FolderMan::unloadAndDeleteAllFolders()
     return cnt;
 }
 
-// add a monitor to the local file system. If there is a change in the
-// file system, the method slotFolderMonitorFired is triggered through
-// the SignalMapper
-void FolderMan::registerFolderMonitor(Folder *folder)
+void FolderMan::registerFolderWithSocketApi(Folder *folder)
 {
     if (!folder)
         return;
     if (!QDir(folder->path()).exists())
         return;
 
-    if (!_folderWatchers.contains(folder->alias())) {
-        FolderWatcher *fw = new FolderWatcher(folder->path(), folder);
-
-        // Connect the pathChanged signal, which comes with the changed path,
-        // to the signal mapper which maps to the folder alias. The changed path
-        // is lost this way, but we do not need it for the current implementation.
-        connect(fw, &FolderWatcher::pathChanged, folder, &Folder::slotWatchedPathChanged);
-
-        _folderWatchers.insert(folder->alias(), fw);
-    }
-
     // register the folder with the socket API
     if (folder->canSync())
         _socketApi->slotRegisterPath(folder->alias());
-}
-
-void FolderMan::addMonitorPath(const QString &alias, const QString &path)
-{
-    if (!alias.isEmpty() && _folderWatchers.contains(alias)) {
-        FolderWatcher *fw = _folderWatchers[alias];
-
-        if (fw) {
-            fw->addPath(path);
-        }
-    }
-}
-
-void FolderMan::removeMonitorPath(const QString &alias, const QString &path)
-{
-    if (!alias.isEmpty() && _folderWatchers.contains(alias)) {
-        FolderWatcher *fw = _folderWatchers[alias];
-
-        if (fw) {
-            fw->removePath(path);
-        }
-    }
 }
 
 int FolderMan::setupFolders()
@@ -750,7 +711,8 @@ void FolderMan::slotStartScheduledFolderSync()
     if (folder) {
         // Safe to call several times, and necessary to try again if
         // the folder path didn't exist previously.
-        registerFolderMonitor(folder);
+        folder->registerFolderWatcher();
+        registerFolderWithSocketApi(folder);
 
         _currentSyncFolder = folder;
         folder->startSync(QStringList());
@@ -964,7 +926,8 @@ Folder *FolderMan::addFolderInternal(FolderDefinition folderDefinition,
     connect(folder, &Folder::watchedFileChangedExternally,
         &folder->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::slotPathTouched);
 
-    registerFolderMonitor(folder);
+    folder->registerFolderWatcher();
+    registerFolderWithSocketApi(folder);
     return folder;
 }
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -109,9 +109,6 @@ public:
 
     static SyncResult accountStatus(const QList<Folder *> &folders);
 
-    void removeMonitorPath(const QString &alias, const QString &path);
-    void addMonitorPath(const QString &alias, const QString &path);
-
     // Escaping of the alias which is used in QSettings AND the file
     // system, thus need to be escaped.
     static QString escapeAlias(const QString &);
@@ -284,7 +281,9 @@ private:
     // finds all folder configuration files
     // and create the folders
     QString getBackupName(QString fullPathName) const;
-    void registerFolderMonitor(Folder *folder);
+
+    // makes the folder known to the socket api
+    void registerFolderWithSocketApi(Folder *folder);
 
     // restarts the application (Linux only)
     void restartApplication();
@@ -297,9 +296,6 @@ private:
     Folder *_currentSyncFolder;
     QPointer<Folder> _lastSyncFolder;
     bool _syncEnabled;
-
-    /// Watching for file changes in folders
-    QMap<QString, FolderWatcher *> _folderWatchers;
 
     /// Starts regular etag query jobs
     QTimer _etagPollTimer;

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -68,6 +68,11 @@ bool FolderWatcher::pathIsIgnored(const QString &path)
     return false;
 }
 
+bool FolderWatcher::isReliable() const
+{
+    return _isReliable;
+}
+
 void FolderWatcher::changeDetected(const QString &path)
 {
     QStringList paths(path);

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -72,13 +72,29 @@ public:
     /* Check if the path is ignored. */
     bool pathIsIgnored(const QString &path);
 
+    /**
+     * Returns false if the folder watcher can't be trusted to capture all
+     * notifications.
+     *
+     * For example, this can happen on linux if the inotify user limit from
+     * /proc/sys/fs/inotify/max_user_watches is exceeded.
+     */
+    bool isReliable() const;
+
 signals:
     /** Emitted when one of the watched directories or one
      *  of the contained files is changed. */
     void pathChanged(const QString &path);
 
-    /** Emitted if an error occurs */
-    void error(const QString &error);
+    /**
+     * Emitted if some notifications were lost.
+     *
+     * Would happen, for example, if the number of pending notifications
+     * exceeded the allocated buffer size on Windows. Note that the folder
+     * watcher could still be able to capture all future notifications -
+     * i.e. isReliable() is orthogonal to losing changes occasionally.
+     */
+    void lostChanges();
 
 protected slots:
     // called from the implementations to indicate a change in path
@@ -93,6 +109,7 @@ private:
     QTime _timer;
     QSet<QString> _lastPaths;
     Folder *_folder;
+    bool _isReliable = true;
 
     friend class FolderWatcherPrivate;
 };

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -78,6 +78,12 @@ void FolderWatcherPrivate::inotifyRegisterPath(const QString &path)
             IN_CLOSE_WRITE | IN_ATTRIB | IN_MOVE | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT | IN_ONLYDIR);
         if (wd > -1) {
             _watches.insert(wd, path);
+        } else {
+            // If we're running out of memory or inotify watches, become
+            // unreliable.
+            if (errno == ENOMEM || errno == ENOSPC) {
+                _parent->_isReliable = false;
+            }
         }
     }
 }

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -101,6 +101,7 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
             DWORD errorCode = GetLastError();
             if (errorCode == ERROR_NOTIFY_ENUM_DIR) {
                 qCDebug(lcFolderWatcher) << "The buffer for changes overflowed! Triggering a generic change and resizing";
+                emit lostChanges();
                 emit changed(_path);
                 *increaseBufferSize = true;
             } else {
@@ -199,6 +200,8 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
     _thread = new WatcherThread(path);
     connect(_thread, SIGNAL(changed(const QString &)),
         _parent, SLOT(changeDetected(const QString &)));
+    connect(_thread, SIGNAL(lostChanges()),
+        _parent, SIGNAL(lostChanges()));
     _thread->start();
 }
 

--- a/src/gui/folderwatcher_win.h
+++ b/src/gui/folderwatcher_win.h
@@ -53,6 +53,7 @@ protected:
 
 signals:
     void changed(const QString &path);
+    void lostChanges();
 
 private:
     QString _path;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -36,6 +36,7 @@
 #include <QNetworkProxy>
 
 #define DEFAULT_REMOTE_POLL_INTERVAL 30000 // default remote poll time in milliseconds
+#define DEFAULT_FULL_LOCAL_DISCOVERY_INTERVAL (60 * 60 * 1000) // 1 hour
 #define DEFAULT_MAX_LOG_LINES 20000
 
 namespace OCC {
@@ -45,6 +46,7 @@ Q_LOGGING_CATEGORY(lcConfigFile, "sync.configfile", QtInfoMsg)
 //static const char caCertsKeyC[] = "CaCertificates"; only used from account.cpp
 static const char remotePollIntervalC[] = "remotePollInterval";
 static const char forceSyncIntervalC[] = "forceSyncInterval";
+static const char fullLocalDiscoveryIntervalC[] = "fullLocalDiscoveryInterval";
 static const char notificationRefreshIntervalC[] = "notificationRefreshInterval";
 static const char monoIconsC[] = "monoIcons";
 static const char promptDeleteC[] = "promptDeleteAllFiles";
@@ -404,6 +406,13 @@ quint64 ConfigFile::forceSyncInterval(const QString &connection) const
         interval = pollInterval;
     }
     return interval;
+}
+
+qint64 ConfigFile::fullLocalDiscoveryInterval() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.beginGroup(defaultConnection());
+    return settings.value(QLatin1String(fullLocalDiscoveryIntervalC), DEFAULT_FULL_LOCAL_DISCOVERY_INTERVAL).toLongLong();
 }
 
 quint64 ConfigFile::notificationRefreshInterval(const QString &connection) const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -72,6 +72,13 @@ public:
     /* Force sync interval, in milliseconds */
     quint64 forceSyncInterval(const QString &connection = QString()) const;
 
+    /**
+     * Interval in milliseconds within which full local discovery is required
+     *
+     * Use -1 to disable regular full local discoveries.
+     */
+    qint64 fullLocalDiscoveryInterval() const;
+
     bool monoIcons() const;
     void setMonoIcons(bool);
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -813,6 +813,7 @@ void SyncEngine::startSync()
     }
 
     _csync_ctx->read_remote_from_db = true;
+    _lastLocalDiscoveryStyle = _csync_ctx->local_discovery_style;
 
     bool ok;
     auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
@@ -1553,6 +1554,12 @@ bool SyncEngine::wasFileTouched(const QString &fn) const
 AccountPtr SyncEngine::account() const
 {
     return _account;
+}
+
+void SyncEngine::setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QByteArray> dirs)
+{
+    _csync_ctx->local_discovery_style = style;
+    _csync_ctx->locally_touched_dirs = std::move(dirs);
 }
 
 void SyncEngine::abort()

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -25,6 +25,7 @@
 #include <QMap>
 #include <QStringList>
 #include <QSharedPointer>
+#include <set>
 
 #include <csync.h>
 
@@ -92,12 +93,29 @@ public:
     AccountPtr account() const;
     SyncJournalDb *journal() const { return _journal; }
     QString localPath() const { return _localPath; }
+
     /**
      * Minimum age, in milisecond, of a file that can be uploaded.
      * Files more recent than that are not going to be uploaeded as they are considered
      * too young and possibly still changing
      */
     static qint64 minimumFileAgeForUpload; // in ms
+
+    /**
+     * Control whether local discovery should read from filesystem or db.
+     *
+     * If style is Partial, the paths is a set of file paths relative to
+     * the synced folder. All the parent directories of these paths will not
+     * be read from the db and scanned on the filesystem.
+     *
+     * Note, the style and paths are only retained for the next sync and
+     * revert afterwards. Use _lastLocalDiscoveryStyle to discover the last
+     * sync's style.
+     */
+    void setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QByteArray> dirs = {});
+
+    /** Access the last sync run's local discovery style */
+    LocalDiscoveryStyle lastLocalDiscoveryStyle() const { return _lastLocalDiscoveryStyle; }
 
 signals:
     void csyncUnavailable();
@@ -272,6 +290,9 @@ private:
 
     /** List of unique errors that occurred in a sync run. */
     QSet<QString> _uniqueErrors;
+
+    /** The kind of local discovery the last sync run used */
+    LocalDiscoveryStyle _lastLocalDiscoveryStyle = LocalDiscoveryStyle::DatabaseAndFilesystem;
 };
 }
 


### PR DESCRIPTION
Use the data from the db instead and only check the file system when a file watcher event suggests it's necessary.

Since we're not confident that file watcher events are good enough, we still do a full local discovery every hour for now. This also doesn't get rid of the initial sync after client startup. But incremental syncs should be sped up significantly.

See #2297 