### PR TITLE
HttpCreds: Fix retry after wrong password

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -32,10 +32,11 @@ namespace OCC {
 
 void HttpCredentialsGui::askFromUser()
 {
-    // Unfortunately there's a bug that doesn't allow us to send the "is this
-    // OAuth2 or Basic auth?" GET request directly. Scheduling it for the event
-    // loop works though. See #5989.
-    QMetaObject::invokeMethod(this, "askFromUserAsync", Qt::QueuedConnection);
+    // This function can be called from AccountState::slotInvalidCredentials,
+    // which (indirectly, through HttpCredentials::invalidateToken) schedules
+    // a cache wipe of the qnam. We can only execute a network job again once
+    // the cache has been cleared, otherwise we'd interfere with the job.
+    QTimer::singleShot(100, this, &HttpCredentialsGui::askFromUserAsync);
 }
 
 void HttpCredentialsGui::askFromUserAsync()

--- a/src/gui/creds/httpcredentialsgui.h
+++ b/src/gui/creds/httpcredentialsgui.h
@@ -60,12 +60,12 @@ public:
 private slots:
     void asyncAuthResult(OAuth::Result, const QString &user, const QString &accessToken, const QString &refreshToken);
     void showDialog();
+    void askFromUserAsync();
 
 signals:
     void authorisationLinkChanged();
 
 private:
-    Q_INVOKABLE void askFromUserAsync();
 
     QScopedPointer<OAuth, QScopedPointerObjectDeleteLater<OAuth>> _asyncAuth;
 };

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -881,8 +881,14 @@ bool DetermineAuthTypeJob::finished()
 void DetermineAuthTypeJob::send(const QUrl &url)
 {
     QNetworkRequest req;
+
     // Prevent HttpCredentialsAccessManager from setting an Authorization header.
     req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
+    // Don't reuse previous auth credentials
+    req.setAttribute(QNetworkRequest::AuthenticationReuseAttribute, QNetworkRequest::Manual);
+    // Don't send cookies, we can't determine the auth type if we're logged in
+    req.setAttribute(QNetworkRequest::CookieLoadControlAttribute, QNetworkRequest::Manual);
+
     sendRequest("GET", url, req);
 }
 


### PR DESCRIPTION
This is an ugly solution.

See  #5989

@ogoffart Do you know if timers are stable in this way? I think we'll have to look very carefully at how the credential / account machinery works together in this case.