### PR TITLE
Activity: Allow sorting of issues and protocol #6086

### DIFF
--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -107,6 +107,16 @@ void IssuesWidget::showEvent(QShowEvent *ev)
 {
     ConfigFile cfg;
     cfg.restoreGeometryHeader(_ui->_treeWidget->header());
+
+    // Sorting by section was newly enabled. But if we restore the header
+    // from a state where sorting was disabled, both of these flags will be
+    // false and sorting will be impossible!
+    _ui->_treeWidget->header()->setSectionsClickable(true);
+    _ui->_treeWidget->header()->setSortIndicatorShown(true);
+
+    // Switch back to "first important, then by time" ordering
+    _ui->_treeWidget->sortByColumn(0, Qt::DescendingOrder);
+
     QWidget::showEvent(ev);
 }
 
@@ -119,6 +129,8 @@ void IssuesWidget::hideEvent(QHideEvent *ev)
 
 void IssuesWidget::cleanItems(const QString &folder)
 {
+    _ui->_treeWidget->setSortingEnabled(false);
+
     // The issue list is a state, clear it and let the next sync fill it
     // with ignored files and propagation errors.
     int itemCnt = _ui->_treeWidget->topLevelItemCount();
@@ -129,6 +141,9 @@ void IssuesWidget::cleanItems(const QString &folder)
             delete item;
         }
     }
+
+    _ui->_treeWidget->setSortingEnabled(true);
+
     // update the tabtext
     emit(issueCountUpdated(_ui->_treeWidget->topLevelItemCount()));
 }
@@ -240,7 +255,7 @@ bool IssuesWidget::shouldBeVisible(QTreeWidgetItem *item, AccountState *filterAc
     const QString &filterFolderAlias) const
 {
     bool visible = true;
-    auto status = item->data(0, Qt::UserRole);
+    auto status = item->data(3, Qt::UserRole);
     visible &= (_ui->showIgnores->isChecked() || status != SyncFileItem::FileIgnored);
     visible &= (_ui->showWarnings->isChecked()
         || (status != SyncFileItem::SoftError
@@ -368,13 +383,14 @@ void IssuesWidget::addError(const QString &folderAlias, const QString &message,
 
     QIcon icon = Theme::instance()->syncStateIcon(SyncResult::Error);
 
-    QTreeWidgetItem *twitem = new QTreeWidgetItem(columns);
+    QTreeWidgetItem *twitem = new SortedTreeWidgetItem(columns);
     twitem->setData(0, Qt::SizeHintRole, QSize(0, ActivityItemDelegate::rowHeight()));
+    twitem->setData(0, Qt::UserRole, timestamp);
     twitem->setIcon(0, icon);
     twitem->setToolTip(0, longTimeStr);
-    twitem->setToolTip(3, message);
-    twitem->setData(0, Qt::UserRole, SyncFileItem::NormalError);
     twitem->setData(2, Qt::UserRole, folderAlias);
+    twitem->setToolTip(3, message);
+    twitem->setData(3, Qt::UserRole, SyncFileItem::NormalError);
 
     addItem(twitem);
     addErrorWidget(twitem, message, category);

--- a/src/gui/issueswidget.ui
+++ b/src/gui/issueswidget.ui
@@ -99,6 +99,9 @@
      <property name="rootIsDecorated">
       <bool>false</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <property name="columnCount">
       <number>4</number>
      </property>

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -35,6 +35,21 @@ namespace Ui {
 class Application;
 
 /**
+ * A QTreeWidgetItem with special sorting.
+ *
+ * It allows items for global entries to be moved to the top if the
+ * sorting section is the "Time" column.
+ */
+class SortedTreeWidgetItem : public QTreeWidgetItem
+{
+public:
+    using QTreeWidgetItem::QTreeWidgetItem;
+
+private:
+    bool operator<(const QTreeWidgetItem &other) const override;
+};
+
+/**
  * @brief The ProtocolWidget class
  * @ingroup gui
  */

--- a/src/gui/protocolwidget.ui
+++ b/src/gui/protocolwidget.ui
@@ -35,6 +35,9 @@
      <property name="uniformRowHeights">
       <bool>true</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <property name="columnCount">
       <number>4</number>
      </property>


### PR DESCRIPTION
The issues tab uses custom ordering where overall and summary sync
issues are displayed first. This ordering is preserved by creating
special sorting logic for the "time" column.

It needed special handling anyway, since sorting by time-string would
have yielded incorrect results.