### PR TITLE
owncloudsetupwizard: Fix "add new account" if the wizard is already visible

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -70,6 +70,7 @@ static QPointer<OwncloudSetupWizard> wiz = 0;
 void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *parent)
 {
     if (!wiz.isNull()) {
+        bringWizardToFrontIfVisible();
         return;
     }
 


### PR DESCRIPTION
Clicking on the "Add new Account" from the systray menu should raise
the wizard, even if it is already running.

Relates to issue #6105