### PR TITLE
Sharing: fix overlay icons directly after sharing a file

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -841,6 +841,11 @@ void Folder::slotTransmissionProgress(const ProgressInfo &pi)
 // a item is completed: count the errors and forward to the ProgressDispatcher
 void Folder::slotItemCompleted(const SyncFileItemPtr &item)
 {
+    if (item->_instruction == CSYNC_INSTRUCTION_NONE || item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA) {
+        // We only care about the updates that deserve to be shown in the UI
+        return;
+    }
+
     // add new directories or remove gone away dirs to the watcher
     if (item->isDirectory() && item->_instruction == CSYNC_INSTRUCTION_NEW) {
         FolderMan::instance()->addMonitorPath(alias(), path() + item->_file);

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -64,6 +64,8 @@ public:
      */
     AccountPtr account() const;
 
+    QString path() const;
+
     /*
      * Get the id
      */

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -293,13 +293,10 @@ private slots:
     void slotLinkShareCreated(const QJsonDocument &reply);
     void slotShareCreated(const QJsonDocument &reply);
     void slotOcsError(int statusCode, const QString &message);
-    void slotCreateShare(const QJsonDocument &reply);
-
 private:
     QSharedPointer<LinkShare> parseLinkShare(const QJsonObject &data);
     QSharedPointer<Share> parseShare(const QJsonObject &data);
 
-    QMap<QObject *, QVariant> _jobContinuation;
     AccountPtr _account;
 };
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -571,7 +571,6 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
         dir = SyncFileItem::None;
         // For directories, metadata-only updates will be done after all their files are propagated.
         if (!isDirectory) {
-            emit syncItemDiscovered(*item);
 
             // Update the database now already:  New remote fileid or Etag or RemotePerm
             // Or for files that were detected as "resolved conflict".
@@ -683,8 +682,6 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
     }
 
     _syncItemMap.insert(key, item);
-
-    emit syncItemDiscovered(*item);
     return re;
 }
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -607,6 +607,9 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
                 }
 
                 _journal->setFileRecordMetadata(item->toSyncJournalFileRecordWithInode(filePath));
+
+                // This might have changed the shared flag, so we must notify SyncFileStatusTracker for example
+                emit itemCompleted(item);
             } else {
                 // The local tree is walked first and doesn't have all the info from the server.
                 // Update only outdated data from the disk.

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -105,8 +105,6 @@ signals:
     // During update, before reconcile
     void rootEtag(QString);
 
-    // before actual syncing (after update+reconcile) for each item
-    void syncItemDiscovered(const SyncFileItem &);
     // after the above signals. with the items that actually need propagating
     void aboutToPropagate(SyncFileItemVector &);
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -16,7 +16,7 @@ bool itemDidComplete(const QSignalSpy &spy, const QString &path)
     for(const QList<QVariant> &args : spy) {
         auto item = args[0].value<SyncFileItemPtr>();
         if (item->destination() == path)
-            return true;
+            return item->_instruction != CSYNC_INSTRUCTION_NONE && item->_instruction != CSYNC_INSTRUCTION_UPDATE_METADATA;
     }
     return false;
 }

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -436,6 +436,8 @@ private slots:
         fakeFolder.remoteModifier().appendByte("S/s1");
         fakeFolder.remoteModifier().insert("B/b3");
         fakeFolder.remoteModifier().find("B/b3")->extraDavProperties = "<oc:share-types><oc:share-type>0</oc:share-type></oc:share-types>";
+        fakeFolder.remoteModifier().find("A/a1")->isShared = true; // becomes shared
+        fakeFolder.remoteModifier().find("A", true); // change the etags of the parent
 
         StatusPushSpy statusSpy(fakeFolder.syncEngine());
 
@@ -458,6 +460,7 @@ private slots:
         QCOMPARE(statusSpy.statusOf("S/s1"), sharedUpToDateStatus);
         QCOMPARE(statusSpy.statusOf("B/b1").shared(), false);
         QCOMPARE(statusSpy.statusOf("B/b3"), sharedUpToDateStatus);
+        QCOMPARE(statusSpy.statusOf("A/a1"), sharedUpToDateStatus);
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }


### PR DESCRIPTION
See commit message for more information.
The two first commit are just code cleanup
The other commit fix the issue #6098

This include a workaround of the fact that the server don't update the etags.