### PR TITLE
Wizard: Don't report confusing error message #6116

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -279,7 +279,7 @@ void OwncloudSetupWizard::slotNoServerFound(QNetworkReply *reply)
     } else {
         msg = tr("Failed to connect to %1 at %2:<br/>%3")
                   .arg(Utility::escape(Theme::instance()->appNameGUI()),
-                      Utility::escape(reply->url().toString()),
+                      Utility::escape(_ocWizard->account()->url().toString()),
                       Utility::escape(job->errorString()));
     }
     bool isDowngradeAdvised = checkDowngradeAdvised(reply);


### PR DESCRIPTION
For historical reasons CheckServerJob doesn't just check url/ but also
url/owncloud/. However, that means if url/status.php is a 404 and
url/owncloud/status.php is a 404, the user will see the latter url
appear in the error message. That's potentially confusing.

Instead, just show the account url which will be closer to what the
user typed into the account wizard, while being adjusted for protocol
and possible redirects.