### PR TITLE
Credentials: Namespace windows cred keys

### DIFF
--- a/src/libsync/creds/abstractcredentials.cpp
+++ b/src/libsync/creds/abstractcredentials.cpp
@@ -14,6 +14,7 @@
 
 #include <QLoggingCategory>
 #include <QString>
+#include <QCoreApplication>
 
 #include "common/asserts.h"
 #include "creds/abstractcredentials.h"
@@ -53,6 +54,15 @@ QString AbstractCredentials::keychainKey(const QString &url, const QString &user
     QString key = user + QLatin1Char(':') + u;
     if (!accountId.isEmpty()) {
         key += QLatin1Char(':') + accountId;
+#ifdef Q_OS_WIN
+        // On Windows the credential keys aren't namespaced properly
+        // by qtkeychain. To work around that we manually add namespacing
+        // to the generated keys. See #6125.
+        // It's safe to do that since the key format is changing for 2.4
+        // anyway to include the account ids. That means old keys can be
+        // migrated to new namespaced keys on windows for 2.4.
+        key.prepend(QCoreApplication::applicationName() + "_");
+#endif
     }
     return key;
 }


### PR DESCRIPTION
The application name is prepended to the key. QtKeychain doesn't
do that automatically on the platform.

See #6125 

@SamuAlfageme I'd like to ask you to redo the 2.3 -> 2.4 upgrade tests after this patch hits. It's expected that 2.4alpha credentials won't be found or deleted.