### PR TITLE
Autostart: Add 10s delay for gnome

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -77,6 +77,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
            << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl
            << QLatin1String("X-GNOME-Autostart-enabled=") << "true" << endl;
+           << QLatin1String("X-GNOME-Autostart-Delay=10") << endl;
     } else {
         if (!QFile::remove(desktopFileLocation)) {
             qCWarning(lcUtility) << "Could not remove autostart desktop file";


### PR DESCRIPTION
Sometimes the client managed to start before the system tray. Then
there'd be no owncloud client tray icon.

See #6117. Thanks to @RalfJung for proposing this patch.