### PR TITLE
Journal: Don't crash if the db file is readonly

### DIFF
--- a/src/common/ownsql.h
+++ b/src/common/ownsql.h
@@ -48,8 +48,15 @@ public:
     sqlite3 *sqliteDb();
 
 private:
+    enum class CheckDbResult {
+        Ok,
+        CantPrepare,
+        CantExec,
+        NotOk,
+    };
+
     bool openHelper(const QString &filename, int sqliteFlags);
-    bool checkDb();
+    CheckDbResult checkDb();
 
     sqlite3 *_db;
     QString _error; // last error string


### PR DESCRIPTION
Surprisingly sqlite3_open_v2() returns ok on readonly files with
SQLITE_OPEN_READWRITE.

See #6050