### PR TITLE
DetermineAuthType: Adjustments for tight firewalls

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -30,6 +30,8 @@ using namespace QKeychain;
 
 namespace OCC {
 
+Q_LOGGING_CATEGORY(lcHttpCredentialsGui, "sync.credentials.http.gui", QtInfoMsg)
+
 void HttpCredentialsGui::askFromUser()
 {
     // This function can be called from AccountState::slotInvalidCredentials,
@@ -43,8 +45,16 @@ void HttpCredentialsGui::askFromUserAsync()
 {
     // First, we will check what kind of auth we need.
     auto job = new DetermineAuthTypeJob(_account->sharedFromThis(), this);
-    job->setTimeout(30 * 1000);
     QObject::connect(job, &DetermineAuthTypeJob::authType, this, [this](DetermineAuthTypeJob::AuthType type) {
+        if (type == DetermineAuthTypeJob::Unknown) {
+            // network error, timeout, unsupported auth type?
+            // This fallback exists for backwards compatibility reasons:
+            // in versions before 2.4 we tried basic auth when the auth type
+            // couldn't be determined.
+            qCWarning(lcHttpCredentialsGui) << "Could not determine auth type, falling back to Basic";
+            type = DetermineAuthTypeJob::Basic;
+        }
+
         if (type == DetermineAuthTypeJob::OAuth) {
             _asyncAuth.reset(new OAuth(_account, this));
             _asyncAuth->_expectedUser = _user;
@@ -59,7 +69,8 @@ void HttpCredentialsGui::askFromUserAsync()
             // We will re-enter the event loop, so better wait the next iteration
             QMetaObject::invokeMethod(this, "showDialog", Qt::QueuedConnection);
         } else {
-            // Network error? Unsupported auth type?
+            // Unsupported auth type? Shibboleth?
+            qCWarning(lcHttpCredentialsGui) << "Bad http auth type:" << type;
             emit asked();
         }
     });

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -319,7 +319,6 @@ void OwncloudSetupWizard::slotNoServerFoundTimeout(const QUrl &url)
 void OwncloudSetupWizard::slotDetermineAuthType()
 {
     DetermineAuthTypeJob *job = new DetermineAuthTypeJob(_ocWizard->account(), this);
-    job->setIgnoreCredentialFailure(true);
     connect(job, &DetermineAuthTypeJob::authType,
         _ocWizard, &OwncloudWizard::setAuthType);
     job->start();

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -66,6 +66,7 @@ public:
      * requests where custom handling is necessary.
      */
     void setFollowRedirects(bool follow);
+    bool followRedirects() const { return _followRedirects; }
 
     QByteArray responseTimestamp();
 

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -819,69 +819,16 @@ bool JsonApiJob::finished()
 }
 
 DetermineAuthTypeJob::DetermineAuthTypeJob(AccountPtr account, QObject *parent)
-    : AbstractNetworkJob(account, QString(), parent)
-    , _redirects(0)
+    : QObject(parent)
+    , _account(account)
 {
-    // This job implements special redirect handling to detect redirections
-    // to pages that are indicative of Shibboleth-using servers. Hence we
-    // disable the standard job redirection handling here.
-    _followRedirects = false;
 }
 
 void DetermineAuthTypeJob::start()
 {
-    send(account()->davUrl());
-    AbstractNetworkJob::start();
-}
+    qCInfo(lcDetermineAuthTypeJob) << "Determining auth type for" << _account->davUrl();
 
-bool DetermineAuthTypeJob::finished()
-{
-    QUrl redirection = reply()->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
-    if (_redirects >= maxRedirects()) {
-        redirection.clear();
-    }
-
-    auto authChallenge = reply()->rawHeader("WWW-Authenticate").toLower();
-    if (redirection.isEmpty()) {
-        if (authChallenge.contains("bearer ")) {
-            emit authType(OAuth);
-        } else if (!authChallenge.isEmpty()) {
-            emit authType(Basic);
-        } else {
-            // This is also where we end up in case of network error.
-            emit authType(Unknown);
-        }
-    } else if (redirection.toString().endsWith(account()->davPath())) {
-        // do a new run
-        _redirects++;
-        resetTimeout();
-        send(redirection);
-        qCDebug(lcDetermineAuthTypeJob()) << "Redirected to:" << redirection.toString();
-        return false; // don't discard
-    } else {
-#ifndef NO_SHIBBOLETH
-        QRegExp shibbolethyWords("SAML|wayf");
-        shibbolethyWords.setCaseSensitivity(Qt::CaseInsensitive);
-        if (redirection.toString().contains(shibbolethyWords)) {
-            emit authType(Shibboleth);
-        } else
-#endif
-        {
-            // We got redirected to an address that doesn't look like shib
-            // and also doesn't have the davPath. Give up.
-            qCWarning(lcDetermineAuthTypeJob()) << account()->davUrl()
-                                                << "was redirected to the incompatible address"
-                                                << redirection.toString();
-            emit authType(Unknown);
-        }
-    }
-    return true;
-}
-
-void DetermineAuthTypeJob::send(const QUrl &url)
-{
     QNetworkRequest req;
-
     // Prevent HttpCredentialsAccessManager from setting an Authorization header.
     req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
     // Don't reuse previous auth credentials
@@ -889,7 +836,52 @@ void DetermineAuthTypeJob::send(const QUrl &url)
     // Don't send cookies, we can't determine the auth type if we're logged in
     req.setAttribute(QNetworkRequest::CookieLoadControlAttribute, QNetworkRequest::Manual);
 
-    sendRequest("GET", url, req);
+    // Start two parallel requests, one determines whether it's a shib server
+    // and the other checks the HTTP auth method.
+    auto get = _account->sendRequest("GET", _account->davUrl(), req);
+    auto propfind = _account->sendRequest("PROPFIND", _account->davUrl(), req);
+    get->setTimeout(30 * 1000);
+    propfind->setTimeout(30 * 1000);
+    get->setIgnoreCredentialFailure(true);
+    propfind->setIgnoreCredentialFailure(true);
+
+    connect(get, &AbstractNetworkJob::redirected, this, [this, get](QNetworkReply *, const QUrl &target, int) {
+#ifndef NO_SHIBBOLETH
+        QRegExp shibbolethyWords("SAML|wayf");
+        shibbolethyWords.setCaseSensitivity(Qt::CaseInsensitive);
+        if (target.toString().contains(shibbolethyWords)) {
+            _resultGet = Shibboleth;
+            get->setFollowRedirects(false);
+        }
+#endif
+    });
+    connect(get, &SimpleNetworkJob::finishedSignal, this, [this]() {
+        _getDone = true;
+        checkBothDone();
+    });
+    connect(propfind, &SimpleNetworkJob::finishedSignal, this, [this](QNetworkReply *reply) {
+        auto authChallenge = reply->rawHeader("WWW-Authenticate").toLower();
+        if (authChallenge.contains("bearer ")) {
+            _resultPropfind = OAuth;
+        } else if (!authChallenge.isEmpty()) {
+            _resultPropfind = Basic;
+        }
+        _propfindDone = true;
+        checkBothDone();
+    });
+}
+
+void DetermineAuthTypeJob::checkBothDone()
+{
+    if (!_getDone || !_propfindDone)
+        return;
+    auto result = _resultPropfind;
+    // OAuth > Shib > Basic
+    if (_resultGet == Shibboleth && result != OAuth)
+        result = Shibboleth;
+    qCInfo(lcDetermineAuthTypeJob) << "Auth type for" << _account->davUrl() << "is" << result;
+    emit authType(result);
+    deleteLater();
 }
 
 SimpleNetworkJob::SimpleNetworkJob(AccountPtr account, QObject *parent)

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -355,7 +355,7 @@ private:
  * @brief Checks with auth type to use for a server
  * @ingroup libsync
  */
-class OWNCLOUDSYNC_EXPORT DetermineAuthTypeJob : public AbstractNetworkJob
+class OWNCLOUDSYNC_EXPORT DetermineAuthTypeJob : public QObject
 {
     Q_OBJECT
 public:
@@ -367,14 +367,18 @@ public:
     };
 
     explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start();
 signals:
     void authType(AuthType);
-private slots:
-    bool finished() Q_DECL_OVERRIDE;
+
 private:
-    void send(const QUrl &url);
-    int _redirects;
+    void checkBothDone();
+
+    AccountPtr _account;
+    AuthType _resultGet = Unknown;
+    AuthType _resultPropfind = Unknown;
+    bool _getDone = false;
+    bool _propfindDone = false;
 };
 
 /**


### PR DESCRIPTION
With some firewalls we can't GET /remote.php/webdav/. Here we keep the
GET request to detect shibboleth through the redirect pattern but then
use PROPFIND to figure out the http auth method.

This also restores the fallback behavior of assuming basic auth
when no auth type can be determined.

See  #6135

@SamuAlfageme Could you test with the specific problematic server?