### PR TITLE
Protocol: Introduce context menu with "open in browser" action

### DIFF
--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -68,6 +68,7 @@ private slots:
     void slotUpdateFolderFilters();
     void slotAccountAdded(AccountState *account);
     void slotAccountRemoved(AccountState *account);
+    void slotItemContextMenu(const QPoint &pos);
 
 private:
     void updateAccountChoiceVisibility();

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -35,15 +35,24 @@ namespace Ui {
 class Application;
 
 /**
- * A QTreeWidgetItem with special sorting.
+ * The items used in the protocol and issue QTreeWidget
  *
- * It allows items for global entries to be moved to the top if the
+ * Special sorting: It allows items for global entries to be moved to the top if the
  * sorting section is the "Time" column.
  */
-class SortedTreeWidgetItem : public QTreeWidgetItem
+class ProtocolItem : public QTreeWidgetItem
 {
 public:
     using QTreeWidgetItem::QTreeWidgetItem;
+
+    // Shared with IssueWidget
+    static ProtocolItem *create(const QString &folder, const SyncFileItem &item);
+    static QString timeString(QDateTime dt, QLocale::FormatType format = QLocale::NarrowFormat);
+
+    static SyncJournalFileRecord syncJournalRecord(QTreeWidgetItem *item);
+    static Folder *folder(QTreeWidgetItem *item);
+
+    static void openContextMenu(QPoint globalPos, QTreeWidgetItem *item, QWidget *parent);
 
 private:
     bool operator<(const QTreeWidgetItem &other) const override;
@@ -63,10 +72,6 @@ public:
 
     void storeSyncActivity(QTextStream &ts);
 
-    // Shared with IssueWidget
-    static QTreeWidgetItem *createCompletedTreewidgetItem(const QString &folder, const SyncFileItem &item);
-    static QString timeString(QDateTime dt, QLocale::FormatType format = QLocale::NarrowFormat);
-
 public slots:
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);
     void slotOpenFile(QTreeWidgetItem *item, int);
@@ -74,6 +79,9 @@ public slots:
 protected:
     void showEvent(QShowEvent *);
     void hideEvent(QHideEvent *);
+
+private slots:
+    void slotItemContextMenu(const QPoint &pos);
 
 signals:
     void copyToClipboard();

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -492,7 +492,7 @@ void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listen
 }
 
 // Fetches the private link url asynchronously and then calls the target slot
-void fetchPrivateLinkUrl(const QString &localFile, SocketApi *target, void (SocketApi::*targetFun)(const QString &url) const)
+static void fetchPrivateLinkUrlHelper(const QString &localFile, SocketApi *target, void (SocketApi::*targetFun)(const QString &url) const)
 {
     Folder *shareFolder = FolderMan::instance()->folderForPath(localFile);
     if (!shareFolder) {
@@ -505,45 +505,23 @@ void fetchPrivateLinkUrl(const QString &localFile, SocketApi *target, void (Sock
 
     AccountPtr account = shareFolder->accountState()->account();
 
-    // Generate private link ourselves: used as a fallback
     SyncJournalFileRecord rec;
     if (!shareFolder->journalDb()->getFileRecord(file, &rec) || !rec.isValid())
         return;
-    const QString oldUrl =
-        account->deprecatedPrivateLinkUrl(rec.numericFileId()).toString(QUrl::FullyEncoded);
 
-    // Retrieve the new link or numeric file id by PROPFIND
-    PropfindJob *job = new PropfindJob(account, file, target);
-    job->setProperties(
-        QList<QByteArray>()
-        << "http://owncloud.org/ns:fileid" // numeric file id for fallback private link generation
-        << "http://owncloud.org/ns:privatelink");
-    job->setTimeout(10 * 1000);
-    QObject::connect(job, &PropfindJob::result, target, [=](const QVariantMap &result) {
-        auto privateLinkUrl = result["privatelink"].toString();
-        auto numericFileId = result["fileid"].toByteArray();
-        if (!privateLinkUrl.isEmpty()) {
-            (target->*targetFun)(privateLinkUrl);
-        } else if (!numericFileId.isEmpty()) {
-            (target->*targetFun)(account->deprecatedPrivateLinkUrl(numericFileId).toString(QUrl::FullyEncoded));
-        } else {
-            (target->*targetFun)(oldUrl);
-        }
+    fetchPrivateLinkUrl(account, file, rec.numericFileId(), target, [=](const QString &url) {
+        (target->*targetFun)(url);
     });
-    QObject::connect(job, &PropfindJob::finishedWithError, target, [=](QNetworkReply *) {
-        (target->*targetFun)(oldUrl);
-    });
-    job->start();
 }
 
 void SocketApi::command_COPY_PRIVATE_LINK(const QString &localFile, SocketListener *)
 {
-    fetchPrivateLinkUrl(localFile, this, &SocketApi::copyPrivateLinkToClipboard);
+    fetchPrivateLinkUrlHelper(localFile, this, &SocketApi::copyPrivateLinkToClipboard);
 }
 
 void SocketApi::command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *)
 {
-    fetchPrivateLinkUrl(localFile, this, &SocketApi::emailPrivateLink);
+    fetchPrivateLinkUrlHelper(localFile, this, &SocketApi::emailPrivateLink);
 }
 
 void SocketApi::copyPrivateLinkToClipboard(const QString &link) const

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -18,6 +18,8 @@
 
 #include "abstractnetworkjob.h"
 
+#include <functional>
+
 class QUrl;
 class QJsonObject;
 
@@ -401,6 +403,23 @@ signals:
 private slots:
     bool finished() Q_DECL_OVERRIDE;
 };
+
+/**
+ * @brief Runs a PROPFIND to figure out the private link url
+ *
+ * The numericFileId is used only to build the deprecatedPrivateLinkUrl
+ * locally as a fallback. If it's empty and the PROPFIND fails, targetFun
+ * will be called with an empty string.
+ *
+ * The job and signal connections are parented to the target QObject.
+ *
+ * Note: targetFun is guaranteed to be called only through the event
+ * loop and never directly.
+ */
+void OWNCLOUDSYNC_EXPORT fetchPrivateLinkUrl(
+    AccountPtr account, const QString &remotePath,
+    const QByteArray &numericFileId, QObject *target,
+    std::function<void(const QString &url)> targetFun);
 
 } // namespace OCC
 


### PR DESCRIPTION
To do this conveniently a bunch of functionality that's common to
IssueWidget and ProtocolWidget is moved to ProtocolItem.

Also the convenience function to asynchronously retrieve the private
link url is moved from the socket api to the network jobs.

See #6121 