### PR TITLE
Discovery: Treat files starting with '.' as hidden again

### DIFF
--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -635,7 +635,7 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
      * local stat function.
      */
     if( filename[0] == '.' ) {
-        if (filename == ".sys.admin#recall#") { /* recall file shall not be ignored (#4420) */
+        if (filename != ".sys.admin#recall#") { /* recall file shall not be ignored (#4420) */
             dirent->is_hidden = true;
         }
     }


### PR DESCRIPTION
This bug was introduced when strcmp(a, b) != 0 was accidentally
converted to a == b.

See #6145 