### PR TITLE
DetermineAuth: Remove concept of Unknown

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -46,15 +46,6 @@ void HttpCredentialsGui::askFromUserAsync()
     // First, we will check what kind of auth we need.
     auto job = new DetermineAuthTypeJob(_account->sharedFromThis(), this);
     QObject::connect(job, &DetermineAuthTypeJob::authType, this, [this](DetermineAuthTypeJob::AuthType type) {
-        if (type == DetermineAuthTypeJob::Unknown) {
-            // network error, timeout, unsupported auth type?
-            // This fallback exists for backwards compatibility reasons:
-            // in versions before 2.4 we tried basic auth when the auth type
-            // couldn't be determined.
-            qCWarning(lcHttpCredentialsGui) << "Could not determine auth type, falling back to Basic";
-            type = DetermineAuthTypeJob::Basic;
-        }
-
         if (type == DetermineAuthTypeJob::OAuth) {
             _asyncAuth.reset(new OAuth(_account, this));
             _asyncAuth->_expectedUser = _user;
@@ -69,7 +60,7 @@ void HttpCredentialsGui::askFromUserAsync()
             // We will re-enter the event loop, so better wait the next iteration
             QMetaObject::invokeMethod(this, "showDialog", Qt::QueuedConnection);
         } else {
-            // Unsupported auth type? Shibboleth?
+            // Shibboleth?
             qCWarning(lcHttpCredentialsGui) << "Bad http auth type:" << type;
             emit asked();
         }

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -201,13 +201,15 @@ bool OwncloudSetupPage::urlHasChanged()
 
 int OwncloudSetupPage::nextId() const
 {
-    if (_authType == DetermineAuthTypeJob::Basic) {
+    switch (_authType) {
+    case DetermineAuthTypeJob::Basic:
         return WizardCommon::Page_HttpCreds;
-    } else if (_authType == DetermineAuthTypeJob::OAuth) {
+    case DetermineAuthTypeJob::OAuth:
         return WizardCommon::Page_OAuthCreds;
-    } else {
+    case DetermineAuthTypeJob::Shibboleth:
         return WizardCommon::Page_ShibbolethCreds;
     }
+    return WizardCommon::Page_HttpCreds;
 }
 
 QString OwncloudSetupPage::url() const

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -863,8 +863,8 @@ void DetermineAuthTypeJob::start()
         auto authChallenge = reply->rawHeader("WWW-Authenticate").toLower();
         if (authChallenge.contains("bearer ")) {
             _resultPropfind = OAuth;
-        } else if (!authChallenge.isEmpty()) {
-            _resultPropfind = Basic;
+        } else if (authChallenge.isEmpty()) {
+            qCWarning(lcDetermineAuthTypeJob) << "Did not receive WWW-Authenticate reply to auth-test PROPFIND";
         }
         _propfindDone = true;
         checkBothDone();

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -360,8 +360,7 @@ class OWNCLOUDSYNC_EXPORT DetermineAuthTypeJob : public QObject
     Q_OBJECT
 public:
     enum AuthType {
-        Unknown,
-        Basic,
+        Basic, // also the catch-all fallback for backwards compatibility reasons
         OAuth,
         Shibboleth
     };
@@ -375,8 +374,8 @@ private:
     void checkBothDone();
 
     AccountPtr _account;
-    AuthType _resultGet = Unknown;
-    AuthType _resultPropfind = Unknown;
+    AuthType _resultGet = Basic;
+    AuthType _resultPropfind = Basic;
     bool _getDone = false;
     bool _propfindDone = false;
 };


### PR DESCRIPTION
This restores 2.3 behavior. Some servers reply 404 to GETs and PROPFINDs
to the remote.php/webdav/ url and used to work. Being more picky would
break them.

Fixes #6148