### PR TITLE
Sql: db close() failing isn't fatal

### DIFF
--- a/src/common/ownsql.cpp
+++ b/src/common/ownsql.cpp
@@ -184,8 +184,8 @@ void SqlDatabase::close()
 {
     if (_db) {
         SQLITE_DO(sqlite3_close(_db));
-        // Fatal because reopening an unclosed db might be problematic.
-        ENFORCE(_errId == SQLITE_OK, "Error when closing DB");
+        if (_errId != SQLITE_OK)
+            qCWarning(lcSql) << "Closing database failed" << _error;
         _db = 0;
     }
 }


### PR DESCRIPTION
The assert was made fatal when looking at asserts for #5429 #5518
without having a particular problem in mind. Recent reports weakly
suggest that this might lead to occasional crashes for users when
sqlite_close fails in ways that look ignorable.