### PR TITLE
PropagateDownload: Fix GET with redirects #6159

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -135,6 +135,7 @@ void AbstractNetworkJob::adoptRequest(QNetworkReply *reply)
     addTimer(reply);
     setReply(reply);
     setupConnections(reply);
+    newReplyHook(reply);
 }
 
 QUrl AbstractNetworkJob::makeAccountUrl(const QString &relativePath) const

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -108,8 +108,6 @@ signals:
     void redirected(QNetworkReply *reply, const QUrl &targetUrl, int redirectCount);
 
 protected:
-    void setupConnections(QNetworkReply *reply);
-
     /** Initiate a network request, returning a QNetworkReply.
      *
      * Calls setReply() and setupConnections() on it.
@@ -133,6 +131,16 @@ protected:
      * at it and thus not resend it in case of redirects.
      */
     void adoptRequest(QNetworkReply *reply);
+
+    void setupConnections(QNetworkReply *reply);
+
+    /** Can be used by derived classes to set up the network reply.
+     *
+     * Particularly useful when the request is redirected and reply()
+     * changes. For things like setting up additional signal connections
+     * on the new reply.
+     */
+    virtual void newReplyHook(QNetworkReply *) {}
 
     /// Creates a url for the account from a relative path
     QUrl makeAccountUrl(const QString &relativePath) const;

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -43,6 +43,9 @@ class GETFileJob : public AbstractNetworkJob
     bool _hasEmittedFinishedSignal;
     time_t _lastModified;
 
+    /// Will be set to true once we've seen a 2xx response header
+    bool _saveBodyToFile = false;
+
 public:
     // DOES NOT take ownership of the device.
     explicit GETFileJob(AccountPtr account, const QString &path, QFile *device,
@@ -75,6 +78,8 @@ public:
             return true; // discard
         }
     }
+
+    void newReplyHook(QNetworkReply *reply) override;
 
     void setBandwidthManager(BandwidthManager *bwm);
     void setChoked(bool c);


### PR DESCRIPTION
The GET jobs were redirected, but the custom incremental handling
in readyRead didn't propagate to the follow-up job.