### PR TITLE
PropagateDownload: Skip identical files more

### DIFF
--- a/src/csync/csync_util.cpp
+++ b/src/csync/csync_util.cpp
@@ -211,3 +211,10 @@ time_t oc_httpdate_parse( const char *date ) {
     result = timegm(&gmt);
     return result;
 }
+
+
+bool csync_is_collision_safe_hash(const QByteArray &checksum_header)
+{
+    return checksum_header.startsWith("SHA1:")
+        || checksum_header.startsWith("MD5:");
+}

--- a/src/csync/csync_util.h
+++ b/src/csync/csync_util.h
@@ -31,4 +31,14 @@ const char OCSYNC_EXPORT *csync_instruction_str(enum csync_instructions_e instr)
 void OCSYNC_EXPORT csync_memstat_check(void);
 
 bool OCSYNC_EXPORT csync_file_locked_or_open( const char *dir, const char *fname);
+
+/* Returns true if we're reasonably certain that hash equality
+ * for the header means content equality.
+ *
+ * Cryptographic safety is not required - this is mainly
+ * intended to rule out checksums like Adler32 that are not intended for
+ * hashing and have high likelihood of collision with particular inputs.
+ */
+bool OCSYNC_EXPORT csync_is_collision_safe_hash(const QByteArray &checksum_header);
+
 #endif /* _CSYNC_UTIL_H */


### PR DESCRIPTION
Previously we required matching mtimes but that's actually
unnecessary when the question is about whether to skip the
download. We will still update the downloaded file's metadata.

See #6153