### PR TITLE
Re-add doc/ocdoc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "doc/ocdoc"]
+	path = doc/ocdoc
+	url = https://github.com/owncloud/documentation
 [submodule "src/3rdparty/qtmacgoodies"]
 	path = src/3rdparty/qtmacgoodies
 	url = https://github.com/guruz/qtmacgoodies.git


### PR DESCRIPTION
This requirement was pointed out by @jnweiger in https://github.com/owncloud/documentation/issues/3240#issuecomment-345014294.