### PR TITLE
libsync: Fix compilation with TOKEN_AUTH_ONLY

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -93,6 +93,7 @@ void Account::setDavUser(const QString &newDavUser)
     _davUser = newDavUser;
 }
 
+#ifndef TOKEN_AUTH_ONLY
 QImage Account::avatar() const
 {
     return _avatarImg;
@@ -102,6 +103,7 @@ void Account::setAvatar(const QImage &img)
     _avatarImg = img;
     emit accountChangedAvatar();
 }
+#endif
 
 QString Account::displayName() const
 {

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -26,7 +26,10 @@
 #include <QSslCipher>
 #include <QSslError>
 #include <QSharedPointer>
+
+#ifndef TOKEN_AUTH_ONLY
 #include <QPixmap>
+#endif
 
 #include "common/utility.h"
 #include <memory>
@@ -86,8 +89,10 @@ public:
     QString davDisplayName() const;
     void setDavDisplayName(const QString &newDisplayName);
 
+#ifndef TOKEN_AUTH_ONLY
     QImage avatar() const;
     void setAvatar(const QImage &img);
+#endif
 
     /// The name of the account as shown in the toolbar
     QString displayName() const;
@@ -266,7 +271,9 @@ private:
     QString _id;
     QString _davUser;
     QString _displayName;
+#ifndef TOKEN_AUTH_ONLY
     QImage _avatarImg;
+#endif
     QMap<QString, QVariant> _settingsMap;
     QUrl _url;
 

--- a/src/libsync/connectionvalidator.cpp
+++ b/src/libsync/connectionvalidator.cpp
@@ -17,7 +17,6 @@
 #include <QLoggingCategory>
 #include <QNetworkReply>
 #include <QNetworkProxyFactory>
-#include <QPixmap>
 #include <QXmlStreamReader>
 
 #include "connectionvalidator.h"
@@ -333,24 +332,28 @@ void ConnectionValidator::slotUserFetched(const QJsonDocument &json)
     QString user = json.object().value("ocs").toObject().value("data").toObject().value("id").toString();
     if (!user.isEmpty()) {
         _account->setDavUser(user);
-
-        AvatarJob *job = new AvatarJob(_account, this);
-        job->setTimeout(20 * 1000);
-        QObject::connect(job, &AvatarJob::avatarPixmap, this, &ConnectionValidator::slotAvatarImage);
-
-        job->start();
     }
     QString displayName = json.object().value("ocs").toObject().value("data").toObject().value("display-name").toString();
     if (!displayName.isEmpty()) {
         _account->setDavDisplayName(displayName);
     }
+#ifndef TOKEN_AUTH_ONLY
+    AvatarJob *job = new AvatarJob(_account, this);
+    job->setTimeout(20 * 1000);
+    QObject::connect(job, &AvatarJob::avatarPixmap, this, &ConnectionValidator::slotAvatarImage);
+    job->start();
+#else
+    reportResult(Connected);
+#endif
 }
 
+#ifndef TOKEN_AUTH_ONLY
 void ConnectionValidator::slotAvatarImage(const QImage &img)
 {
     _account->setAvatar(img);
     reportResult(Connected);
 }
+#endif
 
 void ConnectionValidator::reportResult(Status status)
 {

--- a/src/libsync/connectionvalidator.h
+++ b/src/libsync/connectionvalidator.h
@@ -123,7 +123,9 @@ protected slots:
 
     void slotCapabilitiesRecieved(const QJsonDocument &);
     void slotUserFetched(const QJsonDocument &);
+#ifndef TOKEN_AUTH_ONLY
     void slotAvatarImage(const QImage &img);
+#endif
 
 private:
     void reportResult(Status status);

--- a/src/libsync/creds/tokencredentials.cpp
+++ b/src/libsync/creds/tokencredentials.cpp
@@ -102,7 +102,7 @@ QString TokenCredentials::password() const
     return _password;
 }
 
-QNetworkAccessManager *TokenCredentials::getQNAM() const
+QNetworkAccessManager *TokenCredentials::createQNAM() const
 {
     AccessManager *qnam = new TokenCredentialsAccessManager(this);
 

--- a/src/libsync/creds/tokencredentials.h
+++ b/src/libsync/creds/tokencredentials.h
@@ -40,7 +40,7 @@ public:
     TokenCredentials(const QString &user, const QString &password, const QString &token);
 
     QString authType() const Q_DECL_OVERRIDE;
-    QNetworkAccessManager *getQNAM() const Q_DECL_OVERRIDE;
+    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
     bool ready() const Q_DECL_OVERRIDE;
     void askFromUser() Q_DECL_OVERRIDE;
     void fetchFromKeychain() Q_DECL_OVERRIDE;

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -27,7 +27,6 @@
 #include <QTimer>
 #include <QMutex>
 #include <QCoreApplication>
-#include <QPixmap>
 #include <QJsonDocument>
 #include <QJsonObject>
 
@@ -626,6 +625,7 @@ bool PropfindJob::finished()
 
 /*********************************************************************************************/
 
+#ifndef TOKEN_AUTH_ONLY
 AvatarJob::AvatarJob(AccountPtr account, QObject *parent)
     : AbstractNetworkJob(account, QString(), parent)
 {
@@ -656,6 +656,7 @@ bool AvatarJob::finished()
     emit(avatarPixmap(avImage));
     return true;
 }
+#endif
 
 /*********************************************************************************************/
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -133,7 +133,7 @@ private:
     QList<QByteArray> _properties;
 };
 
-
+#ifndef TOKEN_AUTH_ONLY
 /**
  * @brief The AvatarJob class
  *
@@ -155,7 +155,7 @@ signals:
      * @brief avatarPixmap - returns either a valid pixmap or not.
      */
 
-    void avatarPixmap(QImage);
+    void avatarPixmap(const QImage &);
 
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
@@ -163,6 +163,7 @@ private slots:
 private:
     QUrl _avatarUrl;
 };
+#endif
 
 /**
  * @brief Send a Proppatch request


### PR DESCRIPTION
This means we cannot use QtGui in libsync.
So this mostly disable the avatar from the account and the avatarjob

Note that there is one logic change: in ConnectionValidator::slotUserFetched
we do the avatar job even if the user is empty. Otherwise we would end up in
a invalid state. This restore the 2.3.x behavior that was broken in
commit e05d6bfcdc39b551d0a29c763afcabcadb5d05a6