### PR TITLE
AccountSettings: Fix the size of the "Add Sync Folder Connection" button

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -59,7 +59,7 @@ QSize FolderStatusDelegate::sizeHint(const QStyleOptionViewItem &option,
     auto classif = static_cast<const FolderStatusModel *>(index.model())->classify(index);
     if (classif == FolderStatusModel::AddButton) {
         const int margins = aliasFm.height(); // same as 2*aliasMargin of paint
-        QFontMetrics fm(option.font);
+        QFontMetrics fm(qApp->font("QPushButton"));
         QStyleOptionButton opt;
         static_cast<QStyleOption &>(opt) = option;
         opt.text = addFolderText();
@@ -138,7 +138,10 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         opt.rect.setWidth(qMin(opt.rect.width(), hint.width()));
         opt.rect.adjust(0, aliasMargin, 0, -aliasMargin);
         opt.rect = QStyle::visualRect(option.direction, option.rect, opt.rect);
+        painter->save();
+        painter->setFont(qApp->font("QPushButton"));
         QApplication::style()->drawControl(QStyle::CE_PushButton, &opt, painter, option.widget);
+        painter->restore();
         return;
     }
 


### PR DESCRIPTION
The problem here is that the QPainter is created on the viewport with is a
QWidget, but QAbstractItemView can have a different font, and the
QStyleOptionViewItem::font is this font. QStyleOptionViewItem::font
was used to compute the sizeHint, and the default font from the QPainter
was used to draw the text, so they could be not in sync.

Fix it by always using the font for QPushButton

Reported in
https://github.com/owncloud/client/issues/6156#issuecomment-346576328