### PR TITLE
Make rename detection consistent for duplicate file ids

### DIFF
--- a/src/csync/csync.cpp
+++ b/src/csync/csync.cpp
@@ -211,14 +211,14 @@ static int _csync_treewalk_visitor(csync_file_stat_t *cur, CSYNC * ctx) {
 
     if (other_file_it == other_tree->cend()) {
         /* Check the renamed path as well. */
-        QByteArray renamed_path = csync_rename_adjust_path(ctx, cur->path);
+        QByteArray renamed_path = csync_rename_adjust_parent_path(ctx, cur->path);
         if (renamed_path != cur->path)
             other_file_it = other_tree->find(renamed_path);
     }
 
     if (other_file_it == other_tree->cend()) {
         /* Check the source path as well. */
-        QByteArray renamed_path = csync_rename_adjust_path_source(ctx, cur->path);
+        QByteArray renamed_path = csync_rename_adjust_parent_path_source(ctx, cur->path);
         if (renamed_path != cur->path)
             other_file_it = other_tree->find(renamed_path);
     }

--- a/src/csync/csync.cpp
+++ b/src/csync/csync.cpp
@@ -314,6 +314,9 @@ int csync_s::reinitialize() {
   local.files.clear();
   remote.files.clear();
 
+  renames.folder_renamed_from.clear();
+  renames.folder_renamed_to.clear();
+
   status = CSYNC_STATUS_INIT;
   SAFE_FREE(error_string);
 

--- a/src/csync/csync_rename.cpp
+++ b/src/csync/csync_rename.cpp
@@ -36,7 +36,7 @@ void csync_rename_record(CSYNC* ctx, const QByteArray &from, const QByteArray &t
     ctx->renames.folder_renamed_from[to] = from;
 }
 
-QByteArray csync_rename_adjust_path(CSYNC* ctx, const QByteArray &path)
+QByteArray csync_rename_adjust_parent_path(CSYNC *ctx, const QByteArray &path)
 {
     if (ctx->renames.folder_renamed_to.empty())
         return path;
@@ -50,11 +50,25 @@ QByteArray csync_rename_adjust_path(CSYNC* ctx, const QByteArray &path)
     return path;
 }
 
-QByteArray csync_rename_adjust_path_source(CSYNC* ctx, const QByteArray &path)
+QByteArray csync_rename_adjust_parent_path_source(CSYNC *ctx, const QByteArray &path)
 {
     if (ctx->renames.folder_renamed_from.empty())
         return path;
-    for (auto p = _parentDir(path); !p.isEmpty(); p = _parentDir(p)) {
+    for (ByteArrayRef p = _parentDir(path); !p.isEmpty(); p = _parentDir(p)) {
+        auto it = ctx->renames.folder_renamed_from.find(p);
+        if (it != ctx->renames.folder_renamed_from.end()) {
+            QByteArray rep = it->second + path.mid(p.length());
+            return rep;
+        }
+    }
+    return path;
+}
+
+QByteArray csync_rename_adjust_full_path_source(CSYNC *ctx, const QByteArray &path)
+{
+    if (ctx->renames.folder_renamed_from.empty())
+        return path;
+    for (ByteArrayRef p = path; !p.isEmpty(); p = _parentDir(p)) {
         auto it = ctx->renames.folder_renamed_from.find(p);
         if (it != ctx->renames.folder_renamed_from.end()) {
             QByteArray rep = it->second + path.mid(p.length());

--- a/src/csync/csync_rename.h
+++ b/src/csync/csync_rename.h
@@ -22,10 +22,19 @@
 
 #include "csync.h"
 
-/* Return the final destination path of a given patch in case of renames */
-QByteArray OCSYNC_EXPORT csync_rename_adjust_path(CSYNC *ctx, const QByteArray &path);
+/* Return the final destination path of a given patch in case of renames
+ *
+ * Does only map the parent directories. If the directory "A" is renamed to
+ * "B" then this function will not map "A" to "B". Only "A/foo" -> "B/foo".
+*/
+QByteArray OCSYNC_EXPORT csync_rename_adjust_parent_path(CSYNC *ctx, const QByteArray &path);
+
 /* Return the source of a given path in case of renames */
-QByteArray OCSYNC_EXPORT csync_rename_adjust_path_source(CSYNC *ctx, const QByteArray &path);
+QByteArray OCSYNC_EXPORT csync_rename_adjust_parent_path_source(CSYNC *ctx, const QByteArray &path);
+
+/* like the parent_path variant, but applying to the full path */
+QByteArray OCSYNC_EXPORT csync_rename_adjust_full_path_source(CSYNC *ctx, const QByteArray &path);
+
 void OCSYNC_EXPORT csync_rename_record(CSYNC *ctx, const QByteArray &from, const QByteArray &to);
 /*  Return the amount of renamed item recorded */
 bool OCSYNC_EXPORT csync_rename_count(CSYNC *ctx);

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -75,7 +75,7 @@ bool DiscoveryJob::isInSelectiveSyncBlackList(const QByteArray &path) const
 
     // Also try to adjust the path if there was renames
     if (csync_rename_count(_csync_ctx)) {
-        QByteArray adjusted = csync_rename_adjust_path_source(_csync_ctx, path);
+        QByteArray adjusted = csync_rename_adjust_parent_path_source(_csync_ctx, path);
         if (adjusted != path) {
             return findPathInList(_selectiveSyncBlackList, QString::fromUtf8(adjusted));
         }


### PR DESCRIPTION
See #6212 and the commit message of the second commit.