### PR TITLE
Move config and remove most dependencies form the sync engine.

### DIFF
--- a/doc/autoupdate.rst
+++ b/doc/autoupdate.rst
@@ -119,7 +119,7 @@ Preventing Automatic Updates in Linux Environments
 
 Because the Linux client does not provide automatic updating functionality, there is no
 need to remove the automatic-update check.  However, if you want to disable it edit your desktop
-client configuration file, ``$HOME/.local/share/data/ownCloud/owncloud.cfg``. 
+client configuration file, ``$HOME/.config/ownCloud/owncloud.cfg``.
 Add this line to the [General] section::
 
     skipUpdateCheck=true

--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -1,13 +1,13 @@
 The ownCloud Client reads a configuration file.  You can locate this configuration file as follows:
 
 On Linux distributions:
-        ``$HOME/.local/share/data/ownCloud/owncloud.cfg``
+        ``$HOME/.config/ownCloud/owncloud.cfg``
 
 On Microsoft Windows systems:
-        ``%LOCALAPPDATA%\ownCloud\owncloud.cfg``
+        ``%APPDATA%\ownCloud\owncloud.cfg``
 
 On MAC OS X systems:
-        ``$HOME/Library/Application Support/ownCloud/owncloud.cfg``
+        ``$HOME/Library/Preferences/ownCloud/owncloud.cfg``
 
 
 The configuration file contains settings using the Microsoft Windows .ini file

--- a/src/cmd/simplesslerrorhandler.cpp
+++ b/src/cmd/simplesslerrorhandler.cpp
@@ -11,7 +11,6 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-#include "configfile.h"
 #include "common/utility.h"
 #include "account.h"
 #include "simplesslerrorhandler.h"

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -51,6 +51,7 @@
 #include <QTranslator>
 #include <QMenu>
 #include <QMessageBox>
+#include <QDesktopServices>
 
 class QSocket;
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -139,6 +139,11 @@ Application::Application(int &argc, char **argv)
     setupLogging();
     setupTranslations();
 
+    // The timeout is initialized with an environment variable, if not, override with the value from the config
+    ConfigFile cfg;
+    if (!AbstractNetworkJob::httpTimeout)
+        AbstractNetworkJob::httpTimeout = cfg.timeout();
+
     _folderManager.reset(new FolderMan);
 
     connect(this, &SharedTools::QtSingleApplication::messageReceived, this, &Application::slotParseMessage);
@@ -166,7 +171,6 @@ Application::Application(int &argc, char **argv)
 
     setQuitOnLastWindowClosed(false);
 
-    ConfigFile cfg;
     _theme->setSystrayUseMonoIcons(cfg.monoIcons());
     connect(_theme, &Theme::systrayUseMonoIconsChanged, this, &Application::slotUseMonoIconsChanged);
 

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -40,6 +40,9 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcNetworkJob, "sync.networkjob", QtInfoMsg)
 
+// If not set, it is overwritten by the Application constructor with the value from the config
+int AbstractNetworkJob::httpTimeout = qEnvironmentVariableIntValue("OWNCLOUD_TIMEOUT");
+
 AbstractNetworkJob::AbstractNetworkJob(AccountPtr account, const QString &path, QObject *parent)
     : QObject(parent)
     , _timedout(false)
@@ -51,7 +54,7 @@ AbstractNetworkJob::AbstractNetworkJob(AccountPtr account, const QString &path, 
     , _redirectCount(0)
 {
     _timer.setSingleShot(true);
-    _timer.setInterval(OwncloudPropagator::httpTimeout() * 1000); // default to 5 minutes.
+    _timer.setInterval((httpTimeout ? httpTimeout : 300) * 1000); // default to 5 minutes.
     connect(&_timer, &QTimer::timeout, this, &AbstractNetworkJob::slotTimeout);
 
     connect(this, &AbstractNetworkJob::networkActivity, this, &AbstractNetworkJob::resetTimeout);

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -88,6 +88,10 @@ public:
      */
     QString errorStringParsingBody(QByteArray *body = 0);
 
+    /** static variable the HTTP timeout (in seconds). If set to 0, the default will be used
+     */
+    static int httpTimeout;
+
 public slots:
     void setTimeout(qint64 msec);
     void resetTimeout();

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -15,7 +15,6 @@
 #include "account.h"
 #include "cookiejar.h"
 #include "networkjobs.h"
-#include "configfile.h"
 #include "accessmanager.h"
 #include "creds/abstractcredentials.h"
 #include "capabilities.h"
@@ -33,6 +32,7 @@
 #include <QDir>
 #include <QSslKey>
 #include <QAuthenticator>
+#include <QStandardPaths>
 
 namespace OCC {
 
@@ -206,8 +206,7 @@ void Account::lendCookieJarTo(QNetworkAccessManager *guest)
 
 QString Account::cookieJarPath()
 {
-    ConfigFile cfg;
-    return cfg.configPath() + "/cookies" + id() + ".db";
+    return QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/cookies" + id() + ".db";
 }
 
 void Account::resetNetworkAccessManager()

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -14,8 +14,6 @@
 
 #include "capabilities.h"
 
-#include "configfile.h"
-
 #include <QVariantMap>
 
 namespace OCC {

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -26,7 +26,6 @@
 #ifndef TOKEN_AUTH_ONLY
 #include <QWidget>
 #include <QHeaderView>
-#include <QDesktopServices>
 #endif
 
 #include <QCoreApplication>
@@ -36,6 +35,7 @@
 #include <QLoggingCategory>
 #include <QSettings>
 #include <QNetworkProxy>
+#include <QStandardPaths>
 
 #define DEFAULT_REMOTE_POLL_INTERVAL 30000 // default remote poll time in milliseconds
 #define DEFAULT_FULL_LOCAL_DISCOVERY_INTERVAL (60 * 60 * 1000) // 1 hour
@@ -252,24 +252,16 @@ QVariant ConfigFile::getPolicySetting(const QString &setting, const QVariant &de
 
 QString ConfigFile::configPath() const
 {
-#ifndef TOKEN_AUTH_ONLY
     if (_confDir.isEmpty()) {
-        //  Qt 5's QStandardPaths::writableLocation gives us wrong results (without /data/),
-        //  so we'll have to use the deprecated version for now
-        _confDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+        // On Unix, use the AppConfigLocation for the settings, that's configurable with the XDG_CONFIG_HOME env variable.
+        // On Windows, use AppDataLocation, that's where the roaming data is and where we should store the config file
+        _confDir = QStandardPaths::writableLocation(Utility::isWindows() ? QStandardPaths::AppDataLocation : QStandardPaths::AppConfigLocation);
     }
-#endif
     QString dir = _confDir;
 
     if (!dir.endsWith(QLatin1Char('/')))
         dir.append(QLatin1Char('/'));
     return dir;
-}
-
-QString ConfigFile::configPathWithAppName() const
-{
-    //HACK
-    return QFileInfo(configFile()).dir().absolutePath().append("/");
 }
 
 static const QLatin1String exclFile("sync-exclude.lst");

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -43,7 +43,6 @@ public:
         SystemScope };
 
     QString configPath() const;
-    QString configPathWithAppName() const;
     QString configFile() const;
     QString excludeFile(Scope scope) const;
     static QString excludeFileFromSystem(); // doesn't access config dir

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -24,6 +24,7 @@
 #include <QWaitCondition>
 #include <QLinkedList>
 #include <deque>
+#include "syncoptions.h"
 
 namespace OCC {
 
@@ -34,52 +35,6 @@ class Account;
  * Its goal is to look at the files in one of the remote and check compared to the db
  * if the files are new, or changed.
  */
-
-struct SyncOptions
-{
-    SyncOptions()
-        : _newBigFolderSizeLimit(-1)
-        , _confirmExternalStorage(false)
-        , _initialChunkSize(10 * 1000 * 1000) // 10 MB
-        , _minChunkSize(1 * 1000 * 1000) // 1 MB
-        , _maxChunkSize(100 * 1000 * 1000) // 100 MB
-        , _targetChunkUploadDuration(60 * 1000) // 1 minute
-        , _parallelNetworkJobs(true)
-    {
-    }
-
-    /** Maximum size (in Bytes) a folder can have without asking for confirmation.
-     * -1 means infinite */
-    qint64 _newBigFolderSizeLimit;
-
-    /** If a confirmation should be asked for external storages */
-    bool _confirmExternalStorage;
-
-    /** The initial un-adjusted chunk size in bytes for chunked uploads, both
-     * for old and new chunking algorithm, which classifies the item to be chunked
-     *
-     * In chunkingNG, when dynamic chunk size adjustments are done, this is the
-     * starting value and is then gradually adjusted within the
-     * minChunkSize / maxChunkSize bounds.
-     */
-    quint64 _initialChunkSize;
-
-    /** The minimum chunk size in bytes for chunked uploads */
-    quint64 _minChunkSize;
-
-    /** The maximum chunk size in bytes for chunked uploads */
-    quint64 _maxChunkSize;
-
-    /** The target duration of chunk uploads for dynamic chunk sizing.
-     *
-     * Set to 0 it will disable dynamic chunk sizing.
-     */
-    quint64 _targetChunkUploadDuration;
-
-    /** Whether parallel network jobs are allowed. */
-    bool _parallelNetworkJobs;
-};
-
 
 struct DiscoveryDirectoryResult
 {

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -22,7 +22,6 @@
 #include "propagateremotemove.h"
 #include "propagateremotemkdir.h"
 #include "propagatorjobs.h"
-#include "configfile.h"
 #include "common/utility.h"
 #include "account.h"
 #include "common/asserts.h"
@@ -552,19 +551,6 @@ bool OwncloudPropagator::isInSharedDirectory(const QString &file)
         }
     }
     return re;
-}
-
-int OwncloudPropagator::httpTimeout()
-{
-    static int timeout = 0;
-    if (!timeout) {
-        timeout = qgetenv("OWNCLOUD_TIMEOUT").toUInt();
-        if (timeout == 0) {
-            ConfigFile cfg;
-            timeout = cfg.timeout();
-        }
-    }
-    return timeout;
 }
 
 bool OwncloudPropagator::localFileNameClash(const QString &relFile)

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -30,7 +30,7 @@
 #include "common/syncjournaldb.h"
 #include "bandwidthmanager.h"
 #include "accountfwd.h"
-#include "discoveryphase.h"
+#include "syncoptions.h"
 
 namespace OCC {
 

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -464,9 +464,6 @@ public:
         }
     }
 
-    // timeout in seconds
-    static int httpTimeout();
-
     AccountPtr account() const;
 
     enum DiskSpaceResult {

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include "owncloudlib.h"
+#include <QString>
+
+
+namespace OCC {
+
+/**
+ * Value class containing the options given to the sync engine
+ */
+struct SyncOptions
+{
+    /** Maximum size (in Bytes) a folder can have without asking for confirmation.
+     * -1 means infinite */
+    qint64 _newBigFolderSizeLimit = -1;
+
+    /** If a confirmation should be asked for external storages */
+    bool _confirmExternalStorage = false;
+
+    /** The initial un-adjusted chunk size in bytes for chunked uploads, both
+     * for old and new chunking algorithm, which classifies the item to be chunked
+     *
+     * In chunkingNG, when dynamic chunk size adjustments are done, this is the
+     * starting value and is then gradually adjusted within the
+     * minChunkSize / maxChunkSize bounds.
+     */
+    quint64 _initialChunkSize = 10 * 1000 * 1000; // 10MB
+
+    /** The minimum chunk size in bytes for chunked uploads */
+    quint64 _minChunkSize = 1 * 1000 * 1000; // 1MB
+
+    /** The maximum chunk size in bytes for chunked uploads */
+    quint64 _maxChunkSize = 100 * 1000 * 1000; // 100MB
+
+    /** The target duration of chunk uploads for dynamic chunk sizing.
+     *
+     * Set to 0 it will disable dynamic chunk sizing.
+     */
+    quint64 _targetChunkUploadDuration = 60 * 1000; // 1 minute
+
+    /** Whether parallel network jobs are allowed. */
+    bool _parallelNetworkJobs = true;
+};
+
+
+}


### PR DESCRIPTION
See individual commit.

Relates to issues #6213 #2245 #1601 and #684

One of the change is that it moves the config directory from
~/.local/share/data/ownCloud/ to ~/.config/ownCloud/
It migrates by moving the folder to the new location and creating a symlink.
