### PR TITLE
Remove use of deprecated Qt API

### DIFF
--- a/cmake/modules/QtVersionAbstraction.cmake
+++ b/cmake/modules/QtVersionAbstraction.cmake
@@ -98,7 +98,7 @@ set(QT_RCC_EXECUTABLE "${Qt5Core_RCC_EXECUTABLE}")
 
 #Enable deprecated symbols
 add_definitions("-DQT_DISABLE_DEPRECATED_BEFORE=0")
-
+add_definitions("-DQT_DEPRECATED_WARNINGS")
 add_definitions("-DQT_USE_QSTRINGBUILDER") #optimize string concatenation
 add_definitions("-DQT_MESSAGELOGCONTEXT") #enable function name and line number in debug output
 

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -53,7 +53,7 @@
 using namespace OCC;
 
 
-static void nullMessageHandler(QtMsgType, const char *)
+static void nullMessageHandler(QtMsgType, const QMessageLogContext &, const QString &)
 {
 }
 
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
 
     csync_set_log_level(options.silent ? 1 : 11);
     if (options.silent) {
-        qInstallMsgHandler(nullMessageHandler);
+        qInstallMessageHandler(nullMessageHandler);
     } else {
         qSetMessagePattern("%{time MM-dd hh:mm:ss:zzz} [ %{type} %{category} ]%{if-debug}\t[ %{function} ]%{endif}:\t%{message}");
     }

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -518,7 +518,7 @@ void Utility::sortFilenames(QStringList &fileNames)
     QCollator collator;
     collator.setNumericMode(true);
     collator.setCaseSensitivity(Qt::CaseInsensitive);
-    qSort(fileNames.begin(), fileNames.end(), collator);
+    std::sort(fileNames.begin(), fileNames.end(), collator);
 }
 
 QUrl Utility::concatUrlPath(const QUrl &url, const QString &concatPath,

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -524,7 +524,7 @@ void Utility::sortFilenames(QStringList &fileNames)
 }
 
 QUrl Utility::concatUrlPath(const QUrl &url, const QString &concatPath,
-    const QList<QPair<QString, QString>> &queryItems)
+    const QUrlQuery &queryItems)
 {
     QString path = url.path();
     if (!concatPath.isEmpty()) {
@@ -540,9 +540,7 @@ QUrl Utility::concatUrlPath(const QUrl &url, const QString &concatPath,
 
     QUrl tmpUrl = url;
     tmpUrl.setPath(path);
-    if (queryItems.size() > 0) {
-        tmpUrl.setQueryItems(queryItems);
-    }
+    tmpUrl.setQuery(queryItems);
     return tmpUrl;
 }
 

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -296,9 +296,7 @@ namespace {
 
         QString description(quint64 value) const
         {
-            return QCoreApplication::translate(
-                "Utility", name, 0, QCoreApplication::UnicodeUTF8,
-                value);
+            return QCoreApplication::translate("Utility", name, 0, value);
         }
     };
 // QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -71,7 +71,7 @@ namespace Utility {
      * @param unit an optional unit that is appended if present.
      * @return the formatted string.
      */
-    OCSYNC_EXPORT QString compactFormatDouble(double value, int prec, const QString &unit = QString::null);
+    OCSYNC_EXPORT QString compactFormatDouble(double value, int prec, const QString &unit = QString());
 
     // porting methods
     OCSYNC_EXPORT QString escape(const QString &);

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -28,6 +28,7 @@
 #include <QLoggingCategory>
 #include <QMap>
 #include <QUrl>
+#include <QUrlQuery>
 #include <functional>
 #include <memory>
 
@@ -175,7 +176,7 @@ namespace Utility {
     /** Appends concatPath and queryItems to the url */
     OCSYNC_EXPORT QUrl concatUrlPath(
         const QUrl &url, const QString &concatPath,
-        const QList<QPair<QString, QString>> &queryItems = (QList<QPair<QString, QString>>()));
+        const QUrlQuery &queryItems = {});
 
     /**  Returns a new settings pre-set in a specific group.  The Settings will be created
          with the given parent. If no parent is specified, the caller must destroy the settings */

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -128,9 +128,9 @@ void ActivityListModel::startFetchJob(AccountState *s)
         this, &ActivityListModel::slotActivitiesReceived);
     job->setProperty("AccountStatePtr", QVariant::fromValue<QPointer<AccountState>>(s));
 
-    QList<QPair<QString, QString>> params;
-    params.append(qMakePair(QString::fromLatin1("page"), QString::fromLatin1("0")));
-    params.append(qMakePair(QString::fromLatin1("pagesize"), QString::fromLatin1("100")));
+    QUrlQuery params;
+    params.addQueryItem(QLatin1String("page"), QLatin1String("0"));
+    params.addQueryItem(QLatin1String("pagesize"), QLatin1String("100"));
     job->addQueryParams(params);
 
     _currentlyFetching.insert(s);

--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -156,12 +156,13 @@ void OAuth::start()
 QUrl OAuth::authorisationLink() const
 {
     Q_ASSERT(_server.isListening());
-    QUrl url = Utility::concatUrlPath(_account->url(), QLatin1String("/index.php/apps/oauth2/authorize"),
-        { { QLatin1String("response_type"), QLatin1String("code") },
-            { QLatin1String("client_id"), Theme::instance()->oauthClientId() },
-            { QLatin1String("redirect_uri"), QLatin1String("http://localhost:") + QString::number(_server.serverPort()) } });
+    QUrlQuery query;
+    query.setQueryItems({ { QLatin1String("response_type"), QLatin1String("code") },
+        { QLatin1String("client_id"), Theme::instance()->oauthClientId() },
+        { QLatin1String("redirect_uri"), QLatin1String("http://localhost:") + QString::number(_server.serverPort()) } });
     if (!_expectedUser.isNull())
-        url.addQueryItem("user", _expectedUser);
+        query.addQueryItem("user", _expectedUser);
+    QUrl url = Utility::concatUrlPath(_account->url(), QLatin1String("/index.php/apps/oauth2/authorize"), query);
     return url;
 }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -342,7 +342,7 @@ private:
     };
 
     void createGuiLog(const QString &filename, LogStatus status, int count,
-        const QString &renameTarget = QString::null);
+        const QString &renameTarget = QString());
 
     AccountStatePtr _accountState;
     FolderDefinition _definition;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1018,7 +1018,7 @@ QString FolderMan::getBackupName(QString fullPathName) const
         fullPathName.chop(1);
 
     if (fullPathName.isEmpty())
-        return QString::null;
+        return QString();
 
     QString newName = fullPathName + tr(" (backup)");
     QFileInfo fi(newName);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -90,7 +90,7 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
     }
 
     // Sort by header text
-    qSort(_folders.begin(), _folders.end(), sortByFolderHeader);
+    std::sort(_folders.begin(), _folders.end(), sortByFolderHeader);
 
     // Set the root _pathIdx after the sorting
     for (int i = 0; i < _folders.size(); ++i) {

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -951,8 +951,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
                 //: Example text: "download 24Kb/s"   (%1 is replaced by 24Kb (translated))
                 fileProgressString.append(tr("download %1/s").arg(Utility::octetsToString(estimatedDownBw)));
 #else
-                fileProgressString.append(trUtf8("\u2193"
-                                                 " %1/s")
+                fileProgressString.append(tr("\u2193 %1/s")
                                               .arg(Utility::octetsToString(estimatedDownBw)));
 #endif
             }
@@ -962,8 +961,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
                 //: Example text: "upload 24Kb/s"   (%1 is replaced by 24Kb (translated))
                 fileProgressString.append(tr("upload %1/s").arg(Utility::octetsToString(estimatedUpBw)));
 #else
-                fileProgressString.append(trUtf8("\u2191"
-                                                 " %1/s")
+                fileProgressString.append(tr("\u2191 %1/s")
                                               .arg(Utility::octetsToString(estimatedUpBw)));
 #endif
             }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -118,7 +118,7 @@ bool FolderWizardLocalPath::isComplete() const
 
 void FolderWizardLocalPath::slotChooseLocalFolder()
 {
-    QString sf = QDesktopServices::storageLocation(QDesktopServices::HomeLocation);
+    QString sf = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
     QDir d(sf);
 
     // open the first entry of the home dir. Otherwise the dir picker comes

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -107,7 +107,7 @@ bool FolderWizardLocalPath::isComplete() const
     _ui.warnLabel->setWordWrap(true);
     if (isOk) {
         _ui.warnLabel->hide();
-        _ui.warnLabel->setText(QString::null);
+        _ui.warnLabel->setText(QString());
     } else {
         _ui.warnLabel->show();
         QString warnings = formatWarnings(warnStrings);

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -19,6 +19,7 @@
 #include <QDesktopServices>
 #include <QLoggingCategory>
 #include <QMessageBox>
+#include <QUrlQuery>
 
 using namespace OCC;
 
@@ -45,8 +46,10 @@ bool Utility::openBrowser(const QUrl &url, QWidget *errorWidgetParent)
 bool Utility::openEmailComposer(const QString &subject, const QString &body, QWidget *errorWidgetParent)
 {
     QUrl url(QLatin1String("mailto:"));
-    url.setQueryItems({ { QLatin1String("subject"), subject },
+    QUrlQuery query;
+    query.setQueryItems({ { QLatin1String("subject"), subject },
         { QLatin1String("body"), body } });
+    url.setQuery(query);
 
     if (!QDesktopServices::openUrl(url)) {
         if (errorWidgetParent) {

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -60,7 +60,7 @@ IgnoreListEditor::IgnoreListEditor(QWidget *parent)
     connect(ui->addPushButton, &QAbstractButton::clicked, this, &IgnoreListEditor::slotAddPattern);
 
     ui->tableWidget->resizeColumnsToContents();
-    ui->tableWidget->horizontalHeader()->setResizeMode(patternCol, QHeaderView::Stretch);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(patternCol, QHeaderView::Stretch);
     ui->tableWidget->verticalHeader()->setVisible(false);
 
     ui->syncHiddenFilesCheckBox->setChecked(!FolderMan::instance()->ignoreHiddenFiles());

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -308,7 +308,7 @@ void SettingsDialog::customizeStyle()
     QString altBase(palette().alternateBase().color().name());
     QString dark(palette().dark().color().name());
     QString background(palette().base().color().name());
-    _toolBar->setStyleSheet(QString::fromAscii(TOOLBAR_CSS).arg(background, dark, highlightColor, altBase));
+    _toolBar->setStyleSheet(QString::fromLatin1(TOOLBAR_CSS).arg(background, dark, highlightColor, altBase));
 
     Q_FOREACH (QAction *a, _actionGroup->actions()) {
         QIcon icon = createColorAwareIcon(a->property("iconPath").toString());

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -379,9 +379,9 @@ QSharedPointer<LinkShare> ShareManager::parseLinkShare(const QJsonObject &data)
         // From ownCloud server version 8 on, a different share link scheme is used.
         url = QUrl(Utility::concatUrlPath(_account->url(), QLatin1String("index.php/s/") + data.value("token").toString())).toString();
     } else {
-        QList<QPair<QString, QString>> queryArgs;
-        queryArgs.append(qMakePair(QString("service"), QString("files")));
-        queryArgs.append(qMakePair(QString("t"), data.value("token").toString()));
+        QUrlQuery queryArgs;
+        queryArgs.addQueryItem(QLatin1String("service"), QLatin1String("files"));
+        queryArgs.addQueryItem(QLatin1String("t"), data.value("token").toString());
         url = QUrl(Utility::concatUrlPath(_account->url(), QLatin1String("public.php"), queryArgs).toString());
     }
 

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -65,7 +65,7 @@ static inline QString removeTrailingSlash(QString path)
     return path;
 }
 
-static QString buildMessage(const QString &verb, const QString &path, const QString &status = QString::null)
+static QString buildMessage(const QString &verb, const QString &path, const QString &status = QString())
 {
     QString msg(verb);
 
@@ -307,7 +307,7 @@ void SocketApi::slotUnregisterPath(const QString &alias)
 
     Folder *f = FolderMan::instance()->folder(alias);
     if (f)
-        broadcastMessage(buildMessage(QLatin1String("UNREGISTER_PATH"), removeTrailingSlash(f->path()), QString::null), true);
+        broadcastMessage(buildMessage(QLatin1String("UNREGISTER_PATH"), removeTrailingSlash(f->path()), QString()), true);
 
     _registeredAliases.remove(alias);
 }

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -270,7 +270,7 @@ void SocketApi::slotReadSocket()
         QString line = QString::fromUtf8(socket->readLine()).normalized(QString::NormalizationForm_C);
         line.chop(1); // remove the '\n'
         qCInfo(lcSocketApi) << "Received SocketAPI message <--" << line << "from" << socket;
-        QByteArray command = line.split(":").value(0).toAscii();
+        QByteArray command = line.split(":").value(0).toLatin1();
         QByteArray functionWithArguments = "command_" + command + "(QString,SocketListener*)";
         int indexOfMethod = staticMetaObject.indexOfMethod(functionWithArguments);
 

--- a/src/gui/sslbutton.h
+++ b/src/gui/sslbutton.h
@@ -36,7 +36,6 @@ class SslButton : public QToolButton
     Q_OBJECT
 public:
     explicit SslButton(QWidget *parent = 0);
-    QString protoToString(QSsl::SslProtocol proto);
     void updateAccountState(AccountState *accountState);
 
 public slots:

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -136,7 +136,7 @@ void SyncRunFileLog::logItem(const SyncFileItem &item)
     if (item._direction == SyncFileItem::None) {
         return;
     }
-    QString ts = QString::fromAscii(item._responseTimeStamp);
+    QString ts = QString::fromLatin1(item._responseTimeStamp);
     if (ts.length() > 6) {
         QRegExp rx("(\\d\\d:\\d\\d:\\d\\d)");
         if (ts.contains(rx)) {

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -90,7 +90,7 @@ QString Updater::getSystemInfo()
 
     return QString::fromLocal8Bit(output.toBase64());
 #else
-    return QString::null;
+    return QString();
 #endif
 }
 

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -41,7 +41,7 @@ Updater *Updater::instance()
 
 QUrl Updater::addQueryParams(const QUrl &url)
 {
-    QUrl paramUrl = url;
+    QUrlQuery query;
     Theme *theme = Theme::instance();
     QString platform = QLatin1String("stranger");
     if (Utility::isLinux()) {
@@ -56,23 +56,25 @@ QUrl Updater::addQueryParams(const QUrl &url)
 
     QString sysInfo = getSystemInfo();
     if (!sysInfo.isEmpty()) {
-        paramUrl.addQueryItem(QLatin1String("client"), sysInfo);
+        query.addQueryItem(QLatin1String("client"), sysInfo);
     }
-    paramUrl.addQueryItem(QLatin1String("version"), clientVersion());
-    paramUrl.addQueryItem(QLatin1String("platform"), platform);
-    paramUrl.addQueryItem(QLatin1String("oem"), theme->appName());
+    query.addQueryItem(QLatin1String("version"), clientVersion());
+    query.addQueryItem(QLatin1String("platform"), platform);
+    query.addQueryItem(QLatin1String("oem"), theme->appName());
 
     QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
-    paramUrl.addQueryItem(QLatin1String("versionsuffix"), suffix);
+    query.addQueryItem(QLatin1String("versionsuffix"), suffix);
     if (suffix.startsWith("nightly")
             || suffix.startsWith("alpha")
             || suffix.startsWith("rc")
             || suffix.startsWith("beta")) {
-        paramUrl.addQueryItem(QLatin1String("channel"), "beta");
+        query.addQueryItem(QLatin1String("channel"), "beta");
         // FIXME: Provide a checkbox in UI to enable regular versions to switch
         // to beta channel
     }
 
+    QUrl paramUrl = url;
+    paramUrl.setQuery(query);
     return paramUrl;
 }
 

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -230,7 +230,7 @@ bool OwncloudAdvancedSetupPage::isConfirmBigFolderChecked() const
 bool OwncloudAdvancedSetupPage::validatePage()
 {
     if (!_created) {
-        setErrorString(QString::null);
+        setErrorString(QString());
         _checking = true;
         startSpinner();
         emit completeChanged();

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -221,7 +221,7 @@ QString OwncloudSetupPage::url() const
 bool OwncloudSetupPage::validatePage()
 {
     if (!_authTypeKnown) {
-        setErrorString(QString::null, false);
+        setErrorString(QString(), false);
         _checking = true;
         startSpinner();
         emit completeChanged();

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -195,7 +195,7 @@ void OwncloudWizard::slotCurrentPageChanged(int id)
     if (id == WizardCommon::Page_Result) {
         disconnect(this, &QDialog::finished, this, &OwncloudWizard::basicSetupFinished);
         emit basicSetupFinished(QDialog::Accepted);
-        appendToConfigurationLog(QString::null);
+        appendToConfigurationLog(QString());
         // Immediately close on show, we currently don't want this page anymore
         done(Accepted);
     }

--- a/src/gui/wizard/owncloudwizardresultpage.cpp
+++ b/src/gui/wizard/owncloudwizardresultpage.cpp
@@ -70,7 +70,7 @@ bool OwncloudWizardResultPage::isComplete() const
 
 void OwncloudWizardResultPage::initializePage()
 {
-    _ui.localFolderLabel->setText(QString::null);
+    _ui.localFolderLabel->setText(QString());
 }
 
 void OwncloudWizardResultPage::setRemoteFolder(const QString &remoteFolder)
@@ -81,7 +81,7 @@ void OwncloudWizardResultPage::setRemoteFolder(const QString &remoteFolder)
 void OwncloudWizardResultPage::setupCustomization()
 {
     // set defaults for the customize labels.
-    _ui.topLabel->setText(QString::null);
+    _ui.topLabel->setText(QString());
     _ui.topLabel->hide();
 
     QVariant variant = Theme::instance()->customMedia(Theme::oCSetupResultTop);

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -326,7 +326,7 @@ QString extractErrorMessage(const QByteArray &errorResponse)
     QXmlStreamReader reader(errorResponse);
     reader.readNextStartElement();
     if (reader.name() != "error") {
-        return QString::null;
+        return QString();
     }
 
     QString exception;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -84,7 +84,7 @@ static const char maxLogLinesC[] = "Logging/maxLogLines";
 
 const char certPath[] = "http_certificatePath";
 const char certPasswd[] = "http_certificatePasswd";
-QString ConfigFile::_confDir = QString::null;
+QString ConfigFile::_confDir = QString();
 bool ConfigFile::_askedUser = false;
 
 ConfigFile::ConfigFile()
@@ -609,12 +609,12 @@ QString ConfigFile::proxyPassword() const
 
 int ConfigFile::useUploadLimit() const
 {
-    return getValue(useUploadLimitC, QString::null, 0).toInt();
+    return getValue(useUploadLimitC, QString(), 0).toInt();
 }
 
 int ConfigFile::useDownloadLimit() const
 {
-    return getValue(useDownloadLimitC, QString::null, 0).toInt();
+    return getValue(useDownloadLimitC, QString(), 0).toInt();
 }
 
 void ConfigFile::setUseUploadLimit(int val)
@@ -629,12 +629,12 @@ void ConfigFile::setUseDownloadLimit(int val)
 
 int ConfigFile::uploadLimit() const
 {
-    return getValue(uploadLimitC, QString::null, 10).toInt();
+    return getValue(uploadLimitC, QString(), 10).toInt();
 }
 
 int ConfigFile::downloadLimit() const
 {
-    return getValue(downloadLimitC, QString::null, 80).toInt();
+    return getValue(downloadLimitC, QString(), 80).toInt();
 }
 
 void ConfigFile::setUploadLimit(int kbytes)

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -56,7 +56,7 @@ public:
     QByteArray caCerts();
     void setCaCerts(const QByteArray &);
 
-    bool passwordStorageAllowed(const QString &connection = QString::null);
+    bool passwordStorageAllowed(const QString &connection = QString());
 
     // max count of lines in the log window
     int maxLogLines() const;
@@ -165,7 +165,7 @@ protected:
     bool dataExists(const QString &group, const QString &key) const;
 
 private:
-    QVariant getValue(const QString &param, const QString &group = QString::null,
+    QVariant getValue(const QString &param, const QString &group = QString(),
         const QVariant &defaultValue = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);
 

--- a/src/libsync/creds/abstractcredentials.cpp
+++ b/src/libsync/creds/abstractcredentials.cpp
@@ -40,11 +40,11 @@ QString AbstractCredentials::keychainKey(const QString &url, const QString &user
     QString u(url);
     if (u.isEmpty()) {
         qCWarning(lcCredentials) << "Empty url in keyChain, error!";
-        return QString::null;
+        return QString();
     }
     if (user.isEmpty()) {
         qCWarning(lcCredentials) << "Error: User is empty!";
-        return QString::null;
+        return QString();
     }
 
     if (!u.endsWith(QChar('/'))) {

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -780,7 +780,7 @@ JsonApiJob::JsonApiJob(const AccountPtr &account, const QString &path, QObject *
 {
 }
 
-void JsonApiJob::addQueryParams(QList<QPair<QString, QString>> params)
+void JsonApiJob::addQueryParams(const QUrlQuery &params)
 {
     _additionalParams = params;
 }
@@ -789,10 +789,9 @@ void JsonApiJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader("OCS-APIREQUEST", "true");
-    QUrl url = Utility::concatUrlPath(account()->url(), path());
-    QList<QPair<QString, QString>> params = _additionalParams;
-    params << qMakePair(QString::fromLatin1("format"), QString::fromLatin1("json"));
-    url.setQueryItems(params);
+    auto query = _additionalParams;
+    query.addQueryItem(QLatin1String("format"), QLatin1String("json"));
+    QUrl url = Utility::concatUrlPath(account()->url(), path(), query);
     sendRequest("GET", url, req);
     AbstractNetworkJob::start();
 }

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -17,7 +17,7 @@
 #define NETWORKJOBS_H
 
 #include "abstractnetworkjob.h"
-
+#include <QUrlQuery>
 #include <functional>
 
 class QUrl;
@@ -340,7 +340,7 @@ public:
      *
      * This function needs to be called before start() obviously.
      */
-    void addQueryParams(QList<QPair<QString, QString>> params);
+    void addQueryParams(const QUrlQuery &params);
 
 public slots:
     void start() Q_DECL_OVERRIDE;
@@ -357,7 +357,7 @@ signals:
     void jsonReceived(const QJsonDocument &json, int statusCode);
 
 private:
-    QList<QPair<QString, QString>> _additionalParams;
+    QUrlQuery _additionalParams;
 };
 
 /**

--- a/src/libsync/owncloudtheme.cpp
+++ b/src/libsync/owncloudtheme.cpp
@@ -43,7 +43,7 @@ QString ownCloudTheme::configFileName() const
 QString ownCloudTheme::about() const
 {
     QString devString;
-    devString = trUtf8("<p>Version %2. For more information visit <a href=\"%3\">https://%4</a></p>"
+    devString = tr("<p>Version %2. For more information visit <a href=\"%3\">https://%4</a></p>"
                        "<p>For known issues and help, please visit: <a href=\"https://central.owncloud.org/c/desktop-client\">https://central.owncloud.org</a></p>"
                        "<p><small>By Klaas Freitag, Daniel Molkentin, Olivier Goffart, Markus Götz, "
                        " Jan-Christoph Borchardt, and others.</small></p>"

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -106,7 +106,7 @@ void SyncResult::appendErrorString(const QString &err)
 QString SyncResult::errorString() const
 {
     if (_errors.isEmpty())
-        return QString::null;
+        return QString();
     return _errors.first();
 }
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -303,7 +303,7 @@ QString Theme::gitSHA1() const
                     .arg(gitSha1.left(6))
                     .arg(__DATE__)
                     .arg(__TIME__)
-                    .arg(QString::fromAscii(qVersion()))
+                    .arg(qVersion())
                     .arg(QSslSocket::sslLibraryVersionString());
 #endif
     return devString;

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -219,7 +219,7 @@ QString Theme::defaultServerFolder() const
 
 QString Theme::overrideServerUrl() const
 {
-    return QString::null;
+    return QString();
 }
 
 QString Theme::forceConfigAuthType() const

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -120,7 +120,7 @@ public:
     /**
     * URL to help file
     */
-    virtual QString helpUrl() const { return QString::null; }
+    virtual QString helpUrl() const { return QString(); }
 
     /**
      * Setting a value here will pre-define the server url.
@@ -149,7 +149,7 @@ public:
     /**
      * Override to encforce a particular locale, i.e. "de" or "pt_BR"
      */
-    virtual QString enforcedLocale() const { return QString::null; }
+    virtual QString enforcedLocale() const { return QString(); }
 
     /** colored, white or black */
     QString systrayIconFlavor(bool mono, bool sysTrayMenuVisible = false) const;

--- a/test/testconcaturl.cpp
+++ b/test/testconcaturl.cpp
@@ -50,7 +50,9 @@ private slots:
         QFETCH(QueryItems, query);
         QFETCH(QString, expected);
         QUrl baseUrl("http://example.com" + base);
-        QUrl resultUrl = Utility::concatUrlPath(baseUrl, concat, query);
+        QUrlQuery urlQuery;
+        urlQuery.setQueryItems(query);
+        QUrl resultUrl = Utility::concatUrlPath(baseUrl, concat, urlQuery);
         QString result = QString::fromUtf8(resultUrl.toEncoded());
         QString expectedFull = "http://example.com" + expected;
         QCOMPARE(result, expectedFull);


### PR DESCRIPTION
Now that we require a recent Qt, we can get rid of most calls of functions deprecated since Qt 5.0