### PR TITLE
SyncEngine: Recover when the PUT reply (or chunkin's MOVE) is lost

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -112,6 +112,7 @@ public:
         qint64 _modtime;
         int _errorCount;
         bool _valid;
+        QByteArray _contentChecksum;
     };
 
     struct PollInfo

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -230,6 +230,7 @@ void PropagateUploadFileNG::startNewUpload()
     pi._valid = true;
     pi._transferid = _transferId;
     pi._modtime = _item->_modtime;
+    pi._contentChecksum = _item->_checksumHeader;
     propagator()->_journal->setUploadInfo(_item->_file, pi);
     propagator()->_journal->commit("Upload info");
     QMap<QByteArray, QByteArray> headers;

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -43,10 +43,24 @@ void PropagateUploadFileV1::doStartUpload()
 
     const SyncJournalDb::UploadInfo progressInfo = propagator()->_journal->getUploadInfo(_item->_file);
 
-    if (progressInfo._valid && progressInfo._modtime == _item->_modtime) {
+    if (progressInfo._valid && progressInfo._modtime == _item->_modtime
+        && (progressInfo._contentChecksum == _item->_checksumHeader || progressInfo._contentChecksum.isEmpty() || _item->_checksumHeader.isEmpty())) {
         _startChunk = progressInfo._chunk;
         _transferId = progressInfo._transferid;
         qCInfo(lcPropagateUpload) << _item->_file << ": Resuming from chunk " << _startChunk;
+    } else if (_chunkCount <= 1 && !_item->_checksumHeader.isEmpty()) {
+        // If there is only one chunk, write the checksum in the database, so if the PUT is sent
+        // to the server, but the connection drops before we get the etag, we can check the checksum
+        // in reconcile (issue #5106)
+        SyncJournalDb::UploadInfo pi;
+        pi._valid = true;
+        pi._chunk = 0;
+        pi._transferid = _transferId;
+        pi._modtime = _item->_modtime;
+        pi._errorCount = 0;
+        pi._contentChecksum = _item->_checksumHeader;
+        propagator()->_journal->setUploadInfo(_item->_file, pi);
+        propagator()->_journal->commit("Upload info");
     }
 
     _currentChunk = 0;
@@ -274,6 +288,7 @@ void PropagateUploadFileV1::slotPutFinished()
         pi._transferid = _transferId;
         pi._modtime = _item->_modtime;
         pi._errorCount = 0; // successful chunk upload resets
+        pi._contentChecksum = _item->_checksumHeader;
         propagator()->_journal->setUploadInfo(_item->_file, pi);
         propagator()->_journal->commit("Upload info");
         startNextChunk();

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -452,7 +452,11 @@ public:
         emit finished();
     }
 
-    void abort() override { }
+    void abort() override
+    {
+        setError(OperationCanceledError, "abort");
+        emit finished();
+    }
     qint64 readData(char *, qint64) override { return 0; }
 };
 
@@ -696,7 +700,12 @@ public:
         emit finished();
     }
 
-    void abort() override { }
+    void abort() override
+    {
+        setError(OperationCanceledError, "abort");
+        emit finished();
+    }
+
     qint64 readData(char *, qint64) override { return 0; }
 };
 

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -441,7 +441,8 @@ public:
         QMetaObject::invokeMethod(this, "respond", Qt::QueuedConnection);
     }
 
-    Q_INVOKABLE void respond() {
+    Q_INVOKABLE virtual void respond()
+    {
         emit uploadProgress(fileInfo->size, fileInfo->size);
         setRawHeader("OC-ETag", fileInfo->etag.toLatin1());
         setRawHeader("ETag", fileInfo->etag.toLatin1());
@@ -615,7 +616,7 @@ class FakeChunkMoveReply : public QNetworkReply
 public:
     FakeChunkMoveReply(FileInfo &uploadsFileInfo, FileInfo &remoteRootFileInfo,
         QNetworkAccessManager::Operation op, const QNetworkRequest &request,
-        quint64 delayMs, QObject *parent)
+        QObject *parent)
         : QNetworkReply{ parent }
     {
         setRequest(request);
@@ -675,10 +676,11 @@ public:
         fileInfo->lastModified = OCC::Utility::qDateTimeFromTime_t(request.rawHeader("X-OC-Mtime").toLongLong());
         remoteRootFileInfo.find(fileName, /*invalidate_etags=*/true);
 
-        QTimer::singleShot(delayMs, this, &FakeChunkMoveReply::respond);
+        QTimer::singleShot(0, this, &FakeChunkMoveReply::respond);
     }
 
-    Q_INVOKABLE void respond() {
+    Q_INVOKABLE virtual void respond()
+    {
         setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 201);
         setRawHeader("OC-ETag", fileInfo->etag.toLatin1());
         setRawHeader("ETag", fileInfo->etag.toLatin1());
@@ -744,10 +746,32 @@ public:
     qint64 readData(char *, qint64) override { return 0; }
 };
 
+// A delayed reply
+template <class OriginalReply>
+class DelayedReply : public OriginalReply
+{
+public:
+    template <typename... Args>
+    explicit DelayedReply(quint64 delayMS, Args &&... args)
+        : OriginalReply(std::forward<Args>(args)...)
+        , _delayMs(delayMS)
+    {
+    }
+    quint64 _delayMs;
+
+    void respond() override
+    {
+        QTimer::singleShot(_delayMs, static_cast<OriginalReply *>(this), [this] {
+            // Explicit call to bases's respond();
+            this->OriginalReply::respond();
+        });
+    }
+};
+
 class FakeQNAM : public QNetworkAccessManager
 {
 public:
-    using Override = std::function<QNetworkReply *(Operation, const QNetworkRequest &)>;
+    using Override = std::function<QNetworkReply *(Operation, const QNetworkRequest &, QIODevice *)>;
 
 private:
     FileInfo _remoteRootFileInfo;
@@ -770,7 +794,7 @@ protected:
     QNetworkReply *createRequest(Operation op, const QNetworkRequest &request,
                                          QIODevice *outgoingData = 0) {
         if (_override) {
-            if (auto reply = _override(op, request))
+            if (auto reply = _override(op, request, outgoingData))
                 return reply;
         }
         const QString fileName = getFilePathFromUrl(request.url());
@@ -796,7 +820,7 @@ protected:
         else if (verb == QLatin1String("MOVE") && !isUpload)
             return new FakeMoveReply{info, op, request, this};
         else if (verb == QLatin1String("MOVE") && isUpload)
-            return new FakeChunkMoveReply{ info, _remoteRootFileInfo, op, request, 0, this };
+            return new FakeChunkMoveReply{ info, _remoteRootFileInfo, op, request, this };
         else {
             qDebug() << verb << outgoingData;
             Q_UNREACHABLE();

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -161,17 +161,6 @@ private slots:
         QVERIFY(!moveChecksumHeader.isEmpty());
         fakeFolder.remoteModifier().find("A/a0")->checksums = moveChecksumHeader;
 
-        // This time it's a real conflict, we have a remote checksum!
-        connection = connect(&fakeFolder.syncEngine(), &SyncEngine::aboutToPropagate, [&](SyncFileItemVector &items) {
-            SyncFileItemPtr a0;
-            for (auto &item : items) {
-                if (item->_file == "A/a0")
-                    a0 = item;
-            }
-
-            QVERIFY(a0);
-            QCOMPARE(a0->_instruction, CSYNC_INSTRUCTION_CONFLICT);
-        });
         QVERIFY(fakeFolder.syncOnce());
         disconnect(connection);
         QCOMPARE(nGET, 0); // no new download, just a metadata update!
@@ -378,6 +367,65 @@ private slots:
         QVERIFY(fakeFolder.uploadState().children.first().name != chunkingId);
     }
 
+    // Check what happens when the connection is dropped on the PUT (non-chunking) or MOVE (chunking)
+    // for on the issue #5106
+    void connectionDroppedBeforeEtagRecieved_data()
+    {
+        QTest::addColumn<bool>("chunking");
+        QTest::newRow("big file") << true;
+        QTest::newRow("small file") << false;
+    }
+    void connectionDroppedBeforeEtagRecieved()
+    {
+        QFETCH(bool, chunking);
+        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
+        fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ { "chunking", "1.0" } } }, { "checksums", QVariantMap{ { "supportedTypes", QStringList() << "SHA1" } } } });
+        const int size = chunking ? 150 * 1000 * 1000 : 300;
+
+        // Make the MOVE never reply, but trigger a client-abort and apply the change remotely
+        QByteArray checksumHeader;
+        int nGET = 0;
+        QScopedValueRollback<int> setHttpTimeout(AbstractNetworkJob::httpTimeout, 1);
+        int responseDelay = AbstractNetworkJob::httpTimeout * 1000 * 1000; // much bigger than http timeout (so a timeout will occur)
+        // This will perform the operation on the server, but the reply will not come to the client
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData) -> QNetworkReply * {
+            if (!chunking && op == QNetworkAccessManager::PutOperation) {
+                checksumHeader = request.rawHeader("OC-Checksum");
+                return new DelayedReply<FakePutReply>(responseDelay, fakeFolder.remoteModifier(), op, request, outgoingData->readAll(), &fakeFolder.syncEngine());
+            } else if (chunking && request.attribute(QNetworkRequest::CustomVerbAttribute) == "MOVE") {
+                checksumHeader = request.rawHeader("OC-Checksum");
+                return new DelayedReply<FakeChunkMoveReply>(responseDelay, fakeFolder.uploadState(), fakeFolder.remoteModifier(), op, request, &fakeFolder.syncEngine());
+            } else if (op == QNetworkAccessManager::GetOperation) {
+                nGET++;
+            }
+            return nullptr;
+        });
+
+
+        // Test 1: a NEW file
+        fakeFolder.localModifier().insert("A/a0", size);
+        QVERIFY(!fakeFolder.syncOnce()); // timeout!
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState()); // but the upload succeeded
+        QVERIFY(!checksumHeader.isEmpty());
+        fakeFolder.remoteModifier().find("A/a0")->checksums = checksumHeader; // The test system don't do that automatically
+        // Should be resolved properly
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nGET, 0);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        // Test 2: Modify the file further
+        fakeFolder.localModifier().appendByte("A/a0");
+        QVERIFY(!fakeFolder.syncOnce()); // timeout!
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState()); // but the upload succeeded
+        fakeFolder.remoteModifier().find("A/a0")->checksums = checksumHeader;
+        // modify again, should not cause conflict
+        fakeFolder.localModifier().appendByte("A/a0");
+        QVERIFY(!fakeFolder.syncOnce()); // now it's trying to upload the modified file
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        fakeFolder.remoteModifier().find("A/a0")->checksums = checksumHeader;
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nGET, 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestChunkingNG)

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -111,7 +111,7 @@ public:
         account->setUrl(sOAuthTestServer);
         account->setCredentials(new FakeCredentials{fakeQnam});
         fakeQnam->setParent(this);
-        fakeQnam->setOverride([this] (QNetworkAccessManager::Operation op, const QNetworkRequest &req) {
+        fakeQnam->setOverride([this](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *) {
             return this->tokenReply(op, req);
         });
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -301,7 +301,7 @@ private slots:
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
 
         int nGET = 0;
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &) {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &, QIODevice *) {
             if (op == QNetworkAccessManager::GetOperation)
                 ++nGET;
             return nullptr;
@@ -431,7 +431,7 @@ private slots:
         int remoteQuota = 1000;
         int n507 = 0, nPUT = 0;
         auto parent = new QObject;
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request) -> QNetworkReply * {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
             if (op == QNetworkAccessManager::PutOperation) {
                 nPUT++;
                 if (request.rawHeader("OC-Total-Length").toInt() > remoteQuota) {
@@ -472,7 +472,7 @@ private slots:
         QByteArray checksumValue;
         QByteArray contentMd5Value;
 
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request) -> QNetworkReply * {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
             if (op == QNetworkAccessManager::GetOperation) {
                 auto reply = new FakeGetReply(fakeFolder.remoteModifier(), op, request, &parent);
                 if (!checksumValue.isNull())

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -158,7 +158,7 @@ private slots:
 
         int nPUT = 0;
         int nDELETE = 0;
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &) {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &, QIODevice *) {
             if (op == QNetworkAccessManager::PutOperation)
                 ++nPUT;
             if (op == QNetworkAccessManager::DeleteOperation)
@@ -268,7 +268,7 @@ private slots:
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
 
         int nGET = 0;
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &) {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &, QIODevice *) {
             if (op == QNetworkAccessManager::GetOperation)
                 ++nGET;
             return nullptr;
@@ -313,7 +313,7 @@ private slots:
         int nPUT = 0;
         int nMOVE = 0;
         int nDELETE = 0;
-        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req) {
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *) {
             if (op == QNetworkAccessManager::GetOperation)
                 ++nGET;
             if (op == QNetworkAccessManager::PutOperation)


### PR DESCRIPTION
This can happen if the upload of a file is finished, but we just got
disconnected right before recieving the reply containing the etag.
So nothing was save din the DB, and we are not sure if the server
recieved the file properly or not. Further local update of the file
will cause a conflict.
   
In order to fix this, store the checksum of the uploading file in
the uploadinfo table of the local db (even if there is no chunking
involved).  And when we have a conflict, check that it is not because
of this situation by checking the entry in the uploadinfo table.
   
Issue #5106

This goes to master because it is an old issue and the fix is quite intrusive as it even add a row in the database.
