### PR TITLE
Config: Look for exclude file in a relative path.

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -306,6 +306,19 @@ QString ConfigFile::excludeFileFromSystem()
         QFileInfo nextToBinary(QCoreApplication::applicationDirPath(), exclFile);
         if (nextToBinary.exists()) {
             fi = nextToBinary;
+        } else {
+            // For AppImage, the file might reside under a temporary mount path
+            QDir d(QCoreApplication::applicationDirPath()); // supposed to be /tmp/mount.xyz/usr/bin
+            d.cdUp(); // go out of bin
+            d.cdUp(); // go out of usr
+            if (!d.isRoot()) { // it is really a mountpoint
+                if (d.cd("etc") && d.cd(Theme::instance()->appName())) {
+                    QFileInfo inMountDir(d, exclFile);
+                    if (inMountDir.exists()) {
+                        fi = inMountDir;
+                    }
+                };
+            }
         }
     }
 #endif


### PR DESCRIPTION
If the application binary is not installed in /usr/bin the client
with this patch considers to check the relative location
`../../etc/owncloud-client/` to find the system exclude.

This is an important bit for AppImage based packages of the client,
as this runs from a temporar mountpoint and the system file can not
be found under /etc.