### PR TITLE
Notifications: Display the link in the subject line.

### DIFF
--- a/src/gui/activitydata.h
+++ b/src/gui/activitydata.h
@@ -57,6 +57,7 @@ public:
     QString _message;
     QString _file;
     QUrl _link;
+    QString _linkText;
     QDateTime _dateTime;
     QString _accName;
 

--- a/src/gui/activitydata.h
+++ b/src/gui/activitydata.h
@@ -70,6 +70,23 @@ public:
 
 
     Identifier ident() const;
+
+    void extractLink( const QString& s )
+    {
+        if (!s.isEmpty()) {
+            // if there is a real whitespace in the link, the part before the space
+            // is rendered as a link text
+            int charPos = s.lastIndexOf(QChar(' '));
+            if( charPos > -1 ) {
+                const QString link = s.mid(charPos+1); // all chars from the char to back
+                _link = QUrl::fromEncoded(link.toUtf8());
+                _linkText = s.mid(0, charPos).toHtmlEscaped();
+            } else {
+                _link = QUrl(s);
+                _linkText.clear();
+            }
+        }
+    }
 };
 
 bool operator==(const Activity &rhs, const Activity &lhs);

--- a/src/gui/activitydata.h
+++ b/src/gui/activitydata.h
@@ -56,12 +56,13 @@ public:
     QString _subject;
     QString _message;
     QString _file;
-    QUrl _link;
-    QString _linkText;
+    QUrl _link;        /* a link that might be passed as part of the activity */
+    QString _linkText; /* unescaped label of the link above */
     QDateTime _dateTime;
-    QString _accName;
+    QString _accName;  /* display name of the account involved */
 
-    QVector<ActivityLink> _links;
+    QVector<ActivityLink> _links; /* These links are transformed into buttons that
+                                   * call links as reactions on the activity */
     /**
      * @brief Sort operator to sort the list youngest first.
      * @param val
@@ -77,10 +78,10 @@ public:
             // if there is a real whitespace in the link, the part before the space
             // is rendered as a link text
             int charPos = s.lastIndexOf(QChar(' '));
-            if( charPos > -1 ) {
+            if (charPos > -1) {
                 const QString link = s.mid(charPos+1); // all chars from the char to back
                 _link = QUrl::fromEncoded(link.toUtf8());
-                _linkText = s.mid(0, charPos).toHtmlEscaped();
+                _linkText = s.mid(0, charPos);
             } else {
                 _link = QUrl(s);
                 _linkText.clear();

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -44,6 +44,16 @@ void NotificationWidget::setActivity(const Activity &activity)
     _ui._subjectLabel->setVisible(!activity._subject.isEmpty());
     _ui._messageLabel->setVisible(!activity._message.isEmpty());
 
+    QString subject = activity._subject;
+    if( !activity._link.isEmpty() ) {
+        // append a link to the message, if that is empty, to subject
+        subject.append(QString("&nbsp;<a href=\"%1\">%2</a>")
+                       .arg(activity._link.toString(QUrl::FullyEncoded))
+                       .arg(activity._linkText));
+        _ui._subjectLabel->setTextFormat(Qt::RichText);
+        _ui._subjectLabel->setOpenExternalLinks(true);
+
+    }
     _ui._subjectLabel->setText(activity._subject);
     _ui._messageLabel->setText(activity._message);
 

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -45,10 +45,10 @@ void NotificationWidget::setActivity(const Activity &activity)
     _ui._messageLabel->setVisible(!activity._message.isEmpty());
 
     QString subject = activity._subject.toHtmlEscaped();
-    if( !activity._link.isEmpty() ) {
+    if (!activity._link.isEmpty()) {
         // append a link to the message, if that is empty, to subject
         QString lText = activity._linkText;
-        if( lText.isEmpty() ) {
+        if (lText.isEmpty()) {
             lText = tr("[link]");
         }
         subject.append( QString("&nbsp;<a href=\"%1\">%2</a>")
@@ -56,9 +56,8 @@ void NotificationWidget::setActivity(const Activity &activity)
                              lText.toHtmlEscaped() ));
         _ui._subjectLabel->setTextFormat(Qt::RichText);
         _ui._subjectLabel->setOpenExternalLinks(true);
-
     }
-    _ui._subjectLabel->setText(activity._subject);
+    _ui._subjectLabel->setText(subject);
     _ui._messageLabel->setText(activity._message);
 
     _ui._notifIcon->setPixmap(QPixmap(":/client/resources/bell.png"));

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -44,7 +44,7 @@ void NotificationWidget::setActivity(const Activity &activity)
     _ui._subjectLabel->setVisible(!activity._subject.isEmpty());
     _ui._messageLabel->setVisible(!activity._message.isEmpty());
 
-    QString subject = activity._subject;
+    QString subject = activity._subject.toHtmlEscaped();
     if( !activity._link.isEmpty() ) {
         // append a link to the message, if that is empty, to subject
         QString lText = activity._linkText;

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -47,9 +47,13 @@ void NotificationWidget::setActivity(const Activity &activity)
     QString subject = activity._subject;
     if( !activity._link.isEmpty() ) {
         // append a link to the message, if that is empty, to subject
-        subject.append(QString("&nbsp;<a href=\"%1\">%2</a>")
-                       .arg(activity._link.toString(QUrl::FullyEncoded))
-                       .arg(activity._linkText));
+        QString lText = activity._linkText;
+        if( lText.isEmpty() ) {
+            lText = tr("[link]");
+        }
+        subject.append( QString("&nbsp;<a href=\"%1\">%2</a>")
+                        .arg(activity._link.toString(QUrl::FullyEncoded),
+                             lText.toHtmlEscaped() ));
         _ui._subjectLabel->setTextFormat(Qt::RichText);
         _ui._subjectLabel->setOpenExternalLinks(true);
 

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -81,7 +81,16 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         a._message = json.value("message").toString();
         QString s = json.value("link").toString();
         if (!s.isEmpty()) {
-            a._link = QUrl(s);
+            // if there is a real whitespace in the link, the part before the space
+            // is rendered as a link text
+            if( s.contains(QChar(' '))) {
+                const QStringList li = s.split(QChar(' '));
+                a._link = QUrl(li.at(1));
+                a._linkText = li.at(0);
+            } else {
+                a._link = QUrl(s);
+                a._linkText = QString("[%1]").arg(tr("link"));
+            }
         }
         a._dateTime = QDateTime::fromString(json.value("datetime").toString(), Qt::ISODate);
 

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -85,7 +85,7 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
             // is rendered as a link text
             if( s.contains(QChar(' '))) {
                 const QStringList li = s.split(QChar(' '));
-                a._link = QUrl(li.at(1));
+                a._link = QUrl::fromEncoded(li.at(1).toLocal8Bit());
                 a._linkText = li.at(0);
             } else {
                 a._link = QUrl(s);

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -79,19 +79,7 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         a._id = json.value("notification_id").toInt();
         a._subject = json.value("subject").toString();
         a._message = json.value("message").toString();
-        QString s = json.value("link").toString();
-        if (!s.isEmpty()) {
-            // if there is a real whitespace in the link, the part before the space
-            // is rendered as a link text
-            if( s.contains(QChar(' '))) {
-                const QStringList li = s.split(QChar(' '));
-                a._link = QUrl::fromEncoded(li.at(1).toLocal8Bit());
-                a._linkText = li.at(0);
-            } else {
-                a._link = QUrl(s);
-                a._linkText = QString("[%1]").arg(tr("link"));
-            }
-        }
+        a.extractLink (json.value("link").toString());
         a._dateTime = QDateTime::fromString(json.value("datetime").toString(), Qt::ISODate);
 
         auto actions = json.value("actions").toArray();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ owncloud_add_test(XmlParse "")
 owncloud_add_test(ChecksumValidator "")
 
 owncloud_add_test(ExcludedFiles "")
-
+owncloud_add_test(ActivityData "")
 owncloud_add_test(FileSystem "")
 owncloud_add_test(Utility "")
 owncloud_add_test(SyncEngine "syncenginetestutils.h")

--- a/test/testactivitydata.cpp
+++ b/test/testactivitydata.cpp
@@ -9,6 +9,8 @@
 #include "activitydata.h"
 #include "common/utility.h"
 
+#define LS(D) QLatin1String(D)
+
 using namespace OCC;
 
 class TestActivityData: public QObject
@@ -29,38 +31,38 @@ private slots:
         Activity a;
         QString link("http://owncloud.org");
         a.extractLink(link);
-        QCOMPARE(a._link.host(), "owncloud.org");
+        QCOMPARE(a._link.host(), LS("owncloud.org"));
     
         Activity b;
         QString link2("Linktext http://owncloud.org");
         b.extractLink(link2);
-        QCOMPARE(b._link.host(), "owncloud.org");
-        QCOMPARE(b._linkText, "Linktext" );
+        QCOMPARE(b._link.host(), LS("owncloud.org"));
+        QCOMPARE(b._linkText, LS("Linktext"));
     }
     void testLinkSplitText() {
         Activity a;
         QString link("Link Text http://owncloud.org");
         a.extractLink(link);
-        QCOMPARE(a._link.host(), "owncloud.org");
-        QCOMPARE(a._linkText, "Link Text" );
+        QCOMPARE(a._link.host(), LS("owncloud.org"));
+        QCOMPARE(a._linkText, LS("Link Text"));
     }
     void testLinkEncoding() {
         Activity a;
         QString link("http://owncloud.org?foo=bar");
         a.extractLink(link);
-        QCOMPARE(a._link.host(), "owncloud.org");
-        QCOMPARE(a._link.query(), "foo=bar");
+        QCOMPARE(a._link.host(), LS("owncloud.org"));
+        QCOMPARE(a._link.query(), LS("foo=bar"));
         
         Activity b;
         b.extractLink("http://owncloud.org?foo=bar%20baz");
-        QCOMPARE(b._link.host(), "owncloud.org");
-        QCOMPARE(b._link.query(QUrl::EncodeSpaces), "foo=bar%20baz");
+        QCOMPARE(b._link.host(), LS("owncloud.org"));
+        QCOMPARE(b._link.query(QUrl::EncodeSpaces), LS("foo=bar%20baz"));
 
         Activity c;
         c.extractLink("дру́жба http://owncloud.org?foo=bar%20baz");
-        QCOMPARE(c._link.host(), "owncloud.org");
-        QCOMPARE(c._link.query(QUrl::EncodeSpaces), "foo=bar%20baz");
-        QCOMPARE(c._linkText,  "дру́жба" );
+        QCOMPARE(c._link.host(), LS("owncloud.org"));
+        QCOMPARE(c._link.query(QUrl::EncodeSpaces), LS("foo=bar%20baz"));
+        QCOMPARE(c._linkText,  QString::fromUtf8("дру́жба"));
     }
 };
 

--- a/test/testactivitydata.cpp
+++ b/test/testactivitydata.cpp
@@ -1,8 +1,8 @@
 /*
  *    This software is in the public domain, furnished "as is", without technical
- *       support, and with no warranty, express or implied, as to its usefulness for
- *          any purpose.
- *          */
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ */
 
 #include <QtTest>
 
@@ -29,38 +29,38 @@ private slots:
         Activity a;
         QString link("http://owncloud.org");
         a.extractLink(link);
-        QVERIFY(a._link.host() == "owncloud.org");
+        QCOMPARE(a._link.host(), "owncloud.org");
     
         Activity b;
         QString link2("Linktext http://owncloud.org");
         b.extractLink(link2);
-        QVERIFY(b._link.host() == "owncloud.org");
-        QVERIFY(b._linkText == "Linktext" );
+        QCOMPARE(b._link.host(), "owncloud.org");
+        QCOMPARE(b._linkText, "Linktext" );
     }
     void testLinkSplitText() {
         Activity a;
         QString link("Link Text http://owncloud.org");
         a.extractLink(link);
-        QVERIFY(a._link.host() == "owncloud.org");
-        QVERIFY(a._linkText == "Link Text" );
+        QCOMPARE(a._link.host(), "owncloud.org");
+        QCOMPARE(a._linkText, "Link Text" );
     }
     void testLinkEncoding() {
         Activity a;
         QString link("http://owncloud.org?foo=bar");
         a.extractLink(link);
-        QVERIFY(a._link.host() == "owncloud.org");
-        QVERIFY(a._link.query() == "foo=bar");
+        QCOMPARE(a._link.host(), "owncloud.org");
+        QCOMPARE(a._link.query(), "foo=bar");
         
         Activity b;
         b.extractLink("http://owncloud.org?foo=bar%20baz");
-        QVERIFY(b._link.host() == "owncloud.org");
-        QVERIFY(b._link.query(QUrl::EncodeSpaces) == "foo=bar%20baz");
+        QCOMPARE(b._link.host(), "owncloud.org");
+        QCOMPARE(b._link.query(QUrl::EncodeSpaces), "foo=bar%20baz");
 
         Activity c;
         c.extractLink("дру́жба http://owncloud.org?foo=bar%20baz");
-        QVERIFY(c._link.host() == "owncloud.org");
-        QVERIFY(c._link.query(QUrl::EncodeSpaces) == "foo=bar%20baz");
-        QVERIFY(c._linkText == "дру́жба" );
+        QCOMPARE(c._link.host(), "owncloud.org");
+        QCOMPARE(c._link.query(QUrl::EncodeSpaces), "foo=bar%20baz");
+        QCOMPARE(c._linkText,  "дру́жба" );
     }
 };
 

--- a/test/testactivitydata.cpp
+++ b/test/testactivitydata.cpp
@@ -1,0 +1,68 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *       support, and with no warranty, express or implied, as to its usefulness for
+ *          any purpose.
+ *          */
+
+#include <QtTest>
+
+#include "activitydata.h"
+#include "common/utility.h"
+
+using namespace OCC;
+
+class TestServerNotify: public QObject
+{
+    Q_OBJECT
+
+private:
+  
+private slots:
+  
+    void testLinkSplitEmpty() {
+        Activity a;
+        QString link;
+        a.extractLink(link);
+        QVERIFY(a._link.isEmpty());
+    }
+    void testLinkSplitSimple() {
+        Activity a;
+        QString link("http://owncloud.org");
+        a.extractLink(link);
+        QVERIFY(a._link.host() == "owncloud.org");
+    
+        Activity b;
+        QString link2("Linktext http://owncloud.org");
+        b.extractLink(link2);
+        QVERIFY(b._link.host() == "owncloud.org");
+        QVERIFY(b._linkText == "Linktext" );
+    }
+    void testLinkSplitText() {
+        Activity a;
+        QString link("Link Text http://owncloud.org");
+        a.extractLink(link);
+        QVERIFY(a._link.host() == "owncloud.org");
+        QVERIFY(a._linkText == "Link Text" );
+    }
+    void testLinkEncoding() {
+        Activity a;
+        QString link("http://owncloud.org?foo=bar");
+        a.extractLink(link);
+        QVERIFY(a._link.host() == "owncloud.org");
+        QVERIFY(a._link.query() == "foo=bar");
+        
+        Activity b;
+        b.extractLink("http://owncloud.org?foo=bar%20baz");
+        QVERIFY(b._link.host() == "owncloud.org");
+        QVERIFY(b._link.query(QUrl::EncodeSpaces) == "foo=bar%20baz");
+
+        Activity c;
+        c.extractLink("дру́жба http://owncloud.org?foo=bar%20baz");
+        QVERIFY(c._link.host() == "owncloud.org");
+        QVERIFY(c._link.query(QUrl::EncodeSpaces) == "foo=bar%20baz");
+        QVERIFY(c._linkText == "дру́жба" );
+    }
+};
+
+QTEST_APPLESS_MAIN(TestServerNotify)
+#include "testservernotify.moc"

--- a/test/testactivitydata.cpp
+++ b/test/testactivitydata.cpp
@@ -11,7 +11,7 @@
 
 using namespace OCC;
 
-class TestServerNotify: public QObject
+class TestActivityData: public QObject
 {
     Q_OBJECT
 
@@ -64,5 +64,5 @@ private slots:
     }
 };
 
-QTEST_APPLESS_MAIN(TestServerNotify)
-#include "testservernotify.moc"
+QTEST_APPLESS_MAIN(TestActivityData)
+#include "testactivitydata.moc"


### PR DESCRIPTION
Added a new data called linkText. If the link in the activity JSON has a space in it, the part before that is considered the link text. If it does not contain a space, the word [link] is used.

Note that the idea to separate the link and the link text  with a space needed because the original specification does not contain a link text, just the link. I am not seeing a downside as long as spaces in the real link are encoded with %20.

This is may be a solution for #6236