### PR TITLE
2.4.0 Website changelog html

### DIFF
--- a/admin/website/changelog-desktop.html
+++ b/admin/website/changelog-desktop.html
@@ -4,7 +4,7 @@
 
 <!-- When doing beta/rc vs release, always check the subdirectory name and the OBS repo name!! //-->
 
-<h3 id="240">Release 2.4.0 <b>rc2</b> <small>December 15th 2017</small></h3>
+<h3 id="240">Release 2.4.0 <small>December 21th 2017</small></h3>
 <ul>
 <li>If you're using 2.4.0 alpha1, please upgrade as previous alphas/rcs had an issue with hidden files and renames!</li>
 <li>OAuth2 authentication support by opening external browser (<a href='https://github.com/owncloud/client/issues/5668'>#5668</a>)</li>
@@ -104,14 +104,14 @@
 <li>Updater: Rudimentary support for beta channel (<a href='https://github.com/owncloud/client/issues/6048'>#6048</a>)</li>
 </ul>
 Download:
-<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.4.0.8852rc2-setup.exe">Windows</a> |
-<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.4.0.8770rc2.pkg">Mac</a> |
-<a href="https://software.opensuse.org/download/package?project=isv%3AownCloud%3Acommunity%3Atesting&amp;package=owncloud-client">Linux</a> |
-<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.4.0-rc2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.4.0-rc2.tar.xz.asc">PGP signature</a>)
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.4.0.8882-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.4.0.8801.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv%3AownCloud%3Adesktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.4.0.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.4.0.tar.xz.asc">PGP signature</a>)
 <br/>Download testpilotcloud client:
-<a href="https://download.owncloud.com/desktop/testing/testpilotcloud-2.4.0.8853rc2-setup.exe">Windows</a> |
-<a href="https://download.owncloud.com/desktop/testing/testpilotcloud-2.4.0.8771rc2.pkg">Mac</a> |
-<a href="https://software.opensuse.org/download.html?project=isv%3AownCloud%3Atestpilot%3Atesting&amp;package=testpilotcloud-client">Linux</a>
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.4.0.8883-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.4.0.8802.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download.html?project=isv%3AownCloud%3Atestpilot&amp;package=testpilotcloud-client">Linux</a>
 
 <h3 id="234">Release 2.3.4 <small>November 3rd 2017</small></h3>
 <ul>

--- a/admin/website/changelog-desktop.html
+++ b/admin/website/changelog-desktop.html
@@ -1,0 +1,1592 @@
+<div class="page-header">
+  <h1>ownCloud Desktop Client Changelog</h1>
+</div>
+
+<!-- When doing beta/rc vs release, always check the subdirectory name and the OBS repo name!! //-->
+
+<h3 id="240">Release 2.4.0 <b>rc2</b> <small>December 15th 2017</small></h3>
+<ul>
+<li>If you're using 2.4.0 alpha1, please upgrade as previous alphas/rcs had an issue with hidden files and renames!</li>
+<li>OAuth2 authentication support by opening external browser (<a href='https://github.com/owncloud/client/issues/5668'>#5668</a>)</li>
+<li>Shibboleth: Change to use OAuth2 if supported (<a href='https://github.com/owncloud/client/issues/6198'>#6198</a>)</li>
+<li>Sharing: Add support for multiple public link shares (<a href='https://github.com/owncloud/client/issues/5655'>#5655</a>)</li>
+<li>Sharing: Add option to copy/email private links (<a href='https://github.com/owncloud/client/issues/5023'>#5023</a>, <a href='https://github.com/owncloud/client/issues/5627'>#5627</a>)</li>
+<li>Sharing: Add option "show file listing" (<a href='https://github.com/owncloud/client/issues/5837'>#5837</a>)</li>
+<li>Sharing: Show warning that links are public (<a href='https://github.com/owncloud/client/issues/5747'>#5747</a>)</li>
+<li>Sharing: Sharing dialog redesign: multiple share links support (<a href='https://github.com/owncloud/client/issues/5695'>#5695</a>)</li>
+<li>Sharing: Make "can edit" partially checked sometimes (<a href='https://github.com/owncloud/client/issues/5642'>#5642</a>)</li>
+<li>Sharing: Trigger a sync for folder affected by a change of sharing (<a href='https://github.com/owncloud/client/issues/6098'>#6098</a>)</li>
+<li>Wizard: Never propose an existing folder for syncing (<a href='https://github.com/owncloud/client/issues/5597'>#5597</a>)</li>
+<li>Wizard: Don't show last page anymore, go to settings directly (<a href='https://github.com/owncloud/client/issues/5726'>#5726</a>)</li>
+<li>Wizard: Handle url-shortener redirects (<a href='https://github.com/owncloud/client/issues/5954'>#5954</a>)</li>
+<li>Wizard: Resolve url/ redirects only if url/status.php not found (<a href='https://github.com/owncloud/client/issues/5954'>#5954</a>)</li>
+<li>Wizard: Add explanation text when server error is shown (<a href='https://github.com/owncloud/client/issues/6157'>#6157</a>)</li>
+<li>Wizard: Update the window size on high dpi screen (<a href='https://github.com/owncloud/client/issues/6156'>#6156</a>)</li>
+<li>Wizard: Don't report confusing error message (<a href='https://github.com/owncloud/client/issues/6116'>#6116</a>)</li>
+<li>Gui: Display the user server avatar (<a href='https://github.com/owncloud/client/issues/5482'>#5482</a>)</li>
+<li>Gui: Use display name of user, not internal name</li>
+<li>Server URL: Update configuration in case of permanent redirection (<a href='https://github.com/owncloud/client/issues/5972'>#5972</a>)</li>
+<li>Gui: Allow to add multiple sync folder connection of the same folder (<a href='https://github.com/owncloud/client/issues/6032'>#6032</a>)</li>
+<li>Tray Menu: More detailed status messages</li>
+<li>Tray Menu: Shibboleth: raise the browser when clicking on the tray (<a href='https://github.com/owncloud/client/issues/6105'>#6105</a>)</li>
+<li>Activity: Link errors from the account tab, allow filtering by account/folder (<a href='https://github.com/owncloud/client/issues/5861'>#5861</a>)</li>
+<li>Activity: Present conflicts more prominently (<a href='https://github.com/owncloud/client/issues/5894'>#5894</a>)</li>
+<li>Activity: Allow sorting the columns in issues and protocol tabs (<a href='https://github.com/owncloud/client/issues/6093'>#6093</a>, <a href='https://github.com/owncloud/client/issues/6086'>#6086</a>)</li>
+<li>Selective Sync: Open sub folder context menu (<a href='https://github.com/owncloud/client/issues/5596'>#5596</a>)</li>
+<li>Selective Sync: Skip excluded folders when reading db (<a href='https://github.com/owncloud/client/issues/5772'>#5772</a>)</li>
+<li>Selective Sync: Remove local files of unselected folder despite other modified files (<a href='https://github.com/owncloud/client/issues/5783'>#5783</a>)</li>
+<li>Excludes: Remove .htaccess form list of excluded files (<a href='https://github.com/owncloud/client/issues/5701'>#5701</a>)</li>
+<li>Excludes: Hardcode desktop.ini</li>
+<li>Excludes: Allow escaping "#" (<a href='https://github.com/owncloud/client/issues/6012'>#6012</a>)</li>
+<li>Excludes: Use faster matching via QRegularExpression (<a href='https://github.com/owncloud/client/issues/6063'>#6063</a>)</li>
+<li>Discovery: Increase the MAX_DEPTH and show deep folders as ignored (<a href='https://github.com/owncloud/client/issues/1067'>#1067</a>)</li>
+<li>Discovery: General speed improvements</li>
+<li>Downloads: Remove empty temporary if disk space full (<a href='https://github.com/owncloud/client/issues/5746'>#5746</a>)</li>
+<li>Downloads: Read Content-MD5 header for object store setups</li>
+<li>Checksums: Add global disable environment variable (<a href='https://github.com/owncloud/client/issues/5017'>#5017</a>)</li>
+<li>Quota: PropagateUpload: Model of remote quota, avoid some uploads (<a href='https://github.com/owncloud/client/issues/5537'>#5537</a>)</li>
+<li>Create favorite also in folder wizard (<a href='https://github.com/owncloud/client/issues/455'>#455</a>)</li>
+<li>Windows: Use the application icon for the Windows 8 sidebar favorite (<a href='https://github.com/owncloud/client/issues/2446'>#2446</a>, <a href='https://github.com/owncloud/client/issues/5690'>#5690</a>)</li>
+<li>macOS: Finder sidebar icon (<a href='https://github.com/owncloud/client/issues/296'>#296</a>)</li>
+<li>Overlay Icons: Consider also the "shared by me" as shared (<a href='https://github.com/owncloud/client/issues/4788'>#4788</a>)</li>
+<li>Overlay Icons: Update right after sharing (<a href='https://github.com/owncloud/client/issues/6115'>#6115</a>)</li>
+<li>Overlay Icons: Fix different case paths not matching (<a href='https://github.com/owncloud/client/issues/5257'>#5257</a>)</li>
+<li>Overlay Icons: Detect changes in the shared flag (<a href='https://github.com/owncloud/client/issues/6098'>#6098</a>)</li>
+<li>Windows Overlay Icons: Potential hang fixes</li>
+<li>Linux Overlay Icons: fix branded nemo and caja shell integration (<a href='https://github.com/owncloud/client/issues/5966'>#5966</a>)</li>
+<li>Credentials: Fix behavior for bad password (<a href='https://github.com/owncloud/client/issues/5989'>#5989</a>)</li>
+<li>Credentials: Don't create empty client cert keychain entries (<a href='https://github.com/owncloud/client/issues/5752'>#5752</a>)</li>
+<li>Credentials: Namespace windows cred keys (<a href='https://github.com/owncloud/client/issues/6125'>#6125</a>)</li>
+<li>Credentials: Use per-account keychain entries (<a href='https://github.com/owncloud/client/issues/5830'>#5830</a>, <a href='https://github.com/owncloud/client/issues/6126'>#6126</a>)</li>
+<li>AccountSettings: Triggering log in re-ask about previously rejected certificates (<a href='https://github.com/owncloud/client/issues/5819'>#5819</a>)</li>
+<li>owncloudcmd: Added bandwidth limit parameter (<a href='https://github.com/owncloud/client/issues/5707'>#5707</a>)</li>
+<li>owncloudcmd: Fix timestamps, Fix --logdebug</li>
+<li>AccountSettings: Sync with clean discovery on Ctrl-F6 (<a href='https://github.com/owncloud/client/issues/5666'>#5666</a>)</li>
+<li>Sync: Dynamic sizing of chunks in chunked uploads for improved big file upload performance (<a href='https://github.com/owncloud/client/issues/5852'>#5852</a>)</li>
+<li>Sync: Introduce overall errors that are not tied to a file (<a href='https://github.com/owncloud/client/issues/5746'>#5746</a>)</li>
+<li>Sync: Better messaging for 507 Insufficient Storage (<a href='https://github.com/owncloud/client/issues/5537'>#5537</a>)</li>
+<li>Sync: Create conflicts by comparing the hash of files with identical mtime/size (<a href='https://github.com/owncloud/client/issues/5589'>#5589</a>)</li>
+<li>Sync: Avoid downloads by comparing the hash of files with identical mtime/size (<a href='https://github.com/owncloud/client/issues/6153'>#6153</a>)</li>
+<li>Sync: Upload conflict files if OWNCLOUD_UPLOAD_CONFLICT_FILES environment variable is set (<a href='https://github.com/owncloud/client/issues/6038'>#6038</a>)</li>
+<li>Sync: Blacklist: Don't let errors become warnings (<a href='https://github.com/owncloud/client/issues/5516'>#5516</a>)</li>
+<li>Sync: Check etag again after active sync (<a href='https://github.com/owncloud/client/issues/4116'>#4116</a>)</li>
+<li>Sync: Rename handling fixes: duplicate file ids (<a href='https://github.com/owncloud/client/issues/6096'>#6096</a>, <a href='https://github.com/owncloud/client/issues/6212'>#6212</a>)</li>
+<li>Sync: Rename handling fixes: File size must be equal</li>
+<li>Sync: Rename handling: Fix duplicate files on abort/resume sync (<a href='https://github.com/owncloud/client/issues/5949'>#5949</a>)</li>
+<li>Sync: Add capability for invalid filename regexes (<a href='https://github.com/owncloud/client/issues/6092'>#6092</a>)</li>
+<li>SyncJournalDB: Fall back to DELETE journal mode if WAL mode does not seem to work (<a href='https://github.com/owncloud/client/issues/5723'>#5723</a>)</li>
+<li>SyncJournalDB: Don't crash if the db file is readonly (<a href='https://github.com/owncloud/client/issues/6050'>#6050</a>)</li>
+<li>SyncJournalDB: DB close error is not fatal</li>
+<li>Fix at least one memory leak</li>
+<li>Documentation improvements</li>
+<li>Logging improvements (With Qt logging categories) (<a href='https://github.com/owncloud/client/issues/5671'>#5671</a>)</li>
+<li>Logging filtering per account (<a href='https://github.com/owncloud/client/issues/5672'>#5672</a>)</li>
+<li>Crash fixes</li>
+<li>Test improvements</li>
+<li>Small UI layout fixes</li>
+<li>Performance improvements</li>
+<li>Maintenance Mode: Detect maintenance mode (<a href='https://github.com/owncloud/client/issues/4485'>#4485</a>)</li>
+<li>Maintenance Mode: Add a 1 to 5 min reconnection delay (<a href='https://github.com/owncloud/client/issues/5872'>#5872</a>)</li>
+<li>HTTP: Send a unique X-Request-ID with each request (<a href='https://github.com/owncloud/client/issues/5853'>#5853</a>)</li>
+<li>HTTP: Support HTTP2 when built and running with Qt 5.9.x (Official packages still on Qt 5.6.x) (<a href='https://github.com/owncloud/client/issues/5659'>#5659</a>)</li>
+<li>owncloudcmd: Don't start if connection or auth fails (<a href='https://github.com/owncloud/client/issues/5692'>#5692</a>)</li>
+<li>csync: Switch build from C to C++ (<a href='https://github.com/owncloud/client/issues/6033'>#6033</a>)</li>
+<li>csync: Refactor a lot to use common data structures to save memory and memory copying</li>
+<li>csync: Switch some data structures to Qt data structures</li>
+<li>csync: Switch to using upper layer SyncJournalDB (<a href='https://github.com/owncloud/client/issues/6087'>#6087</a>)</li>
+<li>Switch 3rdparty/json usage to Qt5's QJson (<a href='https://github.com/owncloud/client/issues/5710'>#5710</a>)</li>
+<li>OpenSSL: Don't require directly, only via Qt (<a href='https://github.com/owncloud/client/issues/5833'>#5833</a>)</li>
+<li>Remove iconv dependency, use Qt for file system locale encoding/decoding (emoji filename support on macOS) (<a href='https://github.com/owncloud/client/issues/5875'>#5875</a>)</li>
+<li>Compilation: Remove Qt 4 code (<a href='https://github.com/owncloud/client/issues/6025'>#6025</a>, <a href='https://github.com/owncloud/client/issues/5702'>#5702</a>, <a href='https://github.com/owncloud/client/issues/5505'>#5505</a>)</li>
+<li>Harmonize source code style with clang-format (<a href='https://github.com/owncloud/client/issues/5732'>#5732</a>)</li>
+<li>Switch over to Qt 5 function pointer signal/slot syntax (<a href='https://github.com/owncloud/client/issues/6041'>#6041</a>)</li>
+<li>Compile with stack-smashing protection on macOS and Linux</li>
+<li>Updater: Rudimentary support for beta channel (<a href='https://github.com/owncloud/client/issues/6048'>#6048</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.4.0.8852rc2-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/testing/ownCloud-2.4.0.8770rc2.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv%3AownCloud%3Acommunity%3Atesting&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.4.0-rc2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.4.0-rc2.tar.xz.asc">PGP signature</a>)
+<br/>Download testpilotcloud client:
+<a href="https://download.owncloud.com/desktop/testing/testpilotcloud-2.4.0.8853rc2-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/testing/testpilotcloud-2.4.0.8771rc2.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download.html?project=isv%3AownCloud%3Atestpilot%3Atesting&amp;package=testpilotcloud-client">Linux</a>
+
+<h3 id="234">Release 2.3.4 <small>November 3rd 2017</small></h3>
+<ul>
+<li>Checksums: Use addData function to avoid endless loop CPU load issues with Office files</li>
+<li>Packaging: Require ZLIB</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.4.8624-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.4.8537.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.4.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.4.tar.xz.asc">PGP signature</a>)
+<br/>Download testpilotcloud client:
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.4.8627-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/testpilotcloud-2.3.4.8541.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download.html?project=isv%3AownCloud%3Atestpilot&amp;package=testpilotcloud-client">Linux</a>
+
+<h3 id="233">Release 2.3.3 <small>August 29th 2017</small></h3>
+<ul>
+	<li>Chunking NG: Don't use old chunking on new DAV endpoint (<a href="https://github.com/owncloud/client/issues/5855">5855</a>)</li>
+	<li>Selective Sync: Skip excluded folders when reading DB, don't let them show errors (<a href="https://github.com/owncloud/client/issues/5772">5772</a>)</li>
+	<li>Settings: Make window bigger so Qt version is always visible (<a href="https://github.com/owncloud/client/issues/5760">5760</a>)</li>
+	<li>Share links: Show warning that public link shares are public (<a href="https://github.com/owncloud/client/issues/5786">5786</a>)</li>
+	<li>Downloads: Re-trigger folder discovery on HTTP 404 (<a href="https://github.com/owncloud/client/issues/5799">5799</a>)</li>
+	<li>Notifications: Propagate "Dismiss" as DELETE to server (<a href="https://github.com/owncloud/client/issues/5922">5922</a>)</li>
+	<li>Overlay Icons: Fix potential hangs on Windows</li>
+	<li>SyncJournalDB: Don't use ._ as filename pattern if that does not work because of SMB storage settings (<a href="https://github.com/owncloud/client/issues/5844">5844</a>)</li>
+	<li>SyncJournalDB: Log reason for sqlite3 opening errors</li>
+	<li>Windows: Fix a memory leak in FileSystem::longWinPath</li>
+	<li>Notifications: Proapgate "Dismiss" button action to server (<a href="https://github.com/owncloud/client/issues/5922">#5922</a>)</li>
+    <li>Switch Linux builds also to Qt 5.6.2 (<a href="https://github.com/owncloud/client/issues/5470">5470</a>)</li>
+	<li>Stopped maintaining Qt 4 support</li>
+  <li>Linux packaging fixes: install the owncloud-client-nemo, owncloud-client-nautilus, owncloud-client-caja, owncloud-client-dolphin package for sync-state icons and a share-with menu in your file manager.</li>
+  <li>Linux deprecation: Releases after 2.3.3 do not support Fedora 24 or lower, openSUSE Leap 42.1 or lower, Debian 7.0 or lower.</li>
+  <li>2.4.0 deprecation: We will drop 32-bit Linux support and MacOS X 10.9 support or lower.</li>
+  <li>Supported platforms are documented at <a href="https://doc.owncloud.org/server/latest/admin_manual/installation/system_requirements.html#desktop">Desktop System Requirements</a>.</li>
+  
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8250-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.3.8242.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.3.tar.xz.asc">PGP signature</a>)
+
+
+<h3 id="232">Release 2.3.2 <small>May 8th 2017</small></h3>
+<ul>
+	<li>Fix more crashes (thanks to everyone submitting to our crash reporter!)</li>
+	<li>Improve compatibility with server 10.0 (<a href="https://github.com/owncloud/client/issues/5691">5691</a>, <tt>X-OC-Total-Size</tt>)</li>
+	<li>Share dialog: UI improvements, Bring to front on tray click</li>
+	<li>owncloudcmd: Align process return value with sync return value (<a href="https://github.com/owncloud/client/issues/3936">3936</a>)</li>
+	<li>Fix disk free check on Windows when opening the local DB</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.2.6928-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.2.4250.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.2.tar.xz.asc">PGP signature</a>)
+
+
+<h3 id="231">Release 2.3.1<small>March 21th 2017</small></h3>
+<ul>
+	<li>Fix several crashes (thanks to everyone submitting to our crash reporter!)</li>
+	<li>Improve HTTP redirect handling (<a href="https://github.com/owncloud/client/issues/5555">#5555</a>)</li>
+	<li>Blacklist: Escalate repeated soft error to normal error (<a href="https://github.com/owncloud/client/issues/5500">#5500</a>)</li>
+	<li>NTFS: Do not attempt to upload two existing files with similar casing (<a href="https://github.com/owncloud/client/issues/5544">#5544</a>)</li>
+	<li>Fix URL for linking to application password generation for ownCloud 10.0 (<a href="https://github.com/owncloud/client/issues/5605">#5605</a>)</li>
+</ul>	
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.1.6824-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.1.4139.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.1.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.1.tar.xz.asc">PGP signature</a>)
+
+<h3 id="230">Release 2.3.0 <small>March 3rd 2017</small></h3>
+<ul>
+    <li>Decreased memory usage during sync</li>
+    <li>Overlay icons: Lower CPU usage</li>
+    <li>Allow to not sync the server's external storages by default</li>
+    <li>Switch Windows and OS X build to Qt 5.6.2</li>
+    <li>Switch to new ownCloud server WebDAV endpoint</li>
+    <li>Chunking NG: New file upload chunking algorithm for the upcoming ownCloud server 10.0</li>
+    <li>Allow to sync a folder to multiple different servers (Filename change from .csync_journal.db to _sync_$HASH.db)</li>
+    <li>Conflicts: Use the local mtime for the conflict file name (<a href="https://github.com/owncloud/client/issues/5273">#5273</a>)</li>
+    <li>"Sync now" menu item</li>
+    <li>SSL Client certificate support improved (Show UI, Store keys in keychain)</li>
+    <li>Propagator: Upload more small files in parallel</li>
+    <li>Sync Engine: Read data-fingerprint property to detect backups (<a href="https://github.com/owncloud/client/issues/2325">#2325</a>)</li>
+    <li>GUI: Show link to ceate an app password/token for syncing</li>
+    <li>Share dialog: Add 'Mail link' button</li>
+    <li>Caja file manager plugin</li>
+    <li>Make "backup detected" message to not trigger in wrong cases</li>
+    <li>SyncEngine: Fix renaming of folder when file are changed (<a href="https://github.com/owncloud/client/issues/5192">#5192</a>)</li>
+    <li>Fix reconnect bug if status.php intermittently returns wrong data (<a href="https://github.com/owncloud/client/issues/5188">#5188</a>)</li>
+    <li>Improve sync scheduling (<a href="https://github.com/owncloud/client/issues/5317">#5317</a>)</li>
+    <li>Overlay icons: Improvements in correctnes</li>
+    <li>Tray menu: Only update on demand to fix Linux desktop integration glitches</li>
+    <li>Progress: Better time/bandwidth estimations</li>
+    <li>Network: Follow certain HTTP redirects (<a href="https://github.com/owncloud/client/issues/2791">#2791</a>)</li>
+    <li>Network: Remove all cookies (including load balancers etc) when logging out</li>
+    <li>Discovery thread: Low priority</li>
+    <li>owncloudsync.log: Write during propagation</li>
+    <li>Better error message for files with trailing spaces on Windows</li>
+    <li>Excludes: Consider files in hidden folders excluded (<a href="https://github.com/owncloud/client/issues/5163">#5163</a>)</li>
+    <li>Allow sync directory to be a symlinked directory</li>
+    <li>Add manifest file on Windows to make the application UAC aware</li>
+    <li>macOS: Improve monochrome tray icons</li>
+    <li>Shibboleth bugfixes</li>
+    <li>Fixes with regards to low disk space</li>
+    <li>A ton of other bugfixes</li>
+    <li>Refactorings</li>
+    <li>Improved documentation</li>
+    <li>Crash fixes</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.0.6780-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.3.0.4097.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.3.0.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.3.0.tar.xz.asc">PGP signature</a>)
+
+
+<h3 id="224">Release 2.2.4 <small>September 27th 2016</small></h3>
+<ul>
+<li>Dolphin Plugin: Use the Application name for the socket path (<a href="https://github.com/owncloud/client/issues/5172">#5172</a>)</li>
+<li>SyncEngine: Fix renaming of folder when file are changed (<a href="https://github.com/owncloud/client/issues/5195">#5195</a>)</li>
+<li>Selective Sync: Fix HTTP request loop and show error in view (<a href="https://github.com/owncloud/client/issues/5154">#5154</a>)</li>
+<li>ConnectionValidator: properly handle error in status.php request (<a href="https://github.com/owncloud/client/issues/5188">#5188</a>)</li>
+<li>Discovery: Set thread priority to low (<a href="https://github.com/owncloud/client/issues/5017">#5017</a>)</li>
+<li>ExcludeFiles: Fix when the folder casing is not the same in the settings and in the FS</li>
+<li>ShareLink: Ensure the password line edit is enabled (<a href="https://github.com/owncloud/client/issues/5117">#5117</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.4.6408-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.4.3709.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.4.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/testing/owncloudclient-2.2.4.tar.xz.asc">PGP signature</a>)
+
+<h3 id="223">Release 2.2.3 <small>August 8th 2016</small></h3>
+<ul>
+<li>SyncEngine: Fix detection of backup (<a href="https://github.com/owncloud/client/issues/5104">#5104</a>)</li>
+<li>Fix bug with overriding URL in config (<a href="https://github.com/owncloud/client/issues/5016">#5016</a>)</li>
+<li>Sharing: Fix bug with file names containing percent encodes (<a href="https://github.com/owncloud/client/issues/5042">#5042</a>, <a href="https://github.com/owncloud/client/issues/5043">#5043</a>)</li>
+<li>Sharing: Permissions for federated shares on servers &gt;=9.1 (<a href="https://github.com/owncloud/client/issues/4996">#4996</a>, <a href="https://github.com/owncloud/client/issues/5001">#5001</a>)</li>
+<li>Overlays: Fix issues with file name casing on OS X and Windows</li>
+<li>Windows: Skip symlinks and junctions again (<a href="https://github.com/owncloud/client/issues/5019">#5019</a>)</li>
+<li>Only accept notification API Capability if endpoint is OCS-enabled (<a href="https://github.com/owncloud/client/issues/5034">#5034</a>)</li>
+<li>Fix windows HiDPI (<a href="https://github.com/owncloud/client/issues/4994">#4994</a>)</li>
+<li>SocketAPI: Use different pipe name to avoid unusual delay (<a href="https://github.com/owncloud/client/issues/4977">#4977</a>)</li>
+<li>Tray: Add minimal mode as workaround and testing tool for Linux issues (<a href="https://github.com/owncloud/client/issues/4985">#4985</a>, <a href="https://github.com/owncloud/client/issues/4990">#4990</a>)</li>
+<li>owncloudcmd: Fix --exclude regression <a href="https://github.com/owncloud/client/issues/4979">#4979</a></li>
+<li>Small memleak: Use the full file stat destructors (<a href="https://github.com/owncloud/client/issues/4992">#4992</a>)</li>
+<li>Fix small QAction memleak (<a href="https://github.com/owncloud/client/issues/5008">#5008</a>)</li>
+<li>Fix crash on shutting down during propagation (<a href="https://github.com/owncloud/client/issues/4979">#4979</a>)</li>
+<li>Decrease memory usage during sync (<a href="https://github.com/owncloud/client/issues/4979">#4979</a>)</li>
+<li>Fix a deadlock when shutting down during discovery (<a href="https://github.com/owncloud/client/issues/4993">#4993</a>)</li>
+<li>Setup csync logging earlier to get all log output (<a href="https://github.com/owncloud/client/issues/4991">#4991</a>)</li>
+<li>Enable Shibboleth debug view with <code>OWNCLOUD_SHIBBOLETH_DEBUG</code> env</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.3.6307-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.3.3601.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.3.tar.xz">Sources</a>
+(<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.3.tar.xz.asc">PGP signature</a>)
+
+<h3 id="222">Release 2.2.2 <small>June 21st 2016</small></h3>
+<ul>
+  <li>Excludes: Don't redundantly add the same exclude files (<a href="https://github.com/owncloud/client/issues/4967">#4967</a>, <a href="https://github.com/owncloud/client/issues/4988">#4988</a>)</li>
+  <li> Excludes: Only log if the pattern was really logged. (<a href="https://github.com/owncloud/client/issues/4989">#4989</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.2.tar.xz.asc">PGP signature</a>)
+
+<h3 id="221">Release 2.2.1 <small>June 6th 2016</small></h3>
+<ul>
+<li>Fix out of memory error when too many uploads happen (<a href="https://github.com/owncloud/client/issues/4611">#4611</a>)</li>
+<li>Fix display errors in progress display (<a href="https://github.com/owncloud/client/issues/4803">#4803</a>, <a href="https://github.com/owncloud/client/issues/4856">#4856</a>)</li>
+<li>LockWatcher: Remember to upload files after they become unlocked (<a href="https://github.com/owncloud/client/issues/4865">#4865</a>) </li>
+<li>Fix overlay icons for files with umlauts (<a href="https://github.com/owncloud/client/issues/4884">#4884</a>)</li>
+<li>Certs: Re-ask for different cert after rejection (<a href="https://github.com/owncloud/client/issues/4898">#4898</a>, <a href="https://github.com/owncloud/client/issues/4911">#4911</a>)</li>
+<li>Progress: Don't count items without propagation jobs (<a href="https://github.com/owncloud/client/issues/4856">#4856</a>, <a href="https://github.com/owncloud/client/issues/4910">#4910</a>)</li>
+<li>Utility: Fix for the translation of minutes, second (<a href="https://github.com/owncloud/client/issues/4855">#4855</a>)</li>
+<li>SyncEngine: invalid the blacklist entry when the rename destination change</li>
+<li>Several fixes to speed up reconnect after connection changes</li>
+<li>Updater: Fix small memory leak</li>
+<li>Linux: Revert forced HiDPI detection settings (<a href="https://github.com/owncloud/client/issues/4840">#4840</a>, <a href="https://github.com/owncloud/client/issues/4861">#4861</a>)</li>
+</ul>
+
+<h3 id="220">Release 2.2.0 <small>May 12th 2016</small></h3>
+<ul>
+<li>Overlay icons: Refactoring - mainly for performance improvements</li>
+<li>Improved error handling with Sync Journal on USB storages (<a href="https://github.com/owncloud/client/issues/4632">#4632</a>)</li>
+<li>Sharing Completion: Improved UI of completion in sharing from desktop. (<a href="https://github.com/owncloud/client/issues/3737">#3737</a>)</li>
+<li>Show server notifications on the client (<a href="https://github.com/owncloud/client/issues/3733">#3733</a>)</li>
+<li>Improved Speed with small files by dynamic parallel request count (<a href="https://github.com/owncloud/client/issues/4529">#4529</a>)</li>
+<li>LockWatcher: Make sure to sync files after apps released exclusive locks on Windows.</li>
+<li>Improved handling of Win32 file locks and network files</li>
+<li>Workaround Ubuntu 16.04 tray icon bug (<a href="https://github.com/owncloud/client/issues/4693">#4693</a>)</li>
+<li>Removed the Alias field from the folder definition (<a href="https://github.com/owncloud/client/issues/4695">#4695</a>)</li>
+<li>Improved netrc parser (<a href="https://github.com/owncloud/client/issues/4691">#4691</a>)</li>
+<li>Improved user notifications about ignored files and conflicts (<a href="https://github.com/owncloud/client/issues/4761">#4761</a>, <a href="https://github.com/owncloud/client/issues/3222">#3222</a>)</li>
+<li>Add warnings for old server versions (<a href="https://github.com/owncloud/client/issues/4523">#4523</a>)</li>
+<li>Enable tranportation checksums if the server supports based on server capabilities (<a href="https://github.com/owncloud/client/issues/3735">#3735</a>)</li>
+<li>Default Chunk-size changed to 10MB (<a href="https://github.com/owncloud/client/issues/4354">#4354</a>)</li>
+<li>Documentation Improvements, ie. about overlay icons</li>
+<li>Translation fixes</li>
+<li>Countless other bugfixes</li>
+<li>Sqlite Update to recent version</li>
+<li>Update of QtKeyChain to support Windows credential store</li>
+<li>Packaging of dolphin overlay icon module for bleeding edge distros</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.0.6076-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.2.0.3358.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.0.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.2.0.tar.xz.asc">PGP signature</a>)
+
+<h3 id="211">Release 2.1.1 <small>Februrary 10th 2016</small></h3>
+<ul>
+<li>UI improvements for HiDPI screens, error messages, RTL languages</li>
+<li>Fix occurences of "Connection Closed" when a new unauthenticated TCP socket is used</li>
+<li>Fix undeliberate WiFi scanning done by Qt Network classes</li>
+<li>Several fixes/improvements to the sharing dialog</li>
+<li>Several fixes/improvements to the server activity tab</li>
+<li>Create the directory when using <tt>--confdir</tt> and it does not exist</li>
+<li>Windows Overlay icons: Fix DLL and icon oddities</li>
+<li>Mac Overlay icons: Don't install legacy Finder plugin on &gt;= 10.10</li>
+<li>Linux Overlay icons: Nemo plugin</li>
+<li>Overlay icons: Fix several wrong icon state computations</li>
+<li>Allow changeable upload chunk size in owncloud.cfg</li>
+<li>Crash fixes on account deletion</li>
+<li>Forget password on explicit sign-out</li>
+<li>OS X: Fix the file system watcher ignoring unicode paths (<a href="https://github.com/owncloud/client/issues/4424">#4424</a>)</li>
+<li>Windows Installer: Update to NSIS 2.50, fixes possible DLL injection</li>
+<li>Sync Engine: .lnk files</li>
+<li>Sync Engine: symlinked syn directories</li>
+<li>Sync Engine: Windows: Fix deleting and replacing of read-only files (<a href="https://github.com/owncloud/client/issues/4308">#4308</a>, <a href="https://github.com/owncloud/client/issues/4277">#4277</a>)</li>
+<li>Sync Engine: Fixes for files becoming directories and vice versa (<a href="https://github.com/owncloud/client/issues/4302">#4302</a>)</li>
+<li>Misc other fixes/improvements</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.1.1.5837-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.1.1.3107.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.1.1.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.1.1.tar.xz.asc">PGP signature</a>)
+
+<h3 id="210">Release 2.1.0 <small>December 3rd 2015</small></h3>
+<ul>
+<li>GUI: Added a separate view for not synced items, ignores, errors</li>
+<li>GUI: Improved upload/download progress UI (<a href="https://github.com/owncloud/client/issues/3403">#3403</a>, <a href="https://github.com/owncloud/client/issues/3569">#3569</a>)</li>
+<li>Allowed sharing with ownCloud internal users and groups from Desktop</li>
+<li>Changed files starting in .* to be considered hidden on all platforms (<a href="https://github.com/owncloud/client/issues/4023">#4023</a>)</li>
+<li>Reflect read-only permissions in filesystem (<a href="https://github.com/owncloud/client/issues/3244">#3244</a>)  </li>
+<li>Blacklist: Clear on successful chunk upload (<a href="https://github.com/owncloud/client/issues/3934">#3934</a>)</li>
+<li>Improved reconnecting after network change/disconnect (<a href="https://github.com/owncloud/client/issues/4167">#4167</a> <a href="https://github.com/owncloud/client/issues/3969">#3969</a> ...)</li>
+<li>Improved performance in Windows file system discovery</li>
+<li>Removed libneon-based propagator. As a consequence, The client can no longer provide bandwith limiting on Linux-distributions where it is using Qt &lt; 5.4</li>
+<li>Performance improvements in the logging functions</li>
+<li>Ensured that local disk space problems are handled gracefully (<a href="https://github.com/owncloud/client/issues/2939">#2939</a>)</li>
+<li>Improved handling of checksums: transport validation, db (<a href="https://github.com/owncloud/client/issues/3735">#3735</a>)</li>
+<li>For *eml-files don't reupload if size and checksum are unchanged (<a href="https://github.com/owncloud/client/issues/3235">#3235</a>)</li>
+<li>Ensured 403 reply code is handled properly (File Firewall) (<a href="https://github.com/owncloud/client/issues/3490">#3490</a>)</li>
+<li>Reduced number of PROPFIND requests to server(<a href="https://github.com/owncloud/client/issues/3964">#3964</a>)</li>
+<li>GUI: Added Account toolbox widget to keep account actions (<a href="https://github.com/owncloud/client/issues/4139">#4139</a>)</li>
+<li>Tray Menu: Added fixes for Recent Activity menu (<a href="https://github.com/owncloud/client/issues/4093">#4093</a>, <a href="https://github.com/owncloud/client/issues/3969">#3969</a>)</li>
+<li>FolderMan: Fixed infinite wait on pause (<a href="https://github.com/owncloud/client/issues/4093">#4093</a>)</li>
+<li>Renamed env variables to include unit (<a href="https://github.com/owncloud/client/issues/2939">#2939</a>)</li>
+<li>FolderStatusModel: Attempt to detect removed undecided files (<a href="https://github.com/owncloud/client/issues/3612">#3612</a>)</li>
+<li>SyncEngine: Don't whipe the white list if the sync was aborted (<a href="https://github.com/owncloud/client/issues/4018">#4018</a>)</li>
+<li>Quota: Handle special negative value for the quota (<a href="https://github.com/owncloud/client/issues/3940">#3940</a>)</li>
+<li>State app name in update notification (<a href="https://github.com/owncloud/client/issues/4020">#4020</a>)</li>
+<li>PropagateUpload: Fixed double-emission of finished (<a href="https://github.com/owncloud/client/issues/3844">#3844</a>)</li>
+<li>GUI: Ensured folder names which are excluded from sync can be clicked</li>
+<li>Shell Integration: Dolphin support, requires KF 5.16 and KDE Application 15.12</li>
+<li>FolderStatusModel: Ensured reset also if a folder was renamed (<a href="https://github.com/owncloud/client/issues/4011">#4011</a>)</li>
+<li>GUI: Fixed accessiblity of remaing items in full settings toolbar (<a href="https://github.com/owncloud/client/issues/3795">#3795</a>)</li>
+<li>Introduced the term "folder sync connection" in more places (<a href="https://github.com/owncloud/client/issues/3757">#3757</a>)</li>
+<li>AccountSettings: Don't disable pause when offline (<a href="https://github.com/owncloud/client/issues/4010">#4010</a>)</li>
+<li>Fixed handling of hidden files (<a href="https://github.com/owncloud/client/issues/3980">#3980</a>)</li>
+<li>Handle download errors while resuming as soft errors (<a href="https://github.com/owncloud/client/issues/4000">#4000</a>)</li>
+<li>SocketAPI: Ensured that the command isn't trimmed (<a href="https://github.com/owncloud/client/issues/3297">#3297</a>)</li>
+<li>Shutdown socket API before removing the db (<a href="https://github.com/owncloud/client/issues/3824">#3824</a>)</li>
+<li>GUI: Made "Keep" default in the delete-all dialog (<a href="https://github.com/owncloud/client/issues/3824">#3824</a>)</li>
+<li>owncloudcmd: Introduced return code 0 for --version and --help</li>
+<li>owncloudcmd: Added --max-sync-retries (<a href="https://github.com/owncloud/client/issues/4037">#4037</a>)</li>
+<li>owncloudcmd: Don't do a check that file are older than 2s (<a href="https://github.com/owncloud/client/issues/4160">#4160</a>)</li>
+<li>Fixed getting size for selective sync (<a href="https://github.com/owncloud/client/issues/3986">#3986</a>)</li>
+<li>Re-added close button in the settings window (<a href="https://github.com/owncloud/client/issues/3713">#3713</a>)</li>
+<li>Added abililty to handle storage limitations gracefully (<a href="https://github.com/owncloud/client/issues/3736">#3736</a>)</li>
+<li>Updated 3rdparty dependencies: sqlite version 3.9.1</li>
+<li>Organized patches to our base Qt version into admin/qt/patches</li>
+<li>Plus: A lot of unmentioned improvements and fixes</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.1.0.5683-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.1.0.2944.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.1.0.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.1.0.tar.xz.asc">PGP signature</a>)
+
+<h3 id="202">Release 2.0.2 <small>October 22nd 2015</small></h3>
+<ul>
+<li>csync_file_stat_s: Save a bit of memory</li>
+<li>Shibboleth: Add our base user agent to WebKit</li>
+<li>SelectiveSync: Increase folder list timeout to 60</li>
+<li>Propagation: Try another sync on 423 Locked (<a href="https://github.com/owncloud/client/issues/3387">#3387</a>)</li>
+<li>Propagation: Make 423 Locked a soft error (<a href="https://github.com/owncloud/client/issues/3387">#3387</a>)</li>
+<li>Propagation: Reset upload blacklist if a chunk succeeds</li>
+<li>Application: Fix crash on early shutdown (<a href="https://github.com/owncloud/client/issues/3898">#3898</a>)</li>
+<li>Linux: Don't show settings dialog always when launched twice (<a href="https://github.com/owncloud/client/issues/3273">#3273</a>, <a href="https://github.com/owncloud/client/issues/3771">#3771</a>, <a href="https://github.com/owncloud/client/issues/3485">#3485</a>)</li>
+<li>win32 vio: Add the OPEN_REPARSE_POINTS flag to the CreateFileW call. (<a href="https://github.com/owncloud/client/issues/3813">#3813</a>)</li>
+<li>AccountSettings: only expand root elements on single click.</li>
+<li>AccountSettings: Do not allow to expand the folder list when disconnected.</li>
+<li>Use application SHORT name for the name of the MacOSX pkg file (ownBrander).</li>
+<li>FolderMan: Fix for removing a syncing folder (<a href="https://github.com/owncloud/client/issues/3843">#3843</a>)</li>
+<li>ConnectionMethodDialog: Don't be insecure on close (<a href="https://github.com/owncloud/client/issues/3863">#3863</a>)</li>
+<li>Updater: Ensure folders are not removed (<a href="https://github.com/owncloud/client/issues/3747">#3747</a>)</li>
+<li>Folder settings: Ensure path is cleaned (<a href="https://github.com/owncloud/client/issues/3811">#3811</a>)</li>
+<li>Propagator: Simplify sub job finished counting (<a href="https://github.com/owncloud/client/issues/3844">#3844</a>)</li>
+<li>Share dialog: Hide settings dialog before showing (<a href="https://github.com/owncloud/client/issues/3783">#3783</a>)</li>
+<li>UI: Only expand 1 level in folder list (<a href="https://github.com/owncloud/client/issues/3585">#3585</a>)</li>
+<li>UI: Allow folder expanding from button click (<a href="https://github.com/owncloud/client/issues/3585">#3585</a>)</li>
+<li>UI: Expand folder treeview on single click (<a href="https://github.com/owncloud/client/issues/3585">#3585</a>)</li>
+<li>GUI: Change tray menu order (<a href="https://github.com/owncloud/client/issues/3657">#3657</a>)</li>
+<li>GUI: Replace term "sign in" with "Log in" and friends.</li>
+<li>SetupPage: Fix crash caused by uninitialized Account object.</li>
+<li>Use a themable WebDAV path all over.</li>
+<li>Units: Back to the "usual" mix units (JEDEC standard).</li>
+<li>csync io: Full UNC path support on Win (<a href="https://github.com/owncloud/client/issues/3748">#3748</a>)</li>
+<li>Tray: Don't use the tray workaround with the KDE theme (<a href="https://github.com/owncloud/client/issues/3706">#3706</a>, <a href="https://github.com/owncloud/client/issues/3765">#3765</a>)</li>
+<li>ShareDialog: Fix folder display (<a href="https://github.com/owncloud/client/issues/3659">#3659</a>)</li>
+<li>AccountSettings: Restore from legacy only once (<a href="https://github.com/owncloud/client/issues/3565">#3565</a>)</li>
+<li>SSL Certificate Error Dialog: show account name (<a href="https://github.com/owncloud/client/issues/3729">#3729</a>)</li>
+<li>Tray notification: Don't show a message about modified folder (<a href="https://github.com/owncloud/client/issues/3613">#3613</a>)</li>
+<li>PropagateLocalRemove:  remove entries from the DB even if there was an error.</li>
+<li>Settings UI improvements (eg. <a href="https://github.com/owncloud/client/issues/3713">#3713</a>, <a href="https://github.com/owncloud/client/issues/3721">#3721</a>, <a href="https://github.com/owncloud/client/issues/3619">#3619</a> and others)</li>
+<li>Folder: Do not create the sync folder if it does not exist (<a href="https://github.com/owncloud/client/issues/3692">#3692</a>)</li>
+<li>Shell integration: don't show share menu item for top level folders</li>
+<li>Tray: Hide while modifying menus (<a href="https://github.com/owncloud/client/issues/3656">#3656</a>, <a href="https://github.com/owncloud/client/issues/3672">#3672</a>)</li>
+<li>AddFolder: Improve remote path selection error handling (<a href="https://github.com/owncloud/client/issues/3573">#3573</a>)</li>
+<li>csync_update: Use excluded_traversal() to improve performance (<a href="https://github.com/owncloud/client/issues/3638">#3638</a>)</li>
+<li>csync_excluded: Add fast _traversal() function (<a href="https://github.com/owncloud/client/issues/3638">#3638</a>)</li>
+<li>csync_exclude: Speed up significantly (<a href="https://github.com/owncloud/client/issues/3638">#3638</a>)</li>
+<li>AccountSettings: Adjust quota info design (<a href="https://github.com/owncloud/client/issues/3644">#3644</a>, <a href="https://github.com/owncloud/client/issues/3651">#3651</a>)</li>
+<li>Adjust buttons on remove folder/account questions (<a href="https://github.com/owncloud/client/issues/3654">#3654</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.2.5569-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.2.2818.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.2.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.2.tar.xz.asc">PGP signature</a>)
+
+<h3 id="201">Release 2.0.1 <small>September 1st 2015</small></h3>
+<ul>
+<li>AccountWizard: fix when the theme specifies an override URL (<a href="https://github.com/owncloud/client/issues/3699">#3699</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.1.5446-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.1.2694.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.1.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.1.tar.xz.asc">PGP signature</a>)
+
+<h3 id="200">Release 2.0.0 <small>August 25th 2015</small></h3>
+<ul>
+<li>Add support for multiple accounts (<a href="https://github.com/owncloud/client/issues/3084">#3084</a>)</li>
+<li>Do not sync down new big folders from server without users consent (<a href="https://github.com/owncloud/client/issues/3148">#3148</a>)</li>
+<li>Integrate Selective Sync into the default UI</li>
+<li>OS X: Support native finder integration for 10.10 Yosemite (<a href="https://github.com/owncloud/client/issues/2340">#2340</a>)</li>
+<li>Fix situation where client would not reconnect after timeout (<a href="https://github.com/owncloud/client/issues/2321">#2321</a>)</li>
+<li>Use SI units for the file sizes</li>
+<li>Improve progress reporting during sync (better estimations, show all files, show all bandwidth)</li>
+<li>Windows: Support paths &gt;255 characters (<a href="https://github.com/owncloud/client/issues/57">#57</a>) by using Windows API instead of POSIX API</li>
+<li>Windows, OS X: Allow to not sync hidden files (<a href="https://github.com/owncloud/client/issues/2086">#2086</a>)</li>
+<li>OS X: Show file name in UI if file has invalid UTF-8 in file name</li>
+<li>Sharing: Make use of Capability API (<a href="https://github.com/owncloud/client/issues/3439">#3439</a>)</li>
+<li>Sharing: Do not allow sharing the root folder (<a href="https://github.com/owncloud/client/issues/3495">#3495</a>)</li>
+<li>Sharing: Show thumbnail</li>
+<li>Client Updater: Check for updates periodically, not only once per run (<a href="https://github.com/owncloud/client/issues/3044">#3044</a>)</li>
+<li>Windows: Remove misleading option to remove sync data (<a href="https://github.com/owncloud/client/issues/3461">#3461</a>)</li>
+<li>Windows: Do not provoke AD account locking if password changes (<a href="https://github.com/owncloud/client/issues/2186">#2186</a>)</li>
+<li>Windows: Fix installer when installing unprivileged (<a href="https://github.com/owncloud/client/issues/2616">#2616</a>, <a href="https://github.com/owncloud/client/issues/2568">#2568</a>)</li>
+<li>Quota: Only refresh from server when UI is shown</li>
+<li>SSL Button: Show more information</li>
+<li>owncloudcmd: Fix <tt>--httpproxy</tt> (<a href="https://github.com/owncloud/client/issues/3465">#3465</a>)</li>
+<li>System proxy: Ask user for credentials if needed</li>
+<li>Several fixes and performance improvements in the sync engine</li>
+<li>Network: Try to use SSL session tickets/identifiers. Check the SSL button to see if they are used.</li>
+<li>Bandwidth Throttling: Provide automatic limit setting for downloads (<a href="https://github.com/owncloud/client/issues/3084">#3084</a>)</li>
+<li>Systray: Workaround for issue with Qt 5.5.0 (<a href="https://github.com/owncloud/client/issues/3656">#3656</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.0.5423-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-2.0.0.2666.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.0.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-2.0.0.tar.xz.asc">PGP signature</a>)
+
+<h3 id="184">Release 1.8.4 <small>July 13th 2015</small></h3>
+<ul>
+<li>Release to ship a security release of openSSL. No source changes of the ownCloud Client code.</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.4.5267-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.4.2531.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.4.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.4.tar.xz.asc">PGP signature</a>)
+
+<h3 id="183">Release 1.8.3 <small>June 23th 2015</small></h3>
+<ul>
+<li>Fix a bug in the Windows Installer that could crash explorer (<a href="https://github.com/owncloud/client/issues/3320">#3320</a>)</li>
+<li>Reduce 'Connection closed' errors (<a href="https://github.com/owncloud/client/issues/3318">#3318</a>, <a href="https://github.com/owncloud/client/issues/3313">#3313</a>, <a href="https://github.com/owncloud/client/issues/3298">#3298</a>)</li>
+<li>Ignores: Force a remote discovery after ignore list change (<a href="https://github.com/owncloud/client/issues/3172">#3172</a>)</li>
+<li>Shibboleth: Avoid crash by letting the webview use its own QNAM (<a href="https://github.com/owncloud/client/issues/3359">#3359</a>)</li>
+<li>System Ignores: Removed *.tmp from system ignore again. If a user wants to ignore *.tmp, it needs to be added to the user ignore list.</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.3.5213-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.3.2458.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.3.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.3.tar.xz.asc">PGP signature</a>)
+
+<h3 id="182">Release 1.8.2 <i>(retracted)</i> <small>June 8th 2015</small></h3>
+<ul>
+<li>Improve reporting of server error messages (<a href="https://github.com/owncloud/client/issues/3220">#3220</a>)</li>
+<li>Discovery: Ignore folders with any 503 (<a href="https://github.com/owncloud/client/issues/3113">#3113</a>)</li>
+<li>Wizard: Show server error message if possible (<a href="https://github.com/owncloud/client/issues/3220">#3220</a>)</li>
+<li>QNAM: Fix handling of mitm cert changes (<a href="https://github.com/owncloud/client/issues/3283">#3283</a>)</li>
+<li>Win32: Installer translations added (<a href="https://github.com/owncloud/client/issues/3277">#3277</a>)</li>
+<li>Win32: Allow concurrent OEM (un-)installers (<a href="https://github.com/owncloud/client/issues/3272">#3272</a>)</li>
+<li>Win32: Make Setup/Update Mutex theme-unique (<a href="https://github.com/owncloud/client/issues/3272">#3272</a>)</li>
+<li>HTTP: Add the branding name to the UserAgent string</li>
+<li>ConnectonValidator: Always run with new credentials (<a href="https://github.com/owncloud/client/issues/3266">#3266</a>)</li>
+<li>Recall Feature: Admins can trigger an upload of a file from client to server again (<a href="https://github.com/owncloud/client/issues/3246">#3246</a>)</li>
+<li>Propagator: Add 'Content-Length: 0' header to MKCOL request (<a href="https://github.com/owncloud/client/issues/3256">#3256</a>)</li>
+<li>Switch on checksum verification through branding or config</li>
+<li>Add ability for checksum verification of up and download</li>
+<li>Fix opening external links for some labels (<a href="https://github.com/owncloud/client/issues/3135">#3135</a>)</li>
+<li>AccountState: Run only a single validator, allow error message overriding (<a href="https://github.com/owncloud/client/issues/3236">#3236</a>, <a href="https://github.com/owncloud/client/issues/3153">#3153</a>)</li>
+<li>SyncJournalDB: Minor fixes and simplificatons</li>
+<li>SyncEngine: Force re-read of folder Etags for upgrades from 1.8.0 and 1.8.1</li>
+<li>Propagator: Limit length of temporary file name (<a href="https://github.com/owncloud/client/issues/2789">#2789</a>)</li>
+<li>ShareDialog: Password ui fixes (<a href="https://github.com/owncloud/client/issues/3189">#3189</a>)</li>
+<li>Fix startup hang by removing QSettings lock file (<a href="https://github.com/owncloud/client/issues/3175">#3175</a>)</li>
+<li>Wizard: Allow SSL cert dialog to show twice (<a href="https://github.com/owncloud/client/issues/3168">#3168</a>)</li>
+<li>ProtocolWidget: Fix rename message (<a href="https://github.com/owncloud/client/issues/3210">#3210</a>)</li>
+<li>Discovery: Test better, treat invalid hrefs as error (<a href="https://github.com/owncloud/client/issues/3176">#3176</a>)</li>
+<li>Propagator: Overwrite local data only if unchanged (<a href="https://github.com/owncloud/client/issues/3156">#3156</a>)</li>
+<li>ShareDialog: Improve error reporting for share API fails</li>
+<li>OSX Updater: Only allow updates only if in /Applications (<a href="https://github.com/owncloud/client/issues/2931">#2931</a>)</li>
+<li>Wizard: Fix lock icon (<a href="https://github.com/owncloud/client/issues/1447">#1447</a>)</li>
+<li>Fix compilation with GCC 5</li>
+<li>Treat any 503 error as temporary (<a href="https://github.com/owncloud/client/issues/3113">#3113</a>)</li>
+<li>Work around for the Qt PUT corruption bug (<a href="https://github.com/owncloud/client/issues/2425">#2425</a>)</li>
+<li>OSX Shell integration: Optimizations</li>
+<li>Windows Shell integration: Optimizations</li>
+</ul>
+<h3 id="181">Release 1.8.1 <small>May 7th 2015</small></h3>
+<ul>
+<li>Make "operation canceled" error a soft error</li>
+<li>Do not throw an error for files that are scheduled to be removed, but can not be found on the server. (<a href="https://github.com/owncloud/client/issues/2919">#2919</a>)</li>
+<li>Windows: Reset QNAM to proper function after hibernation. (<a href="https://github.com/owncloud/client/issues/2899">#2899</a>, <a href="https://github.com/owncloud/client/issues/2895">#2895</a>, <a href="https://github.com/owncloud/client/issues/2973">#2973</a>)</li>
+<li>Fix argument verification of --confdir (<a href="https://github.com/owncloud/client/issues/2453">#2453</a>)</li>
+<li>Fix a crash when accessing a dangling UploadDevice pointer (<a href="https://github.com/owncloud/client/issues/2984">#2984</a>)</li>
+<li>Add-folder wizard: Make sure there is a scrollbar if folder names are too long (<a href="https://github.com/owncloud/client/issues/2962">#2962</a>)</li>
+<li>Add-folder Wizard: Select the newly created folder</li>
+<li>Activity: Correctly restore column sizes (<a href="https://github.com/owncloud/client/issues/3005">#3005</a>)</li>
+<li>SSL Button: do not crash on empty certificate chain</li>
+<li>SSL Button: Make menu creation lazy (<a href="https://github.com/owncloud/client/issues/3007">#3007</a>, <a href="https://github.com/owncloud/client/issues/2990">#2990</a>)</li>
+<li>Lookup system proxy async to avoid hangs (<a href="https://github.com/owncloud/client/issues/2993">#2993</a>, <a href="https://github.com/owncloud/client/issues/2802">#2802</a>)</li>
+<li>ShareDialog: Some GUI refinements</li>
+<li>ShareDialog: On creation of a share always retrieve the share. This makes sure that if a default expiration date is set this is reflected in the dialog. (<a href="https://github.com/owncloud/client/issues/2889">#2889</a>)</li>
+<li>ShareDialog: Only show share dialog if we are connected.</li>
+<li>HttpCreds: Fill pw dialog with previous password. (<a href="https://github.com/owncloud/client/issues/2848">#2848</a>, <a href="https://github.com/owncloud/client/issues/2879">#2879</a>)</li>
+<li>HttpCreds: Delete password from old location. (<a href="https://github.com/owncloud/client/issues/2186">#2186</a>)</li>
+<li>Do not store Session Cookies in the client cookie storage</li>
+<li>CookieJar: Don't accidentally overwrite cookies. (<a href="https://github.com/owncloud/client/issues/2808">#2808</a>)</li>
+<li>ProtocolWidget: Always add seconds to the DateTime locale. (<a href="https://github.com/owncloud/client/issues/2535">#2535</a>)</li>
+<li>Updater: Give context as to which app is about to be updated (<a href="https://github.com/owncloud/client/issues/3040">#3040</a>)</li>
+<li>Windows: Add version information for owncloud.exe. This should help us know what version or build number a crash report was generated with.</li>
+<li>Fix a crash on shutdown in ~SocketApi (<a href="https://github.com/owncloud/client/issues/3057">#3057</a>)</li>
+<li>SyncEngine: Show more timing measurements (<a href="https://github.com/owncloud/client/issues/3064">#3064</a>)</li>
+<li>Discovery: Add warning if returned etag is 0</li>
+<li>Fix a crash caused by an invalid DiscoveryDirectoryResult::iterator (<a href="https://github.com/owncloud/client/issues/3051">#3051</a>)</li>
+<li>Sync: Fix sync of deletions during 503. (<a href="https://github.com/owncloud/client/issues/2894">#2894</a>)</li>
+<li>Handle redirect of auth request. (<a href="https://github.com/owncloud/client/issues/3082">#3082</a>)</li>
+<li>Discovery: Fix parsing of broken XML replies, which fixes local file disappearing (<a href="https://github.com/owncloud/client/issues/3102">#3102</a>)</li>
+<li>Migration: Silently restore files that were deleted locally by bug (<a href="https://github.com/owncloud/client/issues/3102">#3102</a>)</li>
+<li>Sort folder sizes SelectiveSyncTreeView numerically (<a href="https://github.com/owncloud/client/issues/3112">#3112</a>)</li>
+<li>Sync: PropagateDownload: Read the mtime from the file system after writing it (<a href="https://github.com/owncloud/client/issues/3103">#3103</a>)</li>
+<li>Sync: Propagate download: Fix restoring files for which the conflict file exists (<a href="https://github.com/owncloud/client/issues/3106">#3106</a>)</li>
+<li>Use identical User Agents and version for csync and the Qt parts</li>
+<li>Prevent another crash in ~SocketApi (<a href="https://github.com/owncloud/client/issues/3118">#3118</a>)</li>
+<li>Windows: Fix rename of finished file (<a href="https://github.com/owncloud/client/issues/3073">#3073</a>)</li>
+<li>AccountWizard: Fix auth error handling (<a href="https://github.com/owncloud/client/issues/3155">#3155</a>)</li>
+<li>Documentation fixes</li>
+<li>Infrastructure/build fixes</li>
+<li>Win32/OS X: Apply patch from OpenSSL to handle oudated intermediates gracefully (<a href="https://github.com/owncloud/client/issues/3087">#3087</a>)</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.1.5050-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.1.2336.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.1.tar.xz">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.1.tar.xz.asc">PGP signature</a>)
+
+<h3 id="180">Release 1.8.0 <small>Mar 17th 2015</small></h3>
+<ul>
+<li>Mac OS: HIDPI support</li>
+<li>Support Sharing from desktop: Added a share dialog that can be
+opened by context menu in the file managers (Win, Mac, Nautilus).
+It supports public links with password enforcement</li>
+<li>Enhanced usage of parallel HTTP requests for ownCloud 8 servers</li>
+<li>Renamed github repository from mirall to client.</li>
+<li>Mac OS: Use native notification support</li>
+<li>Selective Sync: allow to enforce selective sync in brandings.</li>
+<li>Added ability to build on Windows utilizing MingGW</li>
+<li>SQLite database fixes if running on FAT filesystems</li>
+<li>Improved detection of changing files to upload from local</li>
+<li>Preparations for the multi-account feature</li>
+<li>Fixed experience for Window manager without system tray</li>
+<li>Build with Qt 5.4</li>
+<li>Dropped libneon dependency if Qt 5.4 is available</li>
+<li>Keep files open very short, that avoid lock problems on Windows
+    especially with office software but also others.</li>
+<li>Merged some NetBSD patches</li>
+<li>Selective sync support for owncloudcmd</li>
+<li>Reorganize the source repository</li>
+<li>Prepared direct download</li>
+<li>Added Crashreporter feature to be switched on on demand</li>
+<li>A huge amount of bug fixes in all areas of the client.</li>
+<li>almost 700 commits since 1.7.1</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.0.4893-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.8.0.2139.pkg">Mac</a> |
+<a href="https://software.opensuse.org/download/package?project=isv:ownCloud:desktop&amp;package=owncloud-client">Linux</a> |
+<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.0.tar.bz2">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/owncloudclient-1.8.0.tar.bz2.asc">PGP signature</a>)
+
+<h3>Release 1.7.1 <small>Dec 18th 2014</small></h3>
+<ul>
+<li>Documentation fixes and updates</li>
+<li>Nautilus Python plugin fixed for Python 3</li>
+<li>GUI wording fixes plus improved log messages</li>
+<li>Fix hiding of the database files in the sync directories</li>
+<li>Compare http download size with the header value to avoid broken downloads, bug #2528</li>
+<li>Avoid initial ETag fetch job at startup, which is not needed.</li>
+<li>Add chunk size http header to PUT requests</li>
+<li>Fixed deteteCookie method of our CookieJar, fix for Shibboleth</li>
+<li>Added fallback for distros where XDG_RUNTIME_DIR is undefined</li>
+<li>Fix the setup wizard, bug #1989, #2264</li>
+<li>Fix scheduling of ETag check jobs, bug #2553</li>
+<li>Fix to avoid syncing more than one folder at a time, bug #2407</li>
+<li>Use fife minutes timeout for all network jobs</li>
+<li>Cleanup for Folderwizard wording</li>
+<li>Improve journal check: Remove corrupted journal files, bug #2547</li>
+<li>Fix item count in progress dialog for deletes, bug #1132</li>
+<li>Display correct file count on deletion (#1132)</li>
+<li>Fix reinitializing the folder using the wizard in certain cases (#2606)</li>
+<li>Mac OS: Fixed branding of the pkg file</li>
+<li>Mac OS: Fix display of overlay icons in certain situations (#1132)</li>
+<li>Mac OS: Use a bundled version of OpenSSL (#764, #2600, #2510)</li>
+<li>Win32: improved filesystem watcher</li>
+<li>Win32: Improve threading with shell integration</li>
+<li>Win32: Upgraded to OpenSSL 1.0.1j</li>
+<li>Win32: Improve reliability of Installer, fix removal of Shell Extensions</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.7.1.4382-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.7.1.1655.pkg">Mac</a> |
+<a href="https://download.owncloud.com/desktop/stable/mirall-1.7.1.tar.bz2">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/mirall-1.7.1.tar.bz2.asc">PGP signature</a>)
+
+<h3>Release 1.7.0 <small>Nov 7th 2014</small></h3>
+<ul>
+<li>oC7 Sharing: Handle new sharing options of ownCloud 7 correctly.</li>
+<li>Added Selective sync: Ability to unselect server folders which are</li>
+<li>excluded from syncing, plus GUI and setup GUI</li>
+<li>Improved local change detection: consider file size, detect files</li>
+<li>with ongoing changes and do not upload immediately</li>
+<li>Improved HTTP request timeout handler: all successful requests reset the timeout counter</li>
+<li>Improvements for syncing command line tool: netrc support, improved SSL support, non interactive mode</li>
+<li>Added a socket based API to provide file management shells with status
+    information about the sync status of files. That is a prerequisite for the overlay icons in the file managers.</li>
+<li>Permission system: ownCloud 7 delivers file and folder permissions, added ability to deal with it for shared folders and more.</li>
+<li>Ignore handling: Do not recurse into ignored or excluded directories</li>
+<li>Major sync journal database improvements for more stability and performance</li>
+<li>New library interface to sqlite3</li>
+<li>Improve "resync handling" if errors occur</li>
+<li>Blacklist improvements</li>
+<li>Improved logging: more useful meta info, removed noise</li>
+<li>Updated to latest Qt5 versions on Windows and OS X</li>
+<li>OS X: Sparkle update to provide pkg format properly</li>
+<li>OS X: Change distribution format from dmg to pkg with new installer.</li>
+<li>Win: Fix handling of filenames with trailing dot or space</li>
+</ul>
+Download:
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.7.0.4162-setup.exe">Windows</a> |
+<a href="https://download.owncloud.com/desktop/stable/ownCloud-1.7.0.1339.pkg">Mac</a> |
+<a href="https://download.owncloud.com/desktop/stable/mirall-1.7.0.tar.bz2">Sources</a> (<a href="https://download.owncloud.com/desktop/stable/mirall-1.7.0.tar.bz2">PGP signature</a>)
+
+<h3>Release 1.6.4 <small>Oct 23th 2014</small></h3>
+<ul>
+<li>Fix startup logic, fixes bug #1989</li>
+<li>Fix raise dialog on X11</li>
+<li>Win32: fix overflow when computing the size of file &gt; 4GiB</li>
+<li>Use a fixed function to get files modification time, the original one was broken for certain timezone issues, see core bug #9781 for details</li>
+<li>Added some missing copyright headers</li>
+<li>Avoid data corruption due to wrong error handling, bug #2280</li>
+<li>Do improved request timeout handling to reduce the number of timed out jobs, bug #2155</li>
+</ul>
+
+<h3>Release 1.6.3 <small>Sep 3rd 2014</small></h3>
+<ul>
+<li>Fixed updater on OS X</li>
+<li>Fixed memory leak in SSL button that could lead to quick memory draining</li>
+<li>Fixed upload problem with files &gt;4 GB</li>
+<li>MacOSX, Linux: Bring Settings window to front properly</li>
+<li>Branded clients: If no configuration is detected, try to import the data from a previously configured ownCloud Server installation.</li>
+</ul>
+
+<h3>Release 1.6.2 <small>Jul 28th 2014</small></h3>
+<ul>
+<li>Limit the HTTP buffer size when downloading to limit memory consumption.</li>
+<li>Another small mem leak fixed in HTTP Credentials.</li>
+<li>Fix local file name clash detection for MacOSX.</li>
+<li>Limit maximum wait time to ten seconds in network limiting.</li>
+<li>Fix data corruption while trying to resume and the server does not support it.</li>
+<li>HTTP Credentials: Read password from legacy place if not found.</li>
+<li>Shibboleth: Fix the waiting curser that would not disapear (#1915)</li>
+<li>Limit memory usage to avoid mem wasting and crashes</li>
+<li>Propagator: Fix crash when logging out during upload (#1957)</li>
+<li>Propagator_qnam: Fix signal slot connection (#1963)</li>
+<li>Use more elaborated way to detect that the server was reconfigured (#1948)</li>
+<li>Setup Wizard: Reconfigure Server also if local path was changed (#1948)</li>
+</ul>
+
+<h3>Release 1.6.1 <small>Jun 26th 2014</small></h3>
+
+<ul>
+<li>Fix 'precondition failed' bug with broken upload</li>
+<li>Fix 'precondition failed' bug with broken upload</li>
+<li>Fix openSSL problems for windows deployment</li>
+<li>Fix syncing a folder with '#' in the name</li>
+<li>Fix #1845: do not update parent directory etag before sub directories are removed</li>
+<li>Fix reappearing directories if dirs are removed during its upload</li>
+<li>Fix app version in settings dialog, General tab</li>
+<li>Fix crash in FolderWizard when going offline</li>
+<li>Shibboleth fixes</li>
+<li>More specific error messages (file remove during upload, open local sync file)</li>
+<li>Use QSet rather than QHash in SyncEngine (save memory)</li>
+<li>Fix some memory leaks</li>
+<li>Fix some thread race problems, ie. wait for neon thread to finish before the propagator is shut down</li>
+<li>Fix a lot of issues and warnings found by Coverity</li>
+<li>Fix Mac some settings dialog problems</li>
+</ul>
+
+<h3>Release 1.6.0 <small>May 30th 2014</small></h3>
+
+<ul>
+<li>Minor GUI improvements</li>
+<li>Qt5 compile issues fixed</li>
+<li>Ignore sync log file in filewatcher</li>
+<li>Install libocsync to private library dir and use rpath to localize</li>
+<li>Fix reconnect after server disconnect</li>
+<li>Fix "unknown action" display in Activity window</li>
+<li>Fix memory leaks</li>
+<li>Respect XDG_CONFIG_HOME environment var</li>
+<li>Handle empty fileids in the journal correctly</li>
+<li>Add abilility to compile libowncloudsync without GUI dependendy</li>
+<li>Fix SSL error with previously-expired CAs on Windows</li>
+<li>Fix incorrect folder pause state after start</li>
+<li>Fix a couple of actual potential crashes</li>
+<li>Improve Cookie support (e.g. for cookie-based load-balancers)</li>
+<li>Introduce a general timeout of 300s for network operations</li>
+<li>Improve error handling, blacklisting</li>
+<li>Job-based change propagation, enables faster parallel up/downloads (right now only if no bandwidth limit is set and no proxy is used)</li>
+<li>Significantly reduced CPU load when checking for local and remote changes</li>
+<li>Speed up file stat code on Windows</li>
+<li>Enforce Qt5 for Windows and Mac OS X builds</li>
+<li>Improved owncloudcmd: SSL support, documentation</li>
+<li>Added advanced logging of operations (file .???.log in sync directory)</li>
+<li>Avoid creating a temporary copy of the sync database (.ctmp)</li>
+<li>Enable support for TLS 1.2 negotiation on platforms that use Qt 5.2 or later</li>
+<li>Forward server exception messages to client error messages</li>
+<li>Mac OS X: Support Notification Center in OS X 10.8+</li>
+<li>Mac OS X: Use native settings dialog</li>
+<li>Mac OS X: Fix UI inconsistencies on Mavericks</li>
+<li>Shibboleth: Warn if authenticating with a different user</li>
+<li>Remove vio abstraction in csync</li>
+<li>Avoid data loss when a client file system is not case sensitive</li>
+</ul>
+
+<h3>Release 1.5.4 <small>April 11th 2014</small></h3>
+
+<ul>
+<li>Fix security issue on Windows and Mac OS X. No functional changes</li>
+</ul>
+
+<h3>Release 1.5.3 <small>March 10th 2014</small></h3>
+
+<ul>
+<li>Fix usage of proxies after first sync run (#1502, #1524, #1459, #1521)</li>
+<li>Do not wipe the credentials from config for reconnect (#1499, #1503)</li>
+<li>Do not erase the full account config if an old version of the client stored
+    the password (related to above)</li>
+<li>Fix layout of the network tab (fixes #1491)</li>
+<li>Handle authentication requests by a Shibboleth IdP</li>
+<li>Shibboleth: If no connection is available, don't open the login window</li>
+<li>[Packaging] Debian/Ubuntu: ship sync-exclude.lst</li>
+<li>[Packaging] Fix issues with access to gnome keychain in Fedora and RHEL6</li>
+<li>[Packaging] Ensure all sub packages get updated</li>
+<li>[Packaging] Fix incorrect path in desktop file (RHEL6/CentOS6)</li>
+</ul>
+
+<h3>Release 1.5.2 <small>February 26th 2014</small></h3>
+
+<ul>
+<li>Fix behavior when attempting to rename Shared folder</li>
+<li>Fix potential endless sync loops on Mac OS (#1463)</li>
+<li>Fix potential crash when pausing during update phase (#1442)</li>
+<li>Fix handing of shared directories</li>
+<li>Fix online state handling (#1441, #1459)</li>
+<li>Fix potential crash in c_iconv on Mac OS</li>
+<li>Fix certificate chain display in SSLButton</li>
+<li>Fix sporadicly appearing multiple auth prompts on sign-in</li>
+<li>Show correct state icon in Account Settings right away</li>
+<li>Re-fetch content that gets deleted from read only shared directories</li>
+<li>Do not store the password in the config file, erase existing ones (#1469)</li>
+<li>Shibboleth: Close browser window after login</li>
+<li>Shibboleth: Proper invalidation if timeout during sync</li>
+<li>Shibboleth: Do not pop up IdP login immediately when modifying account</li>
+<li>Shibboleth: Avoid auth on restart by storing cookies in the wallet</li>
+<li>Fix license headers</li>
+</ul>
+
+<h3>Release 1.5.1 <small>February 14th 2014</small></h3>
+
+<p><small>Please note that for the time being csync and mirall/ownCloud Client (oCC) are going to be released together for now. In the future, separated releases will be possible.</small></p>
+<ul>
+  <li>Added an auto updater that updates the client if a more recent version was found automatically (Windows, Mac OS X)</li>
+  <li>Added a button to the account dialog that gives information about the encryption layer used for communication, plus a certificate information widget</li>
+  <li>Preserve the permission settings of local files rather than setting them to a default (Bug #820)</li>
+  <li>Handle windows lnk files correctly (Bug #1307)</li>
+  <li>Detect removes and renames in read only shares and restore the gone away files. (Bug #1386)</li>
+  <li>Fixes sign in/sign out and password dialog. (Bug #1353) <li>Fixed error messages (Bug #1394)</li>
+  <li>Lots of fixes for building with Qt5 <li>Changes to network limits are now also applied during a sync run</li>
+  <li>Fixed mem leak after via valgrind on Mac</li>
+  <li>Imported the ocsync library into miralls repository.  Adopted all build systems and packaging to that.</li>
+  <li>Introduce a new linux packaging scheme following the debian upstream scheme</li>
+  <li>Use a refactored Linux file system watcher based on inotify, incl. unit tests</li>
+  <li>Wizard: Gracefully fall back to HTTP if HTTPS connection fails, issuing a warning</li>
+  <li>Fixed translation misses in the propagator</li>
+  <li>Fixes in proxy configuration</li>
+  <li>Fixes in sync journal handling</li>
+  <li>Fix the upload progress if the local source is still changing when the upload begins.</li>
+  <li>Add proxy support to owncloud commandline client</li>
+  <li>NSIS fixes</li>
+  <li>A lot of other fixes and minor improvements</li>
+  <li>Improve Qt5 compatability</li>
+</ul>
+
+<h3>Release 1.5.0 <small>December 12th 2013</small></h3>
+
+<p>This is a bugfix release with fixes for the 1.5 line. Update is recommended.</p>
+
+<h4>Mirall/ownCloud Client, version 1.5.0</h4>
+csync 0.91.4 required
+<ul>
+<li>New owncloud propagator that skips the vio abstraction layer</li>
+<li>Add owncloudcmd to replace the ocsync command line tool</li>
+<li>Localize Windows installer</li>
+<li>Allow to sign in and out</li>
+<li>Ask for password if missing</li>
+<li>Introduce activity view</li>
+<li>Introduce black list for files which could not be synced</li>
+<li>Enabling accessibility by shipping accessibility enables on OS X (#736)</li>
+<li>Toggle Settings window when clicking on systray icon on Win and KDE (#896)</li>
+<li>FolderWizard: Sanitize error detection (#1201)</li>
+<li>Set proper enable state of blacklist button after the dialog was opened</li>
+<li>Set proper tooltips in blacklist</li>
+<li>Translatable error messages for file errors</li>
+<li>Add man page for owncloudcmd (#1234)</li>
+<li>Don't close setup wizard when the initial sync run is started</li>
+<li>Close the sync journal if a folder gets removed (#1252)</li>
+<li>Activity: Avoid horizontal scrollbar (#1213)</li>
+<li>Fix crash (#1229)</li>
+<li>Resize wizard appropriately (#1130)</li>
+<li>Fix account identity test (#1231)</li>
+<li>Maintain the file type correctly</li>
+<li>Display rename-target in sync protocol action column</li>
+<li>Let recursive removal also remove the top dir</li>
+<li>If item is a directory, remove its contents from the database as well (#1257)</li>
+<li>Install headers for owncloudsync library</li>
+<li>Fix opening the explorer with a selected file in Windows (#1249)</li>
+<li>Add build number into versioning scheme</li>
+<li>Windows: Fix rename of temporary files</li>
+<li>Windows: Fix move file operation</li>
+</ul>
+<h4>ocsync, version 0.91.4, ownCloud release</h4>
+<ul>
+<li>Fix progress bar on win32</li>
+<li>Fix network rate limiting on win32</li>
+<li>Do not check for etag during failing requests</li>
+<li>Start quota timer only after the predecessor returned</li>
+<li>Remove tmp files in case of certain download problems</li>
+<li>Some valgrind fixes</li>
+<li>Theming fix: button behaviour</li>
+<li>Fix a case where a sync loop could happen.</li>
+<li>Multi-linguar installer</li>
+<li>Fix handling of quotes in etags written by older ownClouds</li>
+<li>Fix errno handling in update phase</li>
+<li>Make csync compile on FreeBSD</li>
+<li>Minor cleanups.</li>
+<li>have translatable error message for indiv. file errors.</li>
+<li>Use uint64_t for inode on win32 to fix a type glitch.</li>
+<li>Add test that directrories are properly moved.</li>
+<li>Handle symlinks correctly.</li>
+<li>Do not longer recurse into ignored directories in update phase.</li>
+<li>Added proper symlink detection for win32 platform.</li>
+<li>Close database correctly to fix a potential crash (mirall#1229)</li>
+<li>Handle invalid inodes correctly.</li>
+<li>Use lstat rather than stat to detect symlinks correctly.  (core#6146)</li>
+<li>fix ascii to int conversion for large numbers.</li>
+<li>add support for file ids, needed to detect server side moves.</li>
+<li>removed unused code, ie. database writing code that went to mirall.</li>
+<li>add functions to query the database by fileid.</li>
+<li>add functions to read fileids from PUT replies.</li>
+<li>add server side move detection.</li>
+<li>enhanced test scripts</li>
+<li>Remove ne_sock_init and ne_sock_exit from owncloud module (mirall#1115)</li>
+<li>Renamed 'md5' to 'etag' in code identifiers to avoid confusion.</li>
+<li>add new state EVAL_RENAME </li>
+<li>link the owncloud module directly rather than dl-loading it.</li>
+<li>add a content type header 'application/octet-stream' to PUTs.</li>
+<li>remove -gzip from etag header if its there. (mirall#1195)</li>
+<li>Many minor fixes, refactorings and improvements.</li>
+</ul>
+<hr />
+<h4>Mirall/ownCloud Client, version 1.4.2</h4>
+csync 0.90.4 required
+<ul>
+<li>Do not show the warning icon in the tray (#944)</li>
+<li>Fix manual proxy support when switching (#1016)</li>
+<li>Add folder column to detailed sync protocol (#1037)</li>
+<li>Fix possible endless loop in inotify (#1041)</li>
+<li>Do not elide the progress text (#1049)</li>
+<li>Fix high CPU load (#1073)</li>
+<li>Reconnect if network is unavailable after startup (#1080)</li>
+<li>Ensure paused folder stays paused when syncing with more than one folder (#1083)</li>
+<li>Don't show desktop notification when the user doesn't want to (#1093)</li>
+<li>System tray: Avoid quick flickering up of the ok-icon for the sync prepare state</li>
+<li>Progress: Do not show progress if nothing is transmitted</li>
+<li>Progress: Show number of deletes.</li>
+<li>Fix pause/resume behaviour (#1105)</li>
+</ul>
+<h4>ocsync, version 0.90.4, ownCloud release</h4>
+<ul>
+<li>Disable comparison of local inode values for the win32 platform, workaround for bug #779</li>
+<li>Count renamed and deleted files for progress information.</li>
+<li>Do not reset csync internal error state in helper funcs
+    and do not overwrite error messages.<br/>
+    That fixes error reporting to the client.</li>
+<li>Disable check on inodes on all platforms as inodes are not
+    reliable.</li>
+<li>Fix resuming after user aborting the sync process.</li>
+<li>Enabled HBF debugging permanently.</li>
+</ul>
+<hr />
+
+<h3>Release 1.4.1 September 26th 2013</small></h3>
+<p>This is a bugfix release with fixes for the 1.4 line. Update is recommended.</p>
+
+<h4>Mirall/ownCloud Client, version 1.4.1</h4>
+csync 0.90.2 required
+<ul>
+<li>Fixed app name for ownCloud.</li>
+<li>Translation and documentation fixes.</li>
+<li>Fixed error display in settings/status dialog, displays multi line error messages now correctly.</li>
+<li>Wait up to 30 secs before complaining about missing systray Fixes bug #949</li>
+<li>Fixed utf8 issues with basic auth authentication, fixes bug #941</li>
+<li>Fixed remote folder selector, avoid recursive syncing, fixes bug #962</li>
+<li>Handle and display network problems at startup correctly.</li>
+<li>Enable and disable the folder watcher during syncs correctly.</li>
+<li>Fix setting of thread priority.</li>
+<li>Fixed file size display.</li>
+<li>Fixed various folder wizard issues, bug #992</li>
+<li>Made "Sync started" message optional, fixes bug #934</li>
+<li>Fixed shutdown, avoid crashed config on win32, fixes bug #945</li>
+<li>Pop up config wizard if no server url is configured, fixes bug #1018</li>
+<li>Settings: calculate sidebar width dynamically, fixes bug #1020</li>
+<li>Fixed a crash if sync folders were removed, fixes bug #713</li>
+<li>Do proper resync after network disconnect, fixes bug #1007</li>
+<li>Various minor code fixes</li>
+</ul>
+<h4>ocsync, version 0.90.2, ownCloud release</h4>
+<ul>
+<li>Disable comparison of local inode values for the win32 platform, workaround for bug #779</li>
+<li>detect if server does not send an etag after an upload completed.</li>
+<li>fix crash in case of network timeout, reported as https://github.com/owncloud/client/issues/1010</li>
+<li>compile and cmake fixes for win32</li>
+<li>fixed behaviour of csync_exclude</li>
+<li>documentation and spelling fixes.</li>
+</ul>
+<hr />
+
+<h3>Release 1.4.0 September 4th 2013</small></h3>
+
+<p>This release massively improves user feedback, adds several settings and fixes bugs. Update is recommended.</p>
+
+<h4>Mirall/ownCloud Client, version 1.4.0</h4>
+csync 0.90.0 required
+<ul>
+  <li>New Scheduler: Only sync when there are actual changes in the server</li>
+  <li>Add a Settings Dialog, move Proxy Settings there</li>
+  <li>Transform folder Status Dialog into Account Settings, provide feedback via context menu</li>
+  <li>Add Bandwidth Control</li>
+  <li>Add a visual storage/quota indicator (context menu and account settings)</li>
+  <li>Add progress indication (context menu and account settings)</li>
+  <li>Introduce a sync history, persisting results across syncs</li>
+  <li>Move ability to switch to mono icons from a switch to a Settings option</li>
+  <li>Add "Launch on System Startup" GUI option</li>
+  <li>Add "Show Desktop Nofications" GUI option (enabled by default)</li>
+    top optionally disable sync notifications</li>
+  <li>Add Help item, pointing to online reference</li>
+  <li>Implement graphical selection of remote folders in FolderWizard</li>
+  <li>Allow custom ignore patterns</li>
+  <li>Add an editor for ingore patterns</li>
+  <li>ALlow to flag certain ignore patterns as discardable</li>
+  <li>Ensure to ship with all valid translations</li>
+  <li>Progress Dialog now preserves the last syncned items across sync runs</li>
+  <li>Split Setup Wizard into multiple pages again</li>
+  <li>Implement "--logfile -" to log to stdout</li>
+  <li>Add preliminary support for Shibboleth authentication</li>
+  <li>Linux: Provide more icon sizes</li>
+  <li>Linux: Do not trigger notifier on ignored files</li>
+  <li>Windows: Reduce priority of CSync thread</li>
+  <li>Documentation: Prem. updates to reflect UI changes</li>
+  <li>Significant code refactorings</li>
+  <li>Require Qt 4.7</li>
+  <li>Known issue: Under certain conditions, a file will only get uploaded after up to five minutes</li>
+</ul>
+<h4>ocsync, version 0.90.0, ownCloud release</h4>
+<ul>
+  <li>Added API to get progress information from csync.</li>
+  <li>Added c_rename function to csync std.</li>
+  <li>Fix: Do renames of files before any puts.</li>
+  <li>Improved database integrity checks.</li>
+  <li>Improvements of database writing efficiendy.</li>
+  <li>Fix: stat file on win32 even if its opened by application.</li>
+  <li>httpbf: configurable block size and threshold.</li>
+  <li>Many fixes found by a Coverity check.</li>
+  <li>Fix: use correct stat struct on all platforms</li>
+  <li>Fix: download resuming.</li>
+  <li>ownCloud module: Bandwith limitation added.</li>
+  <li>Added ability to remove ignored files automatically.</li>
+  <li>Fix: Use int64_t and friends</li>
+  <li>Fix: Removed all compile warnings.</li>
+  <li>Left excluded files and links in csync's tree to be able to show.</li>
+    them to the user.</li>
+  <li>Add OC-Total-Length header for better quota handling.</li>
+  <li>Report inbetween progress</li>
+</ul>
+
+<hr />
+
+<h3>Release 1.3.0 <small>June 25th 2013</small></h3>
+<p>This Release introduces big file handling and resuming and introduces significant improvements and fixes. Update is recommended</p>
+
+<h4>Mirall/ownCloud Client, version 1.3.0</h4>
+csync 0.80.0 required
+<ul>
+  <li>Default proxy port to 8080</li>
+  <li>Don't lose proxy settings when changing passwords</li>
+  <li>Support SOCKS5 proxy (useful in combination with ssh -D)</li>
+  <li>Propagate proxy changes to csync at runtime</li>
+  <li>Improve proxy wizard</li>
+  <li>Display proxy errors</li>
+  <li>Solved problems with lock files</li>
+  <li>Warn if for some reason all files are scheduled for removal on either side</li>
+  <li>Avoid infinite loop if authentication fails in certain cases</li>
+  <li>Fix reading the password from the config in certain cases</li>
+  <li>Do not crash when configured sync target disappears</li>
+  <li>Make --help work on windows</li>
+  <li>Make sync feedback less ambiguous.</li>
+  <li>Fix icon tray tooltip sometimes showing repeated content</li>
+  <li>More use of native directory separators on Windows</li>
+  <li>Remove journal when reusing a directory that used to have a journal before</li>
+  <li>Visual clean up of status dialog items</li>
+  <li>Wizard: When changing the URL or user name, allow the user to push his data
+      to the new location or wipe the folder and start from scratch</li>
+  <li>Wizard: Make setting a custom folder as a sync target work again</li>
+  <li>Fix application icon</li>
+  <li>User-Agent now contains "Mozilla/5.0" and the Platform name (for firewall/proxy compat)</li>
+  <li>Server side directory moves will be detected</li>
+  <li>New setup wizard, defaulting to root syncing (only for new setups)</li>
+  <li>Improved thread stop/termination</li>
+</ul>
+<h4>csync, version 0.80.0, ownCloud release</h4>
+<ul>
+  <li>Big file chunking (e.g. up/download of big files should now be no problem anymore)</li>
+  <li>Resuming (download of big files will resume)</li>
+  <li>Fix false conflicts when database is corrupt/missing</li>
+  <li>Fix false conflicts when file is locked</li>
+  <li>Put legitimate conflict files only on client side</li>
+  <li>Fix unreliable sync after push_file failed</li>
+  <li>Fix rename due to inode cast error</li>
+  <li>Make chunking work on nginx setups or through nginx proxies</li>
+  <li>Improve error reporting in csync_update</li>
+  <li>Clean progress database on csync_commit</li>
+  <li>Fix issues detected by Coverity</li>
+  <li>Fix conflict file appearing when a file cannot be stated</li>
+  <li>Do not shadow server errors by not downloading files that have failed to download in the past</li>
+</ul>
+
+<hr />
+
+<h3>Release 1.2.5 <small>April 23rd 2013</small></h3>
+<p>This is another bugfix release for the 1.2 line, coming with important bug fixes. Update is recommended.</p>
+<h4>Mirall/ownCloud Client, version 1.2.5</h4>
+csync 0.70.7 required.
+<ul>
+ <li>[Fixes] NSIS installer fixes.</li>
+ <li>[Fixes] Fix crash race by making certificateChain() thread safe.</li>
+ <li>[Fixes] Build with older CMake versions (CentOS/RHEL 6).</li>
+ <li>[Fixes] Wording in GUI</li>
+ <li>[Fixes] Silently ignore "installed = true" status.php</li>
+ <li>Set log verbosity before calling csync_init.</li>
+ <li>GUI feedback for the statistics copy action.</li>
+ <li>Safer approach for detecting duplicate sync runs.</li>
+</ul>
+<h4>csync, version 0.70.7, ownCloud release</h4>
+<ul>
+  <li>[Fixes] Resource exhaustion</li>
+  <li>Better logging of statedb-related errors</li>
+</ul>
+<h3>Known Problems</h3>
+<ul>
+<li>The about dialog displays ocsync version 0.70.6.<br/>
+That is <b>wrong</b>, actually the version is 0.70.7 as required, only the display is wrong.</li>
+</ul>
+<hr/>
+
+<h3>Release 1.2.4 <small>April 11th 2013</small></h3>
+<p>This is another bugfix release for the 1.2 line, coming with important bug fixes. Update is recommended.</p>
+<h4>Mirall/ownCloud Client, version 1.2.4</h4>
+csync 0.70.6 required.
+<ul>
+  <li>[Fixes] Clarify string in folder wizard</li>
+  <li>[Fixes] Fixed some valgrind warnings</li>
+  <li>[Fixes] Ensure that only one sync thread can ever run</li>
+  <li>[Fixes] Fix default config storage path</li>
+  <li>[Fixes] Skip folders with no absolute path</li>
+  <li>[Fixes] Allow setting the configuration directory on command line</li>
+</ul>
+<h4>csync, version 0.70.6, ownCloud release</h4>
+<ul>
+  <li>[Fixes] Try to avoid to upload incomplete files</li>
+  <li>[Fixes] Increase read timeout to 300 seconds</li>
+  <li>[Fixes] Handle IGNORE status correctly</li>
+  <li>[Fixes] Set path and phash for ignored files</li>
+  <li>[Fixes] Fix some issues discovered by Coverity</li>
+  <li>[Fixes] Make sure to never allow empty pathes in rmdir</li>
+  <li>[Fixes] Fix a crash caused by superfluous free() calls</li>
+</ul>
+<hr/>
+<h3>Release 1.2.3 <small>April 2nd 2013</small></h3>
+<p>This is an immediate update superseeding 1.2.2</p>
+<h4>Mirall/ownCloud Client, version 1.2.3</h4>
+csync 0.70.5 required.
+<ul>
+<li>[Fixes] Unbreak self-signed certificate handling</li>
+</ul>
+<hr/>
+<h3>Release 1.2.2</h3>
+Released <small>April, 2, 2013
+<p>This is another bugfix release for the 1.2 line, coming with important bug fixes. Update is recommended.</p>
+<h4>Mirall/ownCloud Client, version 1.2.2</h4>
+csync 0.70.5 required.
+<ul>
+<li>[Fixes] Do not crash when local file tree contains symlinks.</li>
+<li>[Fixes] Correctly handle locked files on Windows.</li>
+<li>[Fixes] Display errors in all members of the SSL chain.</li>
+<li>[Fixes] Enable Accessibility features on Windows.</li>
+<li>[Fixes] Make setupFavLink work properly on Mac OS.</li>
+<li>[Fixes] Ignore temporary files created by MS Office.</l>
+<li>[Gui] Support Nautilus in setupFavLink.</li>
+</ul>
+<h4>csync, version 0.70.5, ownCloud release</h4>
+<ul>
+<li>[Fixes] detect 'wrong' conflict files on client side.</li>
+<li>[Fixes] Give context to module to enable logging (cmd client).</li>
+<li>[Fixes] Fix version table contents.</li>
+<li>[Fixes] Fix handling of non statable files on Win32.</li>
+<li>[Fixes] Fix renames on clientside on read only shares.</li>
+<li>[Fixes] Various small fixes and improvements.</li>
+</ul>
+<hr/>
+<h3>Release 1.2.1 <small>February 26th 2013</small></h3>
+<p>This is a bugfix release for the 1.2 line</p>
+<h4>Mirall/ownCloud Client, version 1.2.1</h4>
+csync 0.70.4 required.
+<ul>
+<li>[Fixes] Leave configured folders on configuration changes.</li>
+<li>[Fixes] Do not allow to finish the setup dialog if connection can't be established.</li>
+<li>[Fixes] Better handling of credentials in setup dialog.</li>
+<li>[Fixes] Do not leak fd's to /dev/null when using gnutls.</li>
+<li>[Fixes] Stop sync scheduling when configuration wizard starts.</li>
+<li>[Fixes] Clear pending network requests when stepping back in config wizard.</li>
+<li>[Fixes] User password dialog asynchronous issues.</li>
+<li>[Fixes] Make folderman starting and stoping the scheduling.</li>
+<li>[Fixes] Various minor fixes and cleanups.</li>
+<li>[Fixes] Crash on pausing sync.</li>
+<li>[Fixes] Stale lock file after pausing sync.</li>
+<li>[App] Load translations from app dir or bundle as well.</li>
+<li>[Platform] Build fixes and simplifications, ie. build only one lib.</li>
+<li>[Platform] Added some getter/setters for configuration values.</li>
+<li>[Platform] Added man pages.</li>
+<li>[Platform] Simplified/fixed credential store usage and custom configs.</li>
+<li>[Platform] Added soname version to libowncloudsync.</li>
+<li>[Platform] Pull in Qt translations.</li>
+<li>[Gui]  Make sync result popups less annoyingq.</li>
+<li>[Gui] Fix for result popup.</li>
+</ul>
+<h4>csync, version 0.70.4, ownCloud release</h4>
+<ul>
+<lI>[Win32] Ship with up-to-date openssl version to fix SSL problems we saw.</li>
+<li>[Fixes] Fix crash during mkdir.</li>
+<li>[Fixes] Added workaround for problem that server sometimes does not respond properly to PROPFIND (mirall#285)</li>
+<li>[Fixes] Fix handling of deletion of non empty or locked directories.</lI>
+<li>[Fixes] Fixed some potential memory leaks.</li>
+<li>[Fixes] Files with filenames with unix extensions are ignored now.</li>
+</ul>
+<hr/>
+<h3>Release 1.2.0 <small>January 24th 2013</small></h3>
+<p>This is a feature release.</p>
+<h4>Mirall/ownCloud Client, version 1.2.0</h4>
+csync 0.70.3 required.
+<ul>
+<li>[GUI] New status dialog to show a detailed list of synced files. </li>
+<li>[GUI] New tray notifications about synced files. </li>
+<li>[GUI] New platform specific icon set.</li>
+<li>[App] Using cross platform QtKeychain library to store credentials crypted.</li>
+<li>[App] Use cross platform notification for changes in the local file system rather than regular poll.</li>
+<li>[Fixes] Improved SSL Certificate handling and SSL fixes troughout syncing.</li>
+<li>[Fixes] Fixed proxy authentication. </li>
+<li>[Fixes] Allow brackets in folder name alias.</li>
+<li>[Fixes] Lots of other minor fixes.</li>
+<li>[Platform] cmake fixes.</li>
+<li>[Platform] Improved, more detailed error reporting.</li>
+</ul>
+<h4>csync, version 0.70.3, ownCloud release</h4>
+<ul>
+<li>[Platform] Improved module parameter system.</li>
+<li>[Platform] New logging framework. Dropped log4c dependency.</li>
+<li>[Platform] New API to provide sync progress information.</li>
+<li>[Fixes] More efficiency for the ownCloud plugin through less HTTP requests to the server. </li>
+<li>[Fixes] ownCloud plugin: Improved upload performance.</li>
+<li>[Fixes] Improved error reporting to mirall.</li>
+<li>[Fixes] ownCloud plugin: Improved interpretation of HTTP error codes.</li>
+<li>[Fixes] ownCloud plugin: Do not abort on errors with individual files any more.</li>
+<li>[Fixes] ownCloud plugin: Use renamed session cookie correctly.</li>
+<li>[Fixes] Lots of other minor fixes.</li>
+<li>[MacOSX] Use libneon with proper big file support. </li>
+<li>[Win32] Use libneon with openSSL support now.</li>
+</ul>
+<hr/>
+<h3>Release 1.1.4 <small>December 19th 2012</small></h3>
+<p>This is a bugfix release for the 1.1.x line that fixes two significant bugs.</p>
+<ul>
+<li>No changes to mirall/ownCloud Client source.</li>
+<li>[Fixes] csync: Fix encoding issues on MacOSX clients, now the client sends normalized unicode on that platform.</li>
+<li>[Fixes] csync:  The client does a more sophisticated handling of server error states which avoids data clearing in some cases. </li>
+</ul>
+<h3>Known Problems</h3>
+<ul>
+<li>Files > 2GB size can cause problems.</li>
+</ul>
+<hr/>
+<h3>Release 1.1.3 <small>November 30th 2012</small></h3>
+<p>This is a urgent bugfix release for 1.1.2 that fixes two potential crashes.</p>
+<ul>
+<li>No changes to mirall/ownCloud Client source.</li>
+<li>[Fixes] csync: Fix neon resource waste (oc-920)</li>
+<li>[Fixes] csync: Fix a crash in error handling code path (github #123)</li>
+</ul>
+<h3>Known Problems</h3>
+<ul>
+<li>Mac OSX: Filenames and Directories with composited characters can cause up/download problems.</li>
+<li>Syncing of Shared Folders still has issues.</li>
+<li>Files > 2GB size can cause problems.</li>
+</ul>
+<hr/>
+<h3>Release 1.1.2 <small>November 26th 2012</small></h3>
+<p>This is a bugfix and improvement release which solves some severe bugs in the 1.1.1 release.</p>
+
+<h4>Mirall/ownCloud Client, version 1.1.2</h4>
+csync 0.60.2 required.
+<ul>
+<li>[Fixes] Allow to properly cancel the password dialog.</li>
+<li>[Fixes] Share folder name correctly percent encoded with old Qt
+            4.6 builds ie. Debian.</li>
+<li>[Fixes] If local sync dir is not existing, create it.</li>
+<li>[Fixes] lots of other minor fixes.</li>
+<li>[GUI] Display error messages in status dialog.</li>
+<li>[GUI] GUI fixes for the connection wizard.</li>
+<li>[GUI] Show username for connection in statusdialog.</li>
+<li>[GUI] Show intro wizard on new connection setup.</li>
+<li>[APP] Use CredentialStore to better support various credential
+          backends.</li>
+<li>[APP] Handle missing local folder more robustly: Create it if
+         missing instead of ignoring.</li>
+<li>[APP] Simplify treewalk code.</li>
+<li>[Platform] Fix Mac building.</li>
+
+<li>[Fixes] csync: Improved cross platform testing and building capabilities</li>
+<li>[Fixes] csync: Moved journal database to sync directory.</li>
+<li>[Fixes] csync: More memory cleanups and renaming to ocsync issues.</li>
+<li>[Fixes] csync: Fixed Daylight Saving Time time issue on Win32.</li>
+<li>[Fixes] csync: Fixed inode querie for directories on Win32.</li>
+<li>[Fixes] csync: Stricter error checks on HTTP replies from server.</li>
+<li>[Fixes] csync: Detect looping in mkdirs to fix sharing.</li>
+</ul>
+<h3>Known Problems</h3>
+<ul>
+<li>Mac OSX: Filenames and Directories with composited characters can cause up/download problems.</li>
+</ul>
+<hr/>
+
+<h3>Release 1.1.1 <small>October 18th 2012</small></h3>
+<h4>Mirall/ownCloud Client, version 1.1.1</h4>
+csync 0.60.1 required.
+
+<p>This is a bugfix and improvement release which resolves issues that have been found after the initial 1.1.0 release</p>
+
+<ul>
+<li>[GUI]   Allow changing folder name in single folder mode</li>
+<li>[GUI]   Windows: Add license to installer</li>
+<li>[GUI]   owncloud --logwindow will bring up the log window in an already running instance</li>
+<li>[Fixes] Make sure SSL errors are always handled</li>
+<li>[Fixes] Allow special characters in folder alias</li>
+<li>[Fixes] Proper workaround for Menu bug in Ubuntu</li>
+<li>[Fixes] csync: Fix improper memory cleanup which could cause memory leaks and crashes</li>
+<li>[Fixes] csync: Fix memory leak</li>
+<li>[Fixes] csync: Allow single quote (') in file names</li>
+<li>[Fixes] csync: Remove stray temporary files</li>
+</ul>
+
+<hr/>
+
+<h3>Release 1.1.0 <small>October 10th 2012</small></h3>
+<h4>Mirall/ownCloud Client, version 1.1.0</h4>
+csync 0.60.0 required.
+
+<p>This is a big feature release for the sync engine ownCloud client is using. It switches to a new, server based uniq Id based approach.</p>
+
+<ul>
+<li>[GUI]   Added an about dialog</li>
+<li>[GUI]   Improved themeing capabilities of the client.</li>
+<li>[GUI]   Minor fixes in folder assistant.</li>
+<li>[GUI]   Reworked tray context menu.</li>
+<li>[GUI]   Users can now sync the server root folder.</li>
+<li>[Fixes] Proxy support: now supports Proxy Auto-Configuration (PAC)
+            on Windows, reliability fixes across all OSes.</li>
+<li>[Fixes] Url entry field in setup assistant handles http/https correctly.</li>
+<li>[Fixes] Button enable state in status dialog.</li>
+<li>[Fixes] Crash fixed on ending the client, tray icon related.</li>
+<li>[Fixes] Crash through wrong delete operator.</li>
+<li>[MacOS] behave correctly on retina displays.</li>
+<li>[MacOS] fix focus policy</li>
+<li>[MacOS] Packaging improvements.</li>
+<li>[MacOS] Packaging improvements.</li>
+<li>[Platform] Windows: Setup closes client prior to uninstall.</li>
+<li>[Platform] Windows: ownCloud gets added to autorun by default.</li>
+<li>[Platform] insert correct version info from cmake.</li>
+<li>[Platform] csync conf file and database were moved to the users app data
+               directory, away from the .csync dir.</li>
+<li>Renamed exclude.lst to sync-exclude.lst and moved it to
+            /etc/appName()/ for more clean packaging. From the user path,
+            still exclude.lst is read if sync-exclude.lst is not existing.</li>
+<li>Placed custom.ini with customization options to /etc/appName()</li>
+</ul>
+
+<h4>csync, version 0.60.0, ownCloud release</h4>
+<p>The csync ownCloud of ownCloud saw significant changes to support the Id based syncing.<br/>Until these changes appear in csync upstream the ownCloud maintained csync package is renamed to <b>ocsync</b>  to avoid conflicts with the upstream version.</p>
+<ul>
+ <li>simplification of pac based proxy support.</li>
+<li> Renamed ownCloud version of csync to ocsync for ownCloud.</li>
+<li>Migration paths for csync database and config.</li>
+<li>Fixed that exclude patterns are also tested on files basenames.</li>
+<li>Fixed return type for query function if no database exists.</li>
+<li>many minor code cleanups and  fixes</li>
+<li>Fixed crash by removing a bogus free.</li>
+<li>More useful logging.</li>
+<li>ownCloud: Maintain the http session by handling the HTTP Cookie.</li>
+<li>Fixed strncpy handling (mkdir on windows problem).</li>
+<li>extend database with columns uniq id and type.</li>
+<li>Use server maintained uniq IDs for update detection instead of mtimes.</li>
+<li>Maintain uniq IDs in local database.</li>
+<li>Handle change propagation through the file tree locally and remote.</li>
+<li>Added module to build a file tree from the local database (dbtree.c).</li>
+<li>Added methods to query IDs from the server and maintain it locally.</li>
+</ul>
+<hr/>
+<h3>Release 1.0.5 <small>August 14th 2012</small></h3>
+<h4>Mirall/ownCloud Client, version 1.0.5</h4>
+csync 0.50.8 required (no change over 1.0.4).
+<p>This is a pure bugfix release for release 1.0.4. Update is recommended.</p>
+<ul>
+<li>[Fixes] Really configure https if the checkbox is activated in setup wizard.</li>
+</ul>
+<hr/>
+<h3>Release 1.0.4 <small>August 10th 2012</small></h3>
+
+<h4>csync, version 0.50.8, ownCloud release</h4>
+<p>This is a feature and bugfix release.</p>
+<ul>
+<li>Inode equivalent support for Win32 platforms to support rename.</li>
+<li>ownCloud supports propagates renames from local to webdav MOVE.</li>
+<li>ownCloud module works with proxy, settings from mirall.</li>
+<li>improved CMake modules (openSSL)</li>
+<li>Fixed namespace for lastmodified propset.</li>
+<li>Added cmocka based tests for ownCloud module.</li>
+<li>Added a config_test.h config header file.</li>
+<li>Fix link handling: Ignore symlinks.</li>
+<li>Modules can now report their capabilities to csync core.</li>
+<li>A lot of minor fixes and improvements.</li>
+</ul>
+<h4>Mirall/ownCloud Client, version 1.0.4</h4>
+csync 0.50.8 required.
+<ul>
+<li>[APP] ownCloud is now a single instance app, can not start twice any more.</li>
+<li>[APP] Proxy support.</li>
+<li>[APP] Handle HTTP redirection correctly, note new url.</li>
+<li>[APP] More relaxed handling of read only directories in the sync paths.</li>
+<li>[APP] Started to split off a library with sync functionality, eg for KDE.</li>
+<li>[APP] Make ownCloud Info class a singleton, more robust.</li>
+<li>[GUI] New, simplified connection wizard.</li>
+<li>[GUI] Added ability for customized theming.</li>
+<li>[GUI] Improved icon size handling.</li>
+<li>[GUI] Removed Log Window Button, log available through command line.</li>
+<li>[GUI] Proxy configuration dialog added.</li>
+<li>[GUI] Added Translations to languages Slovenian, Polish, Catalan,
+          Portuguese (Brazil), German, Greek, Spanish, Czech, Italian, Slovak,
+          French, Russian, Japanese, Swedish, Portuguese (Portugal)
+          all with translation rate >90%.</lI>
+<li>[Fixes] Loading of self signed certs into Networkmanager (#oc-843)</li>
+<li>[Fixes] Win32: Handle SSL dll loading correctly.</li>
+<li>[Fixes] Many other small fixes and improvements</li>
+</ul>
+<h3>Known Problems</h3>
+<ul></ul>
+<hr/>
+<h3>Release 1.0.3 <small>June 22nd 2012</small></h3>
+
+<h4>csync, version 0.50.7, ownCloud release</h4>
+<p>This is a bugfix and improvement release fixing again encoding issues and streamlining the ownCloud syncing.
+</p>
+<ul>
+<li>Added ability to log to a callback to let an application catch the log output for a log file or window.</li>
+<li>Added push to remote without pushing to temp file first which decreases the number of requests per sync file.</li>
+<li>Fixed file copy function to use wide character (win32).</li>
+<li>Fixed loading of statedb if user has special char (win32).</li>
+</ul>
+<h4>Mirall/ownCloud Client, version 1.0.3</h4>
+csync 0.50.7 required.
+<ul>
+ <li>[GUI] Added a log window which catches the logging if required and allows to save for information.</li>
+<li>[CMI] Added options --help, --logfile and --logflush</li>
+<li>[APP] Allow to specify sync frequency in the config file.</li>
+<li>[Fixes] Do not use csync database files from a sync before.
+</li>
+<li>[Fixes] In Connection wizard, write the final config onyl if the user really accepted. Also remove the former database.
+</li>
+<li>[Fixes] Allow special characters in the sync directory names.</li>
+<li>[Fixes] Win32: Fixed directory removal with special character dirs.</li>
+<li>[Fixes] MacOS: Do not flood the system log any more.</li>
+<li>[Fixes] MacOS: Put app translations to correct places.</li>
+<li>[Fixes] Win32: Fix loading of csync state db.</li>
+<li>[Fixes] Improved some english grammar.</li>
+<li>[Platform] Added krazy2 static code checks.</li>
+</ul>
+<h3>Known Problems</h3>
+<ul>
+<li>MacOS log lacks the information of the dynamic loaded csync owncloud module.</li>
+<li>The log window drags down the client if its open for long. Better use the --logfile option to catch full logs.</li>
+</ul>
+<hr/>
+<h3>Release 1.0.2 <small>May 18th 2012</small></h3>
+
+<h4>csync, version 0.50.6, ownCloud release</h4>
+<p>
+This release is a bugfix release and fixes encoding problems of file and directory names happening cross platform, in particular windows.
+</p>
+<ul>
+<li>Fixed: Directories with 'strange' characters broke sync. (oC bug #613)</li>
+<li>Fixed: Special characters in Windows did not sync correctly. (oC bug #478)</li>
+<li>Make neon handling redirects properly.</li>
+<li>Switch logging off on Apple to not fill the syslog. (oC bug #622)</li>
+</ul>
+
+<h4>Mirall/ownCloud Client, version 1.0.2</h4>
+csync 0.50.6 required.
+
+This version comes with the first iteration of a new icon set for the ownCloud desktop client and comes with a bunch of bug fixes.
+
+<ul>
+<li>[GUI] New icon set for ownCloud client.</li>
+<li>[GUI] No splashscreen any more.(oC Bug #498)</li>
+<li>[GUI] Russian translation added.</li>
+<li>[GUI] Added 'open ownCloud' to traymenu</li>
+<li>[GUI] "Pause" and "Resume" instead of Enable/Disable.</li>
+<li>[Fixes] Long running syncs can be interrupted now.</li>
+<li>[Fixes] Dialogs comes to front on click.</li>
+<li>[Fixes] Open local sync folder from tray and status for win32.</li>
+<li>[Fixes] Load exclude.lst correctly on MacOSX.</li>
+</ul>
+
+<h3>Known Problems</h3>
+none so far.
+<hr/>
+<h3>Release 1.0.1 <small>April 24th 2012</small></h3>
+
+<h4>csync, version 0.50.5, ownCloud release:</h4>
+
+This release reflects our efforts to further improve the platform support of csync and oCC - this release brings us a big step nearer to a MacOSX release in addition to Linux and Windows.
+
+Moreover, in the csync library we improved the error detection and reporting to be able to give the user correct error messages through oCC and avoid unpleasant wrong error message situations.
+
+<ul>
+<li>removed arpg lib dependency</li>
+<li>simplified and fixed CMake files</li>
+<li>MacOS porting efforts</li>
+<li>more granular error reports</li>
+<li>fixed thread savity with error reporting</li>
+</ul>
+
+<h4>Mirall/ownCloud Client, version 1.0.1</h4>
+csync 0.50.5 required.
+
+With this release we deliver the barely missed SSL support to the users, along with a long line of bugfixes and improvements.
+
+SSL support was added, together with a decent certificate warning dialog to warn users about not trusted SSL connections and certificates.
+The password is not longer stored in clear text, yet its still not securely encrypted (which seems not to be possible at all). For those who put security over convenience we added the option to not store the password at all, but enter at startup.
+
+Bugfixes in the following areas also went in: Expect a more robust startup of the app, with more detailed and correct error messages. The sync status display does now display the status faster and and scheduling was fixed.
+
+Also work was done to provide oCC on the MacOSX palatform. The cmake based build system was improved to also create mac dmg packages. Yet to release.
+
+Finally translations were fixed for the Windows platform. Currently German and English are provided.
+
+Detailed list:
+<ul>
+<li>[Security] Support SSL Connections</li>
+<li>[Security] SSL Warning dialog</li>
+<li>[Security] Do not store password in clear text anymore</li>
+<li>[Security] Restrict credentials to the configured host</li>
+<li>[Security] Added ability to forbid local password storage.</li>
+<li>[Fixes] Various fixes of the startup behaviour.</li>
+<li>[Fixes] Various fixes in sync status display</li>
+<li>[GUI] Various error messages for user display improved.</li>
+<li>[GUI] fixed terms and Translations</li>
+<li>[GUI] fixed translation loading</li>
+<li>[Intern] Migrate old credentials to new format</li>
+<li>[Intern] Some code refactorings, got rid of rotten QWebDav lib</li>
+<li>[Intern] lots of cmake cleanups</li>
+<li>[Intern] Backport to Qt Version 4.6 for compat. with older distros.</li>
+<li>[Platform] MacOSX porting efforts</li>
+<li>[Platform] MacOSX Bundle creation added</li>
+<li>[Platform] Enabled translations on Windows.</li>
+</ul>
+
+<h3>Known Problems</h3>
+<ul>
+<li>After the installation on Windows, ownCloud client directly started from the installation program fails to sync. After a restart everything works fine.</li>
+<li>Folders containing special characters in the filename cause problems on the windows platforms.</li>
+</ul>
+
+<h3>Release 1.0.0 <small>April 3rd 2012</small></h3>
+
+First release working on Linux and Windows platforms.


### PR DESCRIPTION
@SamuAlfageme Can you do a smoke test on Windows? My VM is broken...

As discussed with @jnweiger , for now we have this file with the clickable HTML and the download links in this repo. Then the new website can embed it.
@jnweiger Please review and especially check the download links
(you still need to move from testing to stable, also in OBS)
(Also backup the old stable OBS build 2.3.4 to a named OBS project)
See https://github.com/owncloud/client/issues/6160