### PR TITLE
Issues: Speed up insertion and add hard upper limit

### DIFF
--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -18,6 +18,7 @@
 #include <QDialog>
 #include <QDateTime>
 #include <QLocale>
+#include <QTimer>
 
 #include "progressdispatcher.h"
 #include "owncloudgui.h"
@@ -83,6 +84,9 @@ private:
 
     /// Wipes all insufficient remote storgage blacklist entries
     void retryInsufficentRemoteStorageErrors(const QString &folderAlias);
+
+    /// Each insert disables sorting, this timer reenables it
+    QTimer _reenableSorting;
 
     Ui::IssuesWidget *_ui;
 };

--- a/src/gui/issueswidget.ui
+++ b/src/gui/issueswidget.ui
@@ -128,6 +128,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="_tooManyIssuesWarning">
+     <property name="text">
+      <string>There were too many issues. Not all will be visible here.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <spacer name="horizontalSpacer">


### PR DESCRIPTION
Since sorting was enabled permanenty the list would be resorted with
each inserted issue. When inserting thousands of ignored files that
would make the whole ui freeze up.

Instead, sorting is disabled for inserts now and is reenabled after some
time has passed. That way users usually see the sorted view without the
lockups. Also, there's now a maximum of 50k issue entries.

See  #6272