### PR TITLE
deprecate suffix nightly, promote suffix daily

### DIFF
--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -64,7 +64,8 @@ QUrl Updater::addQueryParams(const QUrl &url)
 
     QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
     paramUrl.addQueryItem(QLatin1String("versionsuffix"), suffix);
-    if (suffix.startsWith("nightly")
+    if (suffix.startsWith("daily")
+            || suffix.startsWith("nightly")
             || suffix.startsWith("alpha")
             || suffix.startsWith("rc")
             || suffix.startsWith("beta")) {


### PR DESCRIPTION
We want to change the package suffix of the daily rebuilds.
Please review and find other places where this might have impact.
Backport into all needed branches too.