### PR TITLE
Exclude matching: Speedup the full-path traversal case

### DIFF
--- a/src/csync/csync_exclude.h
+++ b/src/csync/csync_exclude.h
@@ -179,8 +179,9 @@ private:
      *   full("a/b/c/d") == traversal("a") || traversal("a/b") || traversal("a/b/c")
      *
      * The traversal matcher can be extremely fast because it has a fast early-out
-     * case: It checks the bname part of the path against _bnameActivationRegex
-     * and only runs the full regex if the bname activation was triggered.
+     * case: It checks the bname part of the path against _bnameTraversalRegex
+     * and only runs a simplified _fullTraversalRegex on the whole path if bname
+     * activation for it was triggered.
      *
      * Note: The traversal matcher will return not-excluded on some paths that the
      * full matcher would exclude. Example: "b" is excluded. traversal("b/c")
@@ -198,8 +199,10 @@ private:
     QList<QByteArray> _allExcludes;
 
     /// see prepare()
-    QRegularExpression _bnameActivationRegexFile;
-    QRegularExpression _bnameActivationRegexDir;
+    QRegularExpression _bnameTraversalRegexFile;
+    QRegularExpression _bnameTraversalRegexDir;
+    QRegularExpression _fullTraversalRegexFile;
+    QRegularExpression _fullTraversalRegexDir;
     QRegularExpression _fullRegexFile;
     QRegularExpression _fullRegexDir;
 

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -118,10 +118,13 @@ static void check_csync_exclude_add(void **)
     assert_true(excludedFiles->_allExcludes.contains("/tmp/check_csync1/*"));
 
     assert_true(excludedFiles->_fullRegexFile.pattern().contains("csync1"));
-    assert_false(excludedFiles->_bnameActivationRegexFile.pattern().contains("csync1"));
+    assert_true(excludedFiles->_fullTraversalRegexFile.pattern().contains("csync1"));
+    assert_false(excludedFiles->_bnameTraversalRegexFile.pattern().contains("csync1"));
 
     excludedFiles->addManualExclude("foo");
-    assert_true(excludedFiles->_bnameActivationRegexFile.pattern().contains("foo"));
+    assert_true(excludedFiles->_bnameTraversalRegexFile.pattern().contains("foo"));
+    assert_true(excludedFiles->_fullRegexFile.pattern().contains("foo"));
+    assert_false(excludedFiles->_fullTraversalRegexFile.pattern().contains("foo"));
 }
 
 static void check_csync_excluded(void **)


### PR DESCRIPTION
Previously we'd use the full regex when the bname triggered a full-path
matching to take place. Now we have a simplified full-traversal regex
for this case that can be significantly faster to apply.

Triggered by #5017 but doesn't actually solve it.