### PR TITLE
Sync: Deal with file/folder conflicts

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -22,6 +22,7 @@
 #include "propagateremotemove.h"
 #include "propagateremotemkdir.h"
 #include "propagatorjobs.h"
+#include "filesystem.h"
 #include "common/utility.h"
 #include "account.h"
 #include "common/asserts.h"
@@ -368,8 +369,10 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
             return new PropagateRemoteDelete(this, item);
     case CSYNC_INSTRUCTION_NEW:
     case CSYNC_INSTRUCTION_TYPE_CHANGE:
+    case CSYNC_INSTRUCTION_CONFLICT:
         if (item->isDirectory()) {
-            if (item->_direction == SyncFileItem::Down) {
+            // CONFLICT has _direction == None
+            if (item->_direction != SyncFileItem::Up) {
                 auto job = new PropagateLocalMkdir(this, item);
                 job->setDeleteExistingFile(deleteExisting);
                 return job;
@@ -380,7 +383,6 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
             }
         } //fall through
     case CSYNC_INSTRUCTION_SYNC:
-    case CSYNC_INSTRUCTION_CONFLICT:
         if (item->_direction != SyncFileItem::Up) {
             auto job = new PropagateDownloadFile(this, item);
             job->setDeleteExistingFolder(deleteExisting);
@@ -431,6 +433,7 @@ void OwncloudPropagator::start(const SyncFileItemVector &items)
     directories.push(qMakePair(QString(), _rootJob.data()));
     QVector<PropagatorJob *> directoriesToRemove;
     QString removedDirectory;
+    QString maybeConflictDirectory;
     foreach (const SyncFileItemPtr &item, items) {
         if (!removedDirectory.isEmpty() && item->_file.startsWith(removedDirectory)) {
             // this is an item in a directory which is going to be removed.
@@ -461,6 +464,20 @@ void OwncloudPropagator::start(const SyncFileItemVector &items)
             } else {
                 qCWarning(lcPropagator) << "WARNING:  Job within a removed directory?  This should not happen!"
                                         << item->_file << item->_instruction;
+            }
+        }
+
+        // If a CONFLICT item contains files these can't be processed because
+        // the conflict handling is likely to rename the directory. This can happen
+        // when there's a new local directory at the same time as a remote file.
+        if (!maybeConflictDirectory.isEmpty()) {
+            if (item->destination().startsWith(maybeConflictDirectory)) {
+                qCInfo(lcPropagator) << "Skipping job inside CONFLICT directory"
+                                     << item->_file << item->_instruction;
+                item->_instruction = CSYNC_INSTRUCTION_NONE;
+                continue;
+            } else {
+                maybeConflictDirectory.clear();
             }
         }
 
@@ -512,6 +529,12 @@ void OwncloudPropagator::start(const SyncFileItemVector &items)
                 removedDirectory = item->_file + "/";
             } else {
                 directories.top().second->appendTask(item);
+            }
+
+            if (item->_instruction == CSYNC_INSTRUCTION_CONFLICT) {
+                // This might be a file or a directory on the local side. If it's a
+                // directory we want to skip processing items inside it.
+                maybeConflictDirectory = item->_file + "/";
             }
         }
     }
@@ -702,6 +725,72 @@ OwncloudPropagator::DiskSpaceResult OwncloudPropagator::diskSpaceCheck() const
     return DiskSpaceOk;
 }
 
+bool OwncloudPropagator::createConflict(const SyncFileItemPtr &item,
+    PropagatorCompositeJob *composite, QString *error)
+{
+    QString fn = getFilePath(item->_file);
+
+    QString renameError;
+    auto conflictModTime = FileSystem::getModTime(fn);
+    QString conflictFileName = Utility::makeConflictFileName(
+        item->_file, Utility::qDateTimeFromTime_t(conflictModTime));
+    QString conflictFilePath = getFilePath(conflictFileName);
+
+    emit touchedFile(fn);
+    emit touchedFile(conflictFilePath);
+
+    if (!FileSystem::rename(fn, conflictFilePath, &renameError)) {
+        // If the rename fails, don't replace it.
+
+        // If the file is locked, we want to retry this sync when it
+        // becomes available again.
+        if (FileSystem::isFileLocked(fn)) {
+            emit seenLockedFile(fn);
+        }
+
+        if (error)
+            *error = renameError;
+        return false;
+    }
+    qCInfo(lcPropagator) << "Created conflict file" << fn << "->" << conflictFileName;
+
+    // Create a new conflict record. To get the base etag, we need to read it from the db.
+    ConflictRecord conflictRecord;
+    conflictRecord.path = conflictFileName.toUtf8();
+    conflictRecord.baseModtime = item->_previousModtime;
+
+    SyncJournalFileRecord baseRecord;
+    if (_journal->getFileRecord(item->_originalFile, &baseRecord) && baseRecord.isValid()) {
+        conflictRecord.baseEtag = baseRecord._etag;
+        conflictRecord.baseFileId = baseRecord._fileId;
+    } else {
+        // We might very well end up with no fileid/etag for new/new conflicts
+    }
+
+    _journal->setConflictRecord(conflictRecord);
+
+    // Create a new upload job if the new conflict file should be uploaded
+    if (account()->capabilities().uploadConflictFiles()) {
+        if (composite && !QFileInfo(conflictFilePath).isDir()) {
+            SyncFileItemPtr conflictItem = SyncFileItemPtr(new SyncFileItem);
+            conflictItem->_file = conflictFileName;
+            conflictItem->_type = ItemTypeFile;
+            conflictItem->_direction = SyncFileItem::Up;
+            conflictItem->_instruction = CSYNC_INSTRUCTION_NEW;
+            conflictItem->_modtime = conflictModTime;
+            conflictItem->_size = item->_previousSize;
+            emit newItem(conflictItem);
+            composite->appendTask(conflictItem);
+        } else {
+            // Directories we can't process in one go. The next sync run
+            // will take care of uploading the conflict dir contents.
+            _anotherSyncNeeded = true;
+        }
+    }
+
+    return true;
+}
+
 // ================================================================================
 
 PropagatorJob::PropagatorJob(OwncloudPropagator *propagator)
@@ -741,7 +830,7 @@ void PropagatorCompositeJob::slotSubJobAbortFinished()
 
 void PropagatorCompositeJob::appendJob(PropagatorJob *job)
 {
-    job->setCompositeParent(this);
+    job->setAssociatedComposite(this);
     _jobsToDo.append(job);
 }
 
@@ -858,6 +947,7 @@ PropagateDirectory::PropagateDirectory(OwncloudPropagator *propagator, const Syn
 {
     if (_firstJob) {
         connect(_firstJob.data(), &PropagatorJob::finished, this, &PropagateDirectory::slotFirstJobFinished);
+        _firstJob->setAssociatedComposite(&_subJobs);
     }
     connect(&_subJobs, &PropagatorJob::finished, this, &PropagateDirectory::slotSubJobsFinished);
 }
@@ -901,7 +991,9 @@ void PropagateDirectory::slotFirstJobFinished(SyncFileItem::Status status)
 {
     _firstJob.take()->deleteLater();
 
-    if (status != SyncFileItem::Success && status != SyncFileItem::Restoration) {
+    if (status != SyncFileItem::Success
+        && status != SyncFileItem::Restoration
+        && status != SyncFileItem::Conflict) {
         if (_state != Finished) {
             // Synchronously abort
             abort(AbortType::Synchronous);

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -103,11 +103,13 @@ public:
      */
     virtual qint64 committedDiskSpace() const { return 0; }
 
-    /** Set the composite parent job
+    /** Set the associated composite job
      *
-     * Used only from PropagatorCompositeJob itself, when a job is added.
+     * Used only from PropagatorCompositeJob itself, when a job is added
+     * and from PropagateDirectory to associate the subJobs with the first
+     * job.
      */
-    void setCompositeParent(PropagatorCompositeJob *job) { _compositeParent = job; }
+    void setAssociatedComposite(PropagatorCompositeJob *job) { _associatedComposite = job; }
 
 public slots:
     /*
@@ -138,10 +140,13 @@ protected:
 
     /** If this job gets added to a composite job, this will point to the parent.
      *
+     * For the PropagateDirectory::_firstJob it will point to
+     * PropagateDirectory::_subJobs.
+     *
      * That can be useful for jobs that want to spawn follow-up jobs without
      * becoming composite jobs themselves.
      */
-    PropagatorCompositeJob *_compositeParent = nullptr;
+    PropagatorCompositeJob *_associatedComposite = nullptr;
 };
 
 /*
@@ -491,6 +496,18 @@ public:
      *  all jobs that are currently running.
      */
     DiskSpaceResult diskSpaceCheck() const;
+
+    /** Handles a conflict by renaming the file 'item'.
+     *
+     * Sets up conflict records.
+     *
+     * It also creates a new upload job in composite if the item that's
+     * moved away is a file and conflict uploads are requested.
+     *
+     * Returns true on success, false and error on error.
+     */
+    bool createConflict(const SyncFileItemPtr &item,
+        PropagatorCompositeJob *composite, QString *error);
 
 private slots:
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -432,6 +432,7 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
         item->_modtime = file->modtime;
         item->_size = file->size;
         item->_checksumHeader = file->checksumHeader;
+        item->_type = file->type;
     } else {
         if (instruction != CSYNC_INSTRUCTION_NONE) {
             qCWarning(lcEngine) << "ERROR: Instruction" << item->_instruction << "vs" << instruction << "for" << fileUtf8;
@@ -575,8 +576,6 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
     if (!item->_inode) {
         item->_inode = file->inode;
     }
-
-    item->_type = file->type;
 
     SyncFileItem::Direction dir = SyncFileItem::None;
 


### PR DESCRIPTION
Previously conflicts with a different type on both ends lead to sync
errors. Now they are handled in the expected way: the local item gets
renamed and the remote item gets propagated downwards.

This also adds a unittest for the TYPE_CHANGE case. That one looks like
parts of it might be unified with CONFLICT cases.

See  #6312