### PR TITLE
Get rid of the StopWatch in the PropagateUpload job

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -214,10 +214,6 @@ void PropagateUploadFileCommon::slotComputeContentChecksum()
     // change during the checksum calculation
     _item->_modtime = FileSystem::getModTime(filePath);
 
-#ifdef WITH_TESTING
-    _stopWatch.start();
-#endif
-
     QByteArray checksumType = contentChecksumType();
 
     // Maybe the discovery already computed the checksum?
@@ -242,11 +238,6 @@ void PropagateUploadFileCommon::slotComputeContentChecksum()
 void PropagateUploadFileCommon::slotComputeTransmissionChecksum(const QByteArray &contentChecksumType, const QByteArray &contentChecksum)
 {
     _item->_checksumHeader = makeChecksumHeader(contentChecksumType, contentChecksum);
-
-#ifdef WITH_TESTING
-    _stopWatch.addLapTime(QLatin1String("ContentChecksum"));
-    _stopWatch.start();
-#endif
 
     // Reuse the content checksum as the transmission checksum if possible
     const auto supportedTransmissionChecksums =
@@ -291,10 +282,6 @@ void PropagateUploadFileCommon::slotStartUpload(const QByteArray &transmissionCh
         done(SyncFileItem::SoftError, tr("File Removed"));
         return;
     }
-#ifdef WITH_TESTING
-    _stopWatch.addLapTime(QLatin1String("TransmissionChecksum"));
-#endif
-
     time_t prevModtime = _item->_modtime; // the _item value was set in PropagateUploadFile::start()
     // but a potential checksum calculation could have taken some time during which the file could
     // have been changed again, so better check again here.

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -211,12 +211,6 @@ protected:
     bool _finished BITFIELD(1); /// Tells that all the jobs have been finished
     bool _deleteExisting BITFIELD(1);
     quint64 _abortCount; /// Keep track of number of aborted items
-
-// measure the performance of checksum calc and upload
-#ifdef WITH_TESTING
-    Utility::StopWatch _stopWatch;
-#endif
-
     QByteArray _transmissionChecksumHeader;
 
 public:

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -467,17 +467,6 @@ void PropagateUploadFileNG::slotMoveJobFinished()
         return;
     }
     _item->_responseTimeStamp = job->responseTimestamp();
-
-#ifdef WITH_TESTING
-    // performance logging
-    quint64 duration = _stopWatch.stop();
-    qCDebug(lcPropagateUpload) << "*==* duration UPLOAD" << _item->_size
-                               << _stopWatch.durationOfLap(QLatin1String("ContentChecksum"))
-                               << _stopWatch.durationOfLap(QLatin1String("TransmissionChecksum"))
-                               << duration;
-    // The job might stay alive for the whole sync, release this tiny bit of memory.
-    _stopWatch.reset();
-#endif
     finalize();
 }
 

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -318,17 +318,6 @@ void PropagateUploadFileV1::slotPutFinished()
         done(SyncFileItem::SoftError, "Server does not support X-OC-MTime");
     }
 
-#ifdef WITH_TESTING
-    // performance logging
-    quint64 duration = _stopWatch.stop();
-    qCDebug(lcPropagateUpload) << "*==* duration UPLOAD" << _item->_size
-                               << _stopWatch.durationOfLap(QLatin1String("ContentChecksum"))
-                               << _stopWatch.durationOfLap(QLatin1String("TransmissionChecksum"))
-                               << duration;
-    // The job might stay alive for the whole sync, release this tiny bit of memory.
-    _stopWatch.reset();
-#endif
-
     finalize();
 }
 


### PR DESCRIPTION
For issue #6318

The StopWatch is using memory, and we are not really using it.