### PR TITLE
Activity: Avoid misleading message for INSTRUCTION_CONFLICT

### DIFF
--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -216,7 +216,7 @@ void IssuesWidget::slotProgressInfo(const QString &folder, const ProgressInfo &p
 
 void IssuesWidget::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
 {
-    if (!item->hasErrorStatus())
+    if (!item->showInIssuesTab())
         return;
     QTreeWidgetItem *line = ProtocolWidget::createCompletedTreewidgetItem(folder, *item);
     if (!line)

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -195,7 +195,7 @@ QTreeWidgetItem *ProtocolWidget::createCompletedTreewidgetItem(const QString &fo
 
 void ProtocolWidget::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
 {
-    if (item->hasErrorStatus())
+    if (!item->showInProtocolTab())
         return;
     QTreeWidgetItem *line = createCompletedTreewidgetItem(folder, *item);
     if (line) {

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -223,11 +223,10 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         // Connect all shares signals to gui slots
         connect(share.data(), &Share::serverError, this, &ShareLinkWidget::slotServerError);
         connect(share.data(), &Share::shareDeleted, this, &ShareLinkWidget::slotDeleteShareFetched);
-        connect(share.data(), SIGNAL(expireDateSet()), SLOT(slotExpireSet()));
-        connect(share.data(), SIGNAL(publicUploadSet()), SLOT(slotPermissionsSet()));
-        connect(share.data(), SIGNAL(passwordSet()), SLOT(slotPasswordSet()));
-        connect(share.data(), SIGNAL(passwordSetError(int, QString)), SLOT(slotPasswordSetError(int, QString)));
         connect(share.data(), &Share::permissionsSet, this, &ShareLinkWidget::slotPermissionsSet);
+        connect(linkShare.data(), &LinkShare::expireDateSet, this, &ShareLinkWidget::slotExpireSet);
+        connect(linkShare.data(), &LinkShare::passwordSet, this, &ShareLinkWidget::slotPasswordSet);
+        connect(linkShare.data(), &LinkShare::passwordSetError, this, &ShareLinkWidget::slotPasswordSetError);
 
         // Build the table row
         auto row = table->rowCount();

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -178,18 +178,31 @@ public:
 
     /**
      * True if the item had any kind of error.
-     *
-     * Used for deciding whether an item belongs to the protocol or the
-     * issues list on the activity page and for checking whether an
-     * item should be announced in the notification message.
      */
     bool hasErrorStatus() const
     {
         return _status == SyncFileItem::SoftError
             || _status == SyncFileItem::NormalError
             || _status == SyncFileItem::FatalError
-            || _status == SyncFileItem::Conflict
             || !_errorString.isEmpty();
+    }
+
+    /**
+     * Whether this item should appear on the issues tab.
+     */
+    bool showInIssuesTab() const
+    {
+        return hasErrorStatus() || _status == SyncFileItem::Conflict;
+    }
+
+    /**
+     * Whether this item should appear on the protocol tab.
+     */
+    bool showInProtocolTab() const
+    {
+        return !showInIssuesTab()
+            // Don't show conflicts that were resolved as "not a conflict after all"
+            && !(_instruction == CSYNC_INSTRUCTION_CONFLICT && _status == SyncFileItem::Success);
     }
 
     // Variables useful for everybody


### PR DESCRIPTION
The instruction just indicates a potential conflict. If we can determine
that there's no actual conflict, the activity item shouldn't announce
that a conflict file was created.

The "Downloaded" message is not necessarily technically correct, but
seems less confusing than "It looked like there might be a conflict, but
there didn't end up being one after all".

See #6316