### PR TITLE
Logger: --logdebug only show owncloud's debug message

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -219,7 +219,7 @@ void Logger::setLogFlush(bool flush)
 
 void Logger::setLogDebug(bool debug)
 {
-    QLoggingCategory::setFilterRules(debug ? QStringLiteral("qt.*=true\n*.debug=true") : QString());
+    QLoggingCategory::setFilterRules(debug ? QStringLiteral("sync.*.debug=true\ngui.*.debug=true") : QString());
     _logDebug = debug;
 }
 


### PR DESCRIPTION
Recent Qt version show way too many debug messages, spamming the console.
So filter only messages that comes from the client.