### PR TITLE
SocketAPI: "Open in browser" and disable Share entries when sharing is disabled

### DIFF
--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -66,6 +66,7 @@ private slots:
 
     void copyPrivateLinkToClipboard(const QString &link) const;
     void emailPrivateLink(const QString &link) const;
+    void openPrivateLink(const QString &link) const;
 
 private:
     void broadcastMessage(const QString &msg, bool doWait = false);
@@ -82,6 +83,7 @@ private:
     Q_INVOKABLE void command_SHARE(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_COPY_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_OPEN_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
 
     /** Sends translated/branded strings that may be useful to the integration */
     Q_INVOKABLE void command_GET_STRINGS(const QString &argument, SocketListener *listener);


### PR DESCRIPTION

This adds "Open in browser" entry in the menu (Issue #5903)

Also mark the share entries as disabled when sharing is not allowed
or not available for a given file.
If sharing is disabled globaly in the branding or in the server,
the share entry will not be present.
(Issues #4205 and #4608)

Meta issue #6292