### PR TITLE
Don't delete contents behind directory junctions

### DIFF
--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -478,4 +478,22 @@ bool FileSystem::isLnkFile(const QString &filename)
     return filename.endsWith(".lnk");
 }
 
+bool FileSystem::isJunction(const QString &filename)
+{
+#ifdef Q_OS_WIN
+    WIN32_FIND_DATA findData;
+    HANDLE hFind = FindFirstFileEx((const wchar_t *)filename.utf16(), FindExInfoBasic, &findData, FindExSearchNameMatch, NULL, 0);
+    if (hFind != INVALID_HANDLE_VALUE) {
+        FindClose(hFind);
+        return false;
+    }
+    return findData.dwFileAttributes != INVALID_FILE_ATTRIBUTES
+        && findData.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT
+        && findData.dwReserved0 == IO_REPARSE_TAG_MOUNT_POINT;
+#else
+    Q_UNUSED(filename);
+    return false;
+#endif
+}
+
 } // namespace OCC

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -141,7 +141,15 @@ namespace FileSystem {
      */
     bool OCSYNC_EXPORT isFileLocked(const QString &fileName);
 
+    /**
+     * Returns whether the file is a shortcut file (ends with .lnk)
+     */
     bool OCSYNC_EXPORT isLnkFile(const QString &filename);
+
+    /**
+     * Returns whether the file is a junction (windows only)
+     */
+    bool OCSYNC_EXPORT isJunction(const QString &filename);
 
     /*
      * This function takes a path and converts it to a UNC representation of the

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -66,7 +66,7 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
         bool ok;
         // The use of isSymLink here is okay:
         // we never want to go into this branch for .lnk files
-        bool isDir = fi.isDir() && !fi.isSymLink();
+        bool isDir = fi.isDir() && !fi.isSymLink() && !FileSystem::isJunction(fi.absoluteFilePath());
         if (isDir) {
             ok = removeRecursively(path + QLatin1Char('/') + di.fileName()); // recursive
         } else {


### PR DESCRIPTION
QFileInfo::isSymLink() does detect reparse points that are symlinks but
returns false for junctions. The new function FileSystem::isJunction()
can detect those and is used to not recursively delete files inside
directories that are junctions.

See  #6322