### PR TITLE
SyncJournal: Clear etag filter before sync

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -170,9 +170,17 @@ public:
      * Since folders in the selective sync list will not be rediscovered (csync_ftw,
      * _csync_detect_update skip them), the _invalid_ marker will stay. And any
      * child items in the db will be ignored when reading a remote tree from the database.
+     *
+     * Any setFileRecord() call to affected directories before the next sync run will be
+     * adjusted to retain the invalid etag via _etagStorageFilter.
      */
     void avoidReadFromDbOnNextSync(const QString &fileName) { avoidReadFromDbOnNextSync(fileName.toUtf8()); }
     void avoidReadFromDbOnNextSync(const QByteArray &fileName);
+
+    /**
+     * Wipe _etagStorageFilter. Also done implicitly on close().
+     */
+    void clearEtagStorageFilter();
 
     /**
      * Ensures full remote discovery happens on the next sync.
@@ -287,13 +295,20 @@ private:
     QScopedPointer<SqlQuery> _setConflictRecordQuery;
     QScopedPointer<SqlQuery> _deleteConflictRecordQuery;
 
-    /* This is the list of paths we called avoidReadFromDbOnNextSync on.
-     * It means that they should not be written to the DB in any case since doing
-     * that would write the etag and would void the purpose of avoidReadFromDbOnNextSync
+    /* Storing etags to these folders, or their parent folders, is filtered out.
+     *
+     * When avoidReadFromDbOnNextSync() is called some etags to _invalid_ in the
+     * database. If this is done during a sync run, a later propagation job might
+     * undo that by writing the correct etag to the database instead. This filter
+     * will prevent this write and instead guarantee the _invalid_ etag stays in
+     * place.
+     *
+     * The list is cleared on close() (end of sync run) and explicitly with
+     * clearEtagStorageFilter() (start of sync run).
      *
      * The contained paths have a trailing /.
      */
-    QList<QByteArray> _avoidReadFromDbOnNextSyncFilter;
+    QList<QByteArray> _etagStorageFilter;
 
     /** The journal mode to use for the db.
      *

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -839,6 +839,11 @@ void SyncEngine::startSync()
         // database creation error!
     }
 
+    // Functionality like selective sync might have set up etag storage
+    // filtering via avoidReadFromDbOnNextSync(). This *is* the next sync, so
+    // undo the filter to allow this sync to retrieve and store the correct etags.
+    _journal->clearEtagStorageFilter();
+
     _csync_ctx->upload_conflict_files = _account->capabilities().uploadConflictFiles();
     _excludedFiles->setExcludeConflictFiles(!_account->capabilities().uploadConflictFiles());
 


### PR DESCRIPTION
Before, we only cleared the _avoidReadFromDbOnNextSyncFilter *after* a
sync which meant that we had to sync twice after selective sync setup.

Now, we clear the filter *before* a sync as well which allows the actual
next sync to write the correct etags to the db again - instead of only
the sync after that one.

Also expand on comments and rename _avoidReadFromDbOnNextSyncFilter to
_etagStorageFilter.