### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.ini
+++ b/appveyor.ini
@@ -9,6 +9,8 @@ Command=craft
 #Values need to be overwritten to create a chache
 UseCache = True
 CreateCache = False
+QtVersion = 5.9.3
+CacheVersion = Qt_${Variables:QtVersion}
 
 # Settings applicable for all Crafts matrices
 # Settings are Category/key=value
@@ -25,6 +27,7 @@ ShortPath/JunctionDir = C:\CM-SP\
 Packager/CacheDir = ${Variables:Root}\cache
 Packager/UseCache = ${Variables:UseCache}
 Packager/CreateCache = ${Variables:CreateCache}
+Packager/CacheVersion = ${Variables:CacheVersion}
 ; Packager/RepositoryUrl = https://files.kde.org/craft/
 Packager/PackageType = PortablePackager
 Packager/RepositoryUrl = http://ftp.acc.umu.se/mirror/kde.org/files/craft/master/
@@ -35,7 +38,7 @@ ContinuousIntegration/Enabled = True
 # don't try to pip install on the ci
 python-modules.ignored = True
 
-libs/qt5.version = 5.9.3
+libs/qt5.version = ${Variables:QtVersion}
 craft/craft-core.version = master
 
 [windows-msvc2017_64-cl]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
     & cmd /C "git clone -q --depth=1 git://anongit.kde.org/craftmaster.git C:\CraftMaster\CraftMaster 2>&1"
 
     craft $env:TARGET -i craft
+    craft $env:TARGET --add-blueprint-repository [git]https://github.com/owncloud/craft-blueprints-owncloud.git
     craft $env:TARGET --install-deps owncloud-client
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,6 @@ after_build:
 - ps: |
     craft $env:TARGET --src-dir $env:APPVEYOR_BUILD_FOLDER --package owncloud-client
 
-
-on_finish:
-- ps: |
-    Get-ChildItem $env:USERPROFILE\.craft\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
-
 test_script:
 - ps: |
    craft $env:TARGET --src-dir $env:APPVEYOR_BUILD_FOLDER --test owncloud-client
@@ -45,6 +40,3 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - TARGET: windows-msvc2017_64-cl
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-artifacts:
-  - path: binaries/*


### PR DESCRIPTION
Resubmitting the app veyor fixes without the qt 5.10 version bump as we don't have the right binaries in craft cache yet and building it ourselves takes too long for appveyor.