### PR TITLE
SyncEngine: Use separate state for two unicode conversions

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -393,26 +393,38 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
     if (!file)
         return -1;
 
-    QTextCodec::ConverterState utf8State;
-    static QTextCodec *codec = QTextCodec::codecForName("UTF-8");
-    ASSERT(codec);
-    QString fileUtf8 = codec->toUnicode(file->path, file->path.size(), &utf8State);
-    QString renameTarget;
-    QString key = fileUtf8;
-
     auto instruction = file->instruction;
-    if (utf8State.invalidChars > 0 || utf8State.remainingChars > 0) {
-        qCWarning(lcEngine) << "File ignored because of invalid utf-8 sequence: " << file->path;
-        instruction = CSYNC_INSTRUCTION_IGNORE;
-    } else {
-        renameTarget = codec->toUnicode(file->rename_path, file->rename_path.size(), &utf8State);
-        if (utf8State.invalidChars > 0 || utf8State.remainingChars > 0) {
+
+    // Decode utf8 path and rename_path QByteArrays to QStrings
+    QString fileUtf8;
+    QString renameTarget;
+    bool utf8DecodeError = false;
+    {
+        const auto toUnicode = [](QByteArray utf8, QString *result) {
+            static QTextCodec *codec = QTextCodec::codecForName("UTF-8");
+            ASSERT(codec);
+
+            QTextCodec::ConverterState state;
+            *result = codec->toUnicode(utf8, utf8.size(), &state);
+            return !(state.invalidChars > 0 || state.remainingChars > 0);
+        };
+
+        if (!toUnicode(file->path, &fileUtf8)) {
+            qCWarning(lcEngine) << "File ignored because of invalid utf-8 sequence: " << file->path;
+            instruction = CSYNC_INSTRUCTION_IGNORE;
+            utf8DecodeError = true;
+        }
+        if (!toUnicode(file->rename_path, &renameTarget)) {
             qCWarning(lcEngine) << "File ignored because of invalid utf-8 sequence in the rename_path: " << file->path << file->rename_path;
             instruction = CSYNC_INSTRUCTION_IGNORE;
+            utf8DecodeError = true;
         }
-        if (instruction == CSYNC_INSTRUCTION_RENAME) {
-            key = renameTarget;
-        }
+    }
+
+    // key is the handle that the SyncFileItem will have in the map.
+    QString key = fileUtf8;
+    if (instruction == CSYNC_INSTRUCTION_RENAME) {
+        key = renameTarget;
     }
 
     // Gets a default-constructed SyncFileItemPtr or the one from the first walk (=local walk)
@@ -560,7 +572,7 @@ int SyncEngine::treewalkFile(csync_file_stat_t *file, csync_file_stat_t *other, 
         /* No error string */
     }
 
-    if (item->_instruction == CSYNC_INSTRUCTION_IGNORE && (utf8State.invalidChars > 0 || utf8State.remainingChars > 0)) {
+    if (item->_instruction == CSYNC_INSTRUCTION_IGNORE && utf8DecodeError) {
         item->_status = SyncFileItem::NormalError;
         //item->_instruction = CSYNC_INSTRUCTION_ERROR;
         item->_errorString = tr("Filename encoding is not valid");


### PR DESCRIPTION
It's unlikely that there were interaction effects but still seems safer
to use different conversion state for the path and rename_path.