### PR TITLE
Set launch-on-startup when the first account is set up

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -338,7 +338,9 @@ void Application::slotownCloudWizardDone(int res)
         shouldSetAutoStart = shouldSetAutoStart
             && QCoreApplication::applicationDirPath().startsWith("/Applications/");
 #endif
-        Utility::setLaunchOnStartup(_theme->appName(), _theme->appNameGUI(), shouldSetAutoStart);
+        if (shouldSetAutoStart) {
+            Utility::setLaunchOnStartup(_theme->appName(), _theme->appNameGUI(), true);
+        }
 
         _gui->slotShowSettings();
     }


### PR DESCRIPTION
The previous code would disable it when the second account was
configured.

See #6347