### PR TITLE
Utility::fsCasePreserving: remove UNIT_TESTING ifdef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,9 +211,6 @@ endif()
 file( GLOB TRANS_FILES ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
 set(TRANSLATIONS ${TRANS_FILES})
 
-# Make sure we set this before recursing into child folders.
-set(WITH_TESTING ${UNIT_TESTING})
-
 if(BUILD_CLIENT)
     add_subdirectory(src)
     if(NOT BUILD_LIBRARIES_ONLY)

--- a/config.h.in
+++ b/config.h.in
@@ -24,6 +24,4 @@
 #cmakedefine SYSCONFDIR "@SYSCONFDIR@"
 #cmakedefine SHAREDIR "@SHAREDIR@"
 
-#cmakedefine WITH_TESTING 1
-
 #endif

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -254,15 +254,17 @@ void Utility::usleep(int usec)
     QThread::usleep(usec);
 }
 
-bool Utility::fsCasePreserving()
-{
-#ifdef WITH_TESTING
+// This can be overriden from the tests
+OCSYNC_EXPORT bool fsCasePreserving_override = []()-> bool {
     QByteArray env = qgetenv("OWNCLOUD_TEST_CASE_PRESERVING");
     if (!env.isEmpty())
         return env.toInt();
-#endif
+    return Utility::isWindows() || Utility::isMac();
+}();
 
-    return isWindows() || isMac();
+bool Utility::fsCasePreserving()
+{
+    return fsCasePreserving_override;
 }
 
 bool Utility::fileNamesEqual(const QString &fn1, const QString &fn2)

--- a/src/csync/config_csync.h.cmake
+++ b/src/csync/config_csync.h.cmake
@@ -17,4 +17,3 @@
 #cmakedefine HAVE___MINGW_ASPRINTF 1
 #cmakedefine HAVE_ASPRINTF 1
 
-#cmakedefine WITH_TESTING 1

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -11,6 +11,10 @@
 
 using namespace OCC::Utility;
 
+namespace OCC {
+OCSYNC_EXPORT extern bool fsCasePreserving_override;
+}
+
 class TestUtility : public QObject
 {
     Q_OBJECT
@@ -150,12 +154,12 @@ private slots:
 
     void testFsCasePreserving()
     {
-        qputenv("OWNCLOUD_TEST_CASE_PRESERVING", "1");
-        QVERIFY(fsCasePreserving());
-        qputenv("OWNCLOUD_TEST_CASE_PRESERVING", "0");
-        QVERIFY(! fsCasePreserving());
-        qunsetenv("OWNCLOUD_TEST_CASE_PRESERVING");
         QVERIFY(isMac() || isWindows() ? fsCasePreserving() : ! fsCasePreserving());
+        QScopedValueRollback<bool> scope(OCC::fsCasePreserving_override);
+        OCC::fsCasePreserving_override = 1;
+        QVERIFY(fsCasePreserving());
+        OCC::fsCasePreserving_override = 0;
+        QVERIFY(! fsCasePreserving());
     }
 
     void testFileNamesEqual()
@@ -178,13 +182,12 @@ private slots:
         QVERIFY(fileNamesEqual(a+"/test", b+"/test")); // both exist
         QVERIFY(fileNamesEqual(a+"/test/TESTI", b+"/test/../test/TESTI")); // both exist
 
-        qputenv("OWNCLOUD_TEST_CASE_PRESERVING", "1");
+        QScopedValueRollback<bool> scope(OCC::fsCasePreserving_override, true);
         QVERIFY(fileNamesEqual(a+"/test", b+"/TEST")); // both exist
 
         QVERIFY(!fileNamesEqual(a+"/test", b+"/test/TESTI")); // both are different
 
         dir.remove();
-        qunsetenv("OWNCLOUD_TEST_CASE_PRESERVING");
     }
 
     void testSanitizeForFileName_data()


### PR DESCRIPTION
Since the release package will be build with unit test, we don't
want to query the env variable at every call to fsCasePreserving.
So only test the env variable at startup.
And the testutility can still change the value.

(The env variable is still used from t8.pl and maybe smashbox)

Issue #6318