### PR TITLE
zsync: use larger rolling hash size to avoid conflicts

### DIFF
--- a/src/libsync/propagatecommonzsync.cpp
+++ b/src/libsync/propagatecommonzsync.cpp
@@ -16,6 +16,11 @@
  *
  */
 
+extern "C" {
+#include "libzsync/zsync.h"
+#include "libzsync/zsyncfile.h"
+}
+
 #include "config.h"
 #include "propagateupload.h"
 #include "owncloudpropagator_p.h"
@@ -35,10 +40,6 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QTemporaryDir>
-
-extern "C" {
-#include "libzsync/zsyncfile.h"
-}
 
 namespace OCC {
 

--- a/src/libsync/propagatecommonzsync.cpp
+++ b/src/libsync/propagatecommonzsync.cpp
@@ -204,17 +204,13 @@ void ZsyncGenerateRunnable::run()
     // We don't care for the optimal checksum lengths computed by
     // compute_rsum_checksum_len() since we use blocks much larger
     // than the default (1 MB instead of 8 kB) and can just store the full
-    // 20 bytes per block.
-    // There was also the following issue about seq_matches == 2:
-    //      this seems to cause unmatched blocks at end of
-    //      files with sizes which are unaligned to blocksize
-    int rsum_len = 4;
+    // 24 bytes per block.
+    int rsum_len = 8;
     int checksum_len = 16;
-    int seq_matches = 1;
 
     if (zsyncfile_write(
             meta.get(), tf.get(),
-            rsum_len, checksum_len, seq_matches,
+            rsum_len, checksum_len,
             0, 0, 0, // recompress
             0, 0, // fname, mtime
             0, 0, // urls

--- a/src/libsync/propagatecommonzsync.h
+++ b/src/libsync/propagatecommonzsync.h
@@ -23,13 +23,6 @@
 #include <QRunnable>
 #include <QThreadPool>
 
-extern "C" {
-#include "librcksum/rcksum.h"
-#include "libzsync/zmap.h"
-#include "libzsync/sha1.h"
-#include "libzsync/zsync.h"
-}
-
 #define ZSYNC_BLOCKSIZE (1 * 1024 * 1024) // must be power of 2
 
 namespace OCC {

--- a/src/libsync/propagatedownloadzsync.cpp
+++ b/src/libsync/propagatedownloadzsync.cpp
@@ -16,6 +16,10 @@
  *
  */
 
+extern "C" {
+#include "libzsync/zsync.h"
+}
+
 #include "config.h"
 #include "owncloudpropagator_p.h"
 #include "propagatedownload.h"

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -12,6 +12,10 @@
  * for more details.
  */
 
+extern "C" {
+#include "libzsync/zsync.h"
+}
+
 #include "config.h"
 #include "propagateupload.h"
 #include "owncloudpropagator_p.h"
@@ -134,7 +138,7 @@ void PropagateUploadFileNG::slotZsyncSeedFinished(void *_zs)
 
     for (const auto &range : _rangesToUpload)
         qCDebug(lcZsyncPut) << "Upload range:" << range.start << range.size;
-    qCDebug(lcZsyncPut) << "Total bytes:" << totalBytes;
+    qCDebug(lcZsyncPut) << "Total bytes:" << totalBytes << "of file size" << _item->_size;
 
     propagator()->reportFileTotal(*_item, totalBytes);
     _bytesToUpload = totalBytes;


### PR DESCRIPTION
This PR is based on top of https://github.com/owncloud/client/pull/6389 and has only one commit https://github.com/owncloud/client/commit/15aff7b0dd188bb9bc8d36c9e7d243b56af2697c. It also depends on https://github.com/ahmedammar/zsync/pull/2

@ahmedammar