### PR TITLE
Dolphin plugin: fall back if $XDG_RUNTIME_DIR is empty

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinpluginhelper.cpp
+++ b/shell_integration/dolphin/ownclouddolphinpluginhelper.cpp
@@ -19,6 +19,7 @@
 
 #include <QtNetwork/QLocalSocket>
 #include <qcoreevent.h>
+#include <QStandardPaths>
 #include <QFile>
 #include "ownclouddolphinpluginhelper.h"
 #include "config.h"
@@ -68,12 +69,14 @@ void OwncloudDolphinPluginHelper::tryConnect()
     if (_socket.state() != QLocalSocket::UnconnectedState) {
         return;
     }
-    QString runtimeDir = QFile::decodeName(qgetenv("XDG_RUNTIME_DIR"));
-    runtimeDir.append( QChar('/'));
-    runtimeDir.append( QLatin1String(APPLICATION_SHORTNAME) );
+    
+    QString socketPath = QStandardPaths::locate(QStandardPaths::RuntimeLocation,
+                                                APPLICATION_SHORTNAME,
+                                                QStandardPaths::LocateDirectory);
+    if(socketPath.isEmpty())
+        return;
 
-    const QString socketPath = runtimeDir + QLatin1String("/socket");
-    _socket.connectToServer(socketPath);
+    _socket.connectToServer(socketPath + QLatin1String("/socket"));
 }
 
 void OwncloudDolphinPluginHelper::slotReadyRead()


### PR DESCRIPTION
As per XDG Base Directories specification:
> If $XDG_RUNTIME_DIR is not set applications should fall back
> to a replacement directory [...]

In practice, the ownCloud client has the fallback, but the plugin
helper does not, and if $XDG_RUNTIME_DIR is not set, the plugin
mysteriously does not work.