### PR TITLE
Excludes: Expand doc, Desktop.ini only in root folder

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -276,9 +276,14 @@ Some system wide file patterns that are used to exclude or ignore files are incl
 
 By default, the ownCloud Client ignores the following files:
 
-* Files matched by one of the patterns defined in the Ignored Files Editor
-* Files containing characters that do not work on certain file systems ``(`\, /, :, ?, *, ", >, <, |`)``.
-* Files starting with ``._sync_xxxxxxx.db`` and the old format ``.csync_journal.db``,  as these files are reserved for journalling.
+* Files matched by one of the patterns defined in the Ignored Files Editor.
+* Files starting with ``._sync_*.db*``, ``.sync_*.db*``, ``.csync_journal.db*``, ``.owncloudsync.log*``,  as these files are reserved for journalling.
+* Files with a name longer than 254 characters.
+* The file ``Desktop.ini`` in the root of a synced folder.
+* Files matching the pattern ``*_conflict-*`` unless conflict file uploading is enabled.
+* Windows only: Files containing characters that do not work on typical Windows filesystems ``(`\, /, :, ?, *, ", >, <, |`)``.
+* Windows only: Files with a trailing space or dot.
+* Windows only: Filenames that are reserved on Windows.
 
 If a pattern selected using a checkbox in the `ignoredFilesEditor-label` (or if
 a line in the exclude file starts with the character ``]`` directly followed by

--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -217,8 +217,8 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(const char *path, bool excludeC
     }
 #endif
 
-    /* We create a desktop.ini on Windows for the sidebar icon, make sure we don't sync them. */
-    if (blen == 11) {
+    /* We create a Desktop.ini on Windows for the sidebar icon, make sure we don't sync it. */
+    if (blen == 11 && path == bname) {
         rc = csync_fnmatch("Desktop.ini", bname, 0);
         if (rc == 0) {
             match = CSYNC_FILE_SILENTLY_EXCLUDED;

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -271,7 +271,8 @@ static void check_csync_excluded_traversal(void **)
     assert_int_equal(check_file_traversal("subdir/.sync_5bdd60bdfcfa.db"), CSYNC_FILE_SILENTLY_EXCLUDED);
 
     /* Other builtin excludes */
-    assert_int_equal(check_file_traversal("foo/Desktop.ini"), CSYNC_FILE_SILENTLY_EXCLUDED);
+    assert_int_equal(check_file_traversal("foo/Desktop.ini"), CSYNC_NOT_EXCLUDED);
+    assert_int_equal(check_file_traversal("Desktop.ini"), CSYNC_FILE_SILENTLY_EXCLUDED);
 
     /* pattern ]*.directory - ignore and remove */
     assert_int_equal(check_file_traversal("my.~directory"), CSYNC_FILE_EXCLUDE_AND_REMOVE);


### PR DESCRIPTION
The Desktop.ini exclude was added for 2.4 because we add such a file to
the synced folder on Windows. It doesn't need to cover subdirectories.

See https://github.com/owncloud/documentation/issues/2832