### PR TITLE
FolderStatusModel: fix potential assert

### DIFF
--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -20,6 +20,7 @@
 #include <QLoggingCategory>
 #include <QVector>
 #include <QElapsedTimer>
+#include <QPointer>
 
 class QNetworkReply;
 namespace OCC {
@@ -28,6 +29,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcFolderStatus)
 
 class Folder;
 class ProgressInfo;
+class LsColJob;
 
 /**
  * @brief The FolderStatusModel class
@@ -59,7 +61,6 @@ public:
             , _size(0)
             , _isExternal(false)
             , _fetched(false)
-            , _fetching(false)
             , _hasError(false)
             , _fetchingLabel(false)
             , _isUndecided(false)
@@ -75,7 +76,7 @@ public:
         bool _isExternal;
 
         bool _fetched; // If we did the LSCOL for this folder already
-        bool _fetching; // Whether a LSCOL job is currently running
+        QPointer<LsColJob> _fetchingJob; // Currently running LsColJob
         bool _hasError; // If the last fetching job ended in an error
         QString _lastErrorString;
         bool _fetchingLabel; // Whether a 'fetching in progress' label is shown.


### PR DESCRIPTION
OCC::FolderStatusModel::slotUpdateDirectories: ASSERT: "parentInfo->_fetching" in file /home/olivier/kdegit/owncloud/mirall/src/gui/folderstatusmodel.cpp, line 599

This can happen if the structure of a folder is change while the user
expands the root folder. In this case, resetSubs() is called which
resets _fetching to false.
Instead, we need to keep a pointer to the job so we can abort it by
deleting it.