### PR TITLE
Theme: unify ownCloudTheme and Theme classes

### DIFF
--- a/src/libsync/owncloudtheme.cpp
+++ b/src/libsync/owncloudtheme.cpp
@@ -19,8 +19,6 @@
 #ifndef TOKEN_AUTH_ONLY
 #include <QPixmap>
 #include <QIcon>
-#include <QStyle>
-#include <QApplication>
 #endif
 #include <QCoreApplication>
 
@@ -35,62 +33,12 @@ ownCloudTheme::ownCloudTheme()
 {
 }
 
-QString ownCloudTheme::configFileName() const
-{
-    return QLatin1String("owncloud.cfg");
-}
-
-QString ownCloudTheme::about() const
-{
-    QString devString;
-    devString = tr("<p>Version %2. For more information visit <a href=\"%3\">https://%4</a></p>"
-                       "<p>For known issues and help, please visit: <a href=\"https://central.owncloud.org/c/desktop-client\">https://central.owncloud.org</a></p>"
-                       "<p><small>By Klaas Freitag, Daniel Molkentin, Olivier Goffart, Markus Götz, "
-                       " Jan-Christoph Borchardt, and others.</small></p>"
-                       "<p>Copyright ownCloud GmbH</p>"
-                       "<p>Licensed under the GNU General Public License (GPL) Version 2.0<br/>"
-                       "ownCloud and the ownCloud Logo are registered trademarks of ownCloud GmbH "
-                       "in the United States, other countries, or both.</p>")
-                    .arg(Utility::escape(MIRALL_VERSION_STRING),
-                        Utility::escape("https://" MIRALL_STRINGIFY(APPLICATION_DOMAIN)),
-                        Utility::escape(MIRALL_STRINGIFY(APPLICATION_DOMAIN)));
-
-    devString += gitSHA1();
-    return devString;
-}
-
 #ifndef TOKEN_AUTH_ONLY
-QIcon ownCloudTheme::trayFolderIcon(const QString &) const
+QVariant ownCloudTheme::customMedia(CustomMediaType)
 {
-    QPixmap fallback = qApp->style()->standardPixmap(QStyle::SP_FileDialogNewFolder);
-    return QIcon::fromTheme("folder", fallback);
+    return QVariant();
 }
-
-QIcon ownCloudTheme::applicationIcon() const
-{
-    return themeIcon(QLatin1String("owncloud-icon"));
-}
-
-
-QVariant ownCloudTheme::customMedia(Theme::CustomMediaType type)
-{
-    if (type == Theme::oCSetupTop) {
-        // return QCoreApplication::translate("ownCloudTheme",
-        //                                   "If you don't have an ownCloud server yet, "
-        //                                   "see <a href=\"https://owncloud.com\">owncloud.com</a> for more info.",
-        //                                   "Top text in setup wizard. Keep short!");
-        return QVariant();
-    } else {
-        return QVariant();
-    }
-}
-
 #endif
-
-QString ownCloudTheme::helpUrl() const
-{
-    return QString::fromLatin1("https://doc.owncloud.org/desktop/%1.%2/").arg(MIRALL_VERSION_MAJOR).arg(MIRALL_VERSION_MINOR);
-}
 
 #ifndef TOKEN_AUTH_ONLY
 QColor ownCloudTheme::wizardHeaderBackgroundColor() const
@@ -109,14 +57,4 @@ QPixmap ownCloudTheme::wizardHeaderLogo() const
 }
 
 #endif
-
-QString ownCloudTheme::appName() const
-{
-    return QLatin1String("ownCloud");
-}
-
-QString ownCloudTheme::appNameGUI() const
-{
-    return QLatin1String("ownCloud");
-}
 }

--- a/src/libsync/owncloudtheme.h
+++ b/src/libsync/owncloudtheme.h
@@ -28,18 +28,6 @@ class ownCloudTheme : public Theme
     Q_OBJECT
 public:
     ownCloudTheme();
-
-    QString configFileName() const Q_DECL_OVERRIDE;
-    QString about() const Q_DECL_OVERRIDE;
-
-#ifndef TOKEN_AUTH_ONLY
-    QIcon trayFolderIcon(const QString &) const Q_DECL_OVERRIDE;
-    QIcon applicationIcon() const Q_DECL_OVERRIDE;
-#endif
-    QString appName() const Q_DECL_OVERRIDE;
-    QString appNameGUI() const Q_DECL_OVERRIDE;
-
-    QString helpUrl() const Q_DECL_OVERRIDE;
 #ifndef TOKEN_AUTH_ONLY
     QVariant customMedia(CustomMediaType type) Q_DECL_OVERRIDE;
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -20,6 +20,8 @@
 #include <QtCore>
 #ifndef TOKEN_AUTH_ONLY
 #include <QtGui>
+#include <QStyle>
+#include <QApplication>
 #endif
 #include <QSslSocket>
 
@@ -105,12 +107,16 @@ QString Theme::version() const
     return MIRALL_VERSION_STRING;
 }
 
+QString Theme::configFileName() const
+{
+    return QStringLiteral(APPLICATION_EXECUTABLE ".cfg");
+}
+
 #ifndef TOKEN_AUTH_ONLY
 
-QIcon Theme::trayFolderIcon(const QString &backend) const
+QIcon Theme::applicationIcon() const
 {
-    Q_UNUSED(backend)
-    return applicationIcon();
+    return themeIcon(QStringLiteral(APPLICATION_ICON_NAME "-icon"));
 }
 
 /*
@@ -217,6 +223,11 @@ QString Theme::defaultServerFolder() const
     return QLatin1String("/");
 }
 
+QString Theme::helpUrl() const
+{
+    return QString::fromLatin1("https://doc.owncloud.org/desktop/%1.%2/").arg(MIRALL_VERSION_MAJOR).arg(MIRALL_VERSION_MINOR);
+}
+
 QString Theme::overrideServerUrl() const
 {
     return QString();
@@ -311,21 +322,21 @@ QString Theme::gitSHA1() const
 
 QString Theme::about() const
 {
-    QString re;
-    re = tr("<p>Version %1. For more information please visit <a href='%2'>%3</a>.</p>")
-             .arg(MIRALL_VERSION_STRING)
-             .arg("http://" MIRALL_STRINGIFY(APPLICATION_DOMAIN))
-             .arg(MIRALL_STRINGIFY(APPLICATION_DOMAIN));
+    QString devString;
+    devString = tr("<p>Version %2. For more information visit <a href=\"%3\">https://%4</a></p>"
+                       "<p>For known issues and help, please visit: <a href=\"https://central.owncloud.org/c/desktop-client\">https://central.owncloud.org</a></p>"
+                       "<p><small>By Klaas Freitag, Daniel Molkentin, Olivier Goffart, Markus Götz, "
+                       " Jan-Christoph Borchardt, and others.</small></p>"
+                       "<p>Copyright ownCloud GmbH</p>"
+                       "<p>Licensed under the GNU General Public License (GPL) Version 2.0<br/>"
+                       "ownCloud and the ownCloud Logo are registered trademarks of ownCloud GmbH "
+                       "in the United States, other countries, or both.</p>")
+                    .arg(Utility::escape(MIRALL_VERSION_STRING),
+                        Utility::escape("https://" MIRALL_STRINGIFY(APPLICATION_DOMAIN)),
+                        Utility::escape(MIRALL_STRINGIFY(APPLICATION_DOMAIN)));
 
-    re += tr("<p>Copyright ownCloud GmbH</p>");
-    re += tr("<p>Distributed by %1 and licensed under the GNU General Public License (GPL) Version 2.0.<br/>"
-             "%2 and the %2 logo are registered trademarks of %1 in the "
-             "United States, other countries, or both.</p>")
-              .arg(APPLICATION_VENDOR)
-              .arg(APPLICATION_NAME);
-
-    re += gitSHA1();
-    return re;
+    devString += gitSHA1();
+    return devString;
 }
 
 #ifndef TOKEN_AUTH_ONLY

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -84,15 +84,10 @@ public:
      * @brief configFileName
      * @return the name of the config file.
      */
-    virtual QString configFileName() const = 0;
+    virtual QString configFileName() const;
 
 #ifndef TOKEN_AUTH_ONLY
     static QString hidpiFileName(const QString &fileName, QPaintDevice *dev = 0);
-
-    /**
-      * the icon that is shown in the tray context menu left of the folder name
-      */
-    virtual QIcon trayFolderIcon(const QString &) const;
 
     /**
       * get an sync state icon
@@ -101,7 +96,7 @@ public:
 
     virtual QIcon folderDisabledIcon() const;
     virtual QIcon folderOfflineIcon(bool sysTray = false, bool sysTrayMenuVisible = false) const;
-    virtual QIcon applicationIcon() const = 0;
+    virtual QIcon applicationIcon() const;
 #endif
 
     virtual QString statusHeaderText(SyncResult::Status) const;
@@ -118,9 +113,11 @@ public:
     virtual bool multiAccount() const;
 
     /**
-    * URL to help file
+    * URL to documentation.
+    * This is opened in the browser when the "Help" action is selected from the tray menu.
+    * (If it is an empty stringn the action is removed from the menu. Defaults to ownCloud's help)
     */
-    virtual QString helpUrl() const { return QString(); }
+    virtual QString helpUrl() const;
 
     /**
      * Setting a value here will pre-define the server url.


### PR DESCRIPTION
The goal is to avoid confusion described in issue #6422 by removing
duplicates between the Theme and owncloudTheme.

 - Use the about from ownCloudTheme everywhere
 - Create default applicationIcons() and condifFileName() that should work
   everywhere
 - trayFolderIcon was removed as it is not used
 - the helpUrl from the default Theme now points to the owncloud client
   documentation. Before there was no help entry by default for branded
   client if the function was not overriden.
 - Do not merge functions that would otherwise break compatibility with
   theme that did not override them. For example colors or customMedia.