### PR TITLE
Folders: Use "Problem" icon for unresolved conflicts

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -245,9 +245,15 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
                 } else if (status == SyncResult::Undefined) {
                     return theme->syncStateIcon(SyncResult::SyncRunning);
                 } else {
-                    // keep the previous icon for the prepare phase.
-                    if (status == SyncResult::Problem) {
-                        return theme->syncStateIcon(SyncResult::Success);
+                    // The "Problem" *result* just means some files weren't
+                    // synced, so we show "Success" in these cases. But we
+                    // do use the "Problem" *icon* for unresolved conflicts.
+                    if (status == SyncResult::Success || status == SyncResult::Problem) {
+                        if (f->syncResult().hasUnresolvedConflicts()) {
+                            return theme->syncStateIcon(SyncResult::Problem);
+                        } else {
+                            return theme->syncStateIcon(SyncResult::Success);
+                        }
                     } else {
                         return theme->syncStateIcon(status);
                     }


### PR DESCRIPTION
For  #6277

@ogoffart Would you mind if I went in and refactored our icon usage to not depend on "SyncResult"? I think the icon enum should be separate from the sync result enum.