### PR TITLE
Add simple persistent logging option

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -373,13 +373,17 @@ void Application::slotownCloudWizardDone(int res)
 void Application::setupLogging()
 {
     // might be called from second instance
-    Logger::instance()->setLogFile(_logFile);
-    Logger::instance()->setLogDir(_logDir);
-    Logger::instance()->setLogExpire(_logExpire);
-    Logger::instance()->setLogFlush(_logFlush);
-    Logger::instance()->setLogDebug(_logDebug);
+    auto logger = Logger::instance();
+    logger->setLogFile(_logFile);
+    logger->setLogDir(_logDir);
+    logger->setLogExpire(_logExpire);
+    logger->setLogFlush(_logFlush);
+    logger->setLogDebug(_logDebug);
+    if (!logger->isLoggingToFile() && ConfigFile().automaticLogDir()) {
+        logger->setupTemporaryFolderLogDir();
+    }
 
-    Logger::instance()->enterNextLogFile();
+    logger->enterNextLogFile();
 
     qCInfo(lcApplication) << QString::fromLatin1("################## %1 locale:[%2] ui_lang:[%3] version:[%4] os:[%5]").arg(_theme->appName()).arg(QLocale::system().name()).arg(property("ui_lang").toString()).arg(_theme->version()).arg(Utility::platformName());
 }

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -96,6 +96,20 @@ LogBrowser::LogBrowser(QWidget *parent)
 
     mainLayout->addWidget(btnbox);
 
+    // button to permanently save logs
+    _permanentLogging = new QCheckBox;
+    _permanentLogging->setText(tr("Permanently save logs"));
+    _permanentLogging->setToolTip(
+        tr("When this option is enabled and no other logging is configured, "
+           "logs will be written to a temporary folder and expire after a few hours. "
+           "This setting persists across client restarts.\n"
+           "\n"
+           "Logs will be written to %1")
+            .arg(Logger::instance()->temporaryFolderLogDirPath()));
+    _permanentLogging->setChecked(ConfigFile().automaticLogDir());
+    btnbox->addButton(_permanentLogging, QDialogButtonBox::ActionRole);
+    connect(_permanentLogging, &QCheckBox::toggled, this, &LogBrowser::togglePermanentLogging);
+
     // clear button
     _clearBtn = new QPushButton;
     _clearBtn->setText(tr("Clear"));
@@ -214,6 +228,20 @@ void LogBrowser::slotSave()
 void LogBrowser::slotClearLog()
 {
     _logWidget->clear();
+}
+
+void LogBrowser::togglePermanentLogging(bool enabled)
+{
+    ConfigFile().setAutomaticLogDir(enabled);
+
+    auto logger = Logger::instance();
+    if (enabled) {
+        if (!logger->isLoggingToFile()) {
+            logger->setupTemporaryFolderLogDir();
+        }
+    } else {
+        logger->disableTemporaryFolderLogDir();
+    }
 }
 
 } // namespace

--- a/src/gui/logbrowser.h
+++ b/src/gui/logbrowser.h
@@ -66,11 +66,13 @@ protected slots:
     void search(const QString &);
     void slotSave();
     void slotClearLog();
+    void togglePermanentLogging(bool enabled);
 
 private:
     LogWidget *_logWidget;
     QLineEdit *_findTermEdit;
     QCheckBox *_logDebugCheckBox;
+    QCheckBox *_permanentLogging;
     QPushButton *_saveBtn;
     QPushButton *_clearBtn;
     QLabel *_statusLabel;

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -165,7 +165,10 @@ void ownCloudGui::slotSyncStateChange(Folder *folder)
 
     qCInfo(lcApplication) << "Sync state changed for folder " << folder->remoteUrl().toString() << ": " << result.statusString();
 
-    if (result.status() == SyncResult::Success || result.status() == SyncResult::Error) {
+    if (result.status() == SyncResult::Success
+        || result.status() == SyncResult::Problem
+        || result.status() == SyncResult::SyncAbortRequested
+        || result.status() == SyncResult::Error) {
         Logger::instance()->enterNextLogFile();
     }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -64,6 +64,7 @@ static const char chunkSizeC[] = "chunkSize";
 static const char minChunkSizeC[] = "minChunkSize";
 static const char maxChunkSizeC[] = "maxChunkSize";
 static const char targetChunkUploadDurationC[] = "targetChunkUploadDuration";
+static const char automaticLogDirC[] = "logToTemporaryLogDir";
 
 static const char proxyHostC[] = "Proxy/host";
 static const char proxyTypeC[] = "Proxy/type";
@@ -734,6 +735,18 @@ void ConfigFile::setCrashReporter(bool enabled)
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(QLatin1String(crashReporterC), enabled);
+}
+
+bool ConfigFile::automaticLogDir() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(QLatin1String(automaticLogDirC), false).toBool();
+}
+
+void ConfigFile::setAutomaticLogDir(bool enabled)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(QLatin1String(automaticLogDirC), enabled);
 }
 
 QString ConfigFile::certificatePath() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -89,6 +89,9 @@ public:
     bool crashReporter() const;
     void setCrashReporter(bool enabled);
 
+    bool automaticLogDir() const;
+    void setAutomaticLogDir(bool enabled);
+
     // proxy settings
     void setProxyType(int proxyType,
         const QString &host = QString(),

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -43,6 +43,8 @@ class OWNCLOUDSYNC_EXPORT Logger : public QObject
     Q_OBJECT
 public:
     bool isNoop() const;
+    bool isLoggingToFile() const;
+
     void log(Log log);
     void doLog(const QString &log);
 
@@ -65,6 +67,22 @@ public:
     bool logDebug() const { return _logDebug; }
     void setLogDebug(bool debug);
 
+    /** Returns where the automatic logdir would be */
+    QString temporaryFolderLogDirPath() const;
+
+    /** Sets up default dir log setup.
+     *
+     * logdir: a temporary folder
+     * logexpire: 4 hours
+     * logdebug: true
+     *
+     * Used in conjunction with ConfigFile::automaticLogDir
+     */
+    void setupTemporaryFolderLogDir();
+
+    /** For switching off via logwindow */
+    void disableTemporaryFolderLogDir();
+
 signals:
     void logWindowLog(const QString &);
 
@@ -86,8 +104,9 @@ private:
     int _logExpire;
     bool _logDebug;
     QScopedPointer<QTextStream> _logstream;
-    QMutex _mutex;
+    mutable QMutex _mutex;
     QString _logDirectory;
+    bool _temporaryFolderLogDir = false;
 };
 
 } // namespace OCC


### PR DESCRIPTION
For #6442 

When the checkbox in the logwindow is enabled and no explicit --logfile etc. are passed, we'll log to a dir in `/tmp` by default, with one log per sync run, compressed on switch and expired after four hours.

There was a bunch of talk around logging while discussing feedback from @moscicki - and while we may add more elaborate schemes this was simple to get ready in time for 2.5. My hope is that this can allow power users (@sagamusix ?) to just leave logging on all the time - and then we end up with logs even for the weird and intermittent problems.

Also, when we ask reporters for logs, we no longer have to explain `--logfile` and `--logdebug` -- just "F12 and enable this check box, find logs here, beware that logs have personal data".

@SamuAlfageme @guruz 