### PR TITLE
Logging: Avoid the word "Error"

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -27,6 +27,7 @@
 #include <QMutex>
 #include <QCoreApplication>
 #include <QAuthenticator>
+#include <QMetaEnum>
 
 #include "networkjobs.h"
 #include "account.h"
@@ -308,6 +309,15 @@ void AbstractNetworkJob::onTimedOut()
     }
 }
 
+QString AbstractNetworkJob::replyStatusString() {
+    Q_ASSERT(reply());
+    if (reply()->error() == QNetworkReply::NoError) {
+        return QLatin1String("OK");
+    } else {
+        QString enumStr = QMetaEnum::fromType<QNetworkReply::NetworkError>().valueToKey(static_cast<int>(reply()->error()));
+        return QStringLiteral("%1 %2").arg(enumStr, errorString());
+    }
+}
 
 NetworkJobTimeoutPauser::NetworkJobTimeoutPauser(QNetworkReply *reply)
 {

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -173,6 +173,8 @@ protected:
     // GET requests that don't set up any HTTP body or other flags.
     bool _followRedirects;
 
+    QString replyStatusString();
+
 private slots:
     void slotFinished();
     void slotTimeout();

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -90,8 +90,7 @@ void RequestEtagJob::start()
 bool RequestEtagJob::finished()
 {
     qCInfo(lcEtagJob) << "Request Etag of" << reply()->request().url() << "FINISHED WITH STATUS"
-                      << reply()->error()
-                      << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                      <<  replyStatusString();
 
     if (reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute) == 207) {
         // Parse DAV response
@@ -148,8 +147,7 @@ void MkColJob::start()
 bool MkColJob::finished()
 {
     qCInfo(lcMkColJob) << "MKCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
-                       << reply()->error()
-                       << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                       << replyStatusString();
 
     emit finished(reply()->error());
     return true;
@@ -355,8 +353,7 @@ void LsColJob::start()
 bool LsColJob::finished()
 {
     qCInfo(lcLsColJob) << "LSCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
-                       << reply()->error()
-                       << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                       << replyStatusString();
 
     QString contentType = reply()->header(QNetworkRequest::ContentTypeHeader).toString();
     int httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
@@ -581,8 +578,7 @@ QList<QByteArray> PropfindJob::properties() const
 bool PropfindJob::finished()
 {
     qCInfo(lcPropfindJob) << "PROPFIND of" << reply()->request().url() << "FINISHED WITH STATUS"
-                          << reply()->error()
-                          << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                          << replyStatusString();
 
     int http_result_code = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
@@ -743,8 +739,7 @@ QMap<QByteArray, QByteArray> ProppatchJob::properties() const
 bool ProppatchJob::finished()
 {
     qCInfo(lcProppatchJob) << "PROPPATCH of" << reply()->request().url() << "FINISHED WITH STATUS"
-                           << reply()->error()
-                           << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                           << replyStatusString();
 
     int http_result_code = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
@@ -803,8 +798,7 @@ void JsonApiJob::start()
 bool JsonApiJob::finished()
 {
     qCInfo(lcJsonApiJob) << "JsonApiJob of" << reply()->request().url() << "FINISHED WITH STATUS"
-                         << reply()->error()
-                         << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                         << replyStatusString();
 
     int statusCode = 0;
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -311,8 +311,7 @@ void GETFileJob::slotReadyRead()
         }
         if (!_hasEmittedFinishedSignal) {
             qCInfo(lcGetJob) << "GET of" << reply()->request().url().toString() << "FINISHED WITH STATUS"
-                             << reply()->error()
-                             << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString())
+                             << replyStatusString()
                              << reply()->rawHeader("Content-Range") << reply()->rawHeader("Content-Length");
 
             emit finishedSignal();

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -53,8 +53,7 @@ void DeleteJob::start()
 bool DeleteJob::finished()
 {
     qCInfo(lcDeleteJob) << "DELETE of" << reply()->request().url() << "FINISHED WITH STATUS"
-                        << reply()->error()
-                        << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                       << replyStatusString();
 
     emit finishedSignal();
     return true;

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -67,8 +67,7 @@ void MoveJob::start()
 bool MoveJob::finished()
 {
     qCInfo(lcMoveJob) << "MOVE of" << reply()->request().url() << "FINISHED WITH STATUS"
-                      << reply()->error()
-                      << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString());
+                      << replyStatusString();
 
     emit finishedSignal();
     return true;

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -120,8 +120,7 @@ public:
     virtual bool finished() Q_DECL_OVERRIDE
     {
         qCInfo(lcPutJob) << "PUT of" << reply()->request().url().toString() << "FINISHED WITH STATUS"
-                         << reply()->error()
-                         << (reply()->error() == QNetworkReply::NoError ? QLatin1String("") : errorString())
+                         << replyStatusString()
                          << reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute)
                          << reply()->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
 


### PR DESCRIPTION
The old code printed "QNetworkReply::NoError"