### PR TITLE
Wizard: Move the 'Skip folder configuration' in a radio button

### DIFF
--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -67,7 +67,6 @@ private slots:
     void slotRemoteFolderExists(QNetworkReply *);
     void slotCreateRemoteFolderFinished(QNetworkReply::NetworkError);
     void slotAssistantFinished(int);
-    void slotSkipFolderConfiguration();
 
 private:
     explicit OwncloudSetupWizard(QObject *parent = 0);

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -62,6 +62,7 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage()
     connect(_ui.rSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
     connect(_ui.rPlaceholderSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotPlaceholderSyncClicked);
     connect(_ui.bSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
+    connect(_ui.rManualFolder, &QAbstractButton::clicked, this, [this] { setRadioChecked(_ui.rManualFolder); });
 
     QIcon appIcon = theme->applicationIcon();
     _ui.lServerIcon->setText(QString());
@@ -235,6 +236,11 @@ QStringList OwncloudAdvancedSetupPage::selectiveSyncBlacklist() const
 bool OwncloudAdvancedSetupPage::usePlaceholderSync() const
 {
     return _ui.rPlaceholderSync->isChecked();
+}
+
+bool OwncloudAdvancedSetupPage::manualFolderConfig() const
+{
+    return _ui.rManualFolder->isChecked();
 }
 
 bool OwncloudAdvancedSetupPage::isConfirmBigFolderChecked() const

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -42,6 +42,7 @@ public:
     QString localFolder() const;
     QStringList selectiveSyncBlacklist() const;
     bool usePlaceholderSync() const;
+    bool manualFolderConfig() const;
     bool isConfirmBigFolderChecked() const;
     void setRemoteFolder(const QString &remoteFolder);
     void setMultipleFoldersExist(bool exist);

--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>912</width>
-    <height>633</height>
+    <height>635</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -240,7 +240,7 @@
           <item>
            <widget class="QRadioButton" name="rSyncEverything">
             <property name="text">
-             <string>S&amp;ync everything from server</string>
+             <string>S&amp;ynchronize everything from server</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -383,6 +383,42 @@
         <item>
          <layout class="QHBoxLayout" name="lPlaceholderSync">
           <item>
+           <widget class="QRadioButton" name="rManualFolder">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this option is selected, the wizard will close without synchronizing anything. You can use the &amp;quot;Add Folder Sync Connection&amp;quot; button from the account settings to choose which pair of local and remote folder you wish to synchronize&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this option is selected, the wizard will close without synchronizing anything. You can use the &amp;quot;Add Folder Sync Connection&amp;quot; button from the account settings to choose which pair of local and remote folder you wish to synchronize&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Manually create folder sync connections </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
            <widget class="QRadioButton" name="rPlaceholderSync">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -391,7 +427,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Create placeholders instead of downloading files (experimental)</string>
+             <string>Create placeholders instead of downloading files (e&amp;xperimental)</string>
             </property>
             <property name="checkable">
              <bool>false</bool>
@@ -399,7 +435,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_5">
+           <spacer name="horizontalSpacer_6">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -456,6 +492,19 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>rSyncEverything</tabstop>
+  <tabstop>confCheckBoxSize</tabstop>
+  <tabstop>confSpinBox</tabstop>
+  <tabstop>confCheckBoxExternal</tabstop>
+  <tabstop>rSelectiveSync</tabstop>
+  <tabstop>bSelectiveSync</tabstop>
+  <tabstop>rManualFolder</tabstop>
+  <tabstop>rPlaceholderSync</tabstop>
+  <tabstop>pbSelectLocalFolder</tabstop>
+  <tabstop>radioButton</tabstop>
+  <tabstop>cbSyncFromScratch</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -485,8 +534,8 @@
      <y>83</y>
     </hint>
     <hint type="destinationlabel">
-     <x>952</x>
-     <y>134</y>
+     <x>864</x>
+     <y>147</y>
     </hint>
    </hints>
   </connection>
@@ -501,8 +550,8 @@
      <y>76</y>
     </hint>
     <hint type="destinationlabel">
-     <x>1076</x>
-     <y>136</y>
+     <x>902</x>
+     <y>147</y>
     </hint>
    </hints>
   </connection>
@@ -519,6 +568,70 @@
     <hint type="destinationlabel">
      <x>382</x>
      <y>174</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rManualFolder</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>pbSelectLocalFolder</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>197</x>
+     <y>269</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>219</x>
+     <y>404</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rManualFolder</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>resolutionWidget</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>260</x>
+     <y>266</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>443</x>
+     <y>437</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rManualFolder</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lLocal</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>163</x>
+     <y>267</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>88</x>
+     <y>438</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rManualFolder</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>lLocalIcon</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>551</x>
+     <y>262</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>54</x>
+     <y>400</y>
     </hint>
    </hints>
   </connection>

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -79,7 +79,6 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
 #endif
     connect(_advancedSetupPage, &OwncloudAdvancedSetupPage::createLocalAndRemoteFolders,
         this, &OwncloudWizard::createLocalAndRemoteFolders);
-    connect(this, &QWizard::customButtonClicked, this, &OwncloudWizard::skipFolderConfiguration);
 
 
     Theme *theme = Theme::instance();
@@ -92,7 +91,6 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     setOption(QWizard::NoCancelButton);
     setTitleFormat(Qt::RichText);
     setSubTitleFormat(Qt::RichText);
-    setButtonText(QWizard::CustomButton1, tr("Skip folders configuration"));
 }
 
 void OwncloudWizard::setAccount(AccountPtr account)
@@ -118,6 +116,11 @@ QStringList OwncloudWizard::selectiveSyncBlacklist() const
 bool OwncloudWizard::usePlaceholderSync() const
 {
     return _advancedSetupPage->usePlaceholderSync();
+}
+
+bool OwncloudWizard::manualFolderConfig() const
+{
+    return _advancedSetupPage->manualFolderConfig();
 }
 
 bool OwncloudWizard::isConfirmBigFolderChecked() const
@@ -207,7 +210,6 @@ void OwncloudWizard::slotCurrentPageChanged(int id)
         done(Accepted);
     }
 
-    setOption(QWizard::HaveCustomButton1, id == WizardCommon::Page_AdvancedSetup);
     if (id == WizardCommon::Page_AdvancedSetup && _credentialsPage == _browserCredsPage) {
         // For OAuth, disable the back button in the Page_AdvancedSetup because we don't want
         // to re-open the browser.

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -64,6 +64,7 @@ public:
     QString localFolder() const;
     QStringList selectiveSyncBlacklist() const;
     bool usePlaceholderSync() const;
+    bool manualFolderConfig() const;
     bool isConfirmBigFolderChecked() const;
 
     void enableFinishOnResultWidget(bool enable);
@@ -97,7 +98,6 @@ signals:
     void createLocalAndRemoteFolders(const QString &, const QString &);
     // make sure to connect to this, rather than finished(int)!!
     void basicSetupFinished(int);
-    void skipFolderConfiguration();
     void needCertificate();
 
 private:


### PR DESCRIPTION
Issue #3664

The goal is to make it more visible than the button.
An alternative would have been to simply rename the button to "Manual folder configuration", but I feel a radio button works better.

Here is how it looks:
![screenshot_20180419_141805](https://user-images.githubusercontent.com/959326/38990999-850e1944-43dc-11e8-85bd-6072242cbe43.png)

cc/ @michaelstingl 
