### PR TITLE
ShareDialog: macOS grey odditiy #5774

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -115,6 +115,7 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
         label->setWordWrap(true);
         label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         layout()->replaceWidget(_ui->shareWidgets, label);
+        _ui->shareWidgets->hide();
         return;
     }
 


### PR DESCRIPTION
Maybe @ogoffart knows why this would be needed at all?
(And only on macOS)

@ckamm how is it on Linux?
@SamuAlfageme might need to check Windows