### PR TITLE
Nautilus: Fix Python3 and remove many debug

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -98,19 +98,16 @@ class SocketConnect(GObject.GObject):
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock_file = os.path.join(get_runtime_dir(), appname, "socket")
             try:
-                print("Socket File: " + sock_file)
                 self._sock.connect(sock_file) # fails if sock_file doesn't exist
                 self.connected = True
-                print("Setting connected to %r." % self.connected )
                 self._watch_id = GObject.io_add_watch(self._sock, GObject.IO_IN, self._handle_notify)
-                print("Socket watch id: " + str(self._watch_id))
 
                 self.sendCommand('VERSION:\n')
                 self.sendCommand('GET_STRINGS:\n')
 
                 return False  # Don't run again
             except Exception as e:
-                print("Could not connect to unix socket. " + str(e))
+                print("Could not connect to unix socket " + sock_file + ". " + str(e))
         except Exception as e:  # Bad habbit
             print("Connect could not be established, try again later.")
             self._sock.close()
@@ -133,7 +130,7 @@ class SocketConnect(GObject.GObject):
 
     # Parses response lines out of collected data, returns list of strings
     def get_available_responses(self):
-        end = self._remainder.rfind('\n')
+        end = self._remainder.rfind(b'\n')
         if end == -1:
             return []
         data = self._remainder[:end]
@@ -154,7 +151,7 @@ class SocketConnect(GObject.GObject):
         return True  # Run again
 
     def handle_server_response(self, line):
-        print("Server response: " + line)
+        # print("Server response: " + line)
         parts = line.split(':')
         action = parts[0]
         args = parts[1:]
@@ -344,7 +341,7 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
 
 
     def context_menu_action(self, menu, action, filename):
-        print("Context menu: " + action + ' ' + filename)
+        # print("Context menu: " + action + ' ' + filename)
         socketConnect.sendCommand(action + ":" + filename + "\n")
 
 


### PR DESCRIPTION
Use b'\n' in the call to rfind, as the _remainder is bytes, not a string.

Remove most of the debug message which happens during normal operation.
They are mostly spamming the nautilus console, and can also cause bug
as they may throw exception in case of wrong encoding.

Issue: #6406 