### PR TITLE
Settings: Add update channel combobox

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -139,7 +139,7 @@ IF( APPLE )
     if(SPARKLE_FOUND)
        # Define this, we need to check in updater.cpp
        add_definitions( -DHAVE_SPARKLE )
-       list(APPEND updater_SRCS updater/sparkleupdater_mac.mm)
+       list(APPEND updater_SRCS updater/sparkleupdater_mac.mm updater/sparkleupdater.h)
    endif()
 ENDIF()
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -130,7 +130,7 @@ void GeneralSettings::loadMiscSettings()
 
 void GeneralSettings::slotUpdateInfo()
 {
-    if (ConfigFile().skipUpdateCheck()) {
+    if (ConfigFile().skipUpdateCheck() || !Updater::instance()) {
         // updater disabled on compile
         _ui->updatesGroupBox->setVisible(false);
         return;
@@ -146,23 +146,18 @@ void GeneralSettings::slotUpdateInfo()
         _ui->updateStateLabel->setText(ocupdater->statusString());
         _ui->restartButton->setVisible(ocupdater->downloadState() == OCUpdater::DownloadComplete);
 
-        // Channel selection
-        _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == "beta" ? 1 : 0);
-        connect(_ui->updateChannel, &QComboBox::currentTextChanged,
-            this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
     }
 #ifdef Q_OS_MAC
     else if (SparkleUpdater *sparkleUpdater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
         _ui->updateStateLabel->setText(sparkleUpdater->statusString());
         _ui->restartButton->setVisible(false);
-
-        // Channel selection
-        _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == "beta" ? 1 : 0);
-        connect(_ui->updateChannel, &QComboBox::currentTextChanged,
-            this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
     }
 #endif
 
+    // Channel selection
+    _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == "beta" ? 1 : 0);
+    connect(_ui->updateChannel, &QComboBox::currentTextChanged,
+        this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
 }
 
 void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
@@ -172,6 +167,12 @@ void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
         updater->setUpdateUrl(Updater::updateUrl());
         updater->checkForUpdate();
     }
+#ifdef Q_OS_MAC
+    else if (SparkleUpdater *updater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
+        updater->setUpdateUrl(Updater::updateUrl());
+        updater->checkForUpdate();
+    }
+#endif
 }
 
 void GeneralSettings::saveMiscSettings()

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -36,6 +36,7 @@
 #include <QNetworkProxy>
 #include <QDir>
 #include <QScopedValueRollback>
+#include <QMessageBox>
 
 namespace OCC {
 
@@ -162,17 +163,46 @@ void GeneralSettings::slotUpdateInfo()
 
 void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
 {
-    ConfigFile().setUpdateChannel(channel);
-    if (OCUpdater *updater = qobject_cast<OCUpdater *>(Updater::instance())) {
-        updater->setUpdateUrl(Updater::updateUrl());
-        updater->checkForUpdate();
-    }
+    if (channel == ConfigFile().updateChannel())
+        return;
+
+    auto msgBox = new QMessageBox(
+        QMessageBox::Warning,
+        tr("Change update channel?"),
+        tr("The update channel determines which client updates will be offered "
+           "for installation. The \"stable\" channel contains only upgrades that "
+           "are considered reliable, while the versions in the \"beta\" channel "
+           "may contain newer features and bugfixes, but have not yet been tested "
+           "thoroughly."
+           "\n\n"
+           "Note that this selects only what pool upgrades are taken from, and that "
+           "there are no downgrades: So going back from the beta channel to "
+           "the stable channel usually cannot be done immediately and means waiting "
+           "for a stable version that is newer than the currently installed beta "
+           "version."),
+        QMessageBox::NoButton,
+        this);
+    msgBox->addButton(tr("Change update channel"), QMessageBox::AcceptRole);
+    msgBox->addButton(tr("Cancel"), QMessageBox::RejectRole);
+    connect(msgBox, &QMessageBox::finished, msgBox, [this, channel, msgBox](int result) {
+        msgBox->deleteLater();
+        if (result == QMessageBox::AcceptRole) {
+            ConfigFile().setUpdateChannel(channel);
+            if (OCUpdater *updater = qobject_cast<OCUpdater *>(Updater::instance())) {
+                updater->setUpdateUrl(Updater::updateUrl());
+                updater->checkForUpdate();
+            }
 #ifdef Q_OS_MAC
-    else if (SparkleUpdater *updater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
-        updater->setUpdateUrl(Updater::updateUrl());
-        updater->checkForUpdate();
-    }
+            else if (SparkleUpdater *updater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
+                updater->setUpdateUrl(Updater::updateUrl());
+                updater->checkForUpdate();
+            }
 #endif
+        } else {
+            _ui->updateChannel->setCurrentText(ConfigFile().updateChannel());
+        }
+    });
+    msgBox->open();
 }
 
 void GeneralSettings::saveMiscSettings()

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -138,9 +138,24 @@ void GeneralSettings::slotUpdateInfo()
         connect(_ui->restartButton, &QAbstractButton::clicked, qApp, &QApplication::quit, Qt::UniqueConnection);
         _ui->updateStateLabel->setText(updater->statusString());
         _ui->restartButton->setVisible(updater->downloadState() == OCUpdater::DownloadComplete);
+
+        // Channel selection
+        _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == "beta" ? 1 : 0);
+        connect(_ui->updateChannel, &QComboBox::currentTextChanged,
+            this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
+
     } else {
         // can't have those infos from sparkle currently
         _ui->updatesGroupBox->setVisible(false);
+    }
+}
+
+void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
+{
+    ConfigFile().setUpdateChannel(channel);
+    if (OCUpdater *updater = qobject_cast<OCUpdater *>(Updater::instance())) {
+        updater->setUpdateUrl(Updater::updateUrl());
+        updater->checkForUpdate();
     }
 }
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -45,6 +45,7 @@ private slots:
     void slotToggleOptionalDesktopNotifications(bool);
     void slotShowInExplorerNavigationPane(bool);
     void slotUpdateInfo();
+    void slotUpdateChannelChanged(const QString &channel);
     void slotIgnoreFilesEditor();
     void loadMiscSettings();
 

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>785</width>
-    <height>523</height>
+    <height>533</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -74,48 +74,88 @@
      <property name="title">
       <string>Updates</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="updateStateLabel">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="restartButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>&amp;Restart &amp;&amp; Update</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Preferred</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="updateChannelLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Channel</string>
+          </property>
+          <property name="buddy">
+           <cstring>updateChannel</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="updateChannel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>stable</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>beta</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="updateStateLabel">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="restartButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Restart &amp;&amp; Update</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -258,7 +298,10 @@
   <tabstop>ignoredFilesButton</tabstop>
   <tabstop>newFolderLimitCheckBox</tabstop>
   <tabstop>newFolderLimitSpinBox</tabstop>
+  <tabstop>newExternalStorage</tabstop>
+  <tabstop>showInExplorerNavigationPaneCheckBox</tabstop>
   <tabstop>crashreporterCheckBox</tabstop>
+  <tabstop>updateChannel</tabstop>
   <tabstop>restartButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -92,6 +92,11 @@ OCUpdater::OCUpdater(const QUrl &url)
 {
 }
 
+void OCUpdater::setUpdateUrl(const QUrl &url)
+{
+    _updateUrl = url;
+}
+
 bool OCUpdater::performUpdate()
 {
     ConfigFile cfg;

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -99,6 +99,8 @@ public:
         UpdateOnlyAvailableThroughSystem };
     explicit OCUpdater(const QUrl &url);
 
+    void setUpdateUrl(const QUrl &url);
+
     bool performUpdate();
 
     void checkForUpdate() Q_DECL_OVERRIDE;

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -23,6 +23,7 @@ namespace OCC {
 
 class SparkleUpdater : public Updater
 {
+    Q_OBJECT
 public:
     SparkleUpdater(const QString &appCastUrl);
     ~SparkleUpdater();
@@ -31,6 +32,8 @@ public:
     void checkForUpdate() Q_DECL_OVERRIDE;
     void backgroundCheckForUpdate() Q_DECL_OVERRIDE;
     bool handleStartup() Q_DECL_OVERRIDE { return false; }
+
+    QString statusString();
 
 private:
     class Private;

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -25,8 +25,10 @@ class SparkleUpdater : public Updater
 {
     Q_OBJECT
 public:
-    SparkleUpdater(const QString &appCastUrl);
+    SparkleUpdater(const QUrl &appCastUrl);
     ~SparkleUpdater();
+
+    void setUpdateUrl(const QUrl &url);
 
     // unused in this updater
     void checkForUpdate() Q_DECL_OVERRIDE;

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -83,7 +83,7 @@ class SparkleUpdater::Private
 };
 
 // Delete ~/Library//Preferences/com.owncloud.desktopclient.plist to re-test
-SparkleUpdater::SparkleUpdater(const QString& appCastUrl)
+SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     : Updater()
 {
     d = new Private;
@@ -99,9 +99,7 @@ SparkleUpdater::SparkleUpdater(const QString& appCastUrl)
     [d->updater resetUpdateCycle];
     [d->updater retain];
 
-    NSURL* url = [NSURL URLWithString:
-            [NSString stringWithUTF8String: appCastUrl.toUtf8().data()]];
-    [d->updater setFeedURL: url];
+    setUpdateUrl(appCastUrl);
 
     // Sparkle 1.8 required
     NSString *userAgent = [NSString stringWithUTF8String: Utility::userAgentString().data()];
@@ -112,6 +110,13 @@ SparkleUpdater::~SparkleUpdater()
 {
     [d->updater release];
     delete d;
+}
+
+void SparkleUpdater::setUpdateUrl(const QUrl &url)
+{
+    NSURL* nsurl = [NSURL URLWithString:
+            [NSString stringWithUTF8String: url.toString().toUtf8().data()]];
+    [d->updater setFeedURL: nsurl];
 }
 
 // FIXME: Should be changed to not instanicate the SparkleUpdater at all in this case

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -114,7 +114,7 @@ SparkleUpdater::~SparkleUpdater()
     delete d;
 }
 
-
+// FIXME: Should be changed to not instanicate the SparkleUpdater at all in this case
 bool autoUpdaterAllowed()
 {
     // See https://github.com/owncloud/client/issues/2931
@@ -141,6 +141,12 @@ void SparkleUpdater::backgroundCheckForUpdate()
     if (autoUpdaterAllowed()) {
         [d->updater checkForUpdatesInBackground];
     }
+}
+
+QString SparkleUpdater::statusString()
+{
+    // FIXME Show the real state depending on the callbacks
+    return QString();
 }
 
 } // namespace OCC

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -23,6 +23,7 @@
 #include "theme.h"
 #include "common/utility.h"
 #include "version.h"
+#include "configfile.h"
 
 #include "config.h"
 
@@ -38,6 +39,27 @@ Updater *Updater::instance()
         _instance = create();
     }
     return _instance;
+}
+
+QUrl Updater::updateUrl()
+{
+    QUrl updateBaseUrl(QString::fromLocal8Bit(qgetenv("OCC_UPDATE_URL")));
+    if (updateBaseUrl.isEmpty()) {
+        updateBaseUrl = QUrl(QLatin1String(APPLICATION_UPDATE_URL));
+    }
+    if (!updateBaseUrl.isValid() || updateBaseUrl.host() == ".") {
+        return QUrl();
+    }
+
+    auto urlQuery = getQueryParams();
+
+#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
+    urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
+#endif
+
+    updateBaseUrl.setQuery(urlQuery);
+
+    return updateBaseUrl;
 }
 
 QUrlQuery Updater::getQueryParams()
@@ -65,14 +87,10 @@ QUrlQuery Updater::getQueryParams()
 
     QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
     query.addQueryItem(QLatin1String("versionsuffix"), suffix);
-    if (suffix.startsWith("daily")
-            || suffix.startsWith("nightly")
-            || suffix.startsWith("alpha")
-            || suffix.startsWith("rc")
-            || suffix.startsWith("beta")) {
-        query.addQueryItem(QLatin1String("channel"), "beta");
-        // FIXME: Provide a checkbox in UI to enable regular versions to switch
-        // to beta channel
+
+    auto channel = ConfigFile().updateChannel();
+    if (channel != "stable") {
+        query.addQueryItem(QLatin1String("channel"), channel);
     }
 
     return query;
@@ -99,30 +117,19 @@ QString Updater::getSystemInfo()
 // To test, cmake with -DAPPLICATION_UPDATE_URL="http://127.0.0.1:8080/test.rss"
 Updater *Updater::create()
 {
-    QUrl updateBaseUrl(QString::fromLocal8Bit(qgetenv("OCC_UPDATE_URL")));
-    if (updateBaseUrl.isEmpty()) {
-        updateBaseUrl = QUrl(QLatin1String(APPLICATION_UPDATE_URL));
-    }
-    if (!updateBaseUrl.isValid() || updateBaseUrl.host() == ".") {
+    auto url = updateUrl();
+    if (url.isEmpty()) {
         qCWarning(lcUpdater) << "Not a valid updater URL, will not do update check";
         return 0;
     }
 
-    auto urlQuery = getQueryParams();
-
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
-#endif
-
-    updateBaseUrl.setQuery(urlQuery);
-
-#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    return new SparkleUpdater(updateBaseUrl.toString());
+    return new SparkleUpdater(url.toString());
 #elif defined(Q_OS_WIN32)
     // the best we can do is notify about updates
-    return new NSISUpdater(updateBaseUrl);
+    return new NSISUpdater(url);
 #else
-    return new PassiveUpdateNotifier(QUrl(updateBaseUrl));
+    return new PassiveUpdateNotifier(url);
 #endif
 }
 

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -124,7 +124,7 @@ Updater *Updater::create()
     }
 
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    return new SparkleUpdater(url.toString());
+    return new SparkleUpdater(url);
 #elif defined(Q_OS_WIN32)
     // the best we can do is notify about updates
     return new NSISUpdater(url);

--- a/src/gui/updater/updater.h
+++ b/src/gui/updater/updater.h
@@ -37,6 +37,7 @@ public:
     };
 
     static Updater *instance();
+    static QUrl updateUrl();
 
     virtual void checkForUpdate() = 0;
     virtual void backgroundCheckForUpdate() = 0;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -18,6 +18,7 @@
 #include "theme.h"
 #include "common/utility.h"
 #include "common/asserts.h"
+#include "version.h"
 
 #include "creds/abstractcredentials.h"
 
@@ -58,6 +59,7 @@ static const char optionalDesktopNoficationsC[] = "optionalDesktopNotifications"
 static const char showInExplorerNavigationPaneC[] = "showInExplorerNavigationPane";
 static const char skipUpdateCheckC[] = "skipUpdateCheck";
 static const char updateCheckIntervalC[] = "updateCheckInterval";
+static const char updateChannelC[] = "updateChannel";
 static const char geometryC[] = "geometry";
 static const char timeoutC[] = "timeout";
 static const char chunkSizeC[] = "chunkSize";
@@ -514,6 +516,28 @@ void ConfigFile::setSkipUpdateCheck(bool skip, const QString &connection)
 
     settings.setValue(QLatin1String(skipUpdateCheckC), QVariant(skip));
     settings.sync();
+}
+
+QString ConfigFile::updateChannel() const
+{
+    QString defaultUpdateChannel = QStringLiteral("stable");
+    QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
+    if (suffix.startsWith("daily")
+        || suffix.startsWith("nightly")
+        || suffix.startsWith("alpha")
+        || suffix.startsWith("rc")
+        || suffix.startsWith("beta")) {
+        defaultUpdateChannel = QStringLiteral("beta");
+    }
+
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(QLatin1String(updateChannelC), defaultUpdateChannel).toString();
+}
+
+void ConfigFile::setUpdateChannel(const QString &channel)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(QLatin1String(updateChannelC), channel);
 }
 
 int ConfigFile::maxLogLines() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -152,6 +152,9 @@ public:
     bool skipUpdateCheck(const QString &connection = QString()) const;
     void setSkipUpdateCheck(bool, const QString &);
 
+    QString updateChannel() const;
+    void setUpdateChannel(const QString &channel);
+
     void saveGeometryHeader(QHeaderView *header);
     void restoreGeometryHeader(QHeaderView *header);
 


### PR DESCRIPTION
Open questions / things this doesn't do:
- Should it ever be hidden when the "Updater" group is shown?
- As a user I'd expect that when I switch the release channel I'll be offered to download the newest version from that channel. I think this important and I'll look at it.

Intended for picking into 2.4 once merged.

For  #6259