### PR TITLE
Revert "Clean up the client docs removing old, outdated, content"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "doc/ocdoc"]
+	path = doc/ocdoc
+	url = https://github.com/owncloud/documentation
 [submodule "src/3rdparty/qtmacgoodies"]
 	path = src/3rdparty/qtmacgoodies
 	url = https://github.com/guruz/qtmacgoodies.git

--- a/doc/owncloud.1.rst
+++ b/doc/owncloud.1.rst
@@ -1,0 +1,34 @@
+:orphan:
+
+owncloud(1)
+-----------
+
+SYNOPSIS
+========
+*owncloud* [`OPTIONS`...]
+
+
+DESCRIPTION
+===========
+The ownCloud Client is a file synchronization desktop utility. It synchronizes files on your local computer, tablet, or handheld device with an ownCloud Server. If you make a change to the files on one device, the change is propagated to all other synchronized devices using the desktop synchronization clients.
+
+Normally, you start the client by clicking on the desktop icon or by starting it from the client application menu. After starting, an ownCloud icon appears in the computer system tray or on your tablet or handheld device.
+
+Options
+=======
+.. include:: options.rst
+
+Config File
+===========
+.. include:: conffile.rst
+
+BUGS
+====
+
+Please report bugs at https://github.com/owncloud/client/issues.
+
+
+SEE ALSO
+========
+:manpage:`owncloudcmd(1)`
+

--- a/doc/owncloudcmd.1.rst
+++ b/doc/owncloudcmd.1.rst
@@ -1,0 +1,98 @@
+:orphan:
+
+owncloudcmd(1)
+--------------
+
+SYNOPSIS
+========
+*owncloudcmd* [`OPTIONS`...] sourcedir owncloudurl
+
+DESCRIPTION
+===========
+owncloudcmd is the command line tool used for the ownCloud file synchronization
+desktop utility.
+
+Contrary to the :manpage:`owncloud(1)` GUI client, `owncloudcmd` only performs
+a single sync run and then exits. In so doing, `owncloudcmd` replaces the
+`ocsync` binary used for the same purpose in earlier releases.
+
+A *sync run* synchronizes a single local directory using a WebDAV share on a
+remote ownCloud server.
+
+To invoke the command line client, provide the local and the remote repository:
+The first parameter is the local directory. The second parameter is
+the server URL.
+
+.. note:: Prior to the 1.6 release of owncloudcmd, the tool only accepted
+   ``owncloud://`` or ``ownclouds://`` in place of ``http://`` and ``https://`` as
+   a scheme. See ``Examples`` for details.
+
+OPTIONS
+=======
+``--user``, ``-u`` ``[user]``
+       Use ``user`` as the login name.
+
+``--password``, ``-p`` ``[password]``
+       Use ``password`` as the password.
+
+``-n``
+       Use ``netrc (5)`` for login.
+
+``--non-interactive``
+       Do not prompt for questions.
+
+``--silent``, ``--s``
+       Inhibits verbose log output.
+
+``--trust``
+       Trust any SSL certificate, including invalid ones.
+
+``--httpproxy  http://[user@pass:]<server>:<port>``
+      Uses ``server`` as HTTP proxy.
+
+``--nonshib``
+      Uses Non Shibboleth WebDAV Authentication
+
+``--davpath [path]``
+      Overrides the WebDAV Path with ``path``
+
+``--exclude [file]``
+      Exclude list file
+
+``--unsyncedfolders [file]``
+      File containing the list of un-synced folders (selective sync)
+
+``--max-sync-retries [n]``
+      Retries maximum n times (defaults to 3)
+
+``-h``
+      Sync hidden files,do not ignore them
+
+Example
+=======
+To synchronize the ownCloud directory ``Music`` to the local directory ``media/music``
+through a proxy listening on port ``8080`` on the gateway machine ``192.168.178.1``,
+the command line would be::
+
+  $ owncloudcmd --httpproxy http://192.168.178.1:8080 \
+                $HOME/media/music \
+                https://server/owncloud/remote.php/webdav/Music
+
+``owncloudcmd`` will enquire user name and password, unless they have
+been specified on the command line or ``-n`` (see `netrc(5)`) has been passed.
+
+Using the legacy scheme, it would be::
+
+  $ owncloudcmd --httpproxy http://192.168.178.1:8080 \
+                $HOME/media/music \
+                ownclouds://server/owncloud/remote.php/webdav/Music
+
+
+BUGS
+====
+Please report bugs at https://github.com/owncloud/client/issues.
+
+SEE ALSO
+========
+:manpage:`owncloud(1)`
+


### PR DESCRIPTION
This reverts commit 3731eba9b60f430aa8d491d77a439219be09f81b. This commit was, I believe, mistakenly added, because of a misunderstanding of why the submodules are there and what they're for. As a result, the build of the docs broke. This commit reverts that previous mistake, hopefully, fixing themes and building the docs.