### PR TITLE
Integrate external themes repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/3rdparty/libcrashreporter-qt"]
 	path = src/3rdparty/libcrashreporter-qt
 	url = git://github.com/guruz/libcrashreporter-qt.git
+[submodule "doc/_shared_assets"]
+	path = doc/_shared_assets
+	url = git@github.com:owncloud/docs-themes.git

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,7 @@ import sys, os
 extensions = ['sphinx.ext.todo']
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['@CMAKE_CURRENT_SOURCE_DIR@/ocdoc/_shared_assets/templates']
+templates_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_shared_assets/templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -95,7 +95,7 @@ pygments_style = 'sphinx'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ['@CMAKE_CURRENT_SOURCE_DIR@/ocdoc/_shared_assets/themes']
+html_theme_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_shared_assets/themes']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -120,7 +120,7 @@ html_short_title = "Client Manual"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/ocdoc/_shared_assets/static']
+html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_shared_assets/static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
This PR integrates [the external themes repository](https://github.com/owncloud/docs-themes) to provide a simplified & consistent way of theming the documentation.

### Relates to

- owncloud/client#6163
- owncloud/client#6169
- #3240
- owncloud/client#6497