### PR TITLE
Placeholder and general backwards compatibility

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -52,11 +52,20 @@ AccountManager *AccountManager::instance()
 
 bool AccountManager::restore()
 {
+    QStringList skipSettingsKeys;
+    backwardMigrationSettingsKeys(&skipSettingsKeys, &skipSettingsKeys);
+
     auto settings = ConfigFile::settingsWithGroup(QLatin1String(accountsC));
     if (settings->status() != QSettings::NoError) {
         qCWarning(lcAccountManager) << "Could not read settings from" << settings->fileName()
                                     << settings->status();
         return false;
+    }
+
+    if (skipSettingsKeys.contains(settings->group())) {
+        // Should not happen: bad container keys should have been deleted
+        qCWarning(lcAccountManager) << "Accounts structure is too new, ignoring";
+        return true;
     }
 
     // If there are no accounts, check the old format.
@@ -68,11 +77,16 @@ bool AccountManager::restore()
 
     foreach (const auto &accountId, settings->childGroups()) {
         settings->beginGroup(accountId);
-        if (auto acc = loadAccountHelper(*settings)) {
-            acc->_id = accountId;
-            if (auto accState = AccountState::loadFromSettings(acc, *settings)) {
-                addAccountState(accState);
+        if (!skipSettingsKeys.contains(settings->group())) {
+            if (auto acc = loadAccountHelper(*settings)) {
+                acc->_id = accountId;
+                if (auto accState = AccountState::loadFromSettings(acc, *settings)) {
+                    addAccountState(accState);
+                }
             }
+        } else {
+            qCInfo(lcAccountManager) << "Account" << accountId << "is too new, ignoring";
+            _additionalBlockedAccountIds.insert(accountId);
         }
         settings->endGroup();
     }
@@ -80,25 +94,22 @@ bool AccountManager::restore()
     return true;
 }
 
-QStringList AccountManager::backwardMigrationKeys()
+void AccountManager::backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys)
 {
     auto settings = ConfigFile::settingsWithGroup(QLatin1String(accountsC));
-    QStringList badKeys;
-
     const int accountsVersion = settings->value(QLatin1String(versionC)).toInt();
     if (accountsVersion <= maxAccountsVersion) {
         foreach (const auto &accountId, settings->childGroups()) {
             settings->beginGroup(accountId);
             const int accountVersion = settings->value(QLatin1String(versionC), 1).toInt();
             if (accountVersion > maxAccountVersion) {
-                badKeys.append(settings->group());
+                ignoreKeys->append(settings->group());
             }
             settings->endGroup();
         }
     } else {
-        badKeys.append(settings->group());
+        deleteKeys->append(settings->group());
     }
-    return badKeys;
 }
 
 bool AccountManager::restoreFromLegacySettings()
@@ -366,6 +377,8 @@ bool AccountManager::isAccountIdAvailable(const QString &id) const
             return false;
         }
     }
+    if (_additionalBlockedAccountIds.contains(id))
+        return false;
     return true;
 }
 

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -81,7 +81,7 @@ public:
      * Returns the list of settings keys that can't be read because
      * they are from the future.
      */
-    static QStringList backwardMigrationKeys();
+    static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
 private:
     // saving and loading Account to settings
@@ -111,5 +111,7 @@ Q_SIGNALS:
 private:
     AccountManager() {}
     QList<AccountStatePtr> _accounts;
+    /// Account ids from settings that weren't read
+    QSet<QString> _additionalBlockedAccountIds;
 };
 }

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -77,6 +77,12 @@ public:
      */
     static AccountPtr createAccount();
 
+    /**
+     * Returns the list of settings keys that can't be read because
+     * they are from the future.
+     */
+    static QStringList backwardMigrationKeys();
+
 private:
     // saving and loading Account to settings
     void saveAccountHelper(Account *account, QSettings &settings, bool saveCredentials = true);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -100,6 +100,12 @@ protected slots:
 private:
     void setHelp();
 
+    /**
+     * Maybe a newer version of the client was used with this config file:
+     * if so, backup, confirm with user and remove the config that can't be read.
+     */
+    bool configBackwardMigration();
+
     QPointer<ownCloudGui> _gui;
 
     Theme *_theme;

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -104,7 +104,7 @@ private:
      * Maybe a newer version of the client was used with this config file:
      * if so, backup, confirm with user and remove the config that can't be read.
      */
-    bool configBackwardMigration();
+    bool configVersionMigration();
 
     QPointer<ownCloudGui> _gui;
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -42,6 +42,8 @@
 #include <QMessageBox>
 #include <QPushButton>
 
+static const char versionC[] = "version";
+
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcFolder, "gui.folder", QtInfoMsg)
@@ -561,6 +563,8 @@ void Folder::saveToSettings() const
     }
 
     settings->beginGroup(settingsGroup);
+    // Note: Each of these groups might have a "version" tag, but that's
+    //       currently unused.
     FolderDefinition::save(*settings, _definition);
 
     settings->sync();
@@ -1125,6 +1129,7 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     settings.setValue(QLatin1String("paused"), folder.paused);
     settings.setValue(QLatin1String("ignoreHiddenFiles"), folder.ignoreHiddenFiles);
     settings.setValue(QLatin1String("usePlaceholders"), folder.useVirtualFiles);
+    settings.setValue(QLatin1String(versionC), maxSettingsVersion());
 
     // Happens only on Windows when the explorer integration is enabled.
     if (!folder.navigationPaneClsid.isNull())

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -78,6 +78,9 @@ public:
     static bool load(QSettings &settings, const QString &alias,
         FolderDefinition *folder);
 
+    /// The highest version in the settings that load() can read
+    static int maxSettingsVersion() { return 1; }
+
     /// Ensure / as separator and trailing /.
     static QString prepareLocalPath(const QString &path);
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -72,7 +72,7 @@ public:
      * Returns a list of keys that can't be read because they are from
      * future versions.
      */
-    static QStringList backwardMigrationKeys();
+    static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
     OCC::Folder::Map map();
 
@@ -304,7 +304,7 @@ private:
     // restarts the application (Linux only)
     void restartApplication();
 
-    void setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool backwardsCompatible);
+    void setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool backwardsCompatible, const QStringList &ignoreKeys);
 
     QSet<Folder *> _disabledFolders;
     Folder::Map _folderMap;
@@ -312,6 +312,9 @@ private:
     Folder *_currentSyncFolder;
     QPointer<Folder> _lastSyncFolder;
     bool _syncEnabled;
+
+    /// Folder aliases from the settings that weren't read
+    QSet<QString> _additionalBlockedFolderAliases;
 
     /// Starts regular etag query jobs
     QTimer _etagPollTimer;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -68,6 +68,12 @@ public:
     int setupFolders();
     int setupFoldersMigration();
 
+    /**
+     * Returns a list of keys that can't be read because they are from
+     * future versions.
+     */
+    static QStringList backwardMigrationKeys();
+
     OCC::Folder::Map map();
 
     /** Adds a folder for an account, ensures the journal is gone and saves it in the settings.

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -16,6 +16,7 @@
 
 #include "configfile.h"
 #include "theme.h"
+#include "version.h"
 #include "common/utility.h"
 #include "common/asserts.h"
 #include "version.h"
@@ -68,6 +69,7 @@ static const char maxChunkSizeC[] = "maxChunkSize";
 static const char targetChunkUploadDurationC[] = "targetChunkUploadDuration";
 static const char automaticLogDirC[] = "logToTemporaryLogDir";
 static const char showExperimentalOptionsC[] = "showExperimentalOptions";
+static const char clientVersionC[] = "clientVersion";
 
 static const char proxyHostC[] = "Proxy/host";
 static const char proxyTypeC[] = "Proxy/type";
@@ -346,7 +348,14 @@ QString ConfigFile::excludeFileFromSystem()
 QString ConfigFile::backup() const
 {
     QString baseFile = configFile();
-    QString backupFile = QString("%1.backup_%2").arg(baseFile, QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"));
+    auto versionString = clientVersionString();
+    if (!versionString.isEmpty())
+        versionString.prepend('_');
+    QString backupFile =
+        QString("%1.backup_%2%3")
+            .arg(baseFile)
+            .arg(QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"))
+            .arg(versionString);
 
     // If this exact file already exists it's most likely that a backup was
     // already done. (two backup calls directly after each other, potentially
@@ -817,6 +826,18 @@ void ConfigFile::setCertificatePasswd(const QString &cPasswd)
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(QLatin1String(certPasswd), cPasswd);
     settings.sync();
+}
+
+QString ConfigFile::clientVersionString() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(QLatin1String(clientVersionC), QString()).toString();
+}
+
+void ConfigFile::setClientVersionString(const QString &version)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(QLatin1String(clientVersionC), version);
 }
 
 Q_GLOBAL_STATIC(QString, g_configFileName)

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -343,6 +343,21 @@ QString ConfigFile::excludeFileFromSystem()
     return fi.absoluteFilePath();
 }
 
+QString ConfigFile::backup() const
+{
+    QString baseFile = configFile();
+    QString backupFile = QString("%1.backup_%2").arg(baseFile, QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"));
+
+    // If this exact file already exists it's most likely that a backup was
+    // already done. (two backup calls directly after each other, potentially
+    // even with source alterations in between!)
+    if (!QFile::exists(backupFile)) {
+        QFile f(baseFile);
+        f.copy(backupFile);
+    }
+    return backupFile;
+}
+
 QString ConfigFile::configFile() const
 {
     return configPath() + Theme::instance()->configFileName();

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -48,6 +48,13 @@ public:
     QString excludeFile(Scope scope) const;
     static QString excludeFileFromSystem(); // doesn't access config dir
 
+    /**
+     * Creates a backup of the file
+     *
+     * Returns the path of the new backup.
+     */
+    QString backup() const;
+
     bool exists();
 
     QString defaultConnection() const;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -170,6 +170,11 @@ public:
     QString certificatePasswd() const;
     void setCertificatePasswd(const QString &cPasswd);
 
+    /** The client version that last used this settings file.
+        Updated by configVersionMigration() at client startup. */
+    QString clientVersionString() const;
+    void setClientVersionString(const QString &version);
+
     /**  Returns a new settings pre-set in a specific group.  The Settings will be created
          with the given parent. If no parent is specified, the caller must destroy the settings */
     static std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = 0);


### PR DESCRIPTION
For #6504 

* Store placeholder folders differently, so 2.4 clients don't see them at all
* Add mechanism to do backwards compatibility in a smarter way next time
* Remove silly "stub" body of placeholders

Open question:
* Remove the placeholder ignore pattern that was added for backwards compatibility but doesn't really work?

@SamuAlfageme 