### PR TITLE
Cleanup upload abort, fix job counting

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -619,32 +619,45 @@ void PropagateUploadFileCommon::finalize()
     done(SyncFileItem::Success);
 }
 
-void PropagateUploadFileCommon::prepareAbort(PropagatorJob::AbortType abortType) {
-    if (!_jobs.empty()) {
-        // Count number of jobs to be aborted asynchronously
-        _abortCount = _jobs.size();
-
-        foreach (AbstractNetworkJob *job, _jobs) {
-            // Check if async abort is requested
-            if (job->reply() && abortType == AbortType::Asynchronous) {
-                // Connect to finished signal of job reply
-                // to asynchonously finish the abort
-                connect(job->reply(), &QNetworkReply::finished, this, &PropagateUploadFileCommon::slotReplyAbortFinished);
-            }
-        }
-    } else if (abortType == AbortType::Asynchronous) {
-        // Empty job list, emit abortFinished immedietaly
-        emit abortFinished();
-    }
-}
-
-void PropagateUploadFileCommon::slotReplyAbortFinished()
+void PropagateUploadFileCommon::abortNetworkJobs(
+    PropagatorJob::AbortType abortType,
+    const std::function<bool(AbstractNetworkJob *)> &mayAbortJob)
 {
-    _abortCount--;
+    // Count the number of jobs that need aborting, and emit the overall
+    // abort signal when they're all done.
+    QSharedPointer<int> runningCount(new int(0));
+    auto oneAbortFinished = [this, runningCount]() {
+        (*runningCount)--;
+        if (*runningCount == 0) {
+            emit this->abortFinished();
+        }
+    };
 
-    if (_abortCount == 0) {
-        emit abortFinished();
+    // Abort all running jobs, except for explicitly excluded ones
+    foreach (AbstractNetworkJob *job, _jobs) {
+        auto reply = job->reply();
+        if (!reply || !reply->isRunning())
+            continue;
+
+        (*runningCount)++;
+
+        // If a job should not be aborted that means we'll never abort before
+        // the hard abort timeout signal comes as runningCount will never go to
+        // zero.
+        // We may however finish before that if the un-abortable job completes
+        // normally.
+        if (!mayAbortJob(job))
+            continue;
+
+        // Abort the job
+        if (abortType == AbortType::Asynchronous) {
+            // Connect to finished signal of job reply to asynchonously finish the abort
+            connect(reply, &QNetworkReply::finished, this, oneAbortFinished);
+        }
+        reply->abort();
     }
-}
 
+    if (*runningCount == 0 && abortType == AbortType::Asynchronous)
+        emit abortFinished();
+}
 }

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -550,19 +550,6 @@ void PropagateUploadFileCommon::slotJobDestroyed(QObject *job)
     _jobs.erase(std::remove(_jobs.begin(), _jobs.end(), job), _jobs.end());
 }
 
-void PropagateUploadFileCommon::abort(PropagatorJob::AbortType abortType)
-{
-    foreach (auto *job, _jobs) {
-        if (job->reply()) {
-            job->reply()->abort();
-        }
-    }
-
-    if (abortType == AbortType::Asynchronous) {
-        emit abortFinished();
-    }
-}
-
 // This function is used whenever there is an error occuring and jobs might be in progress
 void PropagateUploadFileCommon::abortWithError(SyncFileItem::Status status, const QString &error)
 {

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -248,7 +248,6 @@ public:
     void abortWithError(SyncFileItem::Status status, const QString &error);
 
 public slots:
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
     void slotJobDestroyed(QObject *job);
 
 private slots:

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -489,23 +489,11 @@ void PropagateUploadFileNG::slotUploadProgress(qint64 sent, qint64 total)
 
 void PropagateUploadFileNG::abort(PropagatorJob::AbortType abortType)
 {
-    // Prepare abort
-    prepareAbort(abortType);
-
-    // Abort all jobs (if there are any left), except final PUT
-    foreach (AbstractNetworkJob *job, _jobs) {
-        if (job->reply()) {
-            if (abortType == AbortType::Asynchronous && qobject_cast<MoveJob *>(job)){
-                // If it is async abort, dont abort
-                // MoveJob since it might result in conflict,
-                // only PUT and MKDIR jobs can be safely aborted.
-                continue;
-            }
-
-            // Abort the job
-            job->reply()->abort();
-        }
-    }
+    abortNetworkJobs(
+        abortType,
+        [this, abortType](AbstractNetworkJob *job) {
+            return abortType != AbortType::Asynchronous || !qobject_cast<MoveJob *>(job);
+        });
 }
 
 }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -349,28 +349,19 @@ void PropagateUploadFileV1::slotUploadProgress(qint64 sent, qint64 total)
 
 void PropagateUploadFileV1::abort(PropagatorJob::AbortType abortType)
 {
-    // Prepare abort
-    prepareAbort(abortType);
-
-    // Abort all jobs (if there are any left), except final PUT
-    foreach (AbstractNetworkJob *job, _jobs) {
-        if (job->reply()) {
-            // If asynchronous abort allowed,
-            // dont abort final PUT which uploaded its data,
-            // since this might result in conflicts
+    abortNetworkJobs(
+        abortType,
+        [this, abortType](AbstractNetworkJob *job) {
             if (PUTFileJob *putJob = qobject_cast<PUTFileJob *>(job)){
                 if (abortType == AbortType::Asynchronous
                     && _chunkCount > 0
                     && (((_currentChunk + _startChunk) % _chunkCount) == 0)
                     && putJob->device()->atEnd()) {
-                    continue;
+                    return false;
                 }
             }
-
-            // Abort the job
-            job->reply()->abort();
-        }
-    }
+            return true;
+        });
 }
 
 }

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -319,16 +319,11 @@ private slots:
 
         // Make the MOVE never reply, but trigger a client-abort and apply the change remotely
         auto parent = new QObject;
-        QByteArray moveChecksumHeader;
-        int nGET = 0;
         int responseDelay = 2000; // smaller than abort-wait timeout
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
             if (request.attribute(QNetworkRequest::CustomVerbAttribute) == "MOVE") {
                 QTimer::singleShot(50, parent, [&]() { fakeFolder.syncEngine().abort(); });
-                moveChecksumHeader = request.rawHeader("OC-Checksum");
                 return new DelayedReply<FakeChunkMoveReply>(responseDelay, fakeFolder.uploadState(), fakeFolder.remoteModifier(), op, request, parent);
-            } else if (op == QNetworkAccessManager::GetOperation) {
-                nGET++;
             }
             return nullptr;
         });


### PR DESCRIPTION
Relates to #6516 but doesn't fix the issue.

In general: Wouldn't it simplify things if we emitted `abortFinished()` unconditionally, possibly also had the signals connected unconditionally?