### PR TITLE
Credentials: Retry fetching from the keychain in case the keychain is still starting

### DIFF
--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -141,6 +141,7 @@ protected:
     QSslKey _clientSslKey;
     QSslCertificate _clientSslCertificate;
     bool _keychainMigration;
+    bool _retryOnKeyChainError = true; // true if we haven't done yet any reading from keychain
 };
 
 


### PR DESCRIPTION
When owncloud is restored, at boot time, it might be started before the
crendential manager. So if we detect an error, wait 10 seconds and hopefully
it'd be loaded by then.

Issues: #4274, #6522