### PR TITLE
SyncJournal: Check file existence even for open dbs #6049

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -272,6 +272,11 @@ bool SyncJournalDb::sqlFail(const QString &log, const SqlQuery &query)
 bool SyncJournalDb::checkConnect()
 {
     if (_db.isOpen()) {
+        if (!QFile::exists(_dbFile)) {
+            qCWarning(lcDb) << "Database open, but file file" + _dbFile + " does not exist";
+            close();
+            return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
With WAL mode sqlite seems to occasionally crash when the
underlying filesystem goes away.

Shall be picked to 2.4 afterwards.