### PR TITLE
Propagation: Connection closed is a normal error

### DIFF
--- a/src/libsync/owncloudpropagator_p.h
+++ b/src/libsync/owncloudpropagator_p.h
@@ -64,6 +64,12 @@ inline SyncFileItem::Status classifyError(QNetworkReply::NetworkError nerror,
 {
     Q_ASSERT(nerror != QNetworkReply::NoError); // we should only be called when there is an error
 
+    if (nerror == QNetworkReply::RemoteHostClosedError) {
+        // Sometimes server bugs lead to a connection close on certain files,
+        // that shouldn't bring the rest of the syncing to a halt.
+        return SyncFileItem::NormalError;
+    }
+
     if (nerror > QNetworkReply::NoError && nerror <= QNetworkReply::UnknownProxyError) {
         // network error or proxy error -> fatal
         return SyncFileItem::FatalError;


### PR DESCRIPTION
Because it sometimes appears in conjunction with server bugs and we
don't want to halt all syncing for other files in these cases.

See  #6516