### PR TITLE
Wizard: Add a "(recommended)" to the main option

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -240,7 +240,7 @@
           <item>
            <widget class="QRadioButton" name="rSyncEverything">
             <property name="text">
-             <string>S&amp;ynchronize everything from server</string>
+             <string>S&amp;ynchronize everything from server (recommended)</string>
             </property>
             <property name="checked">
              <bool>true</bool>


### PR DESCRIPTION
@jancborchardt 

This will lead to a double parenthesis: "(recommended) (124 MB)". It'd be easy to make it say "(recommended, 124 MB)" if that seems better. (note that the size is not always available)

For #6470