### PR TITLE
Share dialog: use the original name and not the virtual file name

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -81,8 +81,7 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     }
 
     // Set filename
-    QFileInfo lPath(_localPath);
-    QString fileName = lPath.fileName();
+    QString fileName = QFileInfo(_sharePath).fileName();
     _ui->label_name->setText(tr("%1").arg(fileName));
     QFont f(_ui->label_name->font());
     f.setPointSize(f.pointSize() * 1.4);

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -704,7 +704,10 @@ SocketApi::FileData SocketApi::FileData::get(const QString &localFile)
         return data;
 
     data.accountRelativePath = QDir(data.folder->remotePath()).filePath(data.folderRelativePath);
-
+    QString virtualFileExt = QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX);
+    if (data.accountRelativePath.endsWith(virtualFileExt)) {
+        data.accountRelativePath.chop(virtualFileExt.size());
+    }
     return data;
 }
 

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -80,8 +80,11 @@ private:
         SyncJournalFileRecord journalRecord() const;
 
         Folder *folder;
+        // Absolute path of the file locally. (May be a virtual file)
         QString localPath;
+        // Relative path of the file locally, as in the DB. (May be a virtual file)
         QString folderRelativePath;
+        // Path of the file on the server (In case of virtual file, it points to the actual file)
         QString accountRelativePath;
     };
 


### PR DESCRIPTION
When sharing a virtual file, we should actually use the original file name
not the virtual file name

Issue: #6461