### PR TITLE
Fix build without Sparkle.framework

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -148,7 +148,7 @@ void GeneralSettings::slotUpdateInfo()
         _ui->restartButton->setVisible(ocupdater->downloadState() == OCUpdater::DownloadComplete);
 
     }
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
     else if (SparkleUpdater *sparkleUpdater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
         _ui->updateStateLabel->setText(sparkleUpdater->statusString());
         _ui->restartButton->setVisible(false);
@@ -192,7 +192,7 @@ void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
                 updater->setUpdateUrl(Updater::updateUrl());
                 updater->checkForUpdate();
             }
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
             else if (SparkleUpdater *updater = qobject_cast<SparkleUpdater *>(Updater::instance())) {
                 updater->setUpdateUrl(Updater::updateUrl());
                 updater->checkForUpdate();


### PR DESCRIPTION
When Sparkle.framework is not installed, building the latest git master results in the following error:
```
[ 39%] Linking CXX executable ../../bin/owncloud.app/Contents/MacOS/owncloud
Undefined symbols for architecture x86_64:
  "OCC::SparkleUpdater::setUpdateUrl(QUrl const&)", referenced from:
      OCC::GeneralSettings::slotUpdateChannelChanged(QString const&)::$_0::operator()(int) const in generalsettings.cpp.o
  "OCC::SparkleUpdater::statusString()", referenced from:
      OCC::GeneralSettings::slotUpdateInfo() in generalsettings.cpp.o
  "OCC::SparkleUpdater::staticMetaObject", referenced from:
      OCC::SparkleUpdater* qobject_cast<OCC::SparkleUpdater*>(QObject*) in generalsettings.cpp.o
ld: symbol(s) not found for architecture x86_64
```
Adding two HAVE_SPARKLE guards fixes the issue.