### PR TITLE
nautilus shell integration: Fix when there are several branded client installed

### DIFF
--- a/shell_integration/nautilus/setappname.sh
+++ b/shell_integration/nautilus/setappname.sh
@@ -3,4 +3,6 @@
 # this script replaces the line
 #  appname = 'ownCloud'
 # with the correct branding name in the syncstate.py script
-sed -i.org -e 's/appname\s*=\s*'"'"'ownCloud'"'/appname = '$1'/" syncstate.py
+# It also replaces the occurences in the class name so several
+# branding can be loaded (see #6524)
+sed -i.org -e "s/ownCloud/$1/g" syncstate.py

--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -28,10 +28,8 @@ import time
 
 from gi.repository import GObject, Nautilus
 
-# Please do not touch the following line.
-# The reason is that we use a script to adopt this file for branding
-# by replacing this line with the branding app name. If the following
-# line is changed, the script can not match the pattern and fails.
+# Note: setappname.sh will search and replace 'ownCloud' on this file to update this line and other
+# occurrences of the name
 appname = 'ownCloud'
 
 print("Initializing "+appname+"-client-nautilus extension")
@@ -178,7 +176,7 @@ class SocketConnect(GObject.GObject):
 socketConnect = SocketConnect()
 
 
-class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
+class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
         GObject.GObject.__init__(self)
 
@@ -346,7 +344,7 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         socketConnect.sendCommand(action + ":" + filename + "\n")
 
 
-class SyncStateExtension(GObject.GObject, Nautilus.InfoProvider):
+class SyncStateExtension_ownCloud(GObject.GObject, Nautilus.InfoProvider):
     def __init__(self):
         GObject.GObject.__init__(self)
 


### PR DESCRIPTION
It appears that several extension can be loaded at the same time, but their
classname for the extension need to be different, otherwise only the last
loaded one would be active.

Issue #6524