### PR TITLE
Ensure GETFileJob notices finishing 

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -147,6 +147,7 @@ void GETFileJob::newReplyHook(QNetworkReply *reply)
 
     connect(reply, &QNetworkReply::metaDataChanged, this, &GETFileJob::slotMetaDataChanged);
     connect(reply, &QIODevice::readyRead, this, &GETFileJob::slotReadyRead);
+    connect(reply, &QNetworkReply::finished, this, &GETFileJob::slotReadyRead);
     connect(reply, &QNetworkReply::downloadProgress, this, &GETFileJob::downloadProgress);
 }
 

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -729,10 +729,17 @@ public:
         setError(InternalServerError, "Internal Server Fake Error");
         emit metaDataChanged();
         emit readyRead();
+        // finishing can come strictly after readyRead was called
+        QTimer::singleShot(5, this, &FakeErrorReply::slotSetFinished);
+    }
+
+public slots:
+    void slotSetFinished() {
         setFinished(true);
         emit finished();
     }
 
+public:
     void abort() override { }
     qint64 readData(char *buf, qint64 max) override {
         max = qMin<qint64>(max, _body.size());

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -112,7 +112,10 @@ private slots:
             return nullptr;
         });
 
+        bool timedOut = false;
+        QTimer::singleShot(10000, &fakeFolder.syncEngine(), [&]() { timedOut = true; fakeFolder.syncEngine().abort(); });
         QVERIFY(!fakeFolder.syncOnce());  // Fail because A/broken
+        QVERIFY(!timedOut);
         QCOMPARE(getItem(completeSpy, "A/broken")->_status, SyncFileItem::NormalError);
         QVERIFY(getItem(completeSpy, "A/broken")->_errorString.contains(serverMessage));
     }

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -255,7 +255,8 @@ private slots:
             } else if(item->_file == "Y/Z/d3") {
                 QVERIFY(item->_status != SyncFileItem::Success);
             }
-            QVERIFY(item->_file != "Y/Z/d9"); // we should have aborted the sync before d9 starts
+            // We do not know about the other files - maybe the sync was aborted,
+            // maybe they finished before the error caused the abort.
         }
     }
 


### PR DESCRIPTION
It could happen that readyRead was emitted for incoming data while the
download was not yet finished. Then the network job could finish with
no more data arriving - so readyRead wasn't emitted again.

To fix this, the finished signal also gets connected to the readyRead
slot.

For #6581