### PR TITLE
OAuth2: Try to refresh the token even if the credentials weren't ready.

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -314,10 +314,10 @@ void AccountState::slotInvalidCredentials()
 
     if (account()->credentials()->ready()) {
         account()->credentials()->invalidateToken();
-        if (auto creds = qobject_cast<HttpCredentials *>(account()->credentials())) {
-            if (creds->refreshAccessToken())
-                return;
-        }
+    }
+    if (auto creds = qobject_cast<HttpCredentials *>(account()->credentials())) {
+        if (creds->refreshAccessToken())
+            return;
     }
     account()->credentials()->askFromUser();
 }


### PR DESCRIPTION
This can happen when the client is started and the internet connection
was not enabled. Then we would fetch the credentials, but we would
no do the refresh token step (because network is down).
So next time we try to connect, we would also not refresh the token
because the credentials are not marked as 'ready'

Reported in
https://github.com/owncloud/client/issues/6522#issuecomment-396845167