### PR TITLE
Wizard + OAuth: Make opening a new browser after clicking back works again

### DIFF
--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -22,6 +22,7 @@
 #include <QJsonDocument>
 #include "theme.h"
 #include "networkjobs.h"
+#include "creds/httpcredentials.h"
 
 namespace OCC {
 
@@ -85,6 +86,8 @@ void OAuth::start()
                 QString basicAuth = QString("%1:%2").arg(
                     Theme::instance()->oauthClientId(), Theme::instance()->oauthClientSecret());
                 req.setRawHeader("Authorization", "Basic " + basicAuth.toUtf8().toBase64());
+                // We just added the Authorization header, don't let HttpCredentialsAccessManager tamper with it
+                req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
 
                 auto requestBody = new QBuffer;
                 QUrlQuery arguments(QString(

--- a/src/gui/wizard/owncloudoauthcredspage.cpp
+++ b/src/gui/wizard/owncloudoauthcredspage.cpp
@@ -45,6 +45,7 @@ OwncloudOAuthCredsPage::OwncloudOAuthCredsPage()
 
     connect(_ui.openLinkButton, &QCommandLinkButton::clicked, [this] {
         _ui.errorLabel->hide();
+        qobject_cast<OwncloudWizard *>(wizard())->account()->clearCookieJar(); // #6574
         if (_asyncAuth)
             _asyncAuth->openBrowser();
     });


### PR DESCRIPTION
Issue #6574

When there is an error in the advanced page, OwncloudAdvancedSetupPage::updateStatus
(and others) call completeChanged(), which is connected to
QWizardPrivate::_q_updateButtonStates which will re-enable the back button from the
last page.

When the user click "back" and re-open the browser, the account's credentials
already have a oauth token set. So the call to the API to get a new token fails
because we use the previous token instead of using the client's secret_id.
Fix this with the HttpCredentials::DontAddCredentialsAttribute.

Now, this is still not working because the session cookies are confusing the
server.  So we'll clear the cookies when re-opening the browser