### PR TITLE
Introduce an about dialog

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -54,17 +54,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     _ui->autostartCheckBox->setChecked(Utility::hasLaunchOnStartup(Theme::instance()->appName()));
     connect(_ui->autostartCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleLaunchOnStartup);
 
-    // setup about section
-    QString about = Theme::instance()->about();
-    if (about.isEmpty()) {
-        _ui->aboutGroupBox->hide();
-    } else {
-        _ui->aboutLabel->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextBrowserInteraction);
-        _ui->aboutLabel->setText("<qt><style> p{padding-bottom:0; margin-bottom:0;padding-top:2; margin-top: 2; font-size:smaller;};</style>"+about+"</qt>");
-        _ui->aboutLabel->setWordWrap(true);
-        _ui->aboutLabel->setOpenExternalLinks(true);
-    }
-
     loadMiscSettings();
     slotUpdateInfo();
 

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>785</width>
-    <height>533</height>
+    <height>390</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -48,28 +48,6 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QGroupBox" name="aboutGroupBox">
-     <property name="title">
-      <string>About</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QLabel" name="aboutLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>About</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
     <widget class="QGroupBox" name="updatesGroupBox">
      <property name="title">
       <string>Updates</string>
@@ -160,7 +138,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -38,6 +38,8 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QMessageBox>
+#include <QDialog>
+#include <QHBoxLayout>
 
 #if defined(Q_OS_X11)
 #include <QX11Info>
@@ -492,6 +494,10 @@ void ownCloudGui::setupContextMenu()
     // The tray menu is surprisingly problematic. Being able to switch to
     // a minimal version of it is a useful workaround and testing tool.
     if (minimalTrayMenu()) {
+        if (! Theme::instance()->about().isEmpty()) {
+            _contextMenu->addSeparator();
+            _contextMenu->addAction(_actionAbout);
+        }
         _contextMenu->addAction(_actionQuit);
         return;
     }
@@ -693,6 +699,12 @@ void ownCloudGui::updateContextMenu()
         }
         _contextMenu->addAction(_actionLogin);
     }
+
+    if (! Theme::instance()->about().isEmpty()) {
+        _contextMenu->addSeparator();
+        _contextMenu->addAction(_actionAbout);
+    }
+
     _contextMenu->addAction(_actionQuit);
 
     if (_workaroundShowAndHideTray) {
@@ -775,6 +787,8 @@ void ownCloudGui::setupActions()
     QObject::connect(_actionNewAccountWizard, &QAction::triggered, this, &ownCloudGui::slotNewAccountWizard);
     _actionHelp = new QAction(tr("Help"), this);
     QObject::connect(_actionHelp, &QAction::triggered, this, &ownCloudGui::slotHelp);
+    _actionAbout = new QAction(tr("About %1").arg(Theme::instance()->appNameGUI()), this);
+    QObject::connect(_actionAbout, &QAction::triggered, this, &ownCloudGui::slotAbout);
     _actionQuit = new QAction(tr("Quit %1").arg(Theme::instance()->appNameGUI()), this);
     QObject::connect(_actionQuit, SIGNAL(triggered(bool)), _app, SLOT(quit()));
 
@@ -1129,6 +1143,29 @@ void ownCloudGui::slotRemoveDestroyedShareDialogs()
             it.remove();
         }
     }
+}
+
+void ownCloudGui::slotAbout()
+{
+    QString title = tr("About %1").arg(Theme::instance()->appNameGUI());
+    QString about = Theme::instance()->about();
+    QMessageBox *msgBox = new QMessageBox(this->_settingsDialog);
+#ifdef Q_OS_MAC
+    // From Qt doc: "On macOS, the window title is ignored (as required by the macOS Guidelines)."
+    msgBox->setText(title);
+#else
+    msgBox->setWindowTitle(title);
+#endif
+    msgBox->setAttribute(Qt::WA_DeleteOnClose, true);
+    msgBox->setTextFormat(Qt::RichText);
+    msgBox->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    msgBox->setInformativeText("<qt>"+about+"</qt>");
+    msgBox->setStandardButtons(QMessageBox::Ok);
+    QIcon appIcon = Theme::instance()->applicationIcon();
+    // Assume icon is always small enough to fit an about dialog?
+    qDebug() << appIcon.availableSizes().last();
+    msgBox->setIconPixmap(appIcon.pixmap(appIcon.availableSizes().last()));
+    msgBox->show();
 }
 
 

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -108,6 +108,7 @@ private slots:
     void slotUnpauseAllFolders();
     void slotPauseAllFolders();
     void slotNewAccountWizard();
+    void slotAbout();
 
 private:
     void setPauseOnAllFoldersHelper(bool pause);
@@ -148,6 +149,7 @@ private:
     QAction *_actionEstimate;
     QAction *_actionRecent;
     QAction *_actionHelp;
+    QAction *_actionAbout;
     QAction *_actionQuit;
     QAction *_actionCrash;
 


### PR DESCRIPTION
Can someone check if this looks OK on Windows and Linux too?
![screen shot 2018-06-19 at 17 12 43](https://user-images.githubusercontent.com/959327/41607093-7cbac7b8-73e5-11e8-9d96-cc79e8edd555.png)

Menu entry:

![screen shot 2018-06-19 at 15 42 43](https://user-images.githubusercontent.com/959327/41607105-81475eb8-73e5-11e8-9323-7cd483cac514.png)

Dialog now not so high:
![screen shot 2018-06-19 at 15 42 34](https://user-images.githubusercontent.com/959327/41607113-86092d1e-73e5-11e8-9701-5cb5d3d1b504.png)


Every proper application has that!

For decreasing window height in #6075