### PR TITLE
Log: Adjust update/reconcile log verbosity

### DIFF
--- a/src/csync/csync_reconcile.cpp
+++ b/src/csync/csync_reconcile.cpp
@@ -210,7 +210,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                 /* First, check that the file is NOT in our tree (another file with the same name was added) */
                 if (our_tree->findFile(basePath)) {
                     other = nullptr;
-                    qCDebug(lcReconcile, "Origin found in our tree : %s", basePath.constData());
+                    qCInfo(lcReconcile, "Origin found in our tree : %s", basePath.constData());
                 } else {
                     /* Find the potential rename source file in the other tree.
                     * If the renamed file could not be found in the opposite tree, that is because it
@@ -218,7 +218,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                     * The journal is cleaned up later after propagation.
                     */
                     other = other_tree->findFile(basePath);
-                    qCDebug(lcReconcile, "Rename origin in other tree (%s) %s",
+                    qCInfo(lcReconcile, "Rename origin in other tree (%s) %s",
                         basePath.constData(), other ? "found" : "not found");
                 }
 
@@ -229,7 +229,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                     // Some other EVAL_RENAME already claimed other.
                     // We do nothing: maybe a different candidate for
                     // other is found as well?
-                    qCDebug(lcReconcile, "Other has already been renamed to %s",
+                    qCInfo(lcReconcile, "Other has already been renamed to %s",
                         other->rename_path.constData());
                 } else if (cur->type == ItemTypeDirectory
                     // The local replica is reconciled first, so the remote tree would
@@ -241,7 +241,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                     || other->instruction == CSYNC_INSTRUCTION_NONE
                     || other->instruction == CSYNC_INSTRUCTION_UPDATE_METADATA
                     || other->instruction == CSYNC_INSTRUCTION_REMOVE) {
-                    qCDebug(lcReconcile, "Switching %s to RENAME to %s",
+                    qCInfo(lcReconcile, "Switching %s to RENAME to %s",
                         other->path.constData(), cur->path.constData());
                     other->instruction = CSYNC_INSTRUCTION_RENAME;
                     other->rename_path = cur->path;
@@ -261,7 +261,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                     // Local: The remote reconcile will be able to deal with this.
                     // Remote: The local replica has already dealt with this.
                     //         See the EVAL_RENAME case when other was found directly.
-                    qCDebug(lcReconcile, "File in a renamed directory, other side's instruction: %d",
+                    qCInfo(lcReconcile, "File in a renamed directory, other side's instruction: %d",
                         other->instruction);
                     cur->instruction = CSYNC_INSTRUCTION_NONE;
                 } else {
@@ -269,7 +269,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                     // and the instruction in the local tree is NEW while cur has EVAL_RENAME
                     // due to a remote move of the same file. In these scenarios we just
                     // want the instruction to stay NEW.
-                    qCDebug(lcReconcile, "Other already has instruction %d",
+                    qCInfo(lcReconcile, "Other already has instruction %d",
                         other->instruction);
                 }
             };
@@ -277,7 +277,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
             if (ctx->current == LOCAL_REPLICA) {
                 /* use the old name to find the "other" node */
                 OCC::SyncJournalFileRecord base;
-                qCDebug(lcReconcile, "Finding rename origin through inode %" PRIu64 "",
+                qCInfo(lcReconcile, "Finding rename origin through inode %" PRIu64 "",
                     cur->inode);
                 ctx->statedb->getFileRecordByInode(cur->inode, &base);
                 renameCandidateProcessing(base._path);
@@ -290,7 +290,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                 // line.
                 auto basePath = csync_rename_adjust_full_path_source(ctx, cur->path);
                 if (basePath != cur->path) {
-                    qCDebug(lcReconcile, "Trying rename origin by csync_rename mapping %s",
+                    qCInfo(lcReconcile, "Trying rename origin by csync_rename mapping %s",
                         basePath.constData());
                     // We go through getFileRecordsByFileId to ensure the basePath
                     // computed in this way also has the expected fileid.
@@ -303,7 +303,7 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
 
                 // Also feed all the other files with the same fileid if necessary
                 if (!processedRename) {
-                    qCDebug(lcReconcile, "Finding rename origin through file ID %s",
+                    qCInfo(lcReconcile, "Finding rename origin through file ID %s",
                         cur->file_id.constData());
                     ctx->statedb->getFileRecordsByFileId(cur->file_id,
                         [&](const OCC::SyncJournalFileRecord &base) { renameCandidateProcessing(base._path); });

--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -126,12 +126,12 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
        * This code should probably be in csync_exclude, but it does not have the fs parameter.
        * Keep it here for now */
       if (ctx->ignore_hidden_files && (fs->is_hidden)) {
-          qCDebug(lcUpdate, "file excluded because it is a hidden file: %s", fs->path.constData());
+          qCInfo(lcUpdate, "file excluded because it is a hidden file: %s", fs->path.constData());
           excluded = CSYNC_FILE_EXCLUDE_HIDDEN;
       }
   } else {
       /* File is ignored because it's matched by a user- or system exclude pattern. */
-      qCDebug(lcUpdate, "%s excluded  (%d)", fs->path.constData(), excluded);
+      qCInfo(lcUpdate, "%s excluded  (%d)", fs->path.constData(), excluded);
       if (excluded == CSYNC_FILE_EXCLUDE_AND_REMOVE) {
           return 1;
       }
@@ -156,7 +156,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
        */
       QTextEncoder encoder(localCodec, QTextCodec::ConvertInvalidToNull);
       if (encoder.fromUnicode(QString::fromUtf8(fs->path)).contains('\0')) {
-          qCDebug(lcUpdate, "cannot encode %s to local encoding %d",
+          qCInfo(lcUpdate, "cannot encode %s to local encoding %d",
               fs->path.constData(), localCodec->mibEnum());
           excluded = CSYNC_FILE_EXCLUDE_CANNOT_ENCODE;
       }
@@ -164,7 +164,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
 
   if (fs->type == ItemTypeFile ) {
     if (fs->modtime == 0) {
-      qCDebug(lcUpdate, "file: %s - mtime is zero!", fs->path.constData());
+      qCInfo(lcUpdate, "file: %s - mtime is zero!", fs->path.constData());
     }
   }
 
@@ -269,7 +269,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
                   checksumIdentical = fs->checksumHeader == base._checksumHeader;
               }
               if (checksumIdentical) {
-                  qCDebug(lcUpdate, "NOTE: Checksums are identical, file did not actually change: %s", fs->path.constData());
+                  qCInfo(lcUpdate, "NOTE: Checksums are identical, file did not actually change: %s", fs->path.constData());
                   fs->instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
                   goto out;
               }
@@ -293,7 +293,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
            * The metadata comparison ensure that we fetch all the file id or permission when
            * upgrading owncloud
            */
-          qCDebug(lcUpdate, "Reading from database: %s", fs->path.constData());
+          qCInfo(lcUpdate, "Reading from database: %s", fs->path.constData());
           ctx->remote.read_from_db = true;
       }
       /* If it was remembered in the db that the remote dir has ignored files, store
@@ -304,7 +304,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
       }
       if (metadata_differ) {
           /* file id or permissions has changed. Which means we need to update them in the DB. */
-          qCDebug(lcUpdate, "Need to update metadata for: %s", fs->path.constData());
+          qCInfo(lcUpdate, "Need to update metadata for: %s", fs->path.constData());
           fs->instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
       } else {
           fs->instruction = CSYNC_INSTRUCTION_NONE;
@@ -312,7 +312,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
   } else {
       /* check if it's a file and has been renamed */
       if (ctx->current == LOCAL_REPLICA) {
-          qCDebug(lcUpdate, "Checking for rename based on inode # %" PRId64 "", (uint64_t) fs->inode);
+          qCInfo(lcUpdate, "Checking for rename based on inode # %" PRId64 "", (uint64_t) fs->inode);
 
           OCC::SyncJournalFileRecord base;
           if(!ctx->statedb->getFileRecordByInode(fs->inode, &base)) {
@@ -339,13 +339,13 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
                       _rel_to_abs(ctx, fs->path), base._checksumHeader,
                       ctx->callbacks.checksum_userdata);
               if (!fs->checksumHeader.isEmpty()) {
-                  qCDebug(lcUpdate, "checking checksum of potential rename %s %s <-> %s", fs->path.constData(), fs->checksumHeader.constData(), base._checksumHeader.constData());
+                  qCInfo(lcUpdate, "checking checksum of potential rename %s %s <-> %s", fs->path.constData(), fs->checksumHeader.constData(), base._checksumHeader.constData());
                   isRename = fs->checksumHeader == base._checksumHeader;
               }
           }
 
           if (isRename) {
-              qCDebug(lcUpdate, "pot rename detected based on inode # %" PRId64 "", (uint64_t) fs->inode);
+              qCInfo(lcUpdate, "pot rename detected based on inode # %" PRId64 "", (uint64_t) fs->inode);
               /* inode found so the file has been renamed */
               fs->instruction = CSYNC_INSTRUCTION_EVAL_RENAME;
               if (fs->type == ItemTypeDirectory) {
@@ -355,6 +355,8 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
           goto out;
 
       } else {
+          qCInfo(lcUpdate, "Checking for rename based on fileid %s", fs->file_id.constData());
+
           /* Remote Replica Rename check */
           fs->instruction = CSYNC_INSTRUCTION_NEW;
 
@@ -408,7 +410,7 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
                   csync_rename_record(ctx, base._path, fs->path);
               }
 
-              qCDebug(lcUpdate, "remote rename detected based on fileid %s --> %s", base._path.constData(), fs->path.constData());
+              qCInfo(lcUpdate, "remote rename detected based on fileid %s --> %s", base._path.constData(), fs->path.constData());
               fs->instruction = CSYNC_INSTRUCTION_EVAL_RENAME;
               done = true;
           };
@@ -525,11 +527,11 @@ int csync_walker(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> fs) {
       }
       break;
   case ItemTypeSoftLink:
-    qCDebug(lcUpdate, "symlink: %s - not supported", fs->path.constData());
+    qCInfo(lcUpdate, "symlink: %s - not supported", fs->path.constData());
     break;
   default:
+    qCInfo(lcUpdate, "item: %s - item type %d not iterated", fs->path.constData(), fs->type);
     return 0;
-    break;
   }
 
   rc = _csync_detect_update(ctx, std::move(fs));
@@ -552,7 +554,7 @@ static bool fill_tree_from_db(CSYNC *ctx, const char *uri, bool singleFile = fal
              * their correct etags again and we don't run into this case.
              */
             if (rec._etag == "_invalid_") {
-                qCDebug(lcUpdate, "%s selective sync excluded", rec._path.constData());
+                qCInfo(lcUpdate, "%s selective sync excluded", rec._path.constData());
                 skipbase = rec._path;
                 skipbase += '/';
                 return;
@@ -821,7 +823,7 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
   }
 
   csync_vio_closedir(ctx, dh);
-  qCDebug(lcUpdate, " <= Closing walk for %s with read_from_db %d", uri, read_from_db);
+  qCInfo(lcUpdate, " <= Closing walk for %s with read_from_db %d", uri, read_from_db);
 
   return rc;
 


### PR DESCRIPTION
Not having these enabled by default is causing significant extra back
and forth with reporters since they must manually use --logdebug for the
log to be useful.

Cherry pick to 2.4