### PR TITLE
OAuth: Remove the timeout

### DIFF
--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -153,7 +153,6 @@ void OAuth::start()
             });
         }
     });
-    QTimer::singleShot(5 * 60 * 1000, this, [this] { result(Error); });
 }
 
 QUrl OAuth::authorisationLink() const


### PR DESCRIPTION
There is no real reason to have a timeout. The connection can stay open
as long as we are not authenticated. The User can still re-open a browser
from the UI at any time.

Issue #6612