### PR TITLE
Reconcile: When detecting a local move, keep the local mtime

### DIFF
--- a/src/csync/csync_reconcile.cpp
+++ b/src/csync/csync_reconcile.cpp
@@ -194,6 +194,10 @@ static int _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) {
                     if( !cur->file_id.isEmpty() ) {
                         other->file_id = cur->file_id;
                     }
+                    if (ctx->current == LOCAL_REPLICA) {
+                        // Keep the local mtime.
+                        other->modtime = cur->modtime;
+                    }
                     other->inode = cur->inode;
                     cur->instruction = CSYNC_INSTRUCTION_NONE;
                     // We have consumed 'other': exit this loop to not consume another one.


### PR DESCRIPTION
https://github.com/owncloud/client/issues/6629#issuecomment-402450691
(cherry picked from commit 90ec9a97357862d4f410c3ce977afe4ef75c5a27)