### PR TITLE
Wizard: show a message when the URL is invalid

### DIFF
--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -221,12 +221,19 @@ QString OwncloudSetupPage::url() const
 bool OwncloudSetupPage::validatePage()
 {
     if (!_authTypeKnown) {
+        QString u = url();
+        QUrl qurl(u);
+        if (!qurl.isValid() || qurl.host().isEmpty()) {
+            setErrorString(tr("Invalid URL"), false);
+            return false;
+        }
+
         setErrorString(QString(), false);
         _checking = true;
         startSpinner();
         emit completeChanged();
 
-        emit determineAuthType(url());
+        emit determineAuthType(u);
         return false;
     } else {
         // connecting is running


### PR DESCRIPTION
Rather than let Qt show "Host not found"

Issue #6646