### PR TITLE
Nautilus: Guard against None state

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -293,8 +293,8 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
         # and we definitely don't want to show them for IGNORED.
         shareable = False
         state = entry['state']
-        state_ok = state.startswith('OK')
-        state_sync = state.startswith('SYNC')
+        state_ok = state and state.startswith('OK')
+        state_sync = state and state.startswith('SYNC')
         if state_ok:
             shareable = True
         elif state_sync and isDir:


### PR DESCRIPTION
It seems None gets assigned to 'state' in some paths.

See #6643 