### PR TITLE
FolderMan::checkPathValidityForNewFolder: make sure to work with deleted folders

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -138,11 +138,9 @@ public:
      *
      * Note that different accounts are allowed to sync to the same folder.
      *
-     * \a forNewDirectory is internal and is used for recursion.
-     *
      * @returns an empty string if it is allowed, or an error if it is not allowed
      */
-    QString checkPathValidityForNewFolder(const QString &path, const QUrl &serverUrl = QUrl(), bool forNewDirectory = false) const;
+    QString checkPathValidityForNewFolder(const QString &path, const QUrl &serverUrl = QUrl()) const;
 
     /**
      * Attempts to find a non-existing, acceptable path for creating a new sync folder.

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -67,8 +67,10 @@ FolderWizardLocalPath::FolderWizardLocalPath(const AccountPtr &account)
     connect(_ui.localFolderChooseBtn, &QAbstractButton::clicked, this, &FolderWizardLocalPath::slotChooseLocalFolder);
     _ui.localFolderChooseBtn->setToolTip(tr("Click to select a local folder to sync."));
 
+    QUrl serverUrl = _account->url();
+    serverUrl.setUserName(_account->credentials()->user());
     QString defaultPath = QDir::homePath() + QLatin1Char('/') + Theme::instance()->appName();
-    defaultPath = FolderMan::instance()->findGoodPathForNewSyncFolder(defaultPath, account->url());
+    defaultPath = FolderMan::instance()->findGoodPathForNewSyncFolder(defaultPath, serverUrl);
     _ui.localFolderLineEdit->setText(QDir::toNativeSeparators(defaultPath));
     _ui.localFolderLineEdit->setToolTip(tr("Enter the path to the local folder."));
 

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -146,6 +146,12 @@ private slots:
 
         // Invalid paths
         QVERIFY(!folderman->checkPathValidityForNewFolder("").isNull());
+
+
+        // REMOVE ownCloud2 from the filesystem, but keep a folder sync'ed to it.
+        QDir(dirPath + "/ownCloud2/").removeRecursively();
+        QVERIFY(!folderman->checkPathValidityForNewFolder(dirPath + "/ownCloud2/blublu").isNull());
+        QVERIFY(!folderman->checkPathValidityForNewFolder(dirPath + "/ownCloud2/sub/subsub/sub").isNull());
     }
 
     void testFindGoodPathForNewSyncFolder()
@@ -169,6 +175,7 @@ private slots:
         HttpCredentialsTest *cred = new HttpCredentialsTest("testuser", "secret");
         account->setCredentials(cred);
         account->setUrl( url );
+        url.setUserName(cred->user());
 
         AccountStatePtr newAccountState(new AccountState(account));
         FolderMan *folderman = FolderMan::instance();
@@ -190,6 +197,14 @@ private slots:
                  QString(dirPath + "/ownCloud2/bar"));
         QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath + "/sub", url),
                  QString(dirPath + "/sub2"));
+
+        // REMOVE ownCloud2 from the filesystem, but keep a folder sync'ed to it.
+        // We should still not suggest this folder as a new folder.
+        QDir(dirPath + "/ownCloud2/").removeRecursively();
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath + "/ownCloud", url),
+            QString(dirPath + "/ownCloud3"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath + "/ownCloud2", url),
+            QString(dirPath + "/ownCloud22"));
     }
 };
 


### PR DESCRIPTION
Note that we also needed to adjust the server url to contains the user name
in the folder wizard. (As checkPathValidityForNewFolder expect the user name)

Issue #6654