### PR TITLE
Do not require server replies to contain an mtime

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -377,13 +377,11 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(QString file, con
         std::unique_ptr<csync_file_stat_t> file_stat(new csync_file_stat_t);
         file_stat->path = file.toUtf8();
         file_stat->size = -1;
-        file_stat->modtime = -1;
         propertyMapToFileStat(map, file_stat.get());
         if (file_stat->type == ItemTypeDirectory)
             file_stat->size = 0;
         if (file_stat->type == ItemTypeSkip
             || file_stat->size == -1
-            || file_stat->modtime == -1
             || file_stat->remotePerm.isNull()
             || file_stat->etag.isEmpty()
             || file_stat->file_id.isEmpty()) {


### PR DESCRIPTION
The check was added for #6317 in commit
13eb64584f5f96647ced39dcd3252860ebec5a37.

We did see missing mtimes in replies in tests with live servers though.
Possibly those were old incomplete responses cached in the stat cache?