### PR TITLE
Data-Fingerprint: Fix backup detection when fingerprint is empty

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -361,6 +361,10 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(QString file, con
         }
         if (map.contains("data-fingerprint")) {
             _dataFingerprint = map.value("data-fingerprint").toUtf8();
+            if (_dataFingerprint.isEmpty()) {
+                // Placeholder that means that the server supports the feature even if it did not set one.
+                _dataFingerprint = "[empty]";
+            }
         }
     } else {
         // Remove <webDAV-Url>/folder/ from <webDAV-Url>/folder/subfile.txt

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1054,10 +1054,9 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     }
 
     auto databaseFingerprint = _journal->dataFingerprint();
-    // If databaseFingerprint is null, this means that there was no information in the database
-    // (for example, upgrading from a previous version, or first sync)
-    // Note that an empty ("") fingerprint is valid and means it was empty on the server before.
-    if (!databaseFingerprint.isNull()
+    // If databaseFingerprint is empty, this means that there was no information in the database
+    // (for example, upgrading from a previous version, or first sync, or server not supporting fingerprint)
+    if (!databaseFingerprint.isEmpty()
         && _discoveryMainThread->_dataFingerprint != databaseFingerprint) {
         qCInfo(lcEngine) << "data fingerprint changed, assume restore from backup" << databaseFingerprint << _discoveryMainThread->_dataFingerprint;
         restoreOldFiles(syncItems);

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -1030,6 +1030,23 @@ private:
     }
 };
 
+/* Return the FileInfo for a conflict file for the specified relative filename */
+inline const FileInfo *findConflict(FileInfo &dir, const QString &filename)
+{
+    QFileInfo info(filename);
+    const FileInfo *parentDir = dir.find(info.path());
+    if (!parentDir)
+        return nullptr;
+    QString start = info.baseName() + " (conflicted copy";
+    for (const auto &item : parentDir->children) {
+        if (item.name.startsWith(start)) {
+            return &item;
+        }
+    }
+    return nullptr;
+}
+
+
 // QTest::toString overloads
 namespace OCC {
     inline char *toString(const SyncFileStatus &s) {

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -23,20 +23,6 @@ static void applyPermissionsFromName(FileInfo &info) {
         applyPermissionsFromName(sub);
 }
 
-const FileInfo *findConflict(FileInfo &dir, const QString &filename)
-{
-    QFileInfo info(filename);
-    const FileInfo *parentDir = dir.find(info.path());
-    if (!parentDir) return nullptr;
-    QString start = info.baseName() + " (conflicted copy";
-    for (const auto &item : parentDir->children) {
-        if (item.name.startsWith(start)) {
-            return &item;
-        }
-    }
-    return nullptr;
-}
-
 // Check if the expected rows in the DB are non-empty. Note that in some cases they might be, then we cannot use this function
 // https://github.com/owncloud/client/issues/2038
 static void assertCsyncJournalOk(SyncJournalDb &journal)


### PR DESCRIPTION
Add a test to test the data fingerprint feature make me realize it was broken.
The code was relying in the distinction between empty and null QByteArray,
but this was a bad idea as this difference is lost when going through QString.