### PR TITLE
Wizard: pre-select the right radio button...

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -142,6 +142,7 @@ void OwncloudAdvancedSetupPage::initializePage()
 
     if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
         _selectiveSyncBlacklist = QStringList("/");
+        setRadioChecked(_ui.rSelectiveSync);
         QTimer::singleShot(0, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
     }
 


### PR DESCRIPTION
... when the wizardSelectiveSyncDefaultNothing branding option is set

Note: bormally the right option is set when the "choose what to sync"
dialog is closed.  So this was only a problem when the dialog was visible
for the first time, the wrong option would be selected underneath.

Issue #6685