### PR TITLE
SyncEngine: Fix renames making hierarchy inversion

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1245,6 +1245,14 @@ QString SyncEngine::adjustRenamedPath(const QString &original)
     while ((slashPos = original.lastIndexOf('/', slashPos - 1)) > 0) {
         QHash<QString, QString>::const_iterator it = _renamedFolders.constFind(original.left(slashPos));
         if (it != _renamedFolders.constEnd()) {
+            // This is a band-aid fix for a specific problem:
+            // See issue #6694: "hierarchy inversion" and discussion in PR #6695.
+            // There's a larger unfixed issue here, see testInvertFolderHierarchy().
+            auto original_it = _renamedFolders.constFind(original);
+            if (original_it != _renamedFolders.constEnd() && it->startsWith(*original_it)) {
+                return original;
+            }
+
             return *it + original.mid(slashPos);
         }
     }

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -621,6 +621,42 @@ private slots:
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    // Test for https://github.com/owncloud/client/issues/6694
+    void testInvertFolderHierarchy()
+    {
+        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
+        fakeFolder.remoteModifier().mkdir("A/Empty");
+        fakeFolder.remoteModifier().mkdir("A/Empty/Foo");
+        fakeFolder.remoteModifier().mkdir("C/AllEmpty");
+        fakeFolder.remoteModifier().mkdir("C/AllEmpty/Bar");
+        QVERIFY(fakeFolder.syncOnce());
+
+        // "Empty" is after "A", alphabetically
+        fakeFolder.localModifier().rename("A/Empty", "Empty");
+        fakeFolder.localModifier().rename("A", "Empty/A");
+
+        // "AllEmpty" is before "C", alphabetically
+        fakeFolder.localModifier().rename("C/AllEmpty", "AllEmpty");
+        fakeFolder.localModifier().rename("C", "AllEmpty/C");
+
+        auto expectedState = fakeFolder.currentLocalState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), expectedState);
+        QCOMPARE(fakeFolder.currentRemoteState(), expectedState);
+
+        /* FIXME - likely addressed by ogoffart's sync code refactor
+        // Now, the revert, but "crossed"
+        fakeFolder.localModifier().rename("Empty/A", "A");
+        fakeFolder.localModifier().rename("AllEmpty/C", "C");
+        fakeFolder.localModifier().rename("Empty", "C/Empty");
+        fakeFolder.localModifier().rename("AllEmpty", "A/AllEmpty");
+        expectedState = fakeFolder.currentLocalState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), expectedState);
+        QCOMPARE(fakeFolder.currentRemoteState(), expectedState);
+        */
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncMove)


### PR DESCRIPTION
Issue #6694

This is not a problem in the `new_discovery_algo` branch, but let's fix that for 2.5