### PR TITLE
C++: Don't use auto parameters in lambdas

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -84,7 +84,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     connect(_model, &ActivityListModel::activityJobStatusCode,
         this, &ActivityWidget::slotAccountActivityStatus);
 
-    connect(AccountManager::instance(), &AccountManager::accountRemoved, this, [this] (const auto &ast) {
+    connect(AccountManager::instance(), &AccountManager::accountRemoved, this, [this](AccountState *ast) {
         if (_accountsWithoutActivities.remove(ast->account()->displayName()))
             showLabels();
     });


### PR DESCRIPTION
The mingw compiler isn't happy with them.