### PR TITLE
nautilus: Fix GET_MENU_ITEMS with utf8 filenames

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -233,7 +233,7 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
     def ask_for_menu_items(self, files):
         record_separator = '\x1e'
         filesstring = record_separator.join(files)
-        socketConnect.sendCommand('GET_MENU_ITEMS:{}\n'.format(filesstring))
+        socketConnect.sendCommand(u'GET_MENU_ITEMS:{}\n'.format(filesstring))
 
         done = False
         start = time.time()


### PR DESCRIPTION
For python2 there was a problem here when using `'{}'.format(u'ä')` - the adjusted code works for python 2 and 3 (though I've tested 3 only indirectly through the interpreter).

Calling `sendCommand()` with a unicode string also is the right thing to do, as it calls `.encode('utf-8')` on it.

For #6643

@jnweiger Thanks for finding this issue - I hadn't tested clicking the file. :/