### PR TITLE
Make the virtual file suffix in theme consistent

### DIFF
--- a/OWNCLOUD.cmake
+++ b/OWNCLOUD.cmake
@@ -5,7 +5,7 @@ set( APPLICATION_DOMAIN     "owncloud.com" )
 set( APPLICATION_VENDOR     "ownCloud" )
 set( APPLICATION_UPDATE_URL "https://updates.owncloud.com/client/" CACHE string "URL for updater" )
 set( APPLICATION_ICON_NAME  "owncloud" )
-set( APPLICATION_VIRTUALFILE_SUFFIX "owncloud" CACHE STRING "Virtual file suffix (not including the .)")
+set( APPLICATION_VIRTUALFILE_SUFFIX "owncloud_virtual" CACHE STRING "Virtual file suffix (not including the .)")
 
 set( LINUX_PACKAGE_SHORTNAME "owncloud" )
 


### PR DESCRIPTION
By making it `.owncloud_virtual` (EDIT: @ogoffart suggests it should be ".owncloud")

Currently according to #6718 the actual suffix is different on linux and windows (hinting at a bug with the theme handling in cmake?? @dschmidt )