### PR TITLE
Virtual files: Renaming to virtual doesn't delete data

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -355,6 +355,8 @@ void PropagateDownloadFile::start()
     if (_item->_type == ItemTypeVirtualFile) {
         auto fn = propagator()->getFilePath(_item->_file);
         qCDebug(lcPropagateDownload) << "creating virtual file" << fn;
+
+        // NOTE: Other places might depend on contents of placeholder files (like csync_update)
         QFile file(fn);
         file.open(QFile::ReadWrite | QFile::Truncate);
         file.write(" ");


### PR DESCRIPTION
Unfortunately to do this, the local update phase must write to the
database, creating a new side-effect and order dependency (local update
must run before remote update).

For  #6718