### PR TITLE
Add the ownCloud documentation theme as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/3rdparty/libcrashreporter-qt"]
 	path = src/3rdparty/libcrashreporter-qt
 	url = git://github.com/dschmidt/libcrashreporter-qt.git
+[submodule "doc/docs-themes"]
+	path = doc/docs-themes
+	url = https://github.com/owncloud/docs-themes.git


### PR DESCRIPTION
Without this, the HTML documentation isn't able to build successfully, as it fails on the deployment of the generated HTML files to the live server.