### PR TITLE
Discovery:  Do full local discovery when changing the ignore files

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -162,7 +162,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 
     QAction *syncNowWithRemoteDiscovery = new QAction(this);
     syncNowWithRemoteDiscovery->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F6));
-    connect(syncNowWithRemoteDiscovery, &QAction::triggered, this, &AccountSettings::slotScheduleCurrentFolderForceRemoteDiscovery);
+    connect(syncNowWithRemoteDiscovery, &QAction::triggered, this, &AccountSettings::slotScheduleCurrentFolderForceFullDiscovery);
     addAction(syncNowWithRemoteDiscovery);
 
 
@@ -566,10 +566,11 @@ void AccountSettings::slotScheduleCurrentFolder()
     }
 }
 
-void AccountSettings::slotScheduleCurrentFolderForceRemoteDiscovery()
+void AccountSettings::slotScheduleCurrentFolderForceFullDiscovery()
 {
     FolderMan *folderMan = FolderMan::instance();
     if (auto folder = folderMan->folder(selectedFolderAlias())) {
+        folder->slotNextSyncFullLocalDiscovery();
         folder->journalDb()->forceRemoteDiscoveryNextSync();
         folderMan->scheduleFolder(folder);
     }

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -73,7 +73,7 @@ protected slots:
     void slotAddFolder();
     void slotEnableCurrentFolder();
     void slotScheduleCurrentFolder();
-    void slotScheduleCurrentFolderForceRemoteDiscovery();
+    void slotScheduleCurrentFolderForceFullDiscovery();
     void slotForceSyncCurrentFolder();
     void slotRemoveCurrentFolder();
     void slotOpenCurrentFolder(); // sync folder

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -297,6 +297,9 @@ public slots:
      */
     void downloadVirtualFile(const QString &relativepath);
 
+    /** Ensures that the next sync performs a full local discovery. */
+    void slotNextSyncFullLocalDiscovery();
+
 private slots:
     void slotSyncStarted();
     void slotSyncFinished(bool);
@@ -324,9 +327,6 @@ private slots:
      *  FolderMan.
      */
     void slotScheduleThisFolder();
-
-    /** Ensures that the next sync performs a full local discovery. */
-    void slotNextSyncFullLocalDiscovery();
 
     /** Adjust sync result based on conflict data from IssuesWidget.
      *

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -856,6 +856,8 @@ void FolderStatusModel::slotApplySelectiveSync()
             foreach (const auto &it, changes) {
                 folder->journalDb()->avoidReadFromDbOnNextSync(it);
             }
+            // Also make sure we see the local file that had been ignored before
+            folder->slotNextSyncFullLocalDiscovery();
             FolderMan::instance()->scheduleFolder(folder);
         }
     }
@@ -1169,6 +1171,8 @@ void FolderStatusModel::slotSyncAllPendingBigFolders()
         foreach (const auto &it, undecidedList) {
             folder->journalDb()->avoidReadFromDbOnNextSync(it);
         }
+        // Also make sure we see the local file that had been ignored before
+        folder->slotNextSyncFullLocalDiscovery();
         FolderMan::instance()->scheduleFolder(folder);
     }
 

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -140,6 +140,7 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
     // ignored (because the remote etag did not change)   (issue #3172)
     foreach (Folder *folder, folderMan->map()) {
         folder->journalDb()->forceRemoteDiscoveryNextSync();
+        folder->slotNextSyncFullLocalDiscovery();
         folderMan->scheduleFolder(folder);
     }
 }

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -492,6 +492,8 @@ void SelectiveSyncDialog::accept()
         foreach (const auto &it, changes) {
             _folder->journalDb()->avoidReadFromDbOnNextSync(it);
         }
+        // Also make sure we see the local file that had been ignored before
+        _folder->slotNextSyncFullLocalDiscovery();
 
         folderMan->scheduleFolder(_folder);
     }


### PR DESCRIPTION
Since we are now skipping the full local discovery, we also need to
call the method to force a full local discovery while we were making
full remote discovery, for the same reason.

Same applies when applying a selective sync: Normally there should not
be any file or directory with the same same of a blacklisted folder, but
if there is one, it was ignored and now need to be taken in account.

Also make the F6 shortcut do a full local discovery as well.