### PR TITLE
Remove unused installers before copying new ones into the appdata dir

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -296,11 +296,19 @@ void NSISUpdater::slotDownloadFinished()
 
     QUrl url(reply->url());
     _file->close();
+
+    ConfigFile cfg;
+    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+
+    // remove previously downloaded but not used installer
+    QFile oldTargetFile(settings.value(updateAvailableC).toString());
+    if (oldTargetFile.exists()) {
+        oldTargetFile.remove();
+    }
+
     QFile::copy(_file->fileName(), _targetFile);
     setDownloadState(DownloadComplete);
     qCInfo(lcUpdater) << "Downloaded" << url.toString() << "to" << _targetFile;
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
     settings.setValue(updateTargetVersionC, updateInfo().version());
     settings.setValue(updateAvailableC, _targetFile);
 }


### PR DESCRIPTION
relates to #6690.

Usually this should not be a problem, but while testing it's easy to mess up your data dir with left over installers.