### PR TITLE
WIP: Read default folder configuration from a file on the server

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>917</width>
-    <height>604</height>
+    <width>916</width>
+    <height>719</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -236,6 +236,30 @@
          <number>0</number>
         </property>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QRadioButton" name="rDefaultFolders">
+            <property name="text">
+             <string>A&amp;pply default folders configuration (recommended)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QRadioButton" name="rSyncEverything">
@@ -397,7 +421,7 @@
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When this option is selected, the wizard will close without synchronizing anything. You can use the &amp;quot;Add Folder Sync Connection&amp;quot; button from the account settings to choose which pair of local and remote folder you wish to synchronize&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
-             <string>Manually create folder sync connections </string>
+             <string>Ma&amp;nually create folder sync connections </string>
             </property>
            </widget>
           </item>
@@ -427,7 +451,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Use virtual files instead of downloading content immediately (e&amp;xperimental)</string>
+             <string>&amp;Use virtual files instead of downloading content immediately (experimental)</string>
             </property>
             <property name="checkable">
              <bool>false</bool>
@@ -486,8 +510,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>899</width>
-        <height>68</height>
+        <width>904</width>
+        <height>80</height>
        </rect>
       </property>
       <property name="sizePolicy">


### PR DESCRIPTION
This commit will read a file called `.desktopclientconfig` at the root
of the webdav, while running the wizard, before showing the last page.

If the file exist and contains a list of default folder to configure,
hide all the option to configure the remote folders, as the default
configurtation will be applied.

![screenshot_20180903_112503](https://user-images.githubusercontent.com/959326/44978871-016c3e80-af6c-11e8-8622-04e36a3ddf00.png)

The config file should contains a json object. The currently supported
config can be seen in this these example:

```
{ "default_folders": [
    {
        "remote_folder" : "Documents",
        "black_list" :  [ "Archives/1999", "Archives/1998" ]
    },
    {  "remote_folder": "Music"  }
]}
```

The `default_folders` property is a list of folder configuration. The
`remote_folder` property is the path of the folder on the remote. The
`black_list` property is a list of entries for the "choose what to sync".