### PR TITLE
OAuth2: Store 'Account::davUser' in the config, and use that user for…

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -29,6 +29,7 @@ static const char urlC[] = "url";
 static const char authTypeC[] = "authType";
 static const char userC[] = "user";
 static const char httpUserC[] = "http_user";
+static const char davUserC[] = "dav_user";
 static const char caCertsKeyC[] = "CaCertificates";
 static const char accountsC[] = "Accounts";
 static const char versionC[] = "version";
@@ -212,6 +213,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
 {
     settings.setValue(QLatin1String(versionC), maxAccountVersion);
     settings.setValue(QLatin1String(urlC), acc->_url.toString());
+    settings.setValue(QLatin1String(davUserC), acc->_davUser);
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
     if (acc->_credentials) {
         if (saveCredentials) {
@@ -290,6 +292,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     qCInfo(lcAccountManager) << "Account for" << acc->url() << "using auth type" << authType;
 
     acc->_serverVersion = settings.value(QLatin1String(serverVersionC)).toString();
+    acc->_davUser = settings.value(QLatin1String(davUserC)).toString();
 
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));

--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -48,7 +48,7 @@ void HttpCredentialsGui::askFromUserAsync()
     QObject::connect(job, &DetermineAuthTypeJob::authType, this, [this](DetermineAuthTypeJob::AuthType type) {
         if (type == DetermineAuthTypeJob::OAuth) {
             _asyncAuth.reset(new OAuth(_account, this));
-            _asyncAuth->_expectedUser = _user;
+            _asyncAuth->_expectedUser = _account->davUser();
             connect(_asyncAuth.data(), &OAuth::result,
                 this, &HttpCredentialsGui::asyncAuthResult);
             connect(_asyncAuth.data(), &OAuth::destroyed,

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -90,7 +90,10 @@ QString Account::davUser() const
 
 void Account::setDavUser(const QString &newDavUser)
 {
+    if (_davUser == newDavUser)
+        return;
     _davUser = newDavUser;
+    emit wantsAccountSaved(this);
 }
 
 #ifndef TOKEN_AUTH_ONLY


### PR DESCRIPTION
… connecting

We need to use the user id to check if we are connected to the right account.
These might be different from the HTTP Basic Auth login. (LDAP setups)

When the account was configured as an oauth2 account form the wisard, the
http_user was already set correctly to the user id. But when the server is
upgrading from basic auth to oauth2, we need to pick the right login.

Note that Account::davUser() already defaults to the HTTP user when none
is set, so this means the upgrade will be fine if this is not set in the
config.

Issues:
https://github.com/owncloud/oauth2/issues/109
https://github.com/owncloud/enterprise/issues/2781