### PR TITLE
Upload: Do not error out if the server do not send X-OC-MTime:accepted

### DIFF
--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -310,8 +310,6 @@ void PropagateUploadFileV1::slotPutFinished()
         // Normally Owncloud 6 always puts X-OC-MTime
         qCWarning(lcPropagateUpload) << "Server does not support X-OC-MTime" << job->reply()->rawHeader("X-OC-MTime");
         // Well, the mtime was not set
-        done(SyncFileItem::SoftError, "Server does not support X-OC-MTime");
-        return;
     }
 
     finalize();


### PR DESCRIPTION
If the server does not set the mtime, it is not a big problem for the
synchronisation.

The test was used before so we could do a PROPPATCH for server that did not
support this header. But now that all server supports that we don't need to
to the check. (We do not do the PROPPATCH since we got rid of the neon
dependency)

Apparently, it may happen that some backend don't support setting mtime
and this can lead to this error.

https://github.com/owncloud/client/issues/6797