### PR TITLE
Attempt to fix appveyor build

### DIFF
--- a/appveyor.ini
+++ b/appveyor.ini
@@ -42,6 +42,7 @@ ContinuousIntegration/Enabled = True
 # don't try to pip install on the ci
 python-modules.ignored = True
 binary/mysql.ignored = True
+libs/llvm-meta.ignored = True
 
 libs/qt5.version = ${Variables:QtVersion}
 win32libs/openssl.version = ${Variables:OpenSslVersion}


### PR DESCRIPTION
It tries to compile LLVM because of qttools. (qdoc)
Compiling llvm takes way to long and is timing out.
We do not need qdoc anyway.