### PR TITLE
Discovery: Windows: Don't check if a server file name can be encoded

### DIFF
--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -38,6 +38,7 @@
 #include "csync_update.h"
 #include "csync_util.h"
 #include "csync_misc.h"
+#include "common/utility.h"
 
 #include "vio/csync_vio.h"
 
@@ -147,9 +148,10 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
   }
 
   auto localCodec = QTextCodec::codecForLocale();
-  if (ctx->current == REMOTE_REPLICA && localCodec->mibEnum() != 106) {
+  if (!OCC::Utility::isWindows() && ctx->current == REMOTE_REPLICA && localCodec->mibEnum() != 106) {
       /* If the locale codec is not UTF-8, we must check that the filename from the server can
        * be encoded in the local file system.
+       * (Note: on windows, the FS is always UTF-16, so we don't need to check)
        *
        * We cannot use QTextCodec::canEncode() since that can incorrectly return true, see
        * https://bugreports.qt.io/browse/QTBUG-6925.


### PR DESCRIPTION
Because on windows, all filename can be encoded: The file system uses
UTF-16, regardless of the locale

Issue: #6810