### PR TITLE
Move: Fix too many starting slashes in the destination header

### DIFF
--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -89,8 +89,7 @@ void PropagateRemoteMove::start()
     }
 
     QString source = propagator()->_remoteFolder + _item->_file;
-    QString destination = QDir::cleanPath(propagator()->account()->url().path() + QLatin1Char('/')
-        + propagator()->account()->davPath() + propagator()->_remoteFolder + _item->_renameTarget);
+    QString destination = QDir::cleanPath(propagator()->account()->davUrl().path() + propagator()->_remoteFolder + _item->_renameTarget);
     if (_item->_type == ItemTypeVirtualFile || _item->_type == ItemTypeVirtualFileDownload) {
         auto suffix = propagator()->syncOptions()._virtualFileSuffix;
         ASSERT(source.endsWith(suffix) && destination.endsWith(suffix));


### PR DESCRIPTION
QDir::cleanPath does not remove starting slashes on windows.
So use account::davUrl which is already cleaned

Issue: #6824