### PR TITLE
owncloudcmd: fetch the dav user

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -464,13 +464,22 @@ int main(int argc, char **argv)
             loop.quit();
         });
         job->start();
-
         loop.exec();
 
         if (job->reply()->error() != QNetworkReply::NoError){
             std::cout<<"Error connecting to server\n";
             return EXIT_FAILURE;
         }
+
+        job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"));
+        QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {
+            const QJsonObject data = json.object().value("ocs").toObject().value("data").toObject();
+            account->setDavUser(data.value("id").toString());
+            account->setDavDisplayName(data.value("display-name").toString());
+            loop.quit();
+        });
+        job->start();
+        loop.exec();
     }
 
     // much lower age than the default since this utility is usually made to be run right after a change in the tests


### PR DESCRIPTION
This is required to get the new endpoint working when the server
uses ldap or that the dav user is not the same as the login.

Issue #6830