### PR TITLE
Database: future-proof to allow downgrade from future version

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -313,6 +313,20 @@ bool SyncJournalDb::checkConnect()
         qCInfo(lcDb) << "sqlite3 version" << pragma1.stringValue(0);
     }
 
+    {
+        // Future version of the client (2.6) will have an index 'metadata_parent' which
+        // depends on a custom sqlite function which does not exist yet in 2.5.
+        // So make sure to remove the index if it exists, otherwise we will crash when inserting
+        // rows in the metadata database.
+        // This needs to be done before the synchronous mode is enabled.
+        // The 2.6 client will anyway re-creates this index if it does not exist.
+        SqlQuery query(_db);
+        query.prepare("DROP INDEX IF EXISTS metadata_parent;");
+        if (!query.exec()) {
+            return sqlFail("updateMetadataTableStructure: remove index metadata_parent", query);
+        }
+    }
+
     pragma1.prepare("PRAGMA journal_mode=" + _journalMode + ";");
     if (!pragma1.exec()) {
         return sqlFail("Set PRAGMA journal_mode", pragma1);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1141,7 +1141,7 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     settings.setValue(QLatin1String("paused"), folder.paused);
     settings.setValue(QLatin1String("ignoreHiddenFiles"), folder.ignoreHiddenFiles);
     settings.setValue(QLatin1String("usePlaceholders"), folder.useVirtualFiles);
-    settings.setValue(QLatin1String(versionC), maxSettingsVersion());
+    settings.setValue(QLatin1String(versionC), 1);
 
     // Happens only on Windows when the explorer integration is enabled.
     if (!folder.navigationPaneClsid.isNull())

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -79,7 +79,7 @@ public:
         FolderDefinition *folder);
 
     /// The highest version in the settings that load() can read
-    static int maxSettingsVersion() { return 1; }
+    static int maxSettingsVersion() { return 2; }
 
     /// Ensure / as separator and trailing /.
     static QString prepareLocalPath(const QString &path);


### PR DESCRIPTION
The 2.6 client will introduce an index that depends on a custom
function.
This causes insersion onto the metadata database to fail if the database
it opened with older version of the client. (Which will cause the client
to abort)

Delete this index in this version in order to allow downgrade.

OF course this commit need not to be in the 2.6 release