### PR TITLE
Settings: Make FoldersWithPlaceholders group sticky

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -60,7 +60,6 @@ Folder::Folder(const FolderDefinition &definition,
     , _consecutiveFollowUpSyncs(0)
     , _journal(_definition.absoluteJournalPath())
     , _fileLog(new SyncRunFileLog)
-    , _saveBackwardsCompatible(false)
 {
     _timeSinceLastSyncStart.start();
     _timeSinceLastSyncDone.start();
@@ -538,6 +537,8 @@ void Folder::downloadVirtualFile(const QString &_relativepath)
 void Folder::setUseVirtualFiles(bool enabled)
 {
     _definition.useVirtualFiles = enabled;
+    if (enabled)
+        _saveInFoldersWithPlaceholders = true;
     saveToSettings();
 }
 
@@ -558,9 +559,9 @@ void Folder::saveToSettings() const
         }
     }
 
-    if (_definition.useVirtualFiles) {
-        // If virtual files are enabled, save the folder to a group
-        // that will not be read by older (<2.5.0) clients.
+    if (_definition.useVirtualFiles || _saveInFoldersWithPlaceholders) {
+        // If virtual files are enabled or even were enabled at some point,
+        // save the folder to a group that will not be read by older (<2.5.0) clients.
         // The name is from when virtual files were called placeholders.
         settingsGroup = QStringLiteral("FoldersWithPlaceholders");
     } else if (_saveBackwardsCompatible || oneAccountOnly) {

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -235,6 +235,9 @@ public:
       */
     void setSaveBackwardsCompatible(bool save);
 
+    /** Used to have placeholders: save in placeholder config section */
+    void setSaveInFoldersWithPlaceholders() { _saveInFoldersWithPlaceholders = true; }
+
     /**
      * Sets up this folder's folderWatcher if possible.
      *
@@ -400,7 +403,16 @@ private:
      * on the *first* Folder instance that was configured for each local
      * path.
      */
-    bool _saveBackwardsCompatible;
+    bool _saveBackwardsCompatible = false;
+
+    /** Whether the folder should be saved in that settings group
+     *
+     * If it was read from there it had virtual files enabled at some
+     * point and might still have db entries or suffix-virtual files even
+     * if they are disabled right now. This flag ensures folders that
+     * were in that group once never go back.
+     */
+    bool _saveInFoldersWithPlaceholders = false;
 
     /**
      * Watches this folder's local directory for changes.

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -189,22 +189,22 @@ int FolderMan::setupFolders()
 
         // The "backwardsCompatible" flag here is related to migrating old
         // database locations
-        auto process = [&](const QString &groupName, bool backwardsCompatible = false) {
+        auto process = [&](const QString &groupName, bool backwardsCompatible, bool foldersWithPlaceholders) {
             settings->beginGroup(groupName);
             if (skipSettingsKeys.contains(settings->group())) {
                 // Should not happen: bad container keys should have been deleted
                 qCWarning(lcFolderMan) << "Folder structure" << groupName << "is too new, ignoring";
             } else {
-                setupFoldersHelper(*settings, account, backwardsCompatible, skipSettingsKeys);
+                setupFoldersHelper(*settings, account, skipSettingsKeys, backwardsCompatible, foldersWithPlaceholders);
             }
             settings->endGroup();
         };
 
-        process(QStringLiteral("Folders"), true);
+        process(QStringLiteral("Folders"), true, false);
 
         // See Folder::saveToSettings for details about why these exists.
-        process(QStringLiteral("Multifolders"));
-        process(QStringLiteral("FoldersWithPlaceholders"));
+        process(QStringLiteral("Multifolders"), false, false);
+        process(QStringLiteral("FoldersWithPlaceholders"), false, true);
 
         settings->endGroup(); // <account>
     }
@@ -214,7 +214,7 @@ int FolderMan::setupFolders()
     return _folderMap.size();
 }
 
-void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool backwardsCompatible, const QStringList &ignoreKeys)
+void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account, const QStringList &ignoreKeys, bool backwardsCompatible, bool foldersWithPlaceholders)
 {
     foreach (const auto &folderAlias, settings.childGroups()) {
         // Skip folders with too-new version
@@ -253,9 +253,10 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
             Folder *f = addFolderInternal(std::move(folderDefinition), account.data());
             if (f) {
                 // Migration: Mark folders that shall be saved in a backwards-compatible way
-                if (backwardsCompatible) {
+                if (backwardsCompatible)
                     f->setSaveBackwardsCompatible(true);
-                }
+                if (foldersWithPlaceholders)
+                    f->setSaveInFoldersWithPlaceholders();
                 scheduleFolder(f);
                 emit folderSyncStateChange(f);
             }

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -302,7 +302,7 @@ private:
     // restarts the application (Linux only)
     void restartApplication();
 
-    void setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool backwardsCompatible, const QStringList &ignoreKeys);
+    void setupFoldersHelper(QSettings &settings, AccountStatePtr account, const QStringList &ignoreKeys, bool backwardsCompatible, bool foldersWithPlaceholders);
 
     QSet<Folder *> _disabledFolders;
     Folder::Map _folderMap;


### PR DESCRIPTION
If virtual files are disabled on a folder it might still have db entries
or local virtual files that would confuse older client versions.