### PR TITLE
Add Ctrl-Alt-Shift-L as log window shortcut

### DIFF
--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -129,7 +129,7 @@ Logging to a Temporary Directory
 
 1. Open the ownCloud Desktop Client.
 
-2. Press F12 on your keyboard.
+2. Press F12 or Ctrl-L on your keyboard.
 
   The Log Output window opens.
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -135,6 +135,11 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     connect(showLogWindow, &QAction::triggered, gui, &ownCloudGui::slotToggleLogBrowser);
     addAction(showLogWindow);
 
+    QAction *showLogWindow2 = new QAction(this);
+    showLogWindow2->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_L));
+    connect(showLogWindow2, &QAction::triggered, gui, &ownCloudGui::slotToggleLogBrowser);
+    addAction(showLogWindow2);
+
     customizeStyle();
 
     cfg.restoreGeometry(this);


### PR DESCRIPTION
F12 is taken on OSX and there's no other way of showing it.