### PR TITLE
Account: Fix crash when deleting an account

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -55,6 +55,9 @@ AbstractNetworkJob::AbstractNetworkJob(AccountPtr account, const QString &path, 
     , _path(path)
     , _redirectCount(0)
 {
+    // Since we hold a QSharedPointer to the account, this makes no sense. (issue #6893)
+    ASSERT(account != parent);
+
     _timer.setSingleShot(true);
     _timer.setInterval((httpTimeout ? httpTimeout : 300) * 1000); // default to 5 minutes.
     connect(&_timer, &QTimer::timeout, this, &AbstractNetworkJob::slotTimeout);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -262,7 +262,7 @@ QNetworkReply *Account::sendRawRequest(const QByteArray &verb, const QUrl &url, 
 
 SimpleNetworkJob *Account::sendRequest(const QByteArray &verb, const QUrl &url, QNetworkRequest req, QIODevice *data)
 {
-    auto job = new SimpleNetworkJob(sharedFromThis(), this);
+    auto job = new SimpleNetworkJob(sharedFromThis());
     job->startRequest(verb, url, req, data);
     return job;
 }


### PR DESCRIPTION
We should not have request parented to the account, otherwise we might get
a loop on the deletion order.

Issue #6893