### PR TITLE
Directory level control of whether new files are virtual or not

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -401,7 +401,10 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
         }
         // Turn new remote files into virtual files if the option is enabled.
         auto &opts = _discoveryData->_syncOptions;
-        if (!localEntry.isValid() && opts._vfs->mode() != Vfs::Off && opts._newFilesAreVirtual && item->_type == ItemTypeFile) {
+        if (!localEntry.isValid()
+            && item->_type == ItemTypeFile
+            && opts._vfs->mode() != Vfs::Off
+            && directoryPinState() == PinState::OnlineOnly) {
             item->_type = ItemTypeVirtualFile;
             if (isVfsWithSuffix())
                 addVirtualFileSuffix(path._original);
@@ -1307,6 +1310,19 @@ bool ProcessDirectoryJob::runLocalQuery()
         return false;
     }
     return true;
+}
+
+PinState ProcessDirectoryJob::directoryPinState()
+{
+    if (_pinStateCache)
+        return *_pinStateCache;
+
+    // Get the path's pinstate and anchor to the root option
+    _pinStateCache = _discoveryData->_statedb->pinStateForPath(_currentFolder._original.toUtf8());
+    if (*_pinStateCache == PinState::Unspecified)
+        _pinStateCache = _discoveryData->_syncOptions._newFilesAreVirtual ? PinState::OnlineOnly : PinState::AlwaysLocal;
+
+    return *_pinStateCache;
 }
 
 bool ProcessDirectoryJob::isVfsWithSuffix() const

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -18,6 +18,7 @@
 #include "discoveryphase.h"
 #include "syncfileitem.h"
 #include "common/asserts.h"
+#include "common/syncjournaldb.h"
 
 class ExcludedFiles;
 
@@ -177,6 +178,9 @@ private:
       */
     bool runLocalQuery();
 
+    /** Retrieve and cache directory pin state */
+    PinState directoryPinState();
+
     QueryMode _queryServer;
     QueryMode _queryLocal;
 
@@ -216,6 +220,7 @@ private:
     PathTuple _currentFolder;
     bool _childModified = false; // the directory contains modified item what would prevent deletion
     bool _childIgnored = false; // The directory contains ignored item that would prevent deletion
+    Optional<PinState> _pinStateCache; // The directories pin-state, once retrieved, see directoryPinState()
 
 signals:
     void finished();


### PR DESCRIPTION
For #6815

This is targeted for 2.5 in the ticket but I'd like to avoid that if possible since it's a new feature.

Warts:
- Maybe `PinState` should be `NewFilesAreVirtualFlag` or something? With options `NewFilesAreVirtual` and `NewFilesAreDownloaded`? I have some hopes of replacing the action-flag like "ItemTypeVirtualFileDehydration" and "ItemTypeVirtualFileDownload" with something orthogonal to the item type.
- The root folder's state isn't stored in the db (the root has no entry). It's stored in `SyncOptions` instead.
- SocketAPI actions can't control the root's state.
- The root "newFilesAreVirtual" state controls whether selective sync is shown or not. That's now weird, since the flag may be set even though all subfolders are `AlwaysLocal`. Or it's not set even though all subfolders are `OnlineOnly`. Selective sync has lots of overlap with vfs and we need to figure out what to do about it.