### PR TITLE
SocketApi: make sure to discover the file we want to make virtual

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -652,6 +652,7 @@ void SocketApi::command_REPLACE_VIRTUAL_FILE(const QString &filesArg, SocketList
         if (!FileSystem::rename(file, file + suffix)) {
             qCWarning(lcSocketApi) << "Unable to rename " << file;
         }
+        folder->slotWatchedPathChanged(file); // make sure it is in the _localDiscoveryTracker list
         FolderMan::instance()->scheduleFolder(folder);
     }
 }


### PR DESCRIPTION
MacOSX's file system watcher does not deliver events for files modified by
our own process.

Issue: #6844