### PR TITLE
Logging: do not write to a temporary logdir if --logfile is passed

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -473,11 +473,11 @@ void Application::setupLogging()
     logger->setLogExpire(_logExpire);
     logger->setLogFlush(_logFlush);
     logger->setLogDebug(_logDebug);
+    logger->enterNextLogFile();
     if (!logger->isLoggingToFile() && ConfigFile().automaticLogDir()) {
         logger->setupTemporaryFolderLogDir();
+        logger->enterNextLogFile();
     }
-
-    logger->enterNextLogFile();
 
     qCInfo(lcApplication) << QString::fromLatin1("################## %1 locale:[%2] ui_lang:[%3] version:[%4] os:[%5]").arg(_theme->appName()).arg(QLocale::system().name()).arg(property("ui_lang").toString()).arg(_theme->version()).arg(Utility::platformName());
 }


### PR DESCRIPTION
I guess the logger->isLoggingToFile was supposed to check that.
But this is not returning the right value if we did not enter the
logfile already.

Issue #6909