### PR TITLE
Wizard: do not display HTML error page from the server in a message box

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -272,23 +272,6 @@ void OwncloudSetupWizard::slotNoServerFound(QNetworkReply *reply)
     }
     bool isDowngradeAdvised = checkDowngradeAdvised(reply);
 
-    // If a client cert is needed, nginx sends:
-    // 400 "<html>\r\n<head><title>400 No required SSL certificate was sent</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>400 Bad Request</h1></center>\r\n<center>No required SSL certificate was sent</center>\r\n<hr><center>nginx/1.10.0</center>\r\n</body>\r\n</html>\r\n"
-    // If the IP needs to be added as "trusted domain" in oC, oC sends:
-    // https://gist.github.com/guruz/ab6d11df1873c2ad3932180de92e7d82
-    if (resultCode != 200 && contentType.startsWith("text/")) {
-        // FIXME: Synchronous dialogs are not so nice because of event loop recursion
-        // (we already create a dialog further below)
-        QString serverError = reply->peek(1024 * 20);
-        qCDebug(lcWizard) << serverError;
-        QMessageBox messageBox(_ocWizard);
-        messageBox.setText(tr("The server reported the following error:"));
-        messageBox.setInformativeText(serverError);
-        messageBox.addButton(QMessageBox::Ok);
-        messageBox.setTextFormat(Qt::RichText);
-        messageBox.exec();
-    }
-
     // Displays message inside wizard and possibly also another message box
     _ocWizard->displayError(msg, isDowngradeAdvised);
 


### PR DESCRIPTION
It makes no sense to display arbitrary html in a message box.
It is ugly and unfriendly.
The wizard itself already show the error in red.

In case of invalid certificate/ missing clientside certificate, there
is already a dialog that suggest using client side certificates.

Issue #6157