### PR TITLE
Switch to standard opt-out BUILD_TESTING instead of opt-in UNIT_TESTING

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
     commands:
       - mkdir clang-build
       - cd clang-build
-      - cmake -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE="Debug" -DUNIT_TESTING=1 ..
+      - cmake -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE="Debug" -DBUILD_TESTING=1 ..
 
   building-clang:
     image: owncloudci/client:latest
@@ -59,7 +59,7 @@ pipeline:
     commands:
       - mkdir gcc-build
       - cd gcc-build
-      - cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE="Debug" -DUNIT_TESTING=1 ..
+      - cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE="Debug" -DBUILD_TESTING=1 ..
 
   building-gcc:
     image: owncloudci/client:latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,9 +192,11 @@ if(BUILD_SHELL_INTEGRATION)
     add_subdirectory(shell_integration)
 endif()
 
-if(UNIT_TESTING)
+include(CTest)
+if(BUILD_TESTING)
+    enable_testing()
     add_subdirectory(test)
-endif(UNIT_TESTING)
+endif()
 
 configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)

--- a/src/csync/DefineOptions.cmake
+++ b/src/csync/DefineOptions.cmake
@@ -1,2 +1,1 @@
-option(UNIT_TESTING "Build with unit tests" OFF)
 option(MEM_NULL_TESTS "Enable NULL memory testing" OFF)


### PR DESCRIPTION
Compare https://cmake.org/cmake/help/v3.0/module/CTest.html
Craft automatically handles BUILD_TESTING, so we don't need to handle it
in our own blueprint.