### PR TITLE
Render client docs as "Desktop" when generated

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,4 +1,4 @@
-name: client
+name: desktop
 title: Desktop Client
 version: master
 start_page: ROOT:introduction.adoc


### PR DESCRIPTION
### Fixes

https://github.com/owncloud/docs/issues/429