### PR TITLE
Add ownCloud icon to Dolphin context menu

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
@@ -93,6 +93,7 @@ public:
 
         auto menuaction = new QAction(parentWidget);
         menuaction->setText(helper->contextMenuTitle());
+        menuaction->setIcon(QIcon::fromTheme(QStringLiteral("owncloud")));
         menuaction->setMenu(menu);
         return { menuaction };
     }


### PR DESCRIPTION
Most actions in Dolphin's context menu have an icon. 

![image](https://user-images.githubusercontent.com/6377822/49600129-c7537400-f982-11e8-8e43-ac7b284c91d1.png)
