### PR TITLE
Database: Change path for new dbs to .sync_*

### DIFF
--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -55,8 +55,8 @@ Identifying Basic Functionality Problems
 ---------------------
 
 If you see this error message stop your client, delete the
-``._sync_xxxxxxx.db`` file, and then restart your client.
-There is a  hidden ``._sync_xxxxxxx.db`` file inside the folder of every account
+``.sync_xxxxxxx.db`` file, and then restart your client.
+There is a  hidden ``.sync_xxxxxxx.db`` file inside the folder of every account
 configured on your client. 
 
 .. NOTE::

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -731,7 +731,7 @@ void Folder::wipe()
     // Delete files that have been partially downloaded.
     slotDiscardDownloadProgress();
 
-    //Unregister the socket API so it does not keep the ._sync_journal file open
+    //Unregister the socket API so it does not keep the .sync_journal file open
     FolderMan::instance()->socketApi()->slotUnregisterPath(alias());
     _journal.close(); // close the sync journal
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -236,12 +236,13 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 folderDefinition.journalPath = defaultJournalPath;
             }
 
-            // Migration: ._ files sometimes don't work
-            // So if the configured journalPath is the default one ("._sync_*.db")
+            // Migration: ._ files sometimes can't be created.
+            // So if the configured journalPath has a dot-underscore ("._sync_*.db")
             // but the current default doesn't have the underscore, switch to the
-            // new default. See SyncJournalDb::makeDbName().
+            // new default if no db exists yet.
             if (folderDefinition.journalPath.startsWith("._sync_")
-                && defaultJournalPath.startsWith(".sync_")) {
+                && defaultJournalPath.startsWith(".sync_")
+                && !QFile::exists(folderDefinition.absoluteJournalPath())) {
                 folderDefinition.journalPath = defaultJournalPath;
             }
 

--- a/test/scripts/txpl/ownCloud/Test.pm
+++ b/test/scripts/txpl/ownCloud/Test.pm
@@ -455,7 +455,7 @@ sub traverse( $$;$ )
 
 	$isHere = 1 if( $acceptConflicts && !$isHere && $f =~ /conflicted copy/ );
 	$isHere = 1 if( $f =~ /\.csync/ );
-	$isHere = 1 if( $f =~ /\._sync_/ );
+	$isHere = 1 if( $f =~ /\.sync_/ );
 	assert( $isHere, "Filename local, but not remote: $f" );
     }
 

--- a/test/scripts/txpl/t2.pl
+++ b/test/scripts/txpl/t2.pl
@@ -176,7 +176,7 @@ assertLocalAndRemoteDir( 'remoteToLocal1', 1);
 
 printInfo("simulate a owncloud 5 update by removing all the fileid");
 ## simulate a owncloud 5 update by removing all the fileid
-system( "sqlite3 " . localDir() . "._sync_*.db \"UPDATE metadata SET fileid='';\"");
+system( "sqlite3 " . localDir() . ".sync_*.db \"UPDATE metadata SET fileid='';\"");
 #refresh the ids
 csync();
 assertLocalAndRemoteDir( 'remoteToLocal1', 1);

--- a/test/scripts/txpl/t6.pl
+++ b/test/scripts/txpl/t6.pl
@@ -61,7 +61,7 @@ sub getETagFromJournal($$)
 {
     my ($name,$num) = @_;
 
-    my $sql = "sqlite3 " . localDir() . "._sync_*.db \"SELECT md5 FROM metadata WHERE path='$name';\"";
+    my $sql = "sqlite3 " . localDir() . ".sync_*.db \"SELECT md5 FROM metadata WHERE path='$name';\"";
     open(my $fh, '-|', $sql) or die $!;
     my $etag  = <$fh>;
     close $fh;

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -1134,7 +1134,7 @@ public:
         _account->setDavDisplayName("fakename");
         _account->setServerVersion("10.0.0");
 
-        _journalDb.reset(new OCC::SyncJournalDb(localPath() + "._sync_test.db"));
+        _journalDb.reset(new OCC::SyncJournalDb(localPath() + ".sync_test.db"));
         _syncEngine.reset(new OCC::SyncEngine(_account, localPath(), "", _journalDb.get()));
         // Ignore temporary files from the download. (This is in the default exclude list, but we don't load it)
         _syncEngine->excludedFiles().addManualExclude("]*.~*");


### PR DESCRIPTION
This is to avoid issues on OSX, where the ._ prefix has special meaning.

Originally (before 2.3.2) ._ was necessary to guarantee exclusion. But
since then the .sync_ prefix is excluded as well.

This does not affect existing database files.

For  #5904