### PR TITLE
Vfs plugins: Available plugins must load

### DIFF
--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -107,6 +107,13 @@ bool OCC::isVfsPluginAvailable(Vfs::Mode mode)
         return false;
     }
 
+    // Attempting to load the plugin is essential as it could have dependencies that
+    // can't be resolved and thus not be available after all.
+    if (!loader.load()) {
+        qCWarning(lcPlugin) << "Plugin failed to load:" << loader.errorString();
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
A plugin that can't be loaded due to dependency issues should not be
considered as available.