### PR TITLE
Vfs: Ensure older versions gracefully ignore winvfs folders

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1248,11 +1248,16 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     settings.setValue(QLatin1String("targetPath"), folder.targetPath);
     settings.setValue(QLatin1String("paused"), folder.paused);
     settings.setValue(QLatin1String("ignoreHiddenFiles"), folder.ignoreHiddenFiles);
-    settings.setValue(QLatin1String(versionC), maxSettingsVersion());
     settings.setValue(QLatin1String("usePlaceholders"), folder.newFilesAreVirtual);
 
     settings.setValue(QStringLiteral("virtualFilesMode"), Vfs::modeToString(folder.virtualFilesMode));
 
+    // Ensure new vfs modes won't be attempted by older clients
+    if (folder.virtualFilesMode == Vfs::WindowsCfApi) {
+        settings.setValue(QLatin1String(versionC), 3);
+    } else {
+        settings.setValue(QLatin1String(versionC), 2);
+    }
 
     // Happens only on Windows when the explorer integration is enabled.
     if (!folder.navigationPaneClsid.isNull())

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -84,8 +84,14 @@ public:
     static bool load(QSettings &settings, const QString &alias,
         FolderDefinition *folder);
 
-    /// The highest version in the settings that load() can read
-    static int maxSettingsVersion() { return 2; }
+    /** The highest version in the settings that load() can read
+     *
+     * Version 1: initial version (default if value absent in settings)
+     * Version 2: introduction of metadata_parent hash in 2.6.0
+     *            (version remains readable by 2.5.1)
+     * Version 3: introduction of new windows vfs mode in 2.6.0
+     */
+    static int maxSettingsVersion() { return 3; }
 
     /// Ensure / as separator and trailing /.
     static QString prepareLocalPath(const QString &path);


### PR DESCRIPTION
Previously there'd likely be a mess if a 2.6 winvfs folder was attempted
to be used with a 2.5 client. Now the older clients will ignore these
folders.