### PR TITLE
Vfs: Have a static list of potential plugins for now

### DIFF
--- a/src/libsync/vfs/CMakeLists.txt
+++ b/src/libsync/vfs/CMakeLists.txt
@@ -1,4 +1,8 @@
-file(GLOB vfsPlugins RELATIVE ${CMAKE_CURRENT_LIST_DIR} "*")
+# Globbing for plugins has a problem with in-source builds
+# that create directories for the build.
+#file(GLOB vfsPlugins RELATIVE ${CMAKE_CURRENT_LIST_DIR} "*")
+
+SET(vfsPlugins "suffix;win")
 
 foreach(vfsPlugin ${vfsPlugins})
     if(NOT IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/${vfsPlugin}")


### PR DESCRIPTION
Fixes in-source builds and other cases where more non-plugin directories
are created in src/libsync/vfs.

@mrow4a Should fix the smashbox build failure you saw.