### PR TITLE
Progress: Virtual file creation needs no transfer progress

### DIFF
--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -121,10 +121,13 @@ public:
     /** Return true if the size needs to be taken in account in the total amount of time */
     static inline bool isSizeDependent(const SyncFileItem &item)
     {
-        return !item.isDirectory() && (item._instruction == CSYNC_INSTRUCTION_CONFLICT
-                                         || item._instruction == CSYNC_INSTRUCTION_SYNC
-                                         || item._instruction == CSYNC_INSTRUCTION_NEW
-                                         || item._instruction == CSYNC_INSTRUCTION_TYPE_CHANGE);
+        return !item.isDirectory()
+            && (item._instruction == CSYNC_INSTRUCTION_CONFLICT
+                || item._instruction == CSYNC_INSTRUCTION_SYNC
+                || item._instruction == CSYNC_INSTRUCTION_NEW
+                || item._instruction == CSYNC_INSTRUCTION_TYPE_CHANGE)
+            && !(item._type == ItemTypeVirtualFile
+                 || item._type == ItemTypeVirtualFileDehydration);
     }
 
     /**


### PR DESCRIPTION
Treat virtual file creation as a size-less action, similar to
propagating renames or deletions.

For  #6933