### PR TITLE
vfs: Remove newFilesAreVirtual - use root PinState instead

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -435,8 +435,6 @@ void AccountSettings::slotFolderWizardAccepted()
 
     if (folderWizard->property("useVirtualFiles").toBool()) {
         definition.virtualFilesMode = bestAvailableVfsMode();
-        if (definition.virtualFilesMode != Vfs::Off)
-            definition.newFilesAreVirtual = true;
     }
 
     {
@@ -469,6 +467,9 @@ void AccountSettings::slotFolderWizardAccepted()
 
     Folder *f = folderMan->addFolder(_accountState, definition);
     if (f) {
+        if (definition.virtualFilesMode != Vfs::Off && folderWizard->property("useVirtualFiles").toBool())
+            f->setNewFilesAreVirtual(true);
+
         f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, selectiveSyncBlackList);
 
         // The user already accepted the selective sync dialog. everything is in the white list

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -69,18 +69,16 @@ public:
     bool ignoreHiddenFiles;
     /// Which virtual files setting the folder uses
     Vfs::Mode virtualFilesMode = Vfs::Off;
-    /// Whether new files are virtual
-    bool newFilesAreVirtual = false;
     /// The CLSID where this folder appears in registry for the Explorer navigation pane entry.
     QUuid navigationPaneClsid;
 
     /// Whether the vfs mode shall silently be updated if possible
     bool upgradeVfsMode = false;
 
-    /// Saves the folder definition, creating a new settings group.
+    /// Saves the folder definition into the current settings group.
     static void save(QSettings &settings, const FolderDefinition &folder);
 
-    /// Reads a folder definition from a settings group with the name 'alias'.
+    /// Reads a folder definition from the current settings group.
     static bool load(QSettings &settings, const QString &alias,
         FolderDefinition *folder);
 
@@ -271,7 +269,10 @@ public:
     bool supportsVirtualFiles() const;
     void setSupportsVirtualFiles(bool enabled);
 
-    /** whether new remote files shall become virtual locally */
+    /** whether new remote files shall become virtual locally
+     *
+     * This is the root folder pin state and can be overridden by explicit subfolder pin states.
+     */
     bool newFilesAreVirtual() const;
     void setNewFilesAreVirtual(bool enabled);
 
@@ -432,7 +433,7 @@ private:
     /// Reset when no follow-up is requested.
     int _consecutiveFollowUpSyncs;
 
-    SyncJournalDb _journal;
+    mutable SyncJournalDb _journal;
 
     QScopedPointer<SyncRunFileLog> _fileLog;
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -604,14 +604,15 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
             folderDefinition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();
             if (_ocWizard->useVirtualFileSync()) {
                 folderDefinition.virtualFilesMode = bestAvailableVfsMode();
-                if (folderDefinition.virtualFilesMode != Vfs::Off)
-                    folderDefinition.newFilesAreVirtual = true;
             }
             if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
                 folderDefinition.navigationPaneClsid = QUuid::createUuid();
 
             auto f = folderMan->addFolder(account, folderDefinition);
             if (f) {
+                if (folderDefinition.virtualFilesMode != Vfs::Off && _ocWizard->useVirtualFileSync())
+                    f->setNewFilesAreVirtual(true);
+
                 f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList,
                     _ocWizard->selectiveSyncBlacklist());
                 if (!_ocWizard->isConfirmBigFolderChecked()) {

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -401,10 +401,14 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
         }
         // Turn new remote files into virtual files if the option is enabled.
         auto &opts = _discoveryData->_syncOptions;
+        if (!directoryPinState()) {
+            dbError();
+            return;
+        }
         if (!localEntry.isValid()
             && item->_type == ItemTypeFile
             && opts._vfs->mode() != Vfs::Off
-            && directoryPinState() == PinState::OnlineOnly) {
+            && *directoryPinState() == PinState::OnlineOnly) {
             item->_type = ItemTypeVirtualFile;
             if (isVfsWithSuffix())
                 addVirtualFileSuffix(path._original);
@@ -1313,17 +1317,14 @@ bool ProcessDirectoryJob::runLocalQuery()
     return true;
 }
 
-PinState ProcessDirectoryJob::directoryPinState()
+Optional<PinState> ProcessDirectoryJob::directoryPinState()
 {
-    if (_pinStateCache)
-        return *_pinStateCache;
-
-    // Get the path's pinstate and anchor to the root option
-    _pinStateCache = _discoveryData->_statedb->pinStateForPath(_currentFolder._original.toUtf8());
-    if (*_pinStateCache == PinState::Unspecified)
-        _pinStateCache = _discoveryData->_syncOptions._newFilesAreVirtual ? PinState::OnlineOnly : PinState::AlwaysLocal;
-
-    return *_pinStateCache;
+    if (!_pinStateCache) {
+        _pinStateCache = _discoveryData->_statedb->effectivePinStateForPath(
+                _currentFolder._original.toUtf8());
+        // don't cache db errors, just retry next time
+    }
+    return _pinStateCache;
 }
 
 bool ProcessDirectoryJob::isVfsWithSuffix() const

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -179,7 +179,7 @@ private:
     bool runLocalQuery();
 
     /** Retrieve and cache directory pin state */
-    PinState directoryPinState();
+    Optional<PinState> directoryPinState();
 
     QueryMode _queryServer;
     QueryMode _queryLocal;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -100,7 +100,7 @@ void DiscoveryPhase::checkSelectiveSyncNewFolder(const QString &path, RemotePerm
     }
 
     auto limit = _syncOptions._newBigFolderSizeLimit;
-    if (limit < 0 || (_syncOptions._vfs->mode() != Vfs::Off && _syncOptions._newFilesAreVirtual)) {
+    if (limit < 0 || _syncOptions._vfs->mode() != Vfs::Off) {
         // no limit, everything is allowed;
         return callback(false);
     }

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -44,9 +44,6 @@ struct SyncOptions
     /** Create a virtual file for new files instead of downloading. May not be null */
     QSharedPointer<Vfs> _vfs;
 
-    /** True if new files shall be virtual */
-    bool _newFilesAreVirtual = false;
-
     /** The initial un-adjusted chunk size in bytes for chunked uploads, both
      * for old and new chunking algorithm, which classifies the item to be chunked
      *


### PR DESCRIPTION
This unifies how to deal with pin states.

Also enable reading a folders direct pin state vs its effective pin
state.
