### PR TITLE
Vfs <=> selective sync switching

### DIFF
--- a/src/common/result.h
+++ b/src/common/result.h
@@ -43,6 +43,52 @@ public:
     {
     }
 
+    Result(Result &&other)
+        : _isError(other._isError)
+    {
+        if (_isError) {
+            new (&_error) Error(std::move(other._error));
+        } else {
+            new (&_result) T(std::move(other._result));
+        }
+    }
+
+    Result(const Result &other)
+        : _isError(other._isError)
+    {
+        if (_isError) {
+            new (&_error) Error(other._error);
+        } else {
+            new (&_result) T(other._result);
+        }
+    }
+
+    Result &operator=(Result &&other)
+    {
+        if (&other != this) {
+            _isError = other._isError;
+            if (_isError) {
+                new (&_error) Error(std::move(other._error));
+            } else {
+                new (&_result) T(std::move(other._result));
+            }
+        }
+        return *this;
+    }
+
+    Result &operator=(const Result &other)
+    {
+        if (&other != this) {
+            _isError = other._isError;
+            if (_isError) {
+                new (&_error) Error(other._error);
+            } else {
+                new (&_result) T(other._result);
+            }
+        }
+        return *this;
+    }
+
     ~Result()
     {
         if (_isError)
@@ -50,7 +96,9 @@ public:
         else
             _result.~T();
     }
+
     explicit operator bool() const { return !_isError; }
+
     const T &operator*() const &
     {
         ASSERT(!_isError);
@@ -61,6 +109,13 @@ public:
         ASSERT(!_isError);
         return std::move(_result);
     }
+
+    const T *operator->() const
+    {
+        ASSERT(!_isError);
+        return &_result;
+    }
+
     const Error &error() const &
     {
         ASSERT(_isError);

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -2074,6 +2074,22 @@ void SyncJournalDb::wipePinStateForPathAndBelow(const QByteArray &path)
     query.exec();
 }
 
+Optional<QVector<QPair<QByteArray, PinState>>> SyncJournalDb::rawPinStates()
+{
+    QMutexLocker lock(&_mutex);
+    if (!checkConnect())
+        return {};
+
+    SqlQuery query("SELECT path, pinState FROM flags;", _db);
+    query.exec();
+
+    QVector<QPair<QByteArray, PinState>> result;
+    while (query.next()) {
+        result.append({ query.baValue(0), static_cast<PinState>(query.intValue(1)) });
+    }
+    return result;
+}
+
 void SyncJournalDb::commit(const QString &context, bool startTrans)
 {
     QMutexLocker lock(&_mutex);

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1978,14 +1978,17 @@ void SyncJournalDb::markVirtualFileForDownloadRecursively(const QByteArray &path
         return;
 
     static_assert(ItemTypeVirtualFile == 4 && ItemTypeVirtualFileDownload == 5, "");
-    SqlQuery query("UPDATE metadata SET type=5 WHERE " IS_PREFIX_PATH_OF("?1", "path") " AND type=4;", _db);
+    SqlQuery query("UPDATE metadata SET type=5 WHERE "
+                   "(" IS_PREFIX_PATH_OF("?1", "path") " OR ?1 == '') "
+                   "AND type=4;", _db);
     query.bindValue(1, path);
     query.exec();
 
     // We also must make sure we do not read the files from the database (same logic as in avoidReadFromDbOnNextSync)
     // This includes all the parents up to the root, but also all the directory within the selected dir.
     static_assert(ItemTypeDirectory == 2, "");
-    query.prepare("UPDATE metadata SET md5='_invalid_' WHERE (" IS_PREFIX_PATH_OF("?1", "path") " OR " IS_PREFIX_PATH_OR_EQUAL("path", "?1") ") AND type == 2;");
+    query.prepare("UPDATE metadata SET md5='_invalid_' WHERE "
+                  "(" IS_PREFIX_PATH_OF("?1", "path") " OR ?1 == '' OR " IS_PREFIX_PATH_OR_EQUAL("path", "?1") ") AND type == 2;");
     query.bindValue(1, path);
     query.exec();
 }
@@ -2063,7 +2066,9 @@ void SyncJournalDb::wipePinStateForPathAndBelow(const QByteArray &path)
 
     auto &query = _wipePinStateQuery;
     ASSERT(query.initOrReset(QByteArrayLiteral(
-            "DELETE FROM flags WHERE " IS_PREFIX_PATH_OR_EQUAL("?1", "path") ";"),
+            "DELETE FROM flags WHERE "
+            // Allow "" to delete everything
+            " (" IS_PREFIX_PATH_OR_EQUAL("?1", "path") " OR ?1 == '');"),
         _db));
     query.bindValue(1, path);
     query.exec();

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -279,6 +279,7 @@ public:
      *
      * If a path has no explicit PinState "Inherited" is returned.
      *
+     * The path should not have a trailing slash.
      * It's valid to use the root path "".
      *
      * Returns none on db error.
@@ -291,6 +292,7 @@ public:
      * If the exact path has no entry or has an Inherited state,
      * the state of the closest parent path is returned.
      *
+     * The path should not have a trailing slash.
      * It's valid to use the root path "".
      *
      * Never returns PinState::Inherited. If the root is "Inherited"
@@ -303,6 +305,7 @@ public:
     /**
      * Sets a path's pin state.
      *
+     * The path should not have a trailing slash.
      * It's valid to use the root path "".
      */
     void setPinStateForPath(const QByteArray &path, PinState state);
@@ -311,6 +314,7 @@ public:
      * Wipes pin states for a path and below.
      *
      * Used when the user asks a subtree to have a particular pin state.
+     * The path should not have a trailing slash.
      * The path "" wipes every entry.
      */
     void wipePinStateForPathAndBelow(const QByteArray &path);
@@ -319,6 +323,7 @@ public:
      * Returns list of all paths with their pin state as in the db.
      *
      * Returns nothing on db error.
+     * Note that this will have an entry for "".
      */
     Optional<QVector<QPair<QByteArray, PinState>>> rawPinStates();
 

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -269,6 +269,8 @@ public:
     /**
      * Set the 'ItemTypeVirtualFileDownload' to all the files that have the ItemTypeVirtualFile flag
      * within the directory specified path path
+     *
+     * The path "" marks everything.
      */
     void markVirtualFileForDownloadRecursively(const QByteArray &path);
 
@@ -309,6 +311,7 @@ public:
      * Wipes pin states for a path and below.
      *
      * Used when the user asks a subtree to have a particular pin state.
+     * The path "" wipes every entry.
      */
     void wipePinStateForPathAndBelow(const QByteArray &path);
 

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -316,6 +316,13 @@ public:
     void wipePinStateForPathAndBelow(const QByteArray &path);
 
     /**
+     * Returns list of all paths with their pin state as in the db.
+     *
+     * Returns nothing on db error.
+     */
+    Optional<QVector<QPair<QByteArray, PinState>>> rawPinStates();
+
+    /**
      * Only used for auto-test:
      * when positive, will decrease the counter for every database operation.
      * reaching 0 makes the operation fails

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -315,7 +315,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     QAction *ac = menu->addAction(tr("Open folder"));
     connect(ac, &QAction::triggered, this, &AccountSettings::slotOpenCurrentFolder);
 
-    if (!ui->_folderList->isExpanded(index) && !folder->newFilesAreVirtual()) {
+    if (!ui->_folderList->isExpanded(index) && !folder->supportsVirtualFiles()) {
         ac = menu->addAction(tr("Choose what to sync"));
         ac->setEnabled(folderConnected);
         connect(ac, &QAction::triggered, this, &AccountSettings::doExpand);

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -78,6 +78,9 @@ protected slots:
     void slotRemoveCurrentFolder();
     void slotOpenCurrentFolder(); // sync folder
     void slotOpenCurrentLocalSubFolder(); // selected subfolder in sync folder
+    void slotEnableVfsCurrentFolder();
+    void slotDisableVfsCurrentFolder();
+    void slotSetCurrentFolderAvailability(PinState state);
     void slotFolderWizardAccepted();
     void slotFolderWizardRejected();
     void slotDeleteAccount();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -625,9 +625,9 @@ void Folder::setSupportsVirtualFiles(bool enabled)
         _vfs->unregisterFolder();
 
         _vfs.reset(createVfsFromPlugin(newMode).release());
-        startVfs();
 
         _definition.virtualFilesMode = newMode;
+        startVfs();
         if (newMode != Vfs::Off)
             _saveInFoldersWithPlaceholders = true;
         saveToSettings();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1278,16 +1278,19 @@ bool FolderDefinition::load(QSettings &settings, const QString &alias,
     folder->ignoreHiddenFiles = settings.value(QLatin1String("ignoreHiddenFiles"), QVariant(true)).toBool();
     folder->navigationPaneClsid = settings.value(QLatin1String("navigationPaneClsid")).toUuid();
 
-    folder->virtualFilesMode = Vfs::WithSuffix;
+    folder->virtualFilesMode = Vfs::Off;
     QString vfsModeString = settings.value(QStringLiteral("virtualFilesMode")).toString();
     if (!vfsModeString.isEmpty()) {
         if (auto mode = Vfs::modeFromString(vfsModeString)) {
             folder->virtualFilesMode = *mode;
         } else {
-            qCWarning(lcFolder) << "Unknown virtualFilesMode:" << vfsModeString << "assuming 'suffix'";
+            qCWarning(lcFolder) << "Unknown virtualFilesMode:" << vfsModeString << "assuming 'off'";
         }
     } else {
-        folder->upgradeVfsMode = true;
+        if (settings.value(QLatin1String("usePlaceholders")).toBool()) {
+            folder->virtualFilesMode = Vfs::WithSuffix;
+            folder->upgradeVfsMode = true; // maybe winvfs is available?
+        }
     }
 
     // Old settings can contain paths with native separators. In the rest of the

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -562,14 +562,14 @@ void Folder::downloadVirtualFile(const QString &_relativepath)
     // Set in the database that we should download the file
     SyncJournalFileRecord record;
     _journal.getFileRecord(relativepath, &record);
-    if (!record.isValid())
+    if (!record.isValid() && !relativepath.isEmpty())
         return;
     if (record._type == ItemTypeVirtualFile) {
         record._type = ItemTypeVirtualFileDownload;
         _journal.setFileRecord(record);
         // Make sure we go over that file during the discovery
         _journal.avoidReadFromDbOnNextSync(relativepath);
-    } else if (record._type == ItemTypeDirectory) {
+    } else if (record._type == ItemTypeDirectory || relativepath.isEmpty()) {
         _journal.markVirtualFileForDownloadRecursively(relativepath);
     } else {
         qCWarning(lcFolder) << "Invalid existing record " << record._type << " for file " << _relativepath;
@@ -594,11 +594,11 @@ void Folder::dehydrateFile(const QString &_relativepath)
 
     SyncJournalFileRecord record;
     _journal.getFileRecord(relativepath, &record);
-    if (!record.isValid())
+    if (!record.isValid() && !relativepath.isEmpty())
         return;
     if (record._type == ItemTypeFile) {
         markForDehydration(record);
-    } else if (record._type == ItemTypeDirectory) {
+    } else if (record._type == ItemTypeDirectory || relativepath.isEmpty()) {
         _journal.getFilesBelowPath(relativepath, markForDehydration);
     } else {
         qCWarning(lcFolder) << "Invalid existing record " << record._type << " for file " << _relativepath;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -323,6 +323,8 @@ public slots:
     /**
      * Mark a virtual file as being ready for download, and start a sync.
      * relativepath is the path to the file (including the extension)
+     * Passing a folder means that all contained virtual items shall be downloaded.
+     * A relative path of "" downloads everything.
      */
     void downloadVirtualFile(const QString &relativepath);
 
@@ -331,6 +333,7 @@ public slots:
      *
      * relativepath is the path to the file
      * It's allowed to pass a path to a folder: all contained files will be dehydrated.
+     * A relative path of "" dehydrates everything.
      */
     void dehydrateFile(const QString &relativepath);
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -362,7 +362,7 @@ int FolderStatusModel::rowCount(const QModelIndex &parent) const
     auto info = infoForIndex(parent);
     if (!info)
         return 0;
-    if (info->_folder && info->_folder->newFilesAreVirtual())
+    if (info->_folder && info->_folder->supportsVirtualFiles())
         return 0;
     if (info->hasLabel())
         return 1;
@@ -519,7 +519,7 @@ bool FolderStatusModel::hasChildren(const QModelIndex &parent) const
     if (!info)
         return false;
 
-    if (info->_folder && info->_folder->newFilesAreVirtual())
+    if (info->_folder && info->_folder->supportsVirtualFiles())
         return false;
 
     if (!info->_fetched)
@@ -547,7 +547,7 @@ bool FolderStatusModel::canFetchMore(const QModelIndex &parent) const
         // Keep showing the error to the user, it will be hidden when the account reconnects
         return false;
     }
-    if (info->_folder && info->_folder->newFilesAreVirtual()) {
+    if (info->_folder && info->_folder->supportsVirtualFiles()) {
         // Selective sync is hidden in that case
         return false;
     }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -211,8 +211,8 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
     case FolderStatusDelegate::FolderErrorMsg:
         return f->syncResult().errorStrings();
     case FolderStatusDelegate::FolderInfoMsg:
-        return f->newFilesAreVirtual()
-            ? QStringList(tr("New files are being created as virtual files."))
+        return f->supportsVirtualFiles()
+            ? QStringList(tr("Virtual file support is enabled."))
             : QStringList();
     case FolderStatusDelegate::SyncRunning:
         return f->syncResult().status() == SyncResult::SyncRunning;

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -352,7 +352,12 @@ private slots:
             return *state;
         };
 
+        _db.wipePinStateForPathAndBelow("");
+        auto list = _db.rawPinStates();
+        QCOMPARE(list->size(), 0);
+
         // Make a thrice-nested setup
+        make("", PinState::AlwaysLocal);
         make("local", PinState::AlwaysLocal);
         make("online", PinState::OnlineOnly);
         make("inherit", PinState::Inherited);
@@ -362,11 +367,14 @@ private slots:
             make(QByteArray(base) + "online", PinState::OnlineOnly);
 
             for (auto base2 : {"local/", "online/", "inherit/"}) {
-                make(QByteArray(base) + base2 + "/inherit", PinState::Inherited);
-                make(QByteArray(base) + base2 + "/local", PinState::AlwaysLocal);
-                make(QByteArray(base) + base2 + "/online", PinState::OnlineOnly);
+                make(QByteArray(base) + base2 + "inherit", PinState::Inherited);
+                make(QByteArray(base) + base2 + "local", PinState::AlwaysLocal);
+                make(QByteArray(base) + base2 + "online", PinState::OnlineOnly);
             }
         }
+
+        list = _db.rawPinStates();
+        QCOMPARE(list->size(), 4 + 9 + 27);
 
         // Baseline direct checks (the fallback for unset root pinstate is AlwaysLocal)
         QCOMPARE(get("local"), PinState::AlwaysLocal);
@@ -417,12 +425,16 @@ private slots:
         QCOMPARE(getRaw("local/local"), PinState::Inherited);
         QCOMPARE(getRaw("local/local/local"), PinState::Inherited);
         QCOMPARE(getRaw("local/local/online"), PinState::Inherited);
+        list = _db.rawPinStates();
+        QCOMPARE(list->size(), 4 + 9 + 27 - 4);
 
         // Wiping everything
         _db.wipePinStateForPathAndBelow("");
         QCOMPARE(getRaw(""), PinState::Inherited);
         QCOMPARE(getRaw("local"), PinState::Inherited);
         QCOMPARE(getRaw("online"), PinState::Inherited);
+        list = _db.rawPinStates();
+        QCOMPARE(list->size(), 0);
     }
 
 private:

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -417,6 +417,12 @@ private slots:
         QCOMPARE(getRaw("local/local"), PinState::Inherited);
         QCOMPARE(getRaw("local/local/local"), PinState::Inherited);
         QCOMPARE(getRaw("local/local/online"), PinState::Inherited);
+
+        // Wiping everything
+        _db.wipePinStateForPathAndBelow("");
+        QCOMPARE(getRaw(""), PinState::Inherited);
+        QCOMPARE(getRaw("local"), PinState::Inherited);
+        QCOMPARE(getRaw("online"), PinState::Inherited);
     }
 
 private:


### PR DESCRIPTION
There is now a local/online availability switch on folder context menus in the settings as well as a menu entry to switch into vfs mode and away from it.

I looked at migrating between the two analogous settings (selective sync excluded <-> vfs online-only) but it's complex and will probably not produce exactly what users want. So instead I just start with blank vfs and selective sync settings after switching.

Details: When switching on vfs it seems natual to make all excluded paths online-only, the rest available-locally. But then switching on vfs has no visible effect for users that didn't use selective sync unless they manually also switch folders to online-only.

Migrating from vfs to selective sync is just hard since vfs can have arbitrary switches back and forth between online/local folders. Also, online-only folders can totally have locally available files - so setting up selective sync options automatically from that is likely not worth it.

@michaelstingl FYI