### PR TITLE
Fix lookup of system wide settings

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -248,14 +248,14 @@ QVariant ConfigFile::getPolicySetting(const QString &setting, const QVariant &de
     if (Utility::isWindows()) {
         // check for policies first and return immediately if a value is found.
         QSettings userPolicy(QString::fromLatin1("HKEY_CURRENT_USER\\Software\\Policies\\%1\\%2")
-                                 .arg(APPLICATION_VENDOR, Theme::instance()->appName()),
+                                 .arg(APPLICATION_VENDOR, Theme::instance()->appNameGUI()),
             QSettings::NativeFormat);
         if (userPolicy.contains(setting)) {
             return userPolicy.value(setting);
         }
 
         QSettings machinePolicy(QString::fromLatin1("HKEY_LOCAL_MACHINE\\Software\\Policies\\%1\\%2")
-                                    .arg(APPLICATION_VENDOR, APPLICATION_NAME),
+                                    .arg(APPLICATION_VENDOR, Theme::instance()->appNameGUI()),
             QSettings::NativeFormat);
         if (machinePolicy.contains(setting)) {
             return machinePolicy.value(setting);
@@ -615,7 +615,7 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
         systemSetting = systemSettings.value(param, defaultValue);
     } else { // Windows
         QSettings systemSettings(QString::fromLatin1("HKEY_LOCAL_MACHINE\\Software\\%1\\%2")
-                                     .arg(APPLICATION_VENDOR, Theme::instance()->appName()),
+                                     .arg(APPLICATION_VENDOR, Theme::instance()->appNameGUI()),
             QSettings::NativeFormat);
         if (!group.isEmpty()) {
             systemSettings.beginGroup(group);


### PR DESCRIPTION
ConfigFile sets the application name to `appNameGUI()`, so we should also use that for looking up settings in the registry. 

It's also what is used in NSIS to write the `skipUpdateCheck` setting in the registry. [1] For the unbranded ownCloud client it doesn't matter, but if application name and application shortname differ, the current code fails to retrieve the setting correctly. 

Worst of all: it's completely inconsistent: for user policies the shortname is used `appName()` but for machine policies the full application name is used via `APPLICATION_NAME`. Replaced that also with `appNameGUI()` to be more consistent.

[1] https://github.com/owncloud/client/blob/master/cmake/modules/NSIS.template.in#L819