### PR TITLE
Remove unrequired start attribute

### DIFF
--- a/docs/modules/ROOT/pages/building.adoc
+++ b/docs/modules/ROOT/pages/building.adoc
@@ -93,8 +93,6 @@ To set up your build environment for development using http://mxcl.github.com/ho
 . Add the ownCloud repository using the command `brew tap owncloud/owncloud`
 . Install a Qt5 version, ideally from from 5.10.1, using the command `brew install qt5`.
 . Install any missing dependencies, using the command: `brew install $(brew deps owncloud-client)`.
-
-[start=7]
 . Install qtkeychain by running `git clone https://github.com/frankosterfeld/qtkeychain.git`. Make sure you make the
 same install prefix as later while building the client e.g., `-DCMAKE_INSTALL_PREFIX=/Path/to/client/../install`.
 . For compilation of the client, follow the xref:generic-build-instructions[generic build instructions].


### PR DESCRIPTION
I'm not sure why I added the attribute previously, in 0afd511b9cbc30e9586d388c32c72d4d25ddddaf, but it's not necessary and has caused some confusion. Given that, this commit's removing it.