### PR TITLE
HttpCreds: Warn in log if keychain-write jobs fail

### DIFF
--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -116,8 +116,8 @@ private Q_SLOTS:
     void slotReadClientKeyPEMJobDone(QKeychain::Job *);
     void slotReadJobDone(QKeychain::Job *);
 
-    void slotWriteClientCertPEMJobDone();
-    void slotWriteClientKeyPEMJobDone();
+    void slotWriteClientCertPEMJobDone(QKeychain::Job *);
+    void slotWriteClientKeyPEMJobDone(QKeychain::Job *);
     void slotWriteJobDone(QKeychain::Job *);
 
 protected:


### PR DESCRIPTION
Also, calling deleteLater() on jobs is unnecessary (they autodelete
after finished()) and deleting the attached QSettings is also
unnecessary because the settings object is parented to the job.

See  #6776