### PR TITLE
Download: Ignore content-length for compressed HTTP2/SPDY replies #6885

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -641,8 +641,20 @@ void PropagateDownloadFile::slotGetFinished()
      */
     const QByteArray sizeHeader("Content-Length");
     quint64 bodySize = job->reply()->rawHeader(sizeHeader).toULongLong();
+    bool hasSizeHeader = !job->reply()->rawHeader(sizeHeader).isEmpty();
 
-    if (!job->reply()->rawHeader(sizeHeader).isEmpty() && _tmpFile.size() > 0 && bodySize == 0) {
+    // Qt removes the content-length header for transparently decompressed HTTP1 replies
+    // but not for HTTP2 or SPDY replies. For these it remains and contains the size
+    // of the compressed data. See QTBUG-73364.
+    const auto contentEncoding = job->reply()->rawHeader("content-encoding").toLower();
+    if ((contentEncoding == "gzip" || contentEncoding == "deflate")
+        && (job->reply()->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()
+         || job->reply()->attribute(QNetworkRequest::SpdyWasUsedAttribute).toBool())) {
+        bodySize = 0;
+        hasSizeHeader = false;
+    }
+
+    if (hasSizeHeader && _tmpFile.size() > 0 && bodySize == 0) {
         // Strange bug with broken webserver or webfirewall https://github.com/owncloud/client/issues/3373#issuecomment-122672322
         // This happened when trying to resume a file. The Content-Range header was files, Content-Length was == 0
         qCDebug(lcPropagateDownload) << bodySize << _item->_size << _tmpFile.size() << job->resumeStart();


### PR DESCRIPTION
It contains the compressed size.

See https://bugreports.qt.io/browse/QTBUG-73364