### PR TITLE
File watcher: Reduce touch ignore duration

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
     }
 
     // much lower age than the default since this utility is usually made to be run right after a change in the tests
-    SyncEngine::minimumFileAgeForUpload = 0;
+    SyncEngine::minimumFileAgeForUpload = std::chrono::milliseconds(0);
 
     int restartCount = 0;
 restart_sync:

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -55,7 +55,7 @@ static bool fileIsStillChanging(const SyncFileItem &item)
     const QDateTime modtime = Utility::qDateTimeFromTime_t(item._modtime);
     const qint64 msSinceMod = modtime.msecsTo(QDateTime::currentDateTimeUtc());
 
-    return msSinceMod < SyncEngine::minimumFileAgeForUpload
+    return std::chrono::milliseconds(msSinceMod) < SyncEngine::minimumFileAgeForUpload
         // if the mtime is too much in the future we *do* upload the file
         && msSinceMod > -10000;
 }

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -87,12 +87,17 @@ public:
     SyncJournalDb *journal() const { return _journal; }
     QString localPath() const { return _localPath; }
 
-    /**
-     * Minimum age, in milisecond, of a file that can be uploaded.
-     * Files more recent than that are not going to be uploaeded as they are considered
-     * too young and possibly still changing
+    /** Duration in ms that uploads should be delayed after a file change
+     *
+     * In certain situations a file can be written to very regularly over a large
+     * amount of time. Copying a large file could take a while. A logfile could be
+     * updated every second.
+     *
+     * In these cases it isn't desirable to attempt to upload the "unfinished" file.
+     * To avoid that, uploads of files where the distance between the mtime and the
+     * current time is less than this duration are skipped.
      */
-    static qint64 minimumFileAgeForUpload; // in ms
+    static std::chrono::milliseconds minimumFileAgeForUpload;
 
     /**
      * Control whether local discovery should read from filesystem or db.

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -1120,7 +1120,7 @@ public:
         : _localModifier(_tempDir.path())
     {
         // Needs to be done once
-        OCC::SyncEngine::minimumFileAgeForUpload = 0;
+        OCC::SyncEngine::minimumFileAgeForUpload = std::chrono::milliseconds(0);
         OCC::Logger::instance()->setLogFile("-");
 
         QDir rootDir{_tempDir.path()};


### PR DESCRIPTION
On Linux and Windows the file watcher can't distinguish between changes
that were caused by the process itself, like during a sync operation,
and external changes. To work around that the client keeps a list of
files it has touched and blocks notifications on these files for a bit.

The duration of this block was originally and arbitrarily set at 15
seconds. During manual tests I regularly thought there was a bug when
syncs didn't trigger, when the only problem was that my changes happened
too close to a previous sync operation.

This change reduces the duration to three seconds. I imagine that this
is still enough.