### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -83,7 +83,7 @@ struct CmdOptions
     int downlimit;
     int uplimit;
     bool deltasync;
-    quint64 deltasyncminfilesize;
+    qint64 deltasyncminfilesize;
 };
 
 // we can't use csync_set_userdata because the SyncEngine sets it already.

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1203,7 +1203,7 @@ bool SyncJournalDb::updateFileRecordChecksum(const QString &filename,
 }
 
 bool SyncJournalDb::updateLocalMetadata(const QString &filename,
-    qint64 modtime, quint64 size, quint64 inode)
+    qint64 modtime, qint64 size, quint64 inode)
 
 {
     QMutexLocker locker(&_mutex);

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -70,7 +70,7 @@ public:
         const QByteArray &contentChecksum,
         const QByteArray &contentChecksumType);
     bool updateLocalMetadata(const QString &filename,
-        qint64 modtime, quint64 size, quint64 inode);
+        qint64 modtime, qint64 size, quint64 inode);
     bool exists();
     void walCheckpoint();
 
@@ -107,7 +107,7 @@ public:
         {
         }
         int _chunk;
-        int _transferid;
+        uint _transferid;
         qint64 _size;
         qint64 _modtime;
         int _errorCount;

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -145,7 +145,7 @@ public:
      *
      * Returning false and setting error indicates an error.
      */
-    virtual bool updateMetadata(const QString &filePath, time_t modtime, quint64 size, const QByteArray &fileId, QString *error) = 0;
+    virtual bool updateMetadata(const QString &filePath, time_t modtime, qint64 size, const QByteArray &fileId, QString *error) = 0;
 
     /// Create a new dehydrated placeholder. Called from PropagateDownload.
     virtual void createPlaceholder(const SyncFileItem &item) = 0;
@@ -259,7 +259,7 @@ public:
     bool socketApiPinStateActionsShown() const override { return false; }
     bool isHydrating() const override { return false; }
 
-    bool updateMetadata(const QString &, time_t, quint64, const QByteArray &, QString *) override { return true; }
+    bool updateMetadata(const QString &, time_t, qint64, const QByteArray &, QString *) override { return true; }
     void createPlaceholder(const SyncFileItem &) override {}
     void dehydratePlaceholder(const SyncFileItem &) override {}
     void convertToPlaceholder(const QString &, const SyncFileItem &, const QString &) override {}

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -921,7 +921,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
     // item if no items are in progress.
     SyncFileItem curItem = progress._lastCompletedItem;
     qint64 curItemProgress = -1; // -1 means finished
-    quint64 biggerItemSize = -1;
+    qint64 biggerItemSize = 0;
     quint64 estimatedUpBw = 0;
     quint64 estimatedDownBw = 0;
     QString allFilenames;
@@ -1000,13 +1000,11 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
     pi->_progressString = fileProgressString;
 
     // overall progress
-    quint64 completedSize = progress.completedSize();
-    quint64 completedFile = progress.completedFiles();
-    quint64 currentFile = progress.currentFile();
-    if (currentFile == ULLONG_MAX)
-        currentFile = 0;
-    quint64 totalSize = qMax(completedSize, progress.totalSize());
-    quint64 totalFileCount = qMax(currentFile, progress.totalFiles());
+    qint64 completedSize = progress.completedSize();
+    qint64 completedFile = progress.completedFiles();
+    qint64 currentFile = progress.currentFile();
+    qint64 totalSize = qMax(completedSize, progress.totalSize());
+    qint64 totalFileCount = qMax(currentFile, progress.totalFiles());
     QString overallSyncString;
     if (totalSize > 0) {
         QString s1 = Utility::octetsToString(completedSize);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -51,14 +51,14 @@ const char propertyAccountC[] = "oc_account";
 
 ownCloudGui::ownCloudGui(Application *parent)
     : QObject(parent)
-    , _tray(0)
+    , _tray(nullptr)
 #if defined(Q_OS_MAC)
     , _settingsDialog(new SettingsDialogMac(this))
 #else
     , _settingsDialog(new SettingsDialog(this))
 #endif
-    , _logBrowser(0)
-    , _recentActionsMenu(0)
+    , _logBrowser(nullptr)
+    , _recentActionsMenu(nullptr)
     , _app(parent)
 {
     _tray = new Systray();
@@ -808,9 +808,9 @@ void ownCloudGui::setupActions()
         _actionCrashFatal = new QAction("Crash now - qFatal", this);
         connect(_actionCrashFatal, &QAction::triggered, _app, &Application::slotCrashFatal);
     } else {
-        _actionCrash = 0;
-        _actionCrashEnforce = 0;
-        _actionCrashFatal = 0;
+        _actionCrash = nullptr;
+        _actionCrashEnforce = nullptr;
+        _actionCrashFatal = nullptr;
     }
 }
 
@@ -1057,7 +1057,7 @@ void ownCloudGui::slotHelp()
 
 void ownCloudGui::raiseDialog(QWidget *raiseWidget)
 {
-    if (raiseWidget && raiseWidget->parentWidget() == 0) {
+    if (raiseWidget && !raiseWidget->parentWidget()) {
         // Qt has a bug which causes parent-less dialogs to pop-under.
         raiseWidget->showNormal();
         raiseWidget->raise();
@@ -1124,11 +1124,11 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         | SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete
         | SharePermissionShare;
     if (!resharingAllowed) {
-        maxSharingPermissions = 0;
+        maxSharingPermissions = SharePermission(0);
     }
 
 
-    ShareDialog *w = 0;
+    ShareDialog *w = nullptr;
     if (_shareDialogs.contains(localPath) && _shareDialogs[localPath]) {
         qCInfo(lcApplication) << "Raising share dialog" << sharePath << localPath;
         w = _shareDialogs[localPath];

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -859,8 +859,8 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const ProgressInfo &
     }
 
     if (progress.totalSize() == 0) {
-        quint64 currentFile = progress.currentFile();
-        quint64 totalFileCount = qMax(progress.totalFiles(), currentFile);
+        qint64 currentFile = progress.currentFile();
+        qint64 totalFileCount = qMax(progress.totalFiles(), currentFile);
         QString msg;
         if (progress.trustEta()) {
             msg = tr("Syncing %1 of %2  (%3 left)")

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -60,7 +60,7 @@ public:
         QString path;
         QString folderName;
         QDateTime timestamp;
-        quint64 size = 0;
+        qint64 size = 0;
         SyncFileItem::Status status BITFIELD(4);
         SyncFileItem::Direction direction BITFIELD(3);
     };

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -170,19 +170,19 @@ int ConfigFile::timeout() const
     return settings.value(QLatin1String(timeoutC), 300).toInt(); // default to 5 min
 }
 
-quint64 ConfigFile::chunkSize() const
+qint64 ConfigFile::chunkSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(chunkSizeC), 10 * 1000 * 1000).toLongLong(); // default to 10 MB
 }
 
-quint64 ConfigFile::maxChunkSize() const
+qint64 ConfigFile::maxChunkSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(maxChunkSizeC), 100 * 1000 * 1000).toLongLong(); // default to 100 MB
 }
 
-quint64 ConfigFile::minChunkSize() const
+qint64 ConfigFile::minChunkSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(minChunkSizeC), 1000 * 1000).toLongLong(); // default to 1 MB
@@ -714,15 +714,15 @@ void ConfigFile::setDownloadLimit(int kbytes)
     setValue(downloadLimitC, kbytes);
 }
 
-QPair<bool, quint64> ConfigFile::newBigFolderSizeLimit() const
+QPair<bool, qint64> ConfigFile::newBigFolderSizeLimit() const
 {
     auto defaultValue = Theme::instance()->newBigFolderSizeLimit();
     qint64 value = getValue(newBigFolderSizeLimitC, QString(), defaultValue).toLongLong();
     bool use = value >= 0 && getValue(useNewBigFolderSizeLimitC, QString(), true).toBool();
-    return qMakePair(use, quint64(qMax<qint64>(0, value)));
+    return qMakePair(use, qMax<qint64>(0, value));
 }
 
-void ConfigFile::setNewBigFolderSizeLimit(bool isChecked, quint64 mbytes)
+void ConfigFile::setNewBigFolderSizeLimit(bool isChecked, qint64 mbytes)
 {
     setValue(newBigFolderSizeLimitC, mbytes);
     setValue(useNewBigFolderSizeLimitC, isChecked);
@@ -759,13 +759,13 @@ void ConfigFile::setDeltaSyncEnabled(bool enabled)
     setValue(deltaSyncEnabledC, enabled);
 }
 
-quint64 ConfigFile::deltaSyncMinFileSize() const
+qint64 ConfigFile::deltaSyncMinFileSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(deltaSyncMinimumFileSizeC), 10 * 1024 * 1024).toLongLong(); // default to 10 MiB
 }
 
-void ConfigFile::setDeltaSyncMinFileSize(quint64 bytes)
+void ConfigFile::setDeltaSyncMinFileSize(qint64 bytes)
 {
     setValue(deltaSyncMinimumFileSizeC, bytes);
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -127,15 +127,15 @@ public:
     void setUploadLimit(int kbytes);
     void setDownloadLimit(int kbytes);
     /** [checked, size in MB] **/
-    QPair<bool, quint64> newBigFolderSizeLimit() const;
-    void setNewBigFolderSizeLimit(bool isChecked, quint64 mbytes);
+    QPair<bool, qint64> newBigFolderSizeLimit() const;
+    void setNewBigFolderSizeLimit(bool isChecked, qint64 mbytes);
     bool confirmExternalStorage() const;
     void setConfirmExternalStorage(bool);
     /** delta sync */
     bool deltaSyncEnabled() const;
     void setDeltaSyncEnabled(bool enabled);
-    quint64 deltaSyncMinFileSize() const; // bytes
-    void setDeltaSyncMinFileSize(quint64 bytes);
+    qint64 deltaSyncMinFileSize() const; // bytes
+    void setDeltaSyncMinFileSize(qint64 bytes);
 
 
     /** If we should move the files deleted on the server in the trash  */
@@ -151,9 +151,9 @@ public:
     void setShowInExplorerNavigationPane(bool show);
 
     int timeout() const;
-    quint64 chunkSize() const;
-    quint64 maxChunkSize() const;
-    quint64 minChunkSize() const;
+    qint64 chunkSize() const;
+    qint64 maxChunkSize() const;
+    qint64 minChunkSize() const;
     std::chrono::milliseconds targetChunkUploadDuration() const;
 
     void saveGeometry(QWidget *w);

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -359,9 +359,9 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
     return 0;
 }
 
-quint64 OwncloudPropagator::smallFileSize()
+qint64 OwncloudPropagator::smallFileSize()
 {
-    const quint64 smallFileSize = 100 * 1024; //default to 1 MB. Not dynamic right now.
+    const qint64 smallFileSize = 100 * 1024; //default to 1 MB. Not dynamic right now.
     return smallFileSize;
 }
 
@@ -625,12 +625,12 @@ void OwncloudPropagator::scheduleNextJobImpl()
     }
 }
 
-void OwncloudPropagator::reportFileTotal(const SyncFileItem &item, quint64 newSize)
+void OwncloudPropagator::reportFileTotal(const SyncFileItem &item, qint64 newSize)
 {
     emit updateFileTotal(item, newSize);
 }
 
-void OwncloudPropagator::reportProgress(const SyncFileItem &item, quint64 bytes)
+void OwncloudPropagator::reportProgress(const SyncFileItem &item, qint64 bytes)
 {
     emit progress(item, bytes);
 }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -417,7 +417,7 @@ public:
      *
      * This allows skipping of uploads that have a very high likelihood of failure.
      */
-    QHash<QString, quint64> _folderQuota;
+    QHash<QString, qint64> _folderQuota;
 
     /* the maximum number of jobs using bandwidth (uploads or downloads, in parallel) */
     int maximumActiveTransferJob();
@@ -428,8 +428,8 @@ public:
      * if Capabilities::desiredChunkUploadDuration has a target
      * chunk-upload duration set.
      */
-    quint64 _chunkSize;
-    quint64 smallFileSize();
+    qint64 _chunkSize;
+    qint64 smallFileSize();
 
     /* The maximum number of active jobs in parallel  */
     int hardMaximumActiveJob();
@@ -457,8 +457,8 @@ public:
     PropagateItemJob *createJob(const SyncFileItemPtr &item);
 
     void scheduleNextJob();
-    void reportProgress(const SyncFileItem &, quint64 bytes);
-    void reportFileTotal(const SyncFileItem &item, quint64 newSize);
+    void reportProgress(const SyncFileItem &, qint64 bytes);
+    void reportFileTotal(const SyncFileItem &item, qint64 newSize);
 
     void abort()
     {
@@ -542,8 +542,8 @@ private slots:
 signals:
     void newItem(const SyncFileItemPtr &);
     void itemCompleted(const SyncFileItemPtr &);
-    void progress(const SyncFileItem &, quint64 bytes);
-    void updateFileTotal(const SyncFileItem &, quint64 newSize);
+    void progress(const SyncFileItem &, qint64 bytes);
+    void updateFileTotal(const SyncFileItem &, qint64 newSize);
     void finished(bool success);
 
     /** Emitted when propagation has problems with a locked file. */

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -202,7 +202,7 @@ void ProgressInfo::adjustTotalsForFile(const SyncFileItem &item)
     }
 }
 
-void ProgressInfo::updateTotalsForFile(const SyncFileItem &item, quint64 newSize)
+void ProgressInfo::updateTotalsForFile(const SyncFileItem &item, qint64 newSize)
 {
     if (!shouldCountProgress(item)) {
         return;
@@ -218,27 +218,27 @@ void ProgressInfo::updateTotalsForFile(const SyncFileItem &item, quint64 newSize
     _currentItems[item._file]._progress._total = newSize;
 }
 
-quint64 ProgressInfo::totalFiles() const
+qint64 ProgressInfo::totalFiles() const
 {
     return _fileProgress._total;
 }
 
-quint64 ProgressInfo::completedFiles() const
+qint64 ProgressInfo::completedFiles() const
 {
     return _fileProgress._completed;
 }
 
-quint64 ProgressInfo::currentFile() const
+qint64 ProgressInfo::currentFile() const
 {
     return completedFiles() + _currentItems.size();
 }
 
-quint64 ProgressInfo::totalSize() const
+qint64 ProgressInfo::totalSize() const
 {
     return _sizeProgress._total;
 }
 
-quint64 ProgressInfo::completedSize() const
+qint64 ProgressInfo::completedSize() const
 {
     return _sizeProgress._completed;
 }
@@ -258,7 +258,7 @@ void ProgressInfo::setProgressComplete(const SyncFileItem &item)
     _lastCompletedItem = item;
 }
 
-void ProgressInfo::setProgressItem(const SyncFileItem &item, quint64 completed)
+void ProgressInfo::setProgressItem(const SyncFileItem &item, qint64 completed)
 {
     if (!shouldCountProgress(item)) {
         return;
@@ -329,8 +329,8 @@ ProgressInfo::Estimates ProgressInfo::totalProgress() const
                                     1.0);
 
     double beOptimistic = nearMaxFps * slowTransfer;
-    size.estimatedEta = (1.0 - beOptimistic) * size.estimatedEta
-        + beOptimistic * optimisticEta();
+    size.estimatedEta = quint64((1.0 - beOptimistic) * size.estimatedEta
+        + beOptimistic * optimisticEta());
 
     return size;
 }
@@ -375,7 +375,7 @@ void ProgressInfo::updateEstimates()
 
 void ProgressInfo::recomputeCompletedSize()
 {
-    quint64 r = _totalSizeOfCompletedJobs;
+    qint64 r = _totalSizeOfCompletedJobs;
     foreach (const ProgressItem &i, _currentItems) {
         if (isSizeDependent(i._item))
             r += i._progress._completed;
@@ -386,21 +386,21 @@ void ProgressInfo::recomputeCompletedSize()
 ProgressInfo::Estimates ProgressInfo::Progress::estimates() const
 {
     Estimates est;
-    est.estimatedBandwidth = _progressPerSec;
-    if (_progressPerSec != 0) {
-        est.estimatedEta = (_total - _completed) / _progressPerSec * 1000.0;
+    est.estimatedBandwidth = qint64(_progressPerSec);
+    if (_progressPerSec != 0.0) {
+        est.estimatedEta = quint64((_total - _completed) / _progressPerSec * 1000.0);
     } else {
-        est.estimatedEta = 0; // looks better than quint64 max
+        est.estimatedEta = 0; // looks better than qint64 max
     }
     return est;
 }
 
-quint64 ProgressInfo::Progress::completed() const
+qint64 ProgressInfo::Progress::completed() const
 {
     return _completed;
 }
 
-quint64 ProgressInfo::Progress::remaining() const
+qint64 ProgressInfo::Progress::remaining() const
 {
     return _total - _completed;
 }
@@ -421,7 +421,7 @@ void ProgressInfo::Progress::update()
     _prevCompleted = _completed;
 }
 
-void ProgressInfo::Progress::setCompleted(quint64 completed)
+void ProgressInfo::Progress::setCompleted(qint64 completed)
 {
     _completed = qMin(completed, _total);
     _prevCompleted = qMin(_prevCompleted, _completed);

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -107,16 +107,16 @@ public:
      * adjustTotalsForFile() while newSize is the newly determined actual
      * size.
      */
-    void updateTotalsForFile(const SyncFileItem &item, quint64 newSize);
+    void updateTotalsForFile(const SyncFileItem &item, qint64 newSize);
 
-    quint64 totalFiles() const;
-    quint64 completedFiles() const;
+    qint64 totalFiles() const;
+    qint64 completedFiles() const;
 
-    quint64 totalSize() const;
-    quint64 completedSize() const;
+    qint64 totalSize() const;
+    qint64 completedSize() const;
 
     /** Number of a file that is currently in progress. */
-    quint64 currentFile() const;
+    qint64 currentFile() const;
 
     /** Return true if the size needs to be taken in account in the total amount of time */
     static inline bool isSizeDependent(const SyncFileItem &item)
@@ -136,7 +136,7 @@ public:
     struct Estimates
     {
         /// Estimated completion amount per second. (of bytes or files)
-        quint64 estimatedBandwidth;
+        qint64 estimatedBandwidth;
 
         /// Estimated time remaining in milliseconds.
         quint64 estimatedEta;
@@ -160,8 +160,8 @@ public:
         /** Returns the estimates about progress per second and eta. */
         Estimates estimates() const;
 
-        quint64 completed() const;
-        quint64 remaining() const;
+        qint64 completed() const;
+        qint64 remaining() const;
 
     private:
         /**
@@ -173,19 +173,19 @@ public:
          * Changes the _completed value and does sanity checks on
          * _prevCompleted and _total.
          */
-        void setCompleted(quint64 completed);
+        void setCompleted(qint64 completed);
 
         // Updated by update()
         double _progressPerSec;
-        quint64 _prevCompleted;
+        qint64 _prevCompleted;
 
         // Used to get to a good value faster when
         // progress measurement stats. See update().
         double _initialSmoothing;
 
         // Set and updated by ProgressInfo
-        quint64 _completed;
-        quint64 _total;
+        qint64 _completed;
+        qint64 _total;
 
         friend class ProgressInfo;
     };
@@ -207,7 +207,7 @@ public:
 
     void setProgressComplete(const SyncFileItem &item);
 
-    void setProgressItem(const SyncFileItem &item, quint64 completed);
+    void setProgressItem(const SyncFileItem &item, qint64 completed);
 
     /**
      * Get the total completion estimate
@@ -254,7 +254,7 @@ private:
     Progress _fileProgress;
 
     // All size from completed jobs only.
-    quint64 _totalSizeOfCompletedJobs;
+    qint64 _totalSizeOfCompletedJobs;
 
     // The fastest observed rate of files per second in this sync.
     double _maxFilesPerSecond;

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -69,7 +69,7 @@ QString OWNCLOUDSYNC_EXPORT createDownloadTmpFileName(const QString &previous)
 // DOES NOT take ownership of the device.
 GETFileJob::GETFileJob(AccountPtr account, const QString &path, QIODevice *device,
     const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-    quint64 resumeStart, QObject *parent)
+    qint64 resumeStart, QObject *parent)
     : GETJob(account, path, parent)
     , _device(device)
     , _headers(headers)
@@ -83,7 +83,7 @@ GETFileJob::GETFileJob(AccountPtr account, const QString &path, QIODevice *devic
 
 GETFileJob::GETFileJob(AccountPtr account, const QUrl &url, QIODevice *device,
     const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-    quint64 resumeStart, QObject *parent)
+    qint64 resumeStart, QObject *parent)
     : GETJob(account, url.toEncoded(), parent)
     , _device(device)
     , _headers(headers)
@@ -205,12 +205,12 @@ void GETFileJob::slotMetaDataChanged()
         return;
     }
 
-    quint64 start = 0;
+    qint64 start = 0;
     QByteArray ranges = reply()->rawHeader("Content-Range");
     if (!ranges.isEmpty()) {
         QRegExp rx("bytes (\\d+)-");
         if (rx.indexIn(ranges) >= 0) {
-            start = rx.cap(1).toULongLong();
+            start = rx.cap(1).toLongLong();
         }
     }
     if (start != _resumeStart) {
@@ -602,7 +602,7 @@ void PropagateDownloadFile::startFullDownload()
 qint64 PropagateDownloadFile::committedDiskSpace() const
 {
     if (_state == Running) {
-        return qBound(0ULL, _item->_size - _resumeStart - _downloadProgress, _item->_size);
+        return qBound(0LL, _item->_size - _resumeStart - _downloadProgress, _item->_size);
     }
     return 0;
 }
@@ -732,7 +732,7 @@ void PropagateDownloadFile::slotGetFinished()
      * truncated, as described here: https://github.com/owncloud/mirall/issues/2528
      */
     const QByteArray sizeHeader("Content-Length");
-    quint64 bodySize = job->reply()->rawHeader(sizeHeader).toULongLong();
+    qint64 bodySize = job->reply()->rawHeader(sizeHeader).toLongLong();
     bool hasSizeHeader = !job->reply()->rawHeader(sizeHeader).isEmpty();
 
     // Qt removes the content-length header for transparently decompressed HTTP1 replies

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -49,7 +49,7 @@ public:
     }
 
     virtual qint64 currentDownloadPosition() = 0;
-    virtual quint64 resumeStart() { return 0; }
+    virtual qint64 resumeStart() { return 0; }
 
     QByteArray &etag() { return _etag; }
     time_t lastModified() { return _lastModified; }
@@ -115,7 +115,7 @@ private:
     void seedFinished(void *zs);
     void seedFailed(const QString &errorString);
 
-    void startCurrentRange(quint64 start = 0, quint64 end = 0);
+    void startCurrentRange(qint64 start = 0, qint64 end = 0);
 
 private slots:
     void slotReadyRead();
@@ -141,7 +141,7 @@ class OWNCLOUDSYNC_EXPORT GETFileJob : public GETJob
     QByteArray _expectedEtagForResume;
     qint64 _expectedContentLength;
     qint64 _contentLength;
-    quint64 _resumeStart;
+    qint64 _resumeStart;
     QUrl _directDownloadUrl;
     bool _hasEmittedFinishedSignal;
 
@@ -152,11 +152,11 @@ public:
     // DOES NOT take ownership of the device.
     explicit GETFileJob(AccountPtr account, const QString &path, QIODevice *device,
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-        quint64 resumeStart, QObject *parent = 0);
+        qint64 resumeStart, QObject *parent = 0);
     // For directDownloadUrl:
     explicit GETFileJob(AccountPtr account, const QUrl &url, QIODevice *device,
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-        quint64 resumeStart, QObject *parent = 0);
+        qint64 resumeStart, QObject *parent = 0);
 
     qint64 currentDownloadPosition() Q_DECL_OVERRIDE;
 
@@ -176,7 +176,7 @@ public:
 
     void newReplyHook(QNetworkReply *reply) override;
 
-    quint64 resumeStart() Q_DECL_OVERRIDE
+    qint64 resumeStart() Q_DECL_OVERRIDE
     {
         return _resumeStart;
     }
@@ -300,7 +300,7 @@ private slots:
 private:
     void deleteExistingFolder();
 
-    quint64 _resumeStart;
+    qint64 _resumeStart;
     qint64 _downloadProgress;
     QPointer<GETJob> _job;
     QFile _tmpFile;

--- a/src/libsync/propagatedownloadzsync.cpp
+++ b/src/libsync/propagatedownloadzsync.cpp
@@ -62,7 +62,7 @@ GETFileZsyncJob::GETFileZsyncJob(OwncloudPropagator *propagator, SyncFileItemPtr
 {
 }
 
-void GETFileZsyncJob::startCurrentRange(quint64 start, quint64 end)
+void GETFileZsyncJob::startCurrentRange(qint64 start, qint64 end)
 {
     // The end of the range might exceed the file size.
     // It's size-1 because the Range header is end-inclusive.
@@ -178,7 +178,7 @@ void GETFileZsyncJob::seedFinished(void *zs)
     qCDebug(lcZsyncGet) << "Number of ranges:" << _nrange;
 
     /* If we have no ranges then we have equal files and we are done */
-    if (_nrange == 0 && _item->_size == quint64(zsync_file_length(_zs.get()))) {
+    if (_nrange == 0 && _item->_size == qint64(zsync_file_length(_zs.get()))) {
         _propagator->reportFileTotal(*_item, 0);
         _errorStatus = SyncFileItem::Success;
         _zr.reset();

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -178,8 +178,8 @@ void PropagateUploadFileCommon::start()
     }
 
     // Check if we believe that the upload will fail due to remote quota limits
-    const quint64 quotaGuess = propagator()->_folderQuota.value(
-        QFileInfo(_item->_file).path(), std::numeric_limits<quint64>::max());
+    const qint64 quotaGuess = propagator()->_folderQuota.value(
+        QFileInfo(_item->_file).path(), std::numeric_limits<qint64>::max());
     if (_item->_size > quotaGuess) {
         // Necessary for blacklisting logic
         _item->_httpErrorCode = 507;
@@ -294,7 +294,7 @@ void PropagateUploadFileCommon::slotStartUpload(const QByteArray &transmissionCh
         return;
     }
 
-    quint64 fileSize = FileSystem::getSize(fullFilePath);
+    qint64 fileSize = FileSystem::getSize(fullFilePath);
     _item->_size = fileSize;
 
     // But skip the file if the mtime is too close to 'now'!
@@ -546,14 +546,14 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
     abortWithError(status, errorString);
 }
 
-void PropagateUploadFileCommon::adjustLastJobTimeout(AbstractNetworkJob *job, quint64 fileSize)
+void PropagateUploadFileCommon::adjustLastJobTimeout(AbstractNetworkJob *job, qint64 fileSize)
 {
     job->setTimeout(qBound(
         job->timeoutMsec(),
         // Calculate 3 minutes for each gigabyte of data
         qint64((3 * 60 * 1000) * fileSize / 1e9),
         // Maximum of 30 minutes
-        qint64(30 * 60 * 1000)));
+        30 * 60 * 1000LL));
 }
 
 void PropagateUploadFileCommon::slotJobDestroyed(QObject *job)

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -291,7 +291,7 @@ protected:
      *
      * See #6527, enterprise#2480
      */
-    static void adjustLastJobTimeout(AbstractNetworkJob *job, quint64 fileSize);
+    static void adjustLastJobTimeout(AbstractNetworkJob *job, qint64 fileSize);
 
     // Bases headers that need to be sent with every chunk
     QMap<QByteArray, QByteArray> headers();
@@ -321,9 +321,9 @@ private:
      */
     int _currentChunk = 0;
     int _chunkCount = 0; /// Total number of chunks for this file
-    int _transferId = 0; /// transfer id (part of the url)
+    uint _transferId = 0; /// transfer id (part of the url)
 
-    quint64 chunkSize() const {
+    qint64 chunkSize() const {
         // Old chunking does not use dynamic chunking algorithm, and does not adjusts the chunk size respectively,
         // thus this value should be used as the one classifing item to be chunked
         return propagator()->syncOptions()._initialChunkSize;
@@ -359,7 +359,7 @@ private:
      * If this job is resuming an upload, this number includes bytes that were
      * sent in previous jobs.
      */
-    quint64 _sent = 0;
+    qint64 _sent = 0;
 
     /** Amount of data that needs to be sent to the server in bytes.
      *
@@ -370,11 +370,11 @@ private:
      * amount of data that needs to be present at the server to finish the upload -
      * regardless of whether previous jobs have already sent something.
      */
-    quint64 _bytesToUpload;
+    qint64 _bytesToUpload;
 
     uint _transferId = 0; /// transfer id (part of the url)
     int _currentChunkOffset = 0; /// byte offset of the next chunk data that will be sent
-    quint64 _currentChunkSize = 0; /// current chunk size
+    qint64 _currentChunkSize = 0; /// current chunk size
     bool _removeJobError = false; /// if not null, there was an error removing the job
     bool _zsyncSupported = false; /// if zsync is supported this will be set to true
     bool _isZsyncMetadataUploadRunning = false; // flag to ensure that zsync metadata upload is complete before job is
@@ -383,17 +383,17 @@ private:
     // (Only used from slotPropfindIterate/slotPropfindFinished because the LsColJob use signals to report data.)
     struct ServerChunkInfo
     {
-        quint64 size;
+        qint64 size;
         QString originalName;
     };
-    QMap<quint64, ServerChunkInfo> _serverChunks;
+    QMap<qint64, ServerChunkInfo> _serverChunks;
 
     // Vector with expected PUT ranges.
     struct UploadRangeInfo
     {
-        quint64 start;
-        quint64 size;
-        quint64 end() const { return start + size; }
+        qint64 start;
+        qint64 size;
+        qint64 end() const { return start + size; }
     };
     QVector<UploadRangeInfo> _rangesToUpload;
 
@@ -409,7 +409,7 @@ private:
      *
      * Retuns false if no matching range was found.
      */
-    bool markRangeAsDone(quint64 start, quint64 size);
+    bool markRangeAsDone(qint64 start, qint64 size);
 
 public:
     PropagateUploadFileNG(OwncloudPropagator *propagator, const SyncFileItemPtr &item)

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -809,13 +809,13 @@ void SyncEngine::finalize(bool success)
     _clearTouchedFilesTimer.start();
 }
 
-void SyncEngine::slotProgress(const SyncFileItem &item, quint64 current)
+void SyncEngine::slotProgress(const SyncFileItem &item, qint64 current)
 {
     _progressInfo->setProgressItem(item, current);
     emit transmissionProgress(*_progressInfo);
 }
 
-void SyncEngine::updateFileTotal(const SyncFileItem &item, quint64 newSize)
+void SyncEngine::updateFileTotal(const SyncFileItem &item, qint64 newSize)
 {
     _progressInfo->updateTotalsForFile(item, newSize);
     emit transmissionProgress(*_progressInfo);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -186,8 +186,8 @@ private slots:
     void slotItemCompleted(const SyncFileItemPtr &item);
     void slotDiscoveryFinished();
     void slotPropagationFinished(bool success);
-    void slotProgress(const SyncFileItem &item, quint64 curent);
-    void updateFileTotal(const SyncFileItem &item, quint64 newSize);
+    void slotProgress(const SyncFileItem &item, qint64 curent);
+    void updateFileTotal(const SyncFileItem &item, qint64 newSize);
     void slotCleanPollsJobAborted(const QString &error);
 
     /** Records that a file was touched by a job. */

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -253,7 +253,7 @@ public:
     csync_instructions_e _instruction;
     time_t _modtime;
     QByteArray _etag;
-    quint64 _size;
+    qint64 _size;
     quint64 _inode;
     QByteArray _fileId;
 
@@ -266,7 +266,7 @@ public:
     QByteArray _checksumHeader;
 
     // The size and modtime of the file getting overwritten (on the disk for downloads, on the server for uploads).
-    quint64 _previousSize;
+    qint64 _previousSize;
     time_t _previousModtime;
 
     QString _directDownloadUrl;

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -51,13 +51,13 @@ struct SyncOptions
      * starting value and is then gradually adjusted within the
      * minChunkSize / maxChunkSize bounds.
      */
-    quint64 _initialChunkSize = 10 * 1000 * 1000; // 10MB
+    qint64 _initialChunkSize = 10 * 1000 * 1000; // 10MB
 
     /** The minimum chunk size in bytes for chunked uploads */
-    quint64 _minChunkSize = 1 * 1000 * 1000; // 1MB
+    qint64 _minChunkSize = 1 * 1000 * 1000; // 1MB
 
     /** The maximum chunk size in bytes for chunked uploads */
-    quint64 _maxChunkSize = 100 * 1000 * 1000; // 100MB
+    qint64 _maxChunkSize = 100 * 1000 * 1000; // 100MB
 
     /** The target duration of chunk uploads for dynamic chunk sizing.
      *
@@ -72,7 +72,7 @@ struct SyncOptions
     bool _deltaSyncEnabled = false;
 
     /** What the minimum file size (in Bytes) is for delta-synchronization */
-    quint64 _deltaSyncMinFileSize = 0;
+    qint64 _deltaSyncMinFileSize = 0;
 };
 
 

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -53,7 +53,7 @@ bool VfsSuffix::isHydrating() const
     return false;
 }
 
-bool VfsSuffix::updateMetadata(const QString &filePath, time_t modtime, quint64, const QByteArray &, QString *)
+bool VfsSuffix::updateMetadata(const QString &filePath, time_t modtime, qint64, const QByteArray &, QString *)
 {
     FileSystem::setModTime(filePath, modtime);
     return true;

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -38,7 +38,7 @@ public:
     bool socketApiPinStateActionsShown() const override { return true; }
     bool isHydrating() const override;
 
-    bool updateMetadata(const QString &filePath, time_t modtime, quint64 size, const QByteArray &fileId, QString *error) override;
+    bool updateMetadata(const QString &filePath, time_t modtime, qint64 size, const QByteArray &fileId, QString *error) override;
 
     void createPlaceholder(const SyncFileItem &item) override;
     void dehydratePlaceholder(const SyncFileItem &item) override;

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -41,7 +41,7 @@ static void partialUpload(FakeFolder &fakeFolder, const QString &name, int size)
 }
 
 // Reduce max chunk size a bit so we get more chunks
-static void setChunkSize(SyncEngine &engine, quint64 size)
+static void setChunkSize(SyncEngine &engine, qint64 size)
 {
     SyncOptions options;
     options._maxChunkSize = size;
@@ -86,7 +86,7 @@ private slots:
         QCOMPARE(fakeFolder.uploadState().children.count(), 1);
         auto chunkingId = fakeFolder.uploadState().children.first().name;
         const auto &chunkMap = fakeFolder.uploadState().children.first().children;
-        quint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](quint64 s, const FileInfo &f) { return s + f.size; });
+        qint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](qint64 s, const FileInfo &f) { return s + f.size; });
         QVERIFY(uploadedSize > 2 * 1000 * 1000); // at least 2 MB
 
         // Add a fake chunk to make sure it gets deleted
@@ -95,7 +95,7 @@ private slots:
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
             if (op == QNetworkAccessManager::PutOperation) {
                 // Test that we properly resuming and are not sending past data again.
-                Q_ASSERT(request.rawHeader("OC-Chunk-Offset").toULongLong() >= uploadedSize);
+                Q_ASSERT(request.rawHeader("OC-Chunk-Offset").toLongLong() >= uploadedSize);
             } else if (op == QNetworkAccessManager::DeleteOperation) {
                 Q_ASSERT(request.url().path().endsWith("/10000"));
             }
@@ -121,7 +121,7 @@ private slots:
         QCOMPARE(fakeFolder.uploadState().children.count(), 1);
         auto chunkingId = fakeFolder.uploadState().children.first().name;
         const auto &chunkMap = fakeFolder.uploadState().children.first().children;
-        quint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](quint64 s, const FileInfo &f) { return s + f.size; });
+        qint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](qint64 s, const FileInfo &f) { return s + f.size; });
         QVERIFY(uploadedSize > 2 * 1000 * 1000); // at least 50 MB
         QVERIFY(chunkMap.size() >= 3); // at least three chunks
 
@@ -177,7 +177,7 @@ private slots:
         QCOMPARE(fakeFolder.uploadState().children.count(), 1);
         auto chunkingId = fakeFolder.uploadState().children.first().name;
         const auto &chunkMap = fakeFolder.uploadState().children.first().children;
-        quint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](quint64 s, const FileInfo &f) { return s + f.size; });
+        qint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](qint64 s, const FileInfo &f) { return s + f.size; });
         QVERIFY(uploadedSize > 5 * 1000 * 1000); // at least 5 MB
 
         // Add a chunk that makes the file completely uploaded
@@ -222,7 +222,7 @@ private slots:
         QCOMPARE(fakeFolder.uploadState().children.count(), 1);
         auto chunkingId = fakeFolder.uploadState().children.first().name;
         const auto &chunkMap = fakeFolder.uploadState().children.first().children;
-        quint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](quint64 s, const FileInfo &f) { return s + f.size; });
+        qint64 uploadedSize = std::accumulate(chunkMap.begin(), chunkMap.end(), 0LL, [](qint64 s, const FileInfo &f) { return s + f.size; });
         QVERIFY(uploadedSize > 5 * 1000 * 1000); // at least 5 MB
 
         // Add a chunk that makes the file more than completely uploaded

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -11,7 +11,7 @@
 
 using namespace OCC;
 
-static constexpr quint64 stopAfter = 3'123'668;
+static constexpr qint64 stopAfter = 3'123'668;
 
 /* A FakeGetReply that sends max 'fakeSize' bytes, but whose ContentLength has the corect size */
 class BrokenFakeGetReply : public FakeGetReply

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -396,28 +396,28 @@ private slots:
             QVERIFY(a1);
             QCOMPARE(a1->_instruction, CSYNC_INSTRUCTION_SYNC);
             QCOMPARE(a1->_direction, SyncFileItem::Up);
-            QCOMPARE(a1->_size, quint64(5));
+            QCOMPARE(a1->_size, qint64(5));
 
             QCOMPARE(Utility::qDateTimeFromTime_t(a1->_modtime), changedMtime);
-            QCOMPARE(a1->_previousSize, quint64(4));
+            QCOMPARE(a1->_previousSize, qint64(4));
             QCOMPARE(Utility::qDateTimeFromTime_t(a1->_previousModtime), initialMtime);
 
             // b2: should have remote size and modtime
             QVERIFY(b1);
             QCOMPARE(b1->_instruction, CSYNC_INSTRUCTION_SYNC);
             QCOMPARE(b1->_direction, SyncFileItem::Down);
-            QCOMPARE(b1->_size, quint64(17));
+            QCOMPARE(b1->_size, qint64(17));
             QCOMPARE(Utility::qDateTimeFromTime_t(b1->_modtime), changedMtime);
-            QCOMPARE(b1->_previousSize, quint64(16));
+            QCOMPARE(b1->_previousSize, qint64(16));
             QCOMPARE(Utility::qDateTimeFromTime_t(b1->_previousModtime), initialMtime);
 
             // c1: conflicts are downloads, so remote size and modtime
             QVERIFY(c1);
             QCOMPARE(c1->_instruction, CSYNC_INSTRUCTION_CONFLICT);
             QCOMPARE(c1->_direction, SyncFileItem::None);
-            QCOMPARE(c1->_size, quint64(25));
+            QCOMPARE(c1->_size, qint64(25));
             QCOMPARE(Utility::qDateTimeFromTime_t(c1->_modtime), changedMtime2);
-            QCOMPARE(c1->_previousSize, quint64(26));
+            QCOMPARE(c1->_previousSize, qint64(26));
             QCOMPARE(Utility::qDateTimeFromTime_t(c1->_previousModtime), changedMtime);
         });
 

--- a/test/testuploadreset.cpp
+++ b/test/testuploadreset.cpp
@@ -46,28 +46,28 @@ private slots:
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 1);
-        QCOMPARE(uploadInfo._transferid, 1);
+        QCOMPARE(uploadInfo._transferid, 1U);
 
         fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 2);
-        QCOMPARE(uploadInfo._transferid, 1);
+        QCOMPARE(uploadInfo._transferid, 1U);
 
         fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 3);
-        QCOMPARE(uploadInfo._transferid, 1);
+        QCOMPARE(uploadInfo._transferid, 1U);
 
         fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 0);
-        QCOMPARE(uploadInfo._transferid, 0);
+        QCOMPARE(uploadInfo._transferid, 0U);
         QVERIFY(!uploadInfo._valid);
     }
 };


### PR DESCRIPTION
Many warnings originated in the fact that the code wasn't consistent about whether it used `qint64` or `quint64` for file sizes. It now consistently uses `qint64`.