### PR TITLE
Vfs: Fix folder dehydration requests on OSX

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -648,13 +648,13 @@ void SocketApi::command_REPLACE_VIRTUAL_FILE(const QString &filesArg, SocketList
                     qCWarning(lcSocketApi) << "Unable to rename " << file;
                 }
             });
-            continue;
-        }
-        SyncJournalFileRecord record;
-        if (!folder->journalDb()->getFileRecord(relativePath, &record) || !record.isValid())
-            continue;
-        if (!FileSystem::rename(file, file + suffix)) {
-            qCWarning(lcSocketApi) << "Unable to rename " << file;
+        } else {
+            SyncJournalFileRecord record;
+            if (!folder->journalDb()->getFileRecord(relativePath, &record) || !record.isValid())
+                continue;
+            if (!FileSystem::rename(file, file + suffix)) {
+                qCWarning(lcSocketApi) << "Unable to rename " << file;
+            }
         }
         folder->slotWatchedPathChanged(file); // make sure it is in the _localDiscoveryTracker list
         FolderMan::instance()->scheduleFolder(folder);


### PR DESCRIPTION
For #6977, already fixed in master.

Since the rename is triggered by the client process the folder watcher
didn't pick up on it on OSX.
