### PR TITLE
Selective sync: Don't collapse tree when entering mode

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -252,7 +252,12 @@ void AccountSettings::slotToggleSignInState()
 
 void AccountSettings::doExpand()
 {
-    ui->_folderList->expandToDepth(0);
+    // Make sure at least the root items are expanded
+    for (int i = 0; i < _model->rowCount(); ++i) {
+        auto idx = _model->index(i);
+        if (!ui->_folderList->isExpanded(idx))
+            ui->_folderList->setExpanded(idx, true);
+    }
 }
 
 void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)


### PR DESCRIPTION
doExpand() is called when the selective sync editing mode is enabled in
the folder settings view. Previously it'd set the expansion to be
exactly the root items. Now, it just expands any root items that are
currently collapsed, leaving all other item expansion unchanged.

For  #7055