### PR TITLE
Download: Remove useless code and add a test

### DIFF
--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -357,7 +357,7 @@ public:
     }
 };
 
-class OwncloudPropagator : public QObject
+class OWNCLOUDSYNC_EXPORT OwncloudPropagator : public QObject
 {
     Q_OBJECT
 public:

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1004,19 +1004,6 @@ void PropagateDownloadFile::downloadFinished()
     // The fileChanged() check is done above to generate better error messages.
     if (!FileSystem::uncheckedRenameReplace(_tmpFile.fileName(), fn, &error)) {
         qCWarning(lcPropagateDownload) << QString("Rename failed: %1 => %2").arg(_tmpFile.fileName()).arg(fn);
-
-        // If we moved away the original file due to a conflict but can't
-        // put the downloaded file in its place, we are in a bad spot:
-        // If we do nothing the next sync run will assume the user deleted
-        // the file!
-        // To avoid that, the file is removed from the metadata table entirely
-        // which makes it look like we're just about to initially download
-        // it.
-        if (isConflict) {
-            propagator()->_journal->deleteFileRecord(fn);
-            propagator()->_journal->commit("download finished");
-        }
-
         // If the file is locked, we want to retry this sync when it
         // becomes available again, otherwise try again directly
         if (FileSystem::isFileLocked(fn)) {

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -134,6 +134,8 @@ public:
      */
     static void wipeVirtualFiles(const QString &localPath, SyncJournalDb &journal, Vfs &vfs);
 
+    auto getPropagator() { return _propagator; } // for the test
+
 signals:
     // During update, before reconcile
     void rootEtag(QString);


### PR DESCRIPTION
From issue #7015, the code is wrong because the path is the file system path and
not the path on the DB.
But since this is a conflict, this means the reconcile will still want to download
the file from the server next sync, so we need not to worry about this case