### PR TITLE
Windows: Forbid chars 0-31 in filenames 

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -202,8 +202,14 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(const char *path, bool excludeC
     }
 
     // Filter out characters not allowed in a filename on windows
+    // see https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file
     for (const char *p = path; *p; p++) {
-        switch (*p) {
+        unsigned char c = *p;
+        if (c < 32) {
+            match = CSYNC_FILE_EXCLUDE_INVALID_CHAR;
+            goto out;
+        }
+        switch (c) {
         case '\\':
         case ':':
         case '?':

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -197,10 +197,10 @@ static void check_csync_excluded(void **)
 
 #ifdef _WIN32
     assert_int_equal(exclude_check_file("file_trailing_space "), CSYNC_FILE_EXCLUDE_TRAILING_SPACE);
-
     assert_int_equal(exclude_check_file("file_trailing_dot."), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     assert_int_equal(exclude_check_file("AUX"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     assert_int_equal(exclude_check_file("file_invalid_char<"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
+    assert_int_equal(exclude_check_file("file_invalid_char\n"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
 #endif
 
     /* ? character */
@@ -301,6 +301,7 @@ static void check_csync_excluded_traversal(void **)
     assert_int_equal(check_file_traversal("file_trailing_dot."), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     assert_int_equal(check_file_traversal("AUX"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     assert_int_equal(check_file_traversal("file_invalid_char<"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
+    assert_int_equal(check_file_traversal("file_invalid_char\n"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
 #endif
 
 


### PR DESCRIPTION
For #6987