### PR TITLE
OwnSql: Distinguish no-data from error 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ ChangeLog
 version 2.5.4 (unreleased)
 * Crash fix: Infinite recursion for bad paths on Windows (#7041)
 * Crash fix: SocketApi mustn't send if readyRead happens after disconnected (#7044)
+* Fix rare sync error causing spurious local deletes (#6677)
 * Disable HTTP2 support due to bugs in Qt 5.12.1 (#7020, QTBUG-73947)
 * Fix loading of persisted cookies when loading accounts (#7054)
 * Windows: Fix breaking of unrelated explorer actions (#7004, #7023)

--- a/src/common/ownsql.h
+++ b/src/common/ownsql.h
@@ -129,7 +129,14 @@ public:
     bool isSelect();
     bool isPragma();
     bool exec();
-    bool next();
+
+    struct NextResult
+    {
+        bool ok = false;
+        bool hasData = false;
+    };
+    NextResult next();
+
     void bindValue(int pos, const QVariant &value);
     QString lastQuery() const;
     int numRowsAffected();

--- a/test/testownsql.cpp
+++ b/test/testownsql.cpp
@@ -71,7 +71,7 @@ private slots:
         q.prepare(sql);
 
         q.exec();
-        while( q.next() ) {
+        while( q.next().hasData ) {
             qDebug() << "Name: " << q.stringValue(1);
             qDebug() << "Address: " << q.stringValue(2);
         }
@@ -83,7 +83,7 @@ private slots:
         q.prepare(sql);
         q.bindValue(1, 2);
         q.exec();
-        if( q.next() ) {
+        if( q.next().hasData ) {
             qDebug() << "Name:" << q.stringValue(1);
             qDebug() << "Address:" << q.stringValue(2);
         }
@@ -96,7 +96,7 @@ private slots:
         int rc = q.prepare(sql);
         qDebug() << "Pragma:" << rc;
         q.exec();
-        if( q.next() ) {
+        if( q.next().hasData ) {
             qDebug() << "P:" << q.stringValue(1);
         }
     }
@@ -118,7 +118,7 @@ private slots:
         SqlQuery q(_db);
         q.prepare(sql);
 
-        if(q.next()) {
+        if(q.next().hasData) {
             QString name = q.stringValue(1);
             QString address = q.stringValue(2);
             QVERIFY( name == QString::fromUtf8("пятницы") );

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -31,7 +31,7 @@ static void assertCsyncJournalOk(SyncJournalDb &journal)
     QVERIFY(db.openReadOnly(journal.databaseFilePath()));
     SqlQuery q("SELECT count(*) from metadata where length(fileId) == 0", db);
     QVERIFY(q.exec());
-    QVERIFY(q.next());
+    QVERIFY(q.next().hasData);
     QCOMPARE(q.intValue(0), 0);
 #if defined(Q_OS_WIN) // Make sure the file does not appear in the FileInfo
     FileSystem::setFileHidden(journal.databaseFilePath() + "-shm", true);


### PR DESCRIPTION
For #6677, fyi @Phlos

This could fix a problem where the client incorrectly decides to delete
local data.

Previously any sqlite3_step() return value that wasn't SQLITE_ROW would
be interpreted as "there's no more data here". Thus an sqlite error at a
bad time could cause the remote discovery to fail to read an unchanged
subtree from the database. These files would then be deleted locally.

With this change sqlite errors from sqlite3_step are detected and
logged. For the particular case of SyncJournalDb::getFilesBelowPath()
the error will now be propagated and the sync run will fail instead of
performing spurious deletes.

Note that many other database functions still don't distinguish
not-found from error cases. Most of them won't have as severe effects on
affected sync runs though.