### PR TITLE
Tray: Try to establish tray after 10s if failed initially

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -741,6 +741,13 @@ void Application::openVirtualFile(const QString &filename)
     });
 }
 
+void Application::tryTrayAgain()
+{
+    qCInfo(lcApplication) << "Trying tray icon, tray available:" << QSystemTrayIcon::isSystemTrayAvailable();
+    if (!_gui->contextMenuVisible())
+        _gui->hideAndShowTray();
+}
+
 bool Application::event(QEvent *event)
 {
 #ifdef Q_OS_MAC

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -80,6 +80,9 @@ public slots:
      */
     void openVirtualFile(const QString &filename);
 
+    /// Attempt to show() the tray icon again. Used if no systray was available initially.
+    void tryTrayAgain();
+
 protected:
     void parseOptions(const QStringList &);
     void setupTranslations();

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -426,6 +426,12 @@ bool ownCloudGui::contextMenuVisible() const
     return _contextMenu->isVisible();
 }
 
+void ownCloudGui::hideAndShowTray()
+{
+    _tray->hide();
+    _tray->show();
+}
+
 static bool minimalTrayMenu()
 {
     static QByteArray var = qgetenv("OWNCLOUD_MINIMAL_TRAY_MENU");

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -61,6 +61,8 @@ public:
     /// Whether the tray menu is visible
     bool contextMenuVisible() const;
 
+    void hideAndShowTray();
+
 signals:
     void setupProxy();
 


### PR DESCRIPTION
When owncloud is started during desktop startup the tray may not yet
be running when the client starts. This will make the client attempt
to create a tray icon again after 10 seconds if there's no tray
during initial startup.

For  #6518