### PR TITLE
Shares: "copy link" action can create shares with expiry

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -145,7 +145,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     if (_account->capabilities().sharePublicLinkEnforceExpireDate()) {
         _ui->checkBox_expire->setEnabled(false);
         _ui->calendar->setMaximumDate(QDate::currentDate().addDays(
-            _account->capabilities().sharePublicLinkExpireDateDays()));
+            _account->capabilities().sharePublicLinkDefaultExpireDateDays()));
         _expiryRequired = true;
     }
 

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -60,14 +60,19 @@ bool Capabilities::sharePublicLinkEnforcePassword() const
     return _capabilities["files_sharing"].toMap()["public"].toMap()["password"].toMap()["enforced"].toBool();
 }
 
+bool Capabilities::sharePublicLinkDefaultExpire() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enabled"].toBool();
+}
+
+int Capabilities::sharePublicLinkDefaultExpireDateDays() const
+{
+    return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt();
+}
+
 bool Capabilities::sharePublicLinkEnforceExpireDate() const
 {
     return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["enforced"].toBool();
-}
-
-int Capabilities::sharePublicLinkExpireDateDays() const
-{
-    return _capabilities["files_sharing"].toMap()["public"].toMap()["expire_date"].toMap()["days"].toInt();
 }
 
 bool Capabilities::sharePublicLinkMultiple() const

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -38,8 +38,9 @@ public:
     bool sharePublicLinkAllowUpload() const;
     bool sharePublicLinkSupportsUploadOnly() const;
     bool sharePublicLinkEnforcePassword() const;
+    bool sharePublicLinkDefaultExpire() const;
+    int sharePublicLinkDefaultExpireDateDays() const;
     bool sharePublicLinkEnforceExpireDate() const;
-    int sharePublicLinkExpireDateDays() const;
     bool sharePublicLinkMultiple() const;
     bool shareResharing() const;
     bool chunkingNg() const;


### PR DESCRIPTION
Previously it gave up if "expiry required" was enabled. Now it'll create
a link share per day with the default expiry for these setups.

For  #7061

@michaelstingl I think this is safe enough that we could include it in 2.5.4 if desired.