### PR TITLE
FolderWatcher: Always notify about conflict files

### DIFF
--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -62,7 +62,7 @@ bool FolderWatcher::pathIsIgnored(const QString &path)
         return false;
 
 #ifndef OWNCLOUD_TEST
-    if (_folder->isFileExcludedAbsolute(path)) {
+    if (_folder->isFileExcludedAbsolute(path) && !Utility::isConflictFile(path)) {
         qCDebug(lcFolderWatcher) << "* Ignoring file" << path;
         return true;
     }


### PR DESCRIPTION
This makes sure that the conflict list can be updated if a user resolves
a conflict by deleting the local conflict file. Previously one had to
wait for the next sync run.

For  #7073