### PR TITLE
Linux: Add autostart delay to avoid tray issues

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -76,7 +76,8 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
            << QLatin1String("Categories=") << QLatin1String("Network") << endl
            << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl
-           << QLatin1String("X-GNOME-Autostart-enabled=") << "true" << endl;
+           << QLatin1String("X-GNOME-Autostart-enabled=") << "true" << endl
+           << QLatin1String("X-GNOME-Autostart-Delay=10") << endl;
     } else {
         if (!QFile::remove(desktopFileLocation)) {
             qCWarning(lcUtility) << "Could not remove autostart desktop file";


### PR DESCRIPTION
It seems that sometimes the tray implementation isn't ready on system
startup. Retrying later seems to not help. Delaying the start of the
client is the workaround that people have reported as effective.

For  #6518 since the internal retry seems to be uneffective.