### PR TITLE
FolderWizard: Don't crash when typing invalid drive

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1320,7 +1320,10 @@ static QString checkPathValidityRecursive(const QString &path)
     QFileInfo selFile(path);
 
     if (!selFile.exists()) {
-        return checkPathValidityRecursive(selFile.dir().path());
+        QString parentPath = selFile.dir().path();
+        if (parentPath != path)
+            return checkPathValidityRecursive(parentPath);
+        return FolderMan::tr("The selected path does not exist!");
     }
 
     if (!selFile.isDir()) {

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -144,6 +144,19 @@ private slots:
         QVERIFY(!folderman->checkPathValidityForNewFolder("/usr/bin/somefolder").isNull());
 #endif
 
+#ifdef Q_OS_WIN // drive-letter tests
+        if (!QFileInfo("v:/").exists()) {
+            QVERIFY(!folderman->checkPathValidityForNewFolder("v:").isNull());
+            QVERIFY(!folderman->checkPathValidityForNewFolder("v:/").isNull());
+            QVERIFY(!folderman->checkPathValidityForNewFolder("v:/foo").isNull());
+        }
+        if (QFileInfo("c:/").isWritable()) {
+            QVERIFY(folderman->checkPathValidityForNewFolder("c:").isNull());
+            QVERIFY(folderman->checkPathValidityForNewFolder("c:/").isNull());
+            QVERIFY(folderman->checkPathValidityForNewFolder("c:/foo").isNull());
+        }
+#endif
+
         // Invalid paths
         QVERIFY(!folderman->checkPathValidityForNewFolder("").isNull());
 


### PR DESCRIPTION
When the user typed "x:" where the drive x didn't exist, the validation
function would loop forever. Now it shows a "path doesn't exist" error.

For  #7041