### PR TITLE
Make handling of _renameTarget consistent

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -366,13 +366,13 @@ void Folder::etagRetreivedFromSyncEngine(const QString &etag)
 void Folder::showSyncResultPopup()
 {
     if (_syncResult.firstItemNew()) {
-        createGuiLog(_syncResult.firstItemNew()->_file, LogStatusNew, _syncResult.numNewItems());
+        createGuiLog(_syncResult.firstItemNew()->destination(), LogStatusNew, _syncResult.numNewItems());
     }
     if (_syncResult.firstItemDeleted()) {
-        createGuiLog(_syncResult.firstItemDeleted()->_file, LogStatusRemove, _syncResult.numRemovedItems());
+        createGuiLog(_syncResult.firstItemDeleted()->destination(), LogStatusRemove, _syncResult.numRemovedItems());
     }
     if (_syncResult.firstItemUpdated()) {
-        createGuiLog(_syncResult.firstItemUpdated()->_file, LogStatusUpdated, _syncResult.numUpdatedItems());
+        createGuiLog(_syncResult.firstItemUpdated()->destination(), LogStatusUpdated, _syncResult.numUpdatedItems());
     }
 
     if (_syncResult.firstItemRenamed()) {
@@ -383,12 +383,12 @@ void Folder::showSyncResultPopup()
         if (renTarget != renSource) {
             status = LogStatusMove;
         }
-        createGuiLog(_syncResult.firstItemRenamed()->_originalFile, status,
+        createGuiLog(_syncResult.firstItemRenamed()->_file, status,
             _syncResult.numRenamedItems(), _syncResult.firstItemRenamed()->_renameTarget);
     }
 
     if (_syncResult.firstNewConflictItem()) {
-        createGuiLog(_syncResult.firstNewConflictItem()->_file, LogStatusConflict, _syncResult.numNewConflictItems());
+        createGuiLog(_syncResult.firstNewConflictItem()->destination(), LogStatusConflict, _syncResult.numNewConflictItems());
     }
     if (int errorCount = _syncResult.numErrorItems()) {
         createGuiLog(_syncResult.firstItemError()->_file, LogStatusError, errorCount);

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -98,11 +98,11 @@ ProtocolItem *ProtocolItem::create(const QString &folder, const SyncFileItem &it
     twitem->setData(0, Qt::SizeHintRole, QSize(0, ActivityItemDelegate::rowHeight()));
     twitem->setIcon(0, icon);
     twitem->setToolTip(0, longTimeStr);
-    twitem->setToolTip(1, item._file);
+    twitem->setToolTip(1, item.destination());
     twitem->setToolTip(3, message);
     ProtocolItem::ExtraData data;
     data.timestamp = timestamp;
-    data.path = item._file;
+    data.path = item.destination();
     data.folderName = folder;
     data.status = item._status;
     data.size = item._size;

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -148,7 +148,7 @@ void SyncRunFileLog::logItem(const SyncFileItem &item)
     _out << ts << L;
     _out << L;
     if (item._instruction != CSYNC_INSTRUCTION_RENAME) {
-        _out << item._file << L;
+        _out << item.destination() << L;
     } else {
         _out << item._file << QLatin1String(" -> ") << item._renameTarget << L;
     }

--- a/src/libsync/localdiscoverytracker.cpp
+++ b/src/libsync/localdiscoverytracker.cpp
@@ -73,6 +73,8 @@ void LocalDiscoveryTracker::slotItemCompleted(const SyncFileItemPtr &item)
                       || item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA))) {
         if (_previousLocalDiscoveryPaths.erase(item->_file.toUtf8()))
             qCDebug(lcLocalDiscoveryTracker) << "wiped successful item" << item->_file;
+        if (!item->_renameTarget.isEmpty() && _previousLocalDiscoveryPaths.erase(item->_renameTarget.toUtf8()))
+            qCDebug(lcLocalDiscoveryTracker) << "wiped successful item" << item->_renameTarget;
     } else {
         _localDiscoveryPaths.insert(item->_file.toUtf8());
         qCDebug(lcLocalDiscoveryTracker) << "inserted error item" << item->_file;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -967,14 +967,11 @@ void PropagateDirectory::slotFirstJobFinished(SyncFileItem::Status status)
 void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
 {
     if (!_item->isEmpty() && status == SyncFileItem::Success) {
-        if (!_item->_renameTarget.isEmpty()) {
-            if (_item->_instruction == CSYNC_INSTRUCTION_RENAME
-                && _item->_originalFile != _item->_renameTarget) {
-                // Remove the stale entries from the database.
-                propagator()->_journal->deleteFileRecord(_item->_originalFile, true);
-            }
-
-            _item->_file = _item->_renameTarget;
+        // If a directory is renamed, recursively delete any stale items
+        // that may still exist below the old path.
+        if (_item->_instruction == CSYNC_INSTRUCTION_RENAME
+            && _item->_originalFile != _item->_renameTarget) {
+            propagator()->_journal->deleteFileRecord(_item->_originalFile, true);
         }
 
         // For new directories we always want to update the etag once

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -374,11 +374,6 @@ void PropagateDownloadFile::start()
         qCDebug(lcPropagateDownload) << "dehydrating file" << _item->_file;
         vfs->dehydratePlaceholder(*_item);
         propagator()->_journal->deleteFileRecord(_item->_originalFile);
-        // NOTE: This is only done because other rename-like ops also adjust _file, even though
-        // updateMetadata() will store at destination() anyway. Doing this may not be necessary
-        // but maybe it has an effect on reporting (destination() and moves aren't handled
-        // consistently everywhere)
-        _item->_file = _item->destination();
         updateMetadata(false);
         return;
     }

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -234,9 +234,7 @@ void PropagateLocalRename::start()
     propagator()->_journal->getFileRecord(_item->_originalFile, &oldRecord);
     propagator()->_journal->deleteFileRecord(_item->_originalFile);
 
-    // store the rename file name in the item.
     const auto oldFile = _item->_file;
-    _item->_file = _item->_renameTarget;
 
     if (!_item->isDirectory()) { // Directories are saved at the end
         SyncFileItem newItem(*_item);

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -356,6 +356,10 @@ private slots:
             QCOMPARE(counter.nDELETE, 0);
             QVERIFY(itemSuccessfulMove(completeSpy, "A/a1m"));
             QVERIFY(itemSuccessfulMove(completeSpy, "B/b1m"));
+            QCOMPARE(findItem(completeSpy, "A/a1m")->_file, QStringLiteral("A/a1"));
+            QCOMPARE(findItem(completeSpy, "A/a1m")->_renameTarget, QStringLiteral("A/a1m"));
+            QCOMPARE(findItem(completeSpy, "B/b1m")->_file, QStringLiteral("B/b1"));
+            QCOMPARE(findItem(completeSpy, "B/b1m")->_renameTarget, QStringLiteral("B/b1m"));
         }
 
         // Touch+Move on same side
@@ -485,6 +489,10 @@ private slots:
             QCOMPARE(counter.nDELETE, 0);
             QVERIFY(itemSuccessfulMove(completeSpy, "AM"));
             QVERIFY(itemSuccessfulMove(completeSpy, "BM"));
+            QCOMPARE(findItem(completeSpy, "AM")->_file, QStringLiteral("A"));
+            QCOMPARE(findItem(completeSpy, "AM")->_renameTarget, QStringLiteral("AM"));
+            QCOMPARE(findItem(completeSpy, "BM")->_file, QStringLiteral("B"));
+            QCOMPARE(findItem(completeSpy, "BM")->_renameTarget, QStringLiteral("BM"));
         }
 
         // Folder move with contents touched on the same side

--- a/test/testsyncvirtualfiles.cpp
+++ b/test/testsyncvirtualfiles.cpp
@@ -780,6 +780,8 @@ private slots:
         QVERIFY(hasDehydratedDbEntries("A/a1"));
         QVERIFY(itemInstruction(completeSpy, "A/a1.owncloud", CSYNC_INSTRUCTION_SYNC));
         QCOMPARE(findItem(completeSpy, "A/a1.owncloud")->_type, ItemTypeVirtualFileDehydration);
+        QCOMPARE(findItem(completeSpy, "A/a1.owncloud")->_file, QStringLiteral("A/a1"));
+        QCOMPARE(findItem(completeSpy, "A/a1.owncloud")->_renameTarget, QStringLiteral("A/a1.owncloud"));
         QVERIFY(isDehydrated("A/a2"));
         QVERIFY(hasDehydratedDbEntries("A/a2"));
         QVERIFY(itemInstruction(completeSpy, "A/a2.owncloud", CSYNC_INSTRUCTION_SYNC));


### PR DESCRIPTION
Previously sometimes _file = _renameTarget, and sometimes not. Now information in _file is always preserved.

It's not entirely consistent yet: SYNC(ItemTypeVirtualFileDehydration) has _file and _renameTarget differ, but SYNC(ItemTypeVirtualFileDownload) has an empty _renameTarget. I started adjusting that, but it felt very awkward since the whole existing download job assumes using _file is fine.