### PR TITLE
When creating local dirs, set mtime to server one

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -980,12 +980,6 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
         if (_item->_instruction == CSYNC_INSTRUCTION_RENAME
             || _item->_instruction == CSYNC_INSTRUCTION_NEW
             || _item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA) {
-            if (PropagateRemoteMkdir *mkdir = qobject_cast<PropagateRemoteMkdir *>(_firstJob.data())) {
-                // special case from MKDIR, get the fileId from the job there
-                if (_item->_fileId.isEmpty() && !mkdir->_item->_fileId.isEmpty()) {
-                    _item->_fileId = mkdir->_item->_fileId;
-                }
-            }
             if (!propagator()->updateMetadata(*_item)) {
                 status = _item->_status = SyncFileItem::FatalError;
                 _item->_errorString = tr("Error writing metadata to the database");

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -974,6 +974,12 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
             propagator()->_journal->deleteFileRecord(_item->_originalFile, true);
         }
 
+        if (_item->_instruction == CSYNC_INSTRUCTION_NEW && _item->_direction == SyncFileItem::Down) {
+            // special case for local MKDIR, set local directory mtime
+            // (it's not synced later at all, but can be nice to have it set initially)
+            FileSystem::setModTime(propagator()->getFilePath(_item->destination()), _item->_modtime);
+        }
+
         // For new directories we always want to update the etag once
         // the directory has been propagated. Otherwise the directory
         // could appear locally without being added to the database.

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -698,6 +698,22 @@ private slots:
         QCOMPARE(QFileInfo(fakeFolder.localPath() + conflictName).permissions(), perm);
     }
 #endif
+
+    // Check that server mtime is set on directories on initial propagation
+    void testDirectoryInitialMtime()
+    {
+        FakeFolder fakeFolder{ FileInfo{} };
+        fakeFolder.remoteModifier().mkdir("foo");
+        fakeFolder.remoteModifier().insert("foo/bar");
+        auto datetime = QDateTime::currentDateTime();
+        datetime.setSecsSinceEpoch(datetime.toSecsSinceEpoch()); // wipe ms
+        fakeFolder.remoteModifier().find("foo")->lastModified = datetime;
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        QCOMPARE(QFileInfo(fakeFolder.localPath() + "foo").lastModified(), datetime);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)


### PR DESCRIPTION
For #7119. Also remove some unused code while reviewing the function.