### PR TITLE
owncloudcmd: Use env vars for chunk sizes

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -540,6 +540,8 @@ restart_sync:
     }
 
     SyncOptions opt;
+    opt.fillFromEnvironmentVariables();
+    opt.verifyChunkSizes();
     opt._deltaSyncEnabled = options.deltasync;
     opt._deltaSyncMinFileSize = options.deltasyncminfilesize;
     SyncEngine engine(account, options.source_dir, folder, &db);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -868,45 +868,18 @@ void Folder::setSyncOptions()
     opt._confirmExternalStorage = cfgFile.confirmExternalStorage();
     opt._moveFilesToTrash = cfgFile.moveToTrash();
     opt._vfs = _vfs;
+    opt._parallelNetworkJobs = _accountState->account()->isHttp2Supported() ? 20 : 6;
 
-    QByteArray chunkSizeEnv = qgetenv("OWNCLOUD_CHUNK_SIZE");
-    if (!chunkSizeEnv.isEmpty()) {
-        opt._initialChunkSize = chunkSizeEnv.toUInt();
-    } else {
-        opt._initialChunkSize = cfgFile.chunkSize();
-    }
-    QByteArray minChunkSizeEnv = qgetenv("OWNCLOUD_MIN_CHUNK_SIZE");
-    if (!minChunkSizeEnv.isEmpty()) {
-        opt._minChunkSize = minChunkSizeEnv.toUInt();
-    } else {
-        opt._minChunkSize = cfgFile.minChunkSize();
-    }
-    QByteArray maxChunkSizeEnv = qgetenv("OWNCLOUD_MAX_CHUNK_SIZE");
-    if (!maxChunkSizeEnv.isEmpty()) {
-        opt._maxChunkSize = maxChunkSizeEnv.toUInt();
-    } else {
-        opt._maxChunkSize = cfgFile.maxChunkSize();
-    }
-
-    int maxParallel = qgetenv("OWNCLOUD_MAX_PARALLEL").toUInt();
-    opt._parallelNetworkJobs = maxParallel ? maxParallel : _accountState->account()->isHttp2Supported() ? 20 : 6;
-
-    // Previously min/max chunk size values didn't exist, so users might
-    // have setups where the chunk size exceeds the new min/max default
-    // values. To cope with this, adjust min/max to always include the
-    // initial chunk size value.
-    opt._minChunkSize = qMin(opt._minChunkSize, opt._initialChunkSize);
-    opt._maxChunkSize = qMax(opt._maxChunkSize, opt._initialChunkSize);
-
-    QByteArray targetChunkUploadDurationEnv = qgetenv("OWNCLOUD_TARGET_CHUNK_UPLOAD_DURATION");
-    if (!targetChunkUploadDurationEnv.isEmpty()) {
-        opt._targetChunkUploadDuration = std::chrono::milliseconds(targetChunkUploadDurationEnv.toUInt());
-    } else {
-        opt._targetChunkUploadDuration = cfgFile.targetChunkUploadDuration();
-    }
+    opt._initialChunkSize = cfgFile.chunkSize();
+    opt._minChunkSize = cfgFile.minChunkSize();
+    opt._maxChunkSize = cfgFile.maxChunkSize();
+    opt._targetChunkUploadDuration = cfgFile.targetChunkUploadDuration();
 
     opt._deltaSyncEnabled = cfgFile.deltaSyncEnabled();
     opt._deltaSyncMinFileSize = cfgFile.deltaSyncMinFileSize();
+
+    opt.fillFromEnvironmentVariables();
+    opt.verifyChunkSizes();
 
     _engine->setSyncOptions(opt);
 }

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -47,6 +47,7 @@ set(libsync_SRCS
     syncfilestatustracker.cpp
     localdiscoverytracker.cpp
     syncresult.cpp
+    syncoptions.cpp
     theme.cpp
     creds/dummycredentials.cpp
     creds/abstractcredentials.cpp

--- a/src/libsync/syncoptions.cpp
+++ b/src/libsync/syncoptions.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) by Olivier Goffart <ogoffart@woboq.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "syncoptions.h"
+
+using namespace OCC;
+
+SyncOptions::SyncOptions()
+    : _vfs(new VfsOff)
+{
+}
+
+SyncOptions::~SyncOptions()
+{
+}
+
+void SyncOptions::fillFromEnvironmentVariables()
+{
+    QByteArray chunkSizeEnv = qgetenv("OWNCLOUD_CHUNK_SIZE");
+    if (!chunkSizeEnv.isEmpty())
+        _initialChunkSize = chunkSizeEnv.toUInt();
+
+    QByteArray minChunkSizeEnv = qgetenv("OWNCLOUD_MIN_CHUNK_SIZE");
+    if (!minChunkSizeEnv.isEmpty())
+        _minChunkSize = minChunkSizeEnv.toUInt();
+
+    QByteArray maxChunkSizeEnv = qgetenv("OWNCLOUD_MAX_CHUNK_SIZE");
+    if (!maxChunkSizeEnv.isEmpty())
+        _maxChunkSize = maxChunkSizeEnv.toUInt();
+
+    QByteArray targetChunkUploadDurationEnv = qgetenv("OWNCLOUD_TARGET_CHUNK_UPLOAD_DURATION");
+    if (!targetChunkUploadDurationEnv.isEmpty())
+        _targetChunkUploadDuration = std::chrono::milliseconds(targetChunkUploadDurationEnv.toUInt());
+
+    int maxParallel = qgetenv("OWNCLOUD_MAX_PARALLEL").toInt();
+    if (maxParallel > 0)
+        _parallelNetworkJobs = maxParallel;
+}
+
+void SyncOptions::verifyChunkSizes()
+{
+    _minChunkSize = qMin(_minChunkSize, _initialChunkSize);
+    _maxChunkSize = qMax(_maxChunkSize, _initialChunkSize);
+}

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -27,9 +27,8 @@ namespace OCC {
  */
 struct SyncOptions
 {
-    SyncOptions()
-        : _vfs(new VfsOff)
-    {}
+    SyncOptions();
+    ~SyncOptions();
 
     /** Maximum size (in Bytes) a folder can have without asking for confirmation.
      * -1 means infinite */
@@ -73,7 +72,22 @@ struct SyncOptions
 
     /** What the minimum file size (in Bytes) is for delta-synchronization */
     qint64 _deltaSyncMinFileSize = 0;
-};
 
+    /** Reads settings from env vars where available.
+     *
+     * Currently reads _initialChunkSize, _minChunkSize, _maxChunkSize,
+     * _targetChunkUploadDuration, _parallelNetworkJobs.
+     */
+    void fillFromEnvironmentVariables();
+
+    /** Ensure min <= initial <= max
+     *
+     * Previously min/max chunk size values didn't exist, so users might
+     * have setups where the chunk size exceeds the new min/max default
+     * values. To cope with this, adjust min/max to always include the
+     * initial chunk size value.
+     */
+    void verifyChunkSizes();
+};
 
 }


### PR DESCRIPTION
Moves a bunch of env var reading from Folder into SyncOptions.

For  #7078