### PR TITLE
Discovery: No fatal error on bad server response 

### DIFF
--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -353,7 +353,15 @@ public:
     void start() Q_DECL_OVERRIDE
     {
         SyncFileItem::Status status = _item->_status;
-        done(status == SyncFileItem::NoStatus ? SyncFileItem::FileIgnored : status, _item->_errorString);
+        if (status == SyncFileItem::NoStatus) {
+            if (_item->_instruction == CSYNC_INSTRUCTION_ERROR) {
+                status = SyncFileItem::NormalError;
+            } else {
+                status = SyncFileItem::FileIgnored;
+                ASSERT(_item->_instruction == CSYNC_INSTRUCTION_IGNORE);
+            }
+        }
+        done(status, _item->_errorString);
     }
 };
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -347,7 +347,6 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
                 QString error;
                 if (!_syncOptions._vfs->updateMetadata(filePath, item->_modtime, item->_size, item->_fileId, &error)) {
                     item->_instruction = CSYNC_INSTRUCTION_ERROR;
-                    item->_status = SyncFileItem::NormalError;
                     item->_errorString = tr("Could not update virtual file metadata: %1").arg(error);
                     return;
                 }


### PR DESCRIPTION
Previously receiving unexpected replies from the server during discovery
would terminate the sync run with a fatal error. Now it only causes an
error on the affected item.

For #6826