### PR TITLE
Discovery: Query data-fingerprint on root item

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1320,6 +1320,8 @@ DiscoverySingleDirectoryJob *ProcessDirectoryJob::startAsyncServerQuery()
 {
     auto serverJob = new DiscoverySingleDirectoryJob(_discoveryData->_account,
         _discoveryData->_remoteFolder + _currentFolder._server, this);
+    if (!_dirItem)
+        serverJob->setIsRootPath(); // query the fingerprint on the root
     connect(serverJob, &DiscoverySingleDirectoryJob::etag, this, &ProcessDirectoryJob::etag);
     _discoveryData->_currentlyActiveJobs++;
     _pendingAsyncJobs++;


### PR DESCRIPTION
Previously the property wasn't queried, meaning the fingerprint logic
couldn't get triggered.