### PR TITLE
Link shares: Adjust creation flow

### DIFF
--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -109,7 +109,9 @@ void OcsShareJob::setPermissions(const QString &shareId,
 
 void OcsShareJob::createLinkShare(const QString &path,
     const QString &name,
-    const QString &password)
+    const QString &password,
+    const QDate &expireDate,
+    const Share::Permissions permissions)
 {
     setVerb("POST");
 
@@ -121,6 +123,12 @@ void OcsShareJob::createLinkShare(const QString &path,
     }
     if (!password.isEmpty()) {
         addParam(QString::fromLatin1("password"), password);
+    }
+    if (!expireDate.isNull()) {
+        addParam(QString::fromLatin1("expireDate"), expireDate.toString("yyyy-MM-dd"));
+    }
+    if (permissions != SharePermissionDefault) {
+        addParam(QString::fromLatin1("permissions"), QString::number(permissions));
     }
 
     addPassStatusCode(403);

--- a/src/gui/ocssharejob.h
+++ b/src/gui/ocssharejob.h
@@ -95,10 +95,14 @@ public:
      * @param path The path of the file/folder to share
      * @param name The name of the link share, empty name auto-generates one
      * @param password Optionally a password for the share
+     * @param expireDate Target expire data (may be null)
+     * @param permissions Desired permissions (SharePermissionDefault leaves to server)
      */
     void createLinkShare(const QString &path,
         const QString &name,
-        const QString &password);
+        const QString &password,
+        const QDate &expireDate,
+        const Share::Permissions permissions);
 
     /**
      * Create a new share

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -19,6 +19,7 @@
 #include "accountfwd.h"
 #include "sharepermissions.h"
 #include "QProgressIndicator.h"
+#include "sharepermissions.h"
 #include <QDialog>
 #include <QSharedPointer>
 #include <QList>
@@ -75,7 +76,7 @@ private slots:
 
     void slotDeleteShareFetched();
     void slotCreateShareFetched(const QSharedPointer<LinkShare> &share);
-    void slotCreateShareRequiresPassword(const QString &message);
+    void slotCreateShareForbidden(const QString &message);
     void slotPasswordSet();
     void slotExpireSet();
     void slotPermissionsSet();
@@ -99,8 +100,13 @@ private:
     /** Retrieve a share's name, accounting for _namesSupported */
     QString shareName(const LinkShare &share) const;
 
+    /** Permission implied by current ui state */
+    SharePermissions uiPermissionState() const;
+
     /**
      * Retrieve the selected share, returning 0 if none.
+     *
+     * Returning 0 means that the "Create new..." item is selected.
      */
     QSharedPointer<LinkShare> selectedShare() const;
 

--- a/src/gui/sharelinkwidget.ui
+++ b/src/gui/sharelinkwidget.ui
@@ -28,24 +28,6 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_create">
-     <item>
-      <widget class="QLineEdit" name="nameLineEdit">
-       <property name="placeholderText">
-        <string>Enter a name to create a new public link...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="createShareButton">
-       <property name="text">
-        <string>&amp;Create new</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QTableWidget" name="linkShares">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -289,6 +271,45 @@
           </spacer>
          </item>
         </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="create" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_create">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="nameLabel">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="nameLineEdit">
+        <property name="placeholderText">
+         <string>Enter name of new share...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="createShareButton">
+        <property name="text">
+         <string>&amp;Create</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -242,14 +242,18 @@ public:
      * @param path The path of the linkshare relative to the user folder on the server
      * @param name The name of the created share, may be empty
      * @param password The password of the share, may be empty
+     * @param expireDate Expire date for share, may be null
+     * @param permissions Desired permissions, SharePermissionDefault lets server decide
      *
      * On success the signal linkShareCreated is emitted
-     * For older server the linkShareRequiresPassword signal is emitted when it seems appropiate
+     * On 403 error the linkShareCreationForbidden error is emitted (if params forbid creation)
      * In case of a server error the serverError signal is emitted
      */
     void createLinkShare(const QString &path,
         const QString &name,
-        const QString &password);
+        const QString &password = QString(),
+        const QDate &expireDate = QDate(),
+        const Share::Permissions permissions = SharePermissionDefault);
 
     /**
      * Tell the manager to create a new share
@@ -282,13 +286,14 @@ signals:
     void sharesFetched(const QList<QSharedPointer<Share>> &shares);
     void serverError(int code, const QString &message);
 
-    /** Emitted when creating a link share with password fails.
+    /** Emitted when creating a link share creation fails with 403.
      *
      * @param message the error message reported by the server
      *
-     * See createLinkShare().
+     * See createLinkShare(). Usually for "needs password" but with
+     * server plugins it can also happen for other issues.
      */
-    void linkShareRequiresPassword(const QString &message);
+    void linkShareCreationForbidden(const QString &message);
 
 private slots:
     void slotSharesFetched(const QJsonDocument &reply);

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -540,7 +540,7 @@ private slots:
 
         // otherwise create a new one
         qCDebug(lcPublicLink) << "Creating new share";
-        _shareManager.createLinkShare(_localFile, shareName, QString());
+        _shareManager.createLinkShare(_localFile, shareName);
     }
 
     void linkShareCreated(const QSharedPointer<LinkShare> &share)


### PR DESCRIPTION
The important thing is that, similar to the web link share creation
flow, the share properties can be set before creation is done. This
allows better handling of error conditions. One such condition is the
password policy app restricting valid expire dates.

See owncloud/enterprise#3271

This significantly adjusts how the link share creation flows, will post images below.