### PR TITLE
Vfs: Mark sqlite temporaries excluded on db-open

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -2257,6 +2257,17 @@ void SyncJournalDb::commitIfNeededAndStartNewTransaction(const QString &context)
     }
 }
 
+bool SyncJournalDb::open()
+{
+    QMutexLocker lock(&_mutex);
+    return checkConnect();
+}
+
+bool SyncJournalDb::isOpen()
+{
+    QMutexLocker lock(&_mutex);
+    return _db.isOpen();
+}
 
 void SyncJournalDb::commitInternal(const QString &context, bool startTrans)
 {
@@ -2273,11 +2284,6 @@ SyncJournalDb::~SyncJournalDb()
     close();
 }
 
-bool SyncJournalDb::isConnected()
-{
-    QMutexLocker lock(&_mutex);
-    return checkConnect();
-}
 
 bool operator==(const SyncJournalDb::DownloadInfo &lhs,
     const SyncJournalDb::DownloadInfo &rhs)

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -213,12 +213,20 @@ public:
     void commit(const QString &context, bool startTrans = true);
     void commitIfNeededAndStartNewTransaction(const QString &context);
 
-    void close();
-
-    /**
-     * return true if everything is correct
+    /** Open the db if it isn't already.
+     *
+     * This usually creates some temporary files next to the db file, like
+     * $dbfile-shm or $dbfile-wal.
+     *
+     * returns true if it could be openend or is currently opened.
      */
-    bool isConnected();
+    bool open();
+
+    /** Returns whether the db is currently openend. */
+    bool isOpen();
+
+    /** Close the database */
+    void close();
 
     /**
      * Returns the checksum type for an id.

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -484,6 +484,13 @@ void Folder::startVfs()
             _vfs.data(), &Vfs::fileStatusChanged);
 
     _vfs->start(vfsParams);
+
+    // Immediately mark the sqlite temporaries as excluded. They get recreated
+    // on db-open and need to get marked again every time.
+    QString stateDbFile = _journal.databaseFilePath();
+    _journal.open();
+    _vfs->fileStatusChanged(stateDbFile + "-wal", SyncFileStatus::StatusExcluded);
+    _vfs->fileStatusChanged(stateDbFile + "-shm", SyncFileStatus::StatusExcluded);
 }
 
 int Folder::slotDiscardDownloadProgress()

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -623,7 +623,7 @@ void FolderMan::slotEtagJobDestroyed(QObject * /*o*/)
 void FolderMan::slotRunOneEtagJob()
 {
     if (_currentEtagJob.isNull()) {
-        Folder *folder;
+        Folder *folder = nullptr;
         foreach (Folder *f, _folderMap) {
             if (f->etagJob()) {
                 // Caveat: always grabs the first folder with a job, but we think this is Ok for now and avoids us having a seperate queue.

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -475,7 +475,7 @@ void SyncEngine::startSync()
     qCInfo(lcEngine) << verStr;
 
     // This creates the DB if it does not exist yet.
-    if (!_journal->isConnected()) {
+    if (!_journal->open()) {
         qCWarning(lcEngine) << "No way to create a sync journal!";
         syncError(tr("Unable to open or create the local sync database. Make sure you have write access in the sync folder."));
         finalize(false);
@@ -618,7 +618,7 @@ void SyncEngine::slotDiscoveryFinished()
     qCInfo(lcEngine) << "#### Discovery end #################################################### " << _stopWatch.addLapTime(QLatin1String("Discovery Finished")) << "ms";
 
     // Sanity check
-    if (!_journal->isConnected()) {
+    if (!_journal->open()) {
         qCWarning(lcEngine) << "Bailing out, DB failure";
         syncError(tr("Cannot open the sync journal"));
         finalize(false);


### PR DESCRIPTION
The previous patch ensured that the sqlite temporaries weren't deleted
and recreated for every sync run, but there was still time between
client startup and the first sync run where they would have the
"needs-sync" icon.

For  #7141