### PR TITLE
Vfs: Distinguish availability error kinds 

### DIFF
--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -105,7 +105,7 @@ bool VfsSuffix::statTypeVirtualFile(csync_file_stat_t *stat, void *)
     return false;
 }
 
-Optional<VfsItemAvailability> VfsSuffix::availability(const QString &folderPath)
+Vfs::AvailabilityResult VfsSuffix::availability(const QString &folderPath)
 {
     const auto suffix = fileSuffix();
     QString pinPath = folderPath;

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -51,7 +51,7 @@ public:
     { return setPinStateInDb(folderPath, state); }
     Optional<PinState> pinState(const QString &folderPath) override
     { return pinStateInDb(folderPath); }
-    Optional<VfsItemAvailability> availability(const QString &folderPath) override;
+    AvailabilityResult availability(const QString &folderPath) override;
 
 public slots:
     void fileStatusChanged(const QString &, SyncFileStatus) override {}


### PR DESCRIPTION
Previously "no-availability" meant db-error and querying the
availability of a nonexistant path returned AllHydrated.

Now, the availability has a DbError and a NoSuchItem error case.

For #7143

Plugin API change, let me merge.