### PR TITLE
[2.6] Change docs version to right value

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: desktop
 title: Desktop Client
-version: master
+version: '2.6'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
This change is required to correctly display the version within the ownCloud docs component selection.