### PR TITLE
Fix ROOT component version in master branch

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: desktop
 title: Desktop Client
-version: '2.6'
+version: 'master'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
This PR fixes the following error, which has been breaking the documentation builds:

```
Error: Duplicate nav: 2.6@desktop:ROOT:nav.adoc
    at ContentCatalog.addFile (/Users/settermjd/Workspace/clients/ownCloud/docs/node_modules/@antora/content-classifier/lib/content-catalog.js:91:13)
    at files.forEach (/Users/settermjd/Workspace/clients/ownCloud/docs/node_modules/@antora/content-classifier/lib/classify-content.js:23:78)
    at Array.forEach (<anonymous>)
    at aggregate.reduce (/Users/settermjd/Workspace/clients/ownCloud/docs/node_modules/@antora/content-classifier/lib/classify-content.js:23:13)
    at Array.reduce (<anonymous>)
    at classifyContent (/Users/settermjd/Workspace/clients/ownCloud/docs/node_modules/@antora/content-classifier/lib/classify-content.js:21:36)
    at aggregateContent.then (/Users/settermjd/Workspace/clients/ownCloud/docs/generator/xref-validator.js:26:79)
    at <anonymous>
```