### PR TITLE
NotificationWidget: Fix buttons being leaked and show top level

### DIFF
--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -65,9 +65,7 @@ void NotificationWidget::setActivity(const Activity &activity)
     _ui._timeLabel->setText(tText);
 
     // always remove the buttons
-    foreach (auto button, _ui._buttonBox->buttons()) {
-        _ui._buttonBox->removeButton(button);
-    }
+    qDeleteAll(_buttons);
     _buttons.clear();
 
     // display buttons for the links


### PR DESCRIPTION
Happens when the activity is updated

QDialogButtonBox::removeButton does not delete the button, it just reparent
it to nullptr.

Issue #7185