### PR TITLE
SocketAPI: Add "show versions" to shell context menu

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -639,6 +639,18 @@ void SocketApi::command_OPEN_PRIVATE_LINK(const QString &localFile, SocketListen
     fetchPrivateLinkUrlHelper(localFile, &SocketApi::openPrivateLink);
 }
 
+void SocketApi::command_OPEN_PRIVATE_LINK_VERSIONS(const QString &localFile, SocketListener *)
+{
+    auto openVersionsLink = [](const QString &link) {
+        QUrl url(link);
+        QUrlQuery query(url);
+        query.addQueryItem(QStringLiteral("details"), QStringLiteral("versionsTabView"));
+        url.setQuery(query);
+        Utility::openBrowser(url, nullptr);
+    };
+    fetchPrivateLinkUrlHelper(localFile, openVersionsLink);
+}
+
 void SocketApi::copyUrlToClipboard(const QString &link)
 {
     QApplication::clipboard()->setText(link);
@@ -895,6 +907,11 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
         if (fileData.folder && fileData.folder->accountState()->isConnected()) {
             sendSharingContextMenuOptions(fileData, listener);
             listener->sendMessage(QLatin1String("MENU_ITEM:OPEN_PRIVATE_LINK") + flagString + tr("Open in browser"));
+
+            // Add link to versions pane if possible
+            if (folder->accountState()->account()->capabilities().privateLinkDetailsParamAvailable()) {
+                listener->sendMessage(QLatin1String("MENU_ITEM:OPEN_PRIVATE_LINK_VERSIONS") + flagString + tr("Show file versions in browser"));
+            }
 
             // Conflict files get conflict resolution actions
             bool isConflict = Utility::isConflictFile(fileData.folderRelativePath);

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -111,6 +111,7 @@ private:
     Q_INVOKABLE void command_COPY_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_OPEN_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_OPEN_PRIVATE_LINK_VERSIONS(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_MAKE_AVAILABLE_LOCALLY(const QString &filesArg, SocketListener *listener);
     Q_INVOKABLE void command_MAKE_ONLINE_ONLY(const QString &filesArg, SocketListener *listener);
     Q_INVOKABLE void command_DELETE_ITEM(const QString &localFile, SocketListener *listener);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -141,6 +141,11 @@ bool Capabilities::privateLinkPropertyAvailable() const
     return _capabilities["files"].toMap()["privateLinks"].toBool();
 }
 
+bool Capabilities::privateLinkDetailsParamAvailable() const
+{
+    return _capabilities["files"].toMap()["privateLinksDetailsParam"].toBool();
+}
+
 QList<int> Capabilities::httpErrorCodesThatResetFailingChunkedUploads() const
 {
     QList<int> list;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -52,6 +52,9 @@ public:
     /// Whether the "privatelink" DAV property is available
     bool privateLinkPropertyAvailable() const;
 
+    /// Whether the "privatelink" DAV property supports the 'details' param
+    bool privateLinkDetailsParamAvailable() const;
+
     /// returns true if the capabilities report notifications
     bool notificationsAvailable() const;
 


### PR DESCRIPTION
The new menu entry depends on the privateLinksDetailsParam
capability of the server.

For  #7196