### PR TITLE
SyncEngine: Fix renaming a single file cause the "delete all file" popup

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -376,6 +376,8 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
         return;
     } else if (item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
         _hasRemoveFile = true;
+    } else if (item->_instruction == CSYNC_INSTRUCTION_RENAME) {
+        _hasNoneFiles = true; // If a file (or every file) has been renamed, it means not al files where deleted
     } else if (item->_instruction == CSYNC_INSTRUCTION_TYPE_CHANGE
         || item->_instruction == CSYNC_INSTRUCTION_SYNC) {
         if (item->_direction == SyncFileItem::Up) {

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -271,6 +271,30 @@ private slots:
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    void testSingleFileRenamed() {
+        FakeFolder fakeFolder{FileInfo{}};
+
+        int aboutToRemoveAllFilesCalled = 0;
+        QObject::connect(&fakeFolder.syncEngine(), &SyncEngine::aboutToRemoveAllFiles,
+            [&](SyncFileItem::Direction , bool *) {
+                aboutToRemoveAllFilesCalled++;
+                QFAIL("should not be called");
+            });
+
+        // add a single file
+        fakeFolder.localModifier().insert("hello.txt");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(aboutToRemoveAllFilesCalled, 0);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        // rename it
+        fakeFolder.localModifier().rename("hello.txt", "goodbye.txt");
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(aboutToRemoveAllFilesCalled, 0);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestAllFilesDeleted)


### PR DESCRIPTION
Possibly a regression, since the new discovery discovers rist the renamed
files as removed

Issue #7204