### PR TITLE
WinUpdater: More useful options on update failure

### DIFF
--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -120,9 +120,9 @@ public slots:
 
 protected slots:
     void backgroundCheckForUpdate() Q_DECL_OVERRIDE;
+    void slotOpenUpdateUrl();
 
 private slots:
-    void slotOpenUpdateUrl();
     void slotVersionInfoArrived();
     void slotTimedOut();
 
@@ -148,9 +148,6 @@ class NSISUpdater : public OCUpdater
 {
     Q_OBJECT
 public:
-    enum UpdateState { NoUpdate = 0,
-        UpdateAvailable,
-        UpdateFailed };
     explicit NSISUpdater(const QUrl &url);
     bool handleStartup() Q_DECL_OVERRIDE;
 private slots:
@@ -159,12 +156,12 @@ private slots:
     void slotWriteFile();
 
 private:
-    NSISUpdater::UpdateState updateStateOnStart();
-    void showDialog(const UpdateInfo &info);
+    void wipeUpdateData();
+    void showNoUrlDialog(const UpdateInfo &info);
+    void showUpdateErrorDialog();
     void versionInfoArrived(const UpdateInfo &info) Q_DECL_OVERRIDE;
     QScopedPointer<QTemporaryFile> _file;
     QString _targetFile;
-    bool _showFallbackMessage;
 };
 
 /**


### PR DESCRIPTION
For #7217 and https://github.com/owncloud/enterprise/issues/3278

Since this is for the updater it needs particuarly thorough review and QA. See below for details.

Need to find a way to make autoupdating fail for tesing.

Expected behaviors:
- Skip this version: Not asked again on restart. Shows as "up to date" in updater info view.
- Ask again later: Asks again on client restart.
- Restart and update: Attempts the updating process again.
- Update manually: Like "skip this version" but also opens browser on updating page.