### PR TITLE
Backport change to stop closing the db connection when a sync finishes

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1216,7 +1216,6 @@ void SyncEngine::finalize(bool success)
     _thread.wait();
 
     _csync_ctx->reinitialize();
-    _journal->close();
 
     qCInfo(lcEngine) << "CSync run took " << _stopWatch.addLapTime(QLatin1String("Sync Finished")) << "ms";
     _stopWatch.stop();

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -27,6 +27,9 @@ static void applyPermissionsFromName(FileInfo &info) {
 // https://github.com/owncloud/client/issues/2038
 static void assertCsyncJournalOk(SyncJournalDb &journal)
 {
+    // The DB is openend in locked mode: close to allow us to access.
+    journal.close();
+
     SqlDatabase db;
     QVERIFY(db.openReadOnly(journal.databaseFilePath()));
     SqlQuery q("SELECT count(*) from metadata where length(fileId) == 0", db);


### PR DESCRIPTION
it seems likely to decrease the severety of #6877: if the database isn't closed and reopened as frequently users are less likely to run into crashes when the sqlite connection switches to wal journaling mode.
