### PR TITLE
Http2: Resend requests on ContentReSend error 

### DIFF
--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -194,7 +194,8 @@ private:
     QPointer<QNetworkReply> _reply; // (QPointer because the NetworkManager may be destroyed before the jobs at exit)
     QString _path;
     QTimer _timer;
-    int _redirectCount;
+    int _redirectCount = 0;
+    int _http2ResendCount = 0;
 
     // Set by the xyzRequest() functions and needed to be able to redirect
     // requests, should it be required.


### PR DESCRIPTION
Since Qt does not yet transparently resend HTTP2 requests in some cases
we do it manually.

The test showed a problem where the initial non-200 reply would close
the target temporary file and the follow-up request couldn't store any
data. Removing that close() call is safe because there also is a
_saveBodyToFile flag that guards writes to the target file.

For #7174