### PR TITLE
Upload: Read file chunks gradually 

### DIFF
--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -36,11 +36,11 @@ class UploadDevice : public QIODevice
 {
     Q_OBJECT
 public:
-    UploadDevice(BandwidthManager *bwm);
+    UploadDevice(const QString &fileName, qint64 start, qint64 size, BandwidthManager *bwm);
     ~UploadDevice();
 
-    /** Reads the data from the file and opens the device */
-    bool prepareAndOpen(const QString &fileName, qint64 start, qint64 size);
+    bool open(QIODevice::OpenMode mode) override;
+    void close() override;
 
     qint64 writeData(const char *, qint64) Q_DECL_OVERRIDE;
     qint64 readData(char *data, qint64 maxlen) Q_DECL_OVERRIDE;
@@ -59,10 +59,15 @@ public:
 signals:
 
 private:
-    // The file data
-    QByteArray _data;
-    // Position in the data
-    qint64 _read;
+    /// The local file to read data from
+    QFile _file;
+
+    /// Start of the file data to use
+    qint64 _start = 0;
+    /// Amount of file data after _start to use
+    qint64 _size = 0;
+    /// Position between _start and _start+_size
+    qint64 _read = 0;
 
     // Bandwidth manager related
     QPointer<BandwidthManager> _bandwidthManager;

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -91,7 +91,6 @@ void PropagateUploadFileV1::startNextChunk()
 
     QString path = _item->_file;
 
-    auto device = std::unique_ptr<UploadDevice>(new UploadDevice(&propagator()->_bandwidthManager));
     qint64 chunkStart = 0;
     qint64 currentChunkSize = fileSize;
     bool isFinalChunk = false;
@@ -125,7 +124,9 @@ void PropagateUploadFileV1::startNextChunk()
     }
 
     const QString fileName = propagator()->getFilePath(_item->_file);
-    if (!device->prepareAndOpen(fileName, chunkStart, currentChunkSize)) {
+    auto device = std::unique_ptr<UploadDevice>(new UploadDevice(
+            fileName, chunkStart, currentChunkSize, &propagator()->_bandwidthManager));
+    if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUpload) << "Could not prepare upload device: " << device->errorString();
 
         // If the file is currently locked, we want to retry the sync


### PR DESCRIPTION
Instead of all at once, to reduce peak memory use.

Changing UploadDevice in this way requires keeping the file open for the
duration of the upload. It also means changes to open(), seek(), close()
to ensure that uses of the device work right when a request needs to
be resent.

Let's consider whether this is safe for 2.5 or should be a 2.6 change!

For #7226