### PR TITLE
SuffixVfs: Simplify logs by avoiding EVAL_RENAME for downloads

### DIFF
--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -197,11 +197,15 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
       auto virtualFilePath = fs->path;
       virtualFilePath.append(ctx->virtual_file_suffix);
       ctx->statedb->getFileRecord(virtualFilePath, &base);
-      if (base.isValid() && base._type == ItemTypeVirtualFile) {
-          fs->type = ItemTypeVirtualFile;
-          fs->path = virtualFilePath;
-      } else {
-          base = OCC::SyncJournalFileRecord();
+      if (base.isValid()) {
+          if (base._type == ItemTypeVirtualFile) {
+              fs->type = ItemTypeVirtualFile;
+              fs->path = virtualFilePath;
+          } else if (base._type == ItemTypeVirtualFileDownload) {
+              // keep everything: fs looks like a remote file
+          } else {
+              base = OCC::SyncJournalFileRecord();
+          }
       }
   }
 


### PR DESCRIPTION
When a file is tagged ItemTypeVirtualFileDownload in the database the
REMOTE pass in csync_update would not find the matching item in the
database. It worked anyway since the rename detection finds it, sees
the type tag and does the right thing. But the logging was confusing.

This change allows the pass to find the matching entry in the database
and proceed to the "db-entry-found" case without going through rename
detection.

Seen in #7231 