### PR TITLE
FolderWatcher: Become unreliable if test notification fails

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1194,6 +1194,7 @@ void Folder::registerFolderWatcher()
     connect(_folderWatcher.data(), &FolderWatcher::becameUnreliable,
         this, &Folder::slotWatcherUnreliable);
     _folderWatcher->init(path());
+    _folderWatcher->startNotificatonTest(path() + QLatin1String(".owncloudsync.log"));
 }
 
 bool Folder::supportsVirtualFiles() const

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -71,6 +71,14 @@ public:
      */
     bool isReliable() const;
 
+    /**
+     * Triggers a change in the path and verifies a notification arrives.
+     *
+     * If no notification is seen, the folderwatcher marks itself as unreliable.
+     * The path must be ignored by the watcher.
+     */
+    void startNotificatonTest(const QString &path);
+
     /// For testing linux behavior only
     int testLinuxWatchCount() const;
 
@@ -109,6 +117,9 @@ private:
     QSet<QString> _lastPaths;
     Folder *_folder;
     bool _isReliable = true;
+
+    /** Path of the expected test notification */
+    QString _testNotificationPath;
 
     friend class FolderWatcherPrivate;
 };

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -171,9 +171,10 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
         if (event->len == 0 || event->wd <= -1)
             continue;
         QByteArray fileName(event->name);
+        // Filter out journal changes - redundant with filtering in
+        // FolderWatcher::pathIsIgnored.
         if (fileName.startsWith("._sync_")
             || fileName.startsWith(".csync_journal.db")
-            || fileName.startsWith(".owncloudsync.log")
             || fileName.startsWith(".sync_")) {
             continue;
         }


### PR DESCRIPTION
Necessary for some filesystems on windows that don't have full file
watching capabilities.

 #7241 https://github.com/owncloud/enterprise/issues/3303