### PR TITLE
Shell extension: Show "show versions" only when available

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -910,7 +910,11 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
             listener->sendMessage(QLatin1String("MENU_ITEM:OPEN_PRIVATE_LINK") + flagString + tr("Open in browser"));
 
             // Add link to versions pane if possible
-            if (folder->accountState()->account()->capabilities().privateLinkDetailsParamAvailable()) {
+            auto &capabilities = folder->accountState()->account()->capabilities();
+            if (capabilities.versioningEnabled()
+                && capabilities.privateLinkDetailsParamAvailable()
+                && isOnTheServer
+                && !record.isDirectory()) {
                 listener->sendMessage(QLatin1String("MENU_ITEM:OPEN_PRIVATE_LINK_VERSIONS") + flagString + tr("Show file versions in browser"));
             }
 

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -170,6 +170,11 @@ bool Capabilities::uploadConflictFiles() const
     return _capabilities[QStringLiteral("uploadConflictFiles")].toBool();
 }
 
+bool Capabilities::versioningEnabled() const
+{
+    return _capabilities["files"].toMap()["versioning"].toBool();
+}
+
 QString Capabilities::zsyncSupportedVersion() const
 {
     return _capabilities[QStringLiteral("dav")].toMap()[QStringLiteral("zsync")].toString();

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -131,6 +131,9 @@ public:
      */
     bool uploadConflictFiles() const;
 
+    /** Is versioning available? */
+    bool versioningEnabled() const;
+
 private:
     QVariantMap _capabilities;
 };


### PR DESCRIPTION
- Don't show it for directories.
- Don't show it when versioning is disabled.

For  #7196