### PR TITLE
UploadDevice: Fix windows issues 

### DIFF
--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -121,16 +121,7 @@ public:
 
     virtual void start() Q_DECL_OVERRIDE;
 
-    virtual bool finished() Q_DECL_OVERRIDE
-    {
-        qCInfo(lcPutJob) << "PUT of" << reply()->request().url().toString() << "FINISHED WITH STATUS"
-                         << replyStatusString()
-                         << reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute)
-                         << reply()->attribute(QNetworkRequest::HttpReasonPhraseAttribute);
-
-        emit finishedSignal();
-        return true;
-    }
+    virtual bool finished() Q_DECL_OVERRIDE;
 
     QIODevice *device()
     {


### PR DESCRIPTION
- Close the UploadDevice to close the QFile after the PUT job is done.
  This allows winvfs to get an oplock on the file later.

- Don't rely on QFile::fileName() to be valid after
  openAndSeekFileSharedRead() was called. The way it is openend on
  Windows makes it have an empty filename.

For #7264