### PR TITLE
Sharing: Create shares with appropriate permissions

### DIFF
--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -295,6 +295,13 @@ void ShareManager::createShare(const QString &path,
     connect(job, &OcsJob::ocsError, this, &ShareManager::slotOcsError);
     connect(job, &OcsShareJob::shareJobFinished, this,
         [=](const QJsonDocument &reply) {
+            // Note: The following code attempts to determine if the item was shared with
+            // the user and what the permissions were. It doesn't do a good job at it since
+            // the == path comparison will mean it doesn't work for subitems of shared
+            // folders. Also, it's nicer if the calling code determines the share-permissions
+            // (see maxSharingPermissions) via a PropFind and passes in valid permissions.
+            // Remove this code for >= 2.7.0.
+
             // Find existing share permissions (if this was shared with us)
             Share::Permissions existingPermissions = SharePermissionDefault;
             foreach (const QJsonValue &element, reply.object()["ocs"].toObject()["data"].toArray()) {

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -298,7 +298,7 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex &index)
             sharee->shareWith(), SharePermission(permissions));
     } else {
         _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
-            sharee->shareWith(), SharePermissionDefault);
+            sharee->shareWith(), _maxSharingPermissions);
     }
 
     _ui->shareeLineEdit->setEnabled(false);


### PR DESCRIPTION
If user A shares something with user B and allows resharing but removes
some other permission then user B should be able to share the item or
any of its contents with user C and the new share permissions should
automatically be <= the permissions of the original share.

Currently this works correctly when resharing the original item but
fails for any subitem, preventing the reshare entirely.

With this patch the reshare will always be created with appropriately
limited permissions.

For #7275