### PR TITLE
Vfs: Retain existing data when enabling vfs

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -651,10 +651,9 @@ bool Folder::newFilesAreVirtual() const
     return pinState && *pinState == PinState::OnlineOnly;
 }
 
-void Folder::setNewFilesAreVirtual(bool enabled)
+void Folder::setRootPinState(PinState state)
 {
-    const auto newPin = enabled ? PinState::OnlineOnly : PinState::AlwaysLocal;
-    _vfs->setPinState(QString(), newPin);
+    _vfs->setPinState(QString(), state);
 
     // We don't actually need discovery, but it's important to recurse
     // into all folders, so the changes can be applied.

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -281,10 +281,11 @@ public:
 
     /** whether new remote files shall become virtual locally
      *
-     * This is the root folder pin state and can be overridden by explicit subfolder pin states.
+     * This happens when the root folder pin state is OnlineOnly, but can be
+     * overridden by explicit subfolder pin states.
      */
     bool newFilesAreVirtual() const;
-    void setNewFilesAreVirtual(bool enabled);
+    void setRootPinState(PinState state);
 
     /** Whether user desires a switch that couldn't be executed yet, see member */
     bool isVfsOnOffSwitchPending() const { return _vfsOnOffPending; }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -268,7 +268,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 // Migrate the old "usePlaceholders" setting to the root folder pin state
                 if (settings.value(QLatin1String(versionC), 1).toInt() == 1
                     && settings.value(QLatin1String("usePlaceholders"), false).toBool()) {
-                    f->setNewFilesAreVirtual(true);
+                    f->setRootPinState(PinState::OnlineOnly);
                 }
 
                 // Migration: Mark folders that shall be saved in a backwards-compatible way

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -628,7 +628,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
             auto f = folderMan->addFolder(account, folderDefinition);
             if (f) {
                 if (folderDefinition.virtualFilesMode != Vfs::Off && _ocWizard->useVirtualFileSync())
-                    f->setNewFilesAreVirtual(true);
+                    f->setRootPinState(PinState::OnlineOnly);
 
                 f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList,
                     _ocWizard->selectiveSyncBlacklist());


### PR DESCRIPTION
Previously all local data was deleted because the root folder was marked
as OnlineOnly.

See #7302