### PR TITLE
FolderWatcher: Wait for ready before testing

### DIFF
--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -81,6 +81,19 @@ void FolderWatcher::startNotificatonTest(const QString &path)
     ASSERT(_testNotificationPath.isEmpty());
     _testNotificationPath = path;
 
+    // Don't do the local file modification immediately:
+    // wait for FolderWatchPrivate::_ready
+    startNotificationTestWhenReady();
+}
+
+void FolderWatcher::startNotificationTestWhenReady()
+{
+    if (!_d->_ready) {
+        QTimer::singleShot(1000, this, &FolderWatcher::startNotificationTestWhenReady);
+        return;
+    }
+
+    auto path = _testNotificationPath;
     if (QFile::exists(path)) {
         auto mtime = FileSystem::getModTime(path);
         FileSystem::setModTime(path, mtime + 1);
@@ -89,12 +102,13 @@ void FolderWatcher::startNotificatonTest(const QString &path)
         f.open(QIODevice::WriteOnly | QIODevice::Append);
     }
 
-    QTimer::singleShot(5000, this, [&]() {
+    QTimer::singleShot(5000, this, [this]() {
         if (!_testNotificationPath.isEmpty())
             emit becameUnreliable(tr("The watcher did not receive a test notification."));
         _testNotificationPath.clear();
     });
 }
+
 
 int FolderWatcher::testLinuxWatchCount() const
 {

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -108,6 +108,9 @@ protected slots:
     void changeDetected(const QString &path);
     void changeDetected(const QStringList &paths);
 
+private slots:
+    void startNotificationTestWhenReady();
+
 protected:
     QHash<QString, int> _pendingPathes;
 

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -41,6 +41,9 @@ public:
 
     int testWatchCount() const { return _pathToWatch.size(); }
 
+    /// On linux the watcher is ready when the ctor finished.
+    bool _ready = 1;
+
 protected slots:
     void slotReceivedNotification(int fd);
     void slotAddFolderRecursive(const QString &path);

--- a/src/gui/folderwatcher_mac.h
+++ b/src/gui/folderwatcher_mac.h
@@ -36,6 +36,9 @@ public:
     void startWatching();
     void doNotifyParent(const QStringList &);
 
+    /// On OSX the watcher is ready when the ctor finished.
+    bool _ready = 1;
+
 private:
     FolderWatcher *_parent;
 

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -85,6 +85,8 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
             break;
         }
 
+        emit ready();
+
         HANDLE handles[] = { _resultEvent, _stopEvent };
         DWORD result = WaitForMultipleObjects(
             2, handles,
@@ -205,6 +207,8 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
         _parent, SLOT(changeDetected(const QString &)));
     connect(_thread, SIGNAL(lostChanges()),
         _parent, SIGNAL(lostChanges()));
+    connect(_thread, &WatcherThread::ready,
+        this, [this]() { _ready = 1; });
     _thread->start();
 }
 

--- a/src/gui/folderwatcher_win.h
+++ b/src/gui/folderwatcher_win.h
@@ -54,6 +54,7 @@ protected:
 signals:
     void changed(const QString &path);
     void lostChanges();
+    void ready();
 
 private:
     QString _path;
@@ -73,6 +74,9 @@ class FolderWatcherPrivate : public QObject
 public:
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
     ~FolderWatcherPrivate();
+
+    /// Set to non-zero once the WatcherThread is capturing events.
+    QAtomicInt _ready;
 
 private:
     FolderWatcher *_parent;


### PR DESCRIPTION
Before on Windows sometimes the file touching was done before the WatcherThread of the FolderWatcher was ready to track events.

For  #7305