### PR TITLE
Vfs: Add hook to allow update-metadata for unchanged files

### DIFF
--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -166,6 +166,13 @@ public:
      */
     virtual void dehydratePlaceholder(const SyncFileItem &item) = 0;
 
+    /** Discovery hook: even unchanged files may need UPDATE_METADATA.
+     *
+     * For instance cfapi vfs wants local hydrated non-placeholder files to
+     * become hydrated placeholder files.
+     */
+    virtual bool needsMetadataUpdate(const SyncFileItem &item) = 0;
+
     /** Convert a new file to a hydrated placeholder.
      *
      * Some VFS integrations expect that every file, including those that have all
@@ -287,6 +294,7 @@ public:
     void dehydratePlaceholder(const SyncFileItem &) override {}
     void convertToPlaceholder(const QString &, const SyncFileItem &, const QString &) override {}
 
+    bool needsMetadataUpdate(const SyncFileItem &item) override { return false; }
     bool isDehydratedPlaceholder(const QString &) override { return false; }
     bool statTypeVirtualFile(csync_file_stat_t *, void *) override { return false; }
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -728,9 +728,11 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                 item->_direction = SyncFileItem::Down;
                 item->_instruction = CSYNC_INSTRUCTION_SYNC;
                 item->_type = ItemTypeVirtualFileDehydration;
-            } else if (!serverModified && dbEntry._inode != localEntry.inode) {
+            } else if (!serverModified
+                && (dbEntry._inode != localEntry.inode
+                    || _discoveryData->_syncOptions._vfs->needsMetadataUpdate(*item))) {
                 item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
-                item->_direction = SyncFileItem::Down; // Does not matter
+                item->_direction = SyncFileItem::Down;
             }
         } else if (!typeChange && isVfsWithSuffix()
             && dbEntry.isVirtualFile() && !localEntry.isVirtualFile

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -342,8 +342,13 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
                 rec._checksumHeader = prev._checksumHeader;
             rec._serverHasIgnoredFiles |= prev._serverHasIgnoredFiles;
 
+            // Ensure it's a placeholder file on disk
+            if (item->_type == ItemTypeFile) {
+                _syncOptions._vfs->convertToPlaceholder(filePath, *item);
+            }
+
             // Update on-disk virtual file metadata
-            if (item->_type == ItemTypeVirtualFile && _syncOptions._vfs) {
+            if (item->_type == ItemTypeVirtualFile) {
                 QString error;
                 if (!_syncOptions._vfs->updateMetadata(filePath, item->_modtime, item->_size, item->_fileId, &error)) {
                     item->_instruction = CSYNC_INSTRUCTION_ERROR;

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -44,6 +44,7 @@ public:
     void dehydratePlaceholder(const SyncFileItem &item) override;
     void convertToPlaceholder(const QString &filename, const SyncFileItem &item, const QString &) override;
 
+    bool needsMetadataUpdate(const SyncFileItem &item) override { return false; }
     bool isDehydratedPlaceholder(const QString &filePath) override;
     bool statTypeVirtualFile(csync_file_stat_t *stat, void *stat_data) override;
 


### PR DESCRIPTION
Allows winvfs to convert files to placeholders when vfs is enabled. This
is required to mark files as in-sync #7329.

Needs matching winvfs change.