### PR TITLE
Vfs: Make move detection work with virtual files 

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -873,7 +873,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         }
 
         // Verify the checksum where possible
-        if (!base._checksumHeader.isEmpty() && item->_type == ItemTypeFile) {
+        if (!base._checksumHeader.isEmpty() && item->_type == ItemTypeFile && base._type == ItemTypeFile) {
             if (computeLocalChecksum(base._checksumHeader, _discoveryData->_localDir + path._original, item)) {
                 qCInfo(lcDisco) << "checking checksum of potential rename " << path._original << item->_checksumHeader << base._checksumHeader;
                 if (item->_checksumHeader != base._checksumHeader) {


### PR DESCRIPTION
Previously a checksum computation could be done on a suffix-placeholder
file, making discovery believe that no move took place.

For #7001