### PR TITLE
Vfs: Ensure pins change with (de-)hydration

### DIFF
--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -89,6 +89,11 @@ void VfsSuffix::dehydratePlaceholder(const SyncFileItem &item)
         setPinState(item._renameTarget, *pin);
         setPinState(item._file, PinState::Inherited);
     }
+
+    // Ensure the pin state isn't contradictory
+    pin = pinState(item._renameTarget);
+    if (pin && *pin == PinState::AlwaysLocal)
+        setPinState(item._renameTarget, PinState::Unspecified);
 }
 
 void VfsSuffix::convertToPlaceholder(const QString &, const SyncFileItem &, const QString &)


### PR DESCRIPTION
Previously an implicit hydration of a file in an online-only folder
would not change the pin state and cause a dehydration on the next
sync.

@HanaGemela FYI