### PR TITLE
Vfs: Require local discovery after disabling vfs

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -637,6 +637,9 @@ void AccountSettings::slotDisableVfsCurrentFolder()
             folder->setRootPinState(PinState::AlwaysLocal);
             folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, {});
 
+            // Prevent issues with missing local files
+            folder->slotNextSyncFullLocalDiscovery();
+
             FolderMan::instance()->scheduleFolder(folder);
 
             ui->_folderList->doItemsLayout();


### PR DESCRIPTION
Without it local files aren't guaranteed to be downloaded #6936.