### PR TITLE
Discovery: Parse etag to be consistent with RequestEtagJob

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -365,7 +365,7 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(QString file, con
     //This works in concerto with the RequestEtagJob and the Folder object to check if the remote folder changed.
     if (map.contains("getetag")) {
         if (_firstEtag.isEmpty()) {
-            _firstEtag = map.value("getetag"); // for directory itself
+            _firstEtag = parseEtag(map.value("getetag").toUtf8()); // for directory itself
         }
     }
 }


### PR DESCRIPTION
This avoids unnecessary sync runs.

For #7345