### PR TITLE
SyncEngine: Don't duplicate fatal errors

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -759,10 +759,6 @@ void SyncEngine::slotItemCompleted(const SyncFileItemPtr &item)
 {
     _progressInfo->setProgressComplete(*item);
 
-    if (item->_status == SyncFileItem::FatalError) {
-        syncError(item->_errorString);
-    }
-
     emit transmissionProgress(*_progressInfo);
     emit itemCompleted(item);
 }


### PR DESCRIPTION
Previously fatal error texts were duplicated: Once they entered the
SyncResult via the SyncFileItem and once via syncError().

syncError is intended for folder-wide sync issues that are not pinned
to particular files. Thus that duplicated path is removed.

For #5088