### PR TITLE
Checksums: Fix crash due to threading issue

### DIFF
--- a/src/common/checksums.h
+++ b/src/common/checksums.h
@@ -94,21 +94,9 @@ public:
     QByteArray checksumType() const;
 
     /**
-     * Computes the checksum for given device.
-     *
-     * done() is emitted when the calculation finishes.
-     *
-     * Does not take ownership of the device.
-     * Does not call open() on the device.
-     */
-    void start(QIODevice *device);
-
-    /**
      * Computes the checksum for the given file path.
      *
      * done() is emitted when the calculation finishes.
-     *
-     * Convenience wrapper for start(QIODevice*) above.
      */
     void start(const QString &filePath);
 
@@ -131,9 +119,6 @@ private slots:
 private:
     QByteArray _checksumType;
 
-    // The convenience wrapper may open a file and must close it too
-    std::unique_ptr<QFile> _file;
-
     // watcher for the checksum calculation thread
     QFutureWatcher<QByteArray> _watcher;
 };
@@ -154,16 +139,6 @@ public:
      * If no checksum is there, or if a correct checksum is there, the signal validated()
      * will be emitted. In case of any kind of error, the signal validationFailed() will
      * be emitted.
-     *
-     * Does not take ownership of the device.
-     * Does not call open() on the device.
-     */
-    void start(QIODevice *device, const QByteArray &checksumHeader);
-
-    /**
-     * Same as above but opening a file by path.
-     *
-     * Convenience function for start(QIODevice*) above
      */
     void start(const QString &filePath, const QByteArray &checksumHeader);
 

--- a/test/testchecksumvalidator.cpp
+++ b/test/testchecksumvalidator.cpp
@@ -192,20 +192,20 @@ using namespace OCC::Utility;
 
         file->seek(0);
         _successDown = false;
-        vali->start(file, adler);
+        vali->start(_testfile, adler);
 
         QTRY_VERIFY(_successDown);
 
         _expectedError = QLatin1String("The downloaded file does not match the checksum, it will be resumed.");
         _errorSeen = false;
         file->seek(0);
-        vali->start(file, "Adler32:543345");
+        vali->start(_testfile, "Adler32:543345");
         QTRY_VERIFY(_errorSeen);
 
         _expectedError = QLatin1String("The checksum header contained an unknown checksum type 'Klaas32'");
         _errorSeen = false;
         file->seek(0);
-        vali->start(file, "Klaas32:543345");
+        vali->start(_testfile, "Klaas32:543345");
         QTRY_VERIFY(_errorSeen);
 
         delete vali;


### PR DESCRIPTION
The checksum computation thread was potentially using a QFile that was
deleted in the gui thread.

For #7368