### PR TITLE
Print critical and fatal messages to stderr

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -22,6 +22,8 @@
 #include <QtGlobal>
 #include <qmetaobject.h>
 
+#include <iostream>
+
 #ifdef ZLIB_FOUND
 #include <zlib.h>
 #endif
@@ -37,6 +39,8 @@ static void mirallLogCatcher(QtMsgType type, const QMessageLogContext &ctx, cons
     auto logger = Logger::instance();
     if (!logger->isNoop()) {
         logger->doLog(qFormatLogMessage(type, ctx, message));
+    } else if(type >= QtCriticalMsg) {
+        std::cerr << qPrintable(qFormatLogMessage(type, ctx, message)) << std::endl;
     }
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
That way we might get a reason why the client crashes (dev setup)