### PR TITLE
OwncloudWizard: Mark vfs as tech preview instead of experimental

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -483,7 +483,8 @@ FolderWizardSelectiveSync::FolderWizardSelectiveSync(const AccountPtr &account)
     layout->addWidget(_selectiveSync);
 
     if (Theme::instance()->showVirtualFilesOption() && bestAvailableVfsMode() != Vfs::Off) {
-        _virtualFilesCheckBox = new QCheckBox(tr("Use virtual files instead of downloading content immediately (experimental)"));
+        _virtualFilesCheckBox = new QCheckBox(tr("Use virtual files instead of downloading content immediately %1").arg(
+                                                  bestAvailableVfsMode() == Vfs::WindowsCfApi ? tr("(tech preview)") : tr("(experimental)")));
         connect(_virtualFilesCheckBox, &QCheckBox::clicked, this, &FolderWizardSelectiveSync::virtualFilesCheckboxClicked);
         connect(_virtualFilesCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
             _selectiveSync->setEnabled(state == Qt::Unchecked);

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -235,27 +235,24 @@ AbstractCredentials *OwncloudWizard::getCredentials() const
 
 void OwncloudWizard::askExperimentalVirtualFilesFeature(const std::function<void(bool enable)> &callback)
 {
-    auto bestVfsMode = bestAvailableVfsMode();
+    const auto bestVfsMode = bestAvailableVfsMode();
     QMessageBox *msgBox = nullptr;
     if (bestVfsMode == Vfs::WindowsCfApi) {
         msgBox = new QMessageBox(
             QMessageBox::Warning,
-            tr("Enable experimental feature?"),
+            tr("Enable technical preview feature?"),
             tr("When the \"virtual files\" mode is enabled no files will be downloaded initially. "
-               "Instead a placeholder file will be created for each file that exists on the server. "
+               "Instead a virtual file will be created for each file that exists on the server. "
                "When a file is opened its contents will be downloaded automatically. "
-               "Alternatively files can be downloaded manually by using their context menu."
+               "Alternatively, files can be downloaded manually by using their context menu."
                "\n\n"
                "The virtual files mode is mutually exclusive with selective sync. "
                "Currently unselected folders will be translated to online-only folders "
-               "and your selective sync settings will be reset."
-               "\n\n"
-               "Switching to this mode will abort any currently running synchronization."
-               "\n\n"
-               "This is a new, experimental mode. If you decide to use it, please report any "
-               "issues that come up."));
+               "and your selective sync settings will be reset."));
+        msgBox->addButton(tr("Enable virtual files"), QMessageBox::AcceptRole);
+        msgBox->addButton(tr("Continue to use selective sync"), QMessageBox::RejectRole);
     } else {
-        ASSERT(bestVfsMode == Vfs::WithSuffix);
+        ASSERT(bestVfsMode == Vfs::WithSuffix)
         msgBox = new QMessageBox(
             QMessageBox::Warning,
             tr("Enable experimental feature?"),
@@ -272,9 +269,9 @@ void OwncloudWizard::askExperimentalVirtualFilesFeature(const std::function<void
                "This is a new, experimental mode. If you decide to use it, please report any "
                "issues that come up.")
                 .arg(APPLICATION_DOTVIRTUALFILE_SUFFIX));
+        msgBox->addButton(tr("Enable experimental placeholder mode"), QMessageBox::AcceptRole);
+        msgBox->addButton(tr("Stay safe"), QMessageBox::RejectRole);
     }
-    msgBox->addButton(tr("Enable experimental mode"), QMessageBox::AcceptRole);
-    msgBox->addButton(tr("Stay safe"), QMessageBox::RejectRole);
     connect(msgBox, &QMessageBox::finished, msgBox, [callback, msgBox](int result) {
         callback(result == QMessageBox::AcceptRole);
         msgBox->deleteLater();


### PR DESCRIPTION
Related issue: https://github.com/owncloud/client/issues/7406