### PR TITLE
ShareLinks: Always show at least readonly permissions

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -149,12 +149,13 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
         _expiryRequired = true;
     }
 
-    // File can't have public upload set; we also hide it if the capability isn't there
-    _ui->widget_editing->setVisible(
-        !_isFile && _account->capabilities().sharePublicLinkAllowUpload());
-    _ui->radio_uploadOnly->setVisible(
-        _account->capabilities().sharePublicLinkSupportsUploadOnly());
-
+    // Hide permissions that are unavailable for files or disabled by capability.
+    bool rwVisible = !_isFile && _account->capabilities().sharePublicLinkAllowUpload();
+    bool uploadOnlyVisible = rwVisible && _account->capabilities().sharePublicLinkSupportsUploadOnly();
+    _ui->radio_readWrite->setVisible(rwVisible);
+    _ui->label_readWrite->setVisible(rwVisible);
+    _ui->radio_uploadOnly->setVisible(uploadOnlyVisible);
+    _ui->label_uploadOnly->setVisible(uploadOnlyVisible);
 
     // Prepare sharing menu
 
@@ -376,17 +377,15 @@ void ShareLinkWidget::slotShareSelectionChanged()
         _ui->calendar->setEnabled(false);
     }
 
-    // Public upload state (box is hidden for files)
-    if (!_isFile) {
-        if (share && share->getPublicUpload()) {
-            if (share->getShowFileListing()) {
-                _ui->radio_readWrite->setChecked(true);
-            } else {
-                _ui->radio_uploadOnly->setChecked(true);
-            }
+    // Public upload state
+    if (share && share->getPublicUpload()) {
+        if (share->getShowFileListing()) {
+            _ui->radio_readWrite->setChecked(true);
         } else {
-            _ui->radio_readOnly->setChecked(true);
+            _ui->radio_uploadOnly->setChecked(true);
         }
+    } else {
+        _ui->radio_readOnly->setChecked(true);
     }
 
     // Name and create button

--- a/src/gui/sharelinkwidget.ui
+++ b/src/gui/sharelinkwidget.ui
@@ -170,7 +170,7 @@
           <number>0</number>
          </property>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="label_readOnly">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -209,7 +209,7 @@
           </widget>
          </item>
          <item row="7" column="0">
-          <widget class="QLabel" name="label_4">
+          <widget class="QLabel" name="label_uploadOnly">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -239,7 +239,7 @@
           </widget>
          </item>
          <item row="4" column="0">
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="label_readWrite">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>


### PR DESCRIPTION
For #7429

The only reason I'd have this in 2.6.0 is because there was a bug where the new sharing permission labels weren't hidden along with the radio button options.