### PR TITLE
Fix incorrect attribute definitions in the docs

### DIFF
--- a/docs/modules/ROOT/pages/building.adoc
+++ b/docs/modules/ROOT/pages/building.adoc
@@ -241,7 +241,7 @@ craft nsis
 craft --package owncloud-client
 ....
 
-Now you should have a file called: `owncloud-client-master-${COMMIT_HASH}-windows-${COMPILER}.exe` in `C:\CraftRoot\tmp`.
+Now you should have a file called: `owncloud-client-master-$\{COMMIT_HASH\}-windows-$\{COMPILER\}.exe` in `C:\CraftRoot\tmp`.
 
 [NOTE]
 ====


### PR DESCRIPTION
In a code sample, two variables were being incorrectly interpreted as AsciiDoc variables, and throwing build warnings. This PR corrects these two references.