### PR TITLE
ConnectionValidator: increase timeout to 57s

### DIFF
--- a/src/gui/connectionvalidator.h
+++ b/src/gui/connectionvalidator.h
@@ -97,7 +97,7 @@ public:
     Q_ENUM(Status);
 
     // How often should the Application ask this object to check for the connection?
-    enum { DefaultCallingIntervalMsec = 32 * 1000 };
+    enum { DefaultCallingIntervalMsec = 62 * 1000 };
 
 public slots:
     /// Checks the server and the authentication.


### PR DESCRIPTION
When the gui thread blocks for several seconds it's possible for the
ConnectionValidator to timeout and decide that the account is
unreachable. It will then terminate all sync runs.

Increasing the timeout makes this less likely to happen. The tradeoff is
that real disconnects will not be detected as quickly.

This does not address the root cause but makes the symptom less likely
to appear.

For #7456