### PR TITLE
Don't store pointer to local job

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -52,7 +52,7 @@ void ProcessDirectoryJob::start()
     }
 
     if (_queryLocal == NormalQuery) {
-        _localJob = startAsyncLocalQuery();
+        startAsyncLocalQuery();
     } else {
         _localQueryDone = true;
     }
@@ -1420,7 +1420,7 @@ DiscoverySingleDirectoryJob *ProcessDirectoryJob::startAsyncServerQuery()
     return serverJob;
 }
 
-DiscoverySingleLocalDirectoryJob *ProcessDirectoryJob::startAsyncLocalQuery()
+void ProcessDirectoryJob::startAsyncLocalQuery()
 {
     QString localPath = _discoveryData->_localDir + _currentFolder._local;
     auto localJob = new DiscoverySingleLocalDirectoryJob(_discoveryData->_account, localPath, _discoveryData->_syncOptions._vfs.data(), this);
@@ -1467,9 +1467,7 @@ DiscoverySingleLocalDirectoryJob *ProcessDirectoryJob::startAsyncLocalQuery()
     });
 
     QThreadPool *pool = QThreadPool::globalInstance();
-    pool->start(localJob);
-
-    return localJob;
+    pool->start(localJob); // QThreadPool takes ownership
 }
 
 

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -206,7 +206,7 @@ private:
       *
       * Fills _localNormalQueryEntries.
       */
-    DiscoverySingleLocalDirectoryJob *startAsyncLocalQuery();
+    void startAsyncLocalQuery();
 
 
     /** Sets _pinState, the directory's pin state
@@ -242,8 +242,6 @@ private:
 
     RemotePermissions _rootPermissions;
     QPointer<DiscoverySingleDirectoryJob> _serverJob;
-
-    QPointer<DiscoverySingleLocalDirectoryJob> _localJob;
 
 
     /** Number of currently running async jobs.


### PR DESCRIPTION
There were crashes in the QPointer assignment. Possibly the thread pool
is done with the job and deletes it before the assignment is done.

Thanks for the backtrace @jnweiger 