### PR TITLE
Checksums: Explicitly close file before reporting result

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -261,7 +261,9 @@ void ComputeChecksum::startImpl(std::unique_ptr<QIODevice> device)
             }
             return QByteArray();
         }
-        return ComputeChecksum::computeNow(sharedDevice.data(), type);
+        auto result = ComputeChecksum::computeNow(sharedDevice.data(), type);
+        sharedDevice->close();
+        return result;
     }));
 }
 


### PR DESCRIPTION
To ensure it's no longer open when the finished signal fires.

For #7468 