### PR TITLE
Investigation around drone test failures

### DIFF
--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -1204,7 +1204,7 @@ public:
         // A new folder will update the local file state database on first sync.
         // To have a state matching what users will encounter, we have to a sync
         // using an identical local/remote file tree first.
-        syncOnce();
+        ENFORCE(syncOnce());
     }
 
     void switchToVfs(QSharedPointer<OCC::Vfs> vfs, bool enableShell = false)


### PR DESCRIPTION
Turns out the drone failures are because of seemingly random errno 11 failures during readdir. These changes should provide better diagnostics and make the source of the failure clearer.