### PR TITLE
Revert "Windows: Use better name for SocketAPI socket #6983"

### DIFF
--- a/shell_integration/windows/OCUtil/CommunicationSocket.cpp
+++ b/shell_integration/windows/OCUtil/CommunicationSocket.cpp
@@ -18,8 +18,6 @@
 #include "UtilConstants.h"
 #include "StringUtil.h"
 
-#include "config.h"
-
 #include <iostream>
 #include <vector>
 #include <array>
@@ -47,14 +45,7 @@ std::wstring getUserName() {
 std::wstring CommunicationSocket::DefaultPipePath()
 {
     auto pipename = std::wstring(L"\\\\.\\pipe\\");
-
-#define WIDEN_(exp)   L##exp
-#define WIDEN(exp)    WIDEN_(exp)
-    pipename += WIDEN(APPLICATION_SHORTNAME);
-#undef WIDEN
-#undef WIDEN_
-
-    pipename += L"-";
+    pipename += L"ownCloud-";
     pipename += getUserName();
     return pipename;
 }

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -183,8 +183,7 @@ SocketApi::SocketApi(QObject *parent)
 
     if (Utility::isWindows()) {
         socketPath = QLatin1String("\\\\.\\pipe\\")
-            + QLatin1String(APPLICATION_SHORTNAME)
-            + QLatin1String("-")
+            + QLatin1String("ownCloud-")
             + QString::fromLocal8Bit(qgetenv("USERNAME"));
         // TODO: once the windows extension supports multiple
         // client connections, switch back to the theme name


### PR DESCRIPTION
This reverts commit ed1e534d24f871a0ab6ea02e4c88eefe3126bf59.

Doesn't make sense to spend effort on this, we keep it as it is.