### PR TITLE
Fix Upload of large (> 2GiB) files

### DIFF
--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -369,7 +369,7 @@ private:
     qint64 _bytesToUpload;
 
     uint _transferId = 0; /// transfer id (part of the url)
-    int _currentChunkOffset = 0; /// byte offset of the next chunk data that will be sent
+    qint64 _currentChunkOffset = 0; /// byte offset of the next chunk data that will be sent
     qint64 _currentChunkSize = 0; /// current chunk size
     bool _removeJobError = false; /// if not null, there was an error removing the job
     bool _zsyncSupported = false; /// if zsync is supported this will be set to true

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -770,7 +770,7 @@ public:
         Q_ASSERT(sourceFolder);
         Q_ASSERT(sourceFolder->isDir);
         int count = 0;
-        int size = 0;
+        qlonglong size = 0;
         qlonglong prev = 0;
         char payload = '\0';
 
@@ -798,7 +798,7 @@ public:
 
         // For zsync, get the size from the header, and allow no-chunk uploads (shrinking files)
         if (zsync) {
-            size = request.rawHeader("OC-Total-File-Length").toInt();
+            size = request.rawHeader("OC-Total-File-Length").toLongLong();
             if (count == 0) {
                 if (auto info = remoteRootFileInfo.find(fileName))
                     payload = info->contentChar;


### PR DESCRIPTION
Issue #7506

This is a regression introduced by the delta sync feature (as the chunk offset
changed from being the chunk number to be the byte offset, it needs to be a
qint64 now)