### PR TITLE
Fix several broken links

### DIFF
--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -1,6 +1,7 @@
 = Appendix B: History and Architecture
 :toc: right
 :toclevels: 1
+:theopengroup-url: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01
 
 == Introduction
 
@@ -154,7 +155,6 @@ The server sends the checksum in an HTTP header with the file. (same format as a
 If no checksum is found in `oc_filecache` (freshly mounted external storage) it is computed and stored in `oc_filecache` on the first download.
 The checksum is then provided on all subsequent downloads but not on the first.
 
-[[ignored-files-label]]
 == Ignored Files
 
 The ownCloud Client supports the ability to exclude or ignore certain files from the synchronization process.
@@ -173,7 +173,7 @@ By default, the ownCloud Client ignores the following files:
 * Windows only: Files with a trailing space or dot.
 * Windows only: Filenames that are reserved on Windows.
 
-If a pattern selected using a checkbox in the `ignoredFilesEditor-label`, or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
+If a pattern selected using a checkbox in the xref:visualtour.adoc#the-ignored-files-editor[Ignored Files Editor], or if a line in the exclude file starts with the character `]` directly followed by the file pattern, files matching the pattern are considered.
 *fleeting meta data*.
 
 These files are ignored and _removed_ by the client if found in the synchronized folder.
@@ -184,8 +184,7 @@ The pattern is only applied for directory components of filenames selected using
 
 To match filenames against the exclude patterns, the UNIX standard C library function `fnmatch` is used.
 This process checks the filename against the specified pattern using standard shell wildcard pattern matching.
-For more information, please refer to link:[The opengroup website.
-<http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01>].
+For more information, please refer to {theopengroup-url}[the pattern matching documentation].
 
 The path that is checked is the relative path under the sync root directory.
 

--- a/docs/modules/ROOT/pages/navigating.adoc
+++ b/docs/modules/ROOT/pages/navigating.adoc
@@ -201,4 +201,4 @@ In addition to excluding files and directories that use patterns defined in this
 * The ownCloud Client always excludes files containing characters that cannot be synchronized to other file systems.
 * Files are removed that cause individual errors three times during a synchronization. However, the client provides the option of retrying a synchronization three additional times on files that produce errors.
 
-For more detailed information see `ignored-files-label`.
+For more detailed information see xref:architecture.adoc#ignored-files[the Ignored Files section].

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -50,7 +50,7 @@ Other issues can affect synchronization of your ownCloud files:
 * Synchronizing the same directory with ownCloud and other synchronization software such as Unison, rsync, Microsoft Windows Offline Folders, or other cloud services such as Dropbox or Microsoft SkyDrive is not supported and should not be attempted.
 In the worst case, it is possible that synchronizing folders or files using ownCloud and other synchronization software or services can result in data loss.
 * If you find that only specific files are not synchronized, the synchronization protocol might be having an effect. Some files are automatically ignored because they are system files, other files might be ignored because their filename contains characters that are not supported on certain file systems.
-For more information about ignored files, see `ignored-files-label`.
+For more detailed information see xref:architecture.adoc#ignored-files[the Ignored Files section].
 * If you are operating your own server, and use the local storage backend (the default), make sure that ownCloud has exclusive access to the directory.
 
 [WARNING]

--- a/docs/modules/ROOT/pages/visualtour.adoc
+++ b/docs/modules/ROOT/pages/visualtour.adoc
@@ -134,4 +134,4 @@ With version 1.5.0 it also ignores files that caused individual errors while syn
 These are listed in the activity view.
 There also is a button to retry the sync for another three times.
 
-For more detailed information see `ignored-files-label`.
+For more detailed information see xref:architecture.adoc#ignored-files[the Ignored Files section].


### PR DESCRIPTION
Fix several broken links in the documentation. Some of the links were incorrectly migrated from the previous Sphinx-Doc implementation. This fixes #7518.