### PR TITLE
Don't show the "All files deleted" popup when unselecting everything with selective sync

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1134,6 +1134,7 @@ void ProcessDirectoryJob::processBlacklisted(const PathTuple &path, const OCC::L
     item->_file = path._target;
     item->_originalFile = path._original;
     item->_inode = localEntry.inode;
+    item->_isSelectiveSync = true;
     if (dbEntry.isValid() && ((dbEntry._modtime == localEntry.modtime && dbEntry._fileSize == localEntry.size) || (localEntry.isDirectory && dbEntry.isDirectory()))) {
         item->_instruction = CSYNC_INSTRUCTION_REMOVE;
         item->_direction = SyncFileItem::Down;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -375,7 +375,7 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
             item->_status = SyncFileItem::Conflict;
         }
         return;
-    } else if (item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
+    } else if (item->_instruction == CSYNC_INSTRUCTION_REMOVE && !item->_isSelectiveSync) {
         _hasRemoveFile = true;
     } else if (item->_instruction == CSYNC_INSTRUCTION_RENAME) {
         _hasNoneFiles = true; // If a file (or every file) has been renamed, it means not al files where deleted

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -105,6 +105,7 @@ public:
         , _errorMayBeBlacklisted(false)
         , _status(NoStatus)
         , _isRestoration(false)
+        , _isSelectiveSync(false)
         , _httpErrorCode(0)
         , _affectedItems(1)
         , _instruction(CSYNC_INSTRUCTION_NONE)
@@ -241,6 +242,7 @@ public:
     // Variables useful to report to the user
     Status _status BITFIELD(4);
     bool _isRestoration BITFIELD(1); // The original operation was forbidden, and this is a restoration
+    bool _isSelectiveSync BITFIELD(1); // The file is removed or ignored because it is in the selective sync list
     quint16 _httpErrorCode;
     RemotePermissions _remotePerm;
     QString _errorString; // Contains a string only in case of error


### PR DESCRIPTION
Issue #7337