### PR TITLE
Updater: Fix Version numer not shown in the user visible string

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -147,7 +147,7 @@ QString OCUpdater::statusString() const
     case Downloading:
         return tr("Downloading %1. Please wait...").arg(updateVersion);
     case DownloadComplete:
-        return tr("%1 available. Restart application to start the update.").arg(Theme::instance()->appNameGUI(), updateVersion);
+        return tr("%1 available. Restart application to start the update.").arg(updateVersion);
     case DownloadFailed:
         return tr("Could not download update. Please click <a href='%1'>here</a> to download the update manually.").arg(_updateInfo.web());
     case DownloadTimedOut:


### PR DESCRIPTION
There was one argument too many in the string.
Bug was introduced in commit 21ac396b

Issue: #7288