### PR TITLE
Remove the build-artifacts Drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -150,12 +150,6 @@ steps:
   - cd docs/
   - make pdf
 
-- name: docs-artifacts
-  pull: always
-  image: owncloud/ubuntu:latest
-  commands:
-  - tree docs/public/
-
 - name: cache-rebuild
   pull: always
   image: plugins/s3-cache:1


### PR DESCRIPTION
This step has been shown to dramatically lengthen build times. As it's
just an output of the generated documentation, it's not strictly necessary, so
is being removed.