### PR TITLE
Updater: Fix crash when there is an XML error

### DIFF
--- a/src/gui/updater/updateinfo.cpp
+++ b/src/gui/updater/updateinfo.cpp
@@ -88,9 +88,9 @@ UpdateInfo UpdateInfo::parseString(const QString &xml, bool *ok)
     int errorLine, errorCol;
     QDomDocument doc;
     if (!doc.setContent(xml, false, &errorMsg, &errorLine, &errorCol)) {
-        qCCritical(lcUpdater) << errorMsg << " at " << errorLine << "," << errorCol;
-        qCCritical(lcUpdater()) << "->" << xml.splitRef("\n")[errorLine] << "<-\n"
-                                << QStringLiteral(" ").repeated(2 + errorCol - 1) << "^\n"
+        qCCritical(lcUpdater).noquote().nospace() << errorMsg << " at " << errorLine << "," << errorCol
+                                << "\n" <<  xml.splitRef("\n").value(errorLine-1) << "\n"
+                                << QString(" ").repeated(errorCol - 1) << "^\n"
                                 << "->" << xml << "<-";
         if (ok)
             *ok = false;


### PR DESCRIPTION
The problem was accessing the lines with an off by one error, while printing
the log.

Other problem included the fact that QDebug added spaces, quotes, and other
things which made the error lot look right in the console.

Issue #7545