### PR TITLE
Discovery: fix TestSyncVirtualFiles::testExtraFilesLocalDehydrated on windows

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -882,11 +882,12 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         }
 
         // The old file must have been deleted.
-        if (QFile::exists(_discoveryData->_localDir + base._path)
+        if (QFile::exists(_discoveryData->_localDir + originalPath)
             // Exception: If the rename changes case only (like "foo" -> "Foo") the
             // old filename might still point to the same file.
             && !(Utility::fsCasePreserving()
-                 && originalPath.compare(path._local, Qt::CaseInsensitive) == 0)) {
+                 && originalPath.compare(path._local, Qt::CaseInsensitive) == 0
+                 && originalPath != path._local)) {
             qCInfo(lcDisco) << "Not a move, base file still exists at" << originalPath;
             return false;
         }


### PR DESCRIPTION
On windows we do a test to know if we should change the case of the files,
but that conflict with the test that checks if the file was still there
when the filename is actually the same. Which can happen with virtual files
as they have two representation (the one with and without suffix).