### PR TITLE
[318] Document how to show/hide the Crash Reporter from the config.ini

### DIFF
--- a/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -14,7 +14,7 @@ You can locate this configuration file as follows:
 | `$HOME/.config/ownCloud/owncloud.cfg`
 | *Microsoft Windows* 
 | `%APPDATA%\ownCloud\owncloud.cfg`
-| *macOS X* 
+| *macOS* 
 |`$HOME/Library/ApplicationSupport/ownCloud/owncloud.cfg`
 |===
 

--- a/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -3,9 +3,18 @@
 The ownCloud Client reads a configuration file.
 You can locate this configuration file as follows:
 
-On Linux distributions: `$HOME/.config/ownCloud/owncloud.cfg`
-On Microsoft Windows systems: `%APPDATA%\ownCloud\owncloud.cfg`
-On MAC OS X systems: `$HOME/Library/Preferences/ownCloud/owncloud.cfg`
+[cols="25%,75%",options="header"]
+|===
+| System
+| Location
+
+| *Linux* 
+| `$HOME/.config/ownCloud/owncloud.cfg`
+| *Microsoft Windows* 
+| `%APPDATA%\ownCloud\owncloud.cfg`
+| *macOS X* 
+|`$HOME/Library/ApplicationSupport/ownCloud/owncloud.cfg`
+|===
 
 The configuration file contains settings using the Microsoft Windows `.ini` file format.
 You can overwrite changes using the ownCloud configuration dialog.

--- a/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -1,4 +1,6 @@
 = Configuration File
+:toc:
+:ini-file-format-url: https://en.wikipedia.org/wiki/INI_file
 
 The ownCloud Client reads a configuration file.
 You can locate this configuration file as follows:
@@ -16,7 +18,7 @@ You can locate this configuration file as follows:
 |`$HOME/Library/ApplicationSupport/ownCloud/owncloud.cfg`
 |===
 
-The configuration file contains settings using the Microsoft Windows `.ini` file format.
+The configuration file contains settings using {ini-file-format-url}[the Microsoft Windows `.ini` file format].
 You can overwrite changes using the ownCloud configuration dialog.
 
 NOTE: Use caution when making changes to the ownCloud Client configuration file. Incorrect settings can produce unintended results.

--- a/docs/modules/ROOT/pages/navigating.adoc
+++ b/docs/modules/ROOT/pages/navigating.adoc
@@ -154,10 +154,13 @@ This also displays notifications sent to users by the ownCloud admin via the Ann
 
 == General Window
 
-The General window has configuration options such as **Launch on System Startup*_,Use Monochrome Icons, andShow Desktop Notifications_*.
-This is where you will find the *Edit Ignored Files* button, to launch the ignored files editor, and **Ask confirmation before downloading folders larger than [folder size]**.
+The General window has configuration options such as "_Launch on System Startup_", "_Use Monochrome Icons_", and "_Show Desktop Notifications_".
+This is where you will find the "_Edit Ignored Files_" button, to launch the ignored files editor, and "_Ask confirmation before downloading folders larger than [folder size]_".
 
 image:client-9.png[image]
+
+TIP: While you can elect whether to show or hide the crash reporter, from the General window, you can also configure whether to show or hide it from xref:advanced_usage/configuration_file.adoc#general-section[the general section of the configuration file] as well. 
+Doing so can help with debugging on-startup-crashes.
 
 == Using the Network Window
 


### PR DESCRIPTION
This PR updates the documentation, adding a link from the GUI config window to the config.ini file documentation. The main reason for doing so is to help ensure that the user knows that they can show and hide the crash reporter from the config file, just in case they need to hide it so that they can debug on-startup crashes. It fixes https://github.com/owncloud/docs/issues/318.