### PR TITLE
Don't ignore file sync notification after an unlock

### DIFF
--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -113,6 +113,12 @@ class Folder : public QObject
     Q_OBJECT
 
 public:
+    enum class ChangeReason {
+        Other,
+        UnLock
+    };
+    Q_ENUM(ChangeReason)
+
     /** Create a new Folder
      */
     Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> vfs, QObject *parent = 0L);
@@ -336,7 +342,7 @@ public slots:
        * changes. Needs to check whether this change should trigger a new
        * sync run to be scheduled.
        */
-    void slotWatchedPathChanged(const QString &path);
+    void slotWatchedPathChanged(const QString &path, ChangeReason reason);
 
     /**
      * Mark a virtual file as being requested for download, and start a sync.

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -864,7 +864,7 @@ void FolderMan::slotWatchedFileUnlocked(const QString &path)
 {
     if (Folder *f = folderForPath(path)) {
         // Treat this equivalently to the file being reported by the file watcher
-        f->slotWatchedPathChanged(path);
+        f->slotWatchedPathChanged(path, Folder::ChangeReason::UnLock);
     }
 }
 


### PR DESCRIPTION
For a usual file sync event we check for actual changes in the local file,
after an unlock the local file might be unchanged so we need to sync it anyhow.

Fixes: owncloud/enterprise#3609