### PR TITLE
Fix for forked repos

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -292,8 +292,6 @@ def build_client_docs(ctx):
     }
 
 def changelog(ctx, trigger = {}, depends_on = []):
-    pipelines = []
-
     result = {
         'kind': 'pipeline',
         'type': 'docker',
@@ -310,7 +308,7 @@ def changelog(ctx, trigger = {}, depends_on = []):
                     'actions': [
                         'clone',
                     ],
-                    'remote': 'https://github.com/%s' % (ctx.repo.slug),
+                    'remote': 'https://github.com/%s' % (ctx.build.source_repo),
                     'branch': ctx.build.source if ctx.build.event == 'pull_request' else 'master',
                     'path': '/drone/src',
                     'netrc_machine': 'github.com',


### PR DESCRIPTION
# Description
Fixes the changelog pipeline for forked repositories

## Before
![Screenshot_2020-01-22 Build #3294 1 1 - owncloud client - Drone CI](https://user-images.githubusercontent.com/4378513/72907321-f8803680-3d33-11ea-96df-c07e8ec1dd8b.png)

## After
![Screenshot_2020-01-22 Build #3302 1 1 - owncloud client - Drone CI(1)](https://user-images.githubusercontent.com/4378513/72907238-d5558700-3d33-11ea-98e1-d93165883f56.png)
