### PR TITLE
Fix warnings and modernize code

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
@@ -37,7 +37,7 @@ public:
     explicit OwncloudDolphinPluginAction(QObject* parent, const QList<QVariant>&)
         : KAbstractFileItemActionPlugin(parent) { }
 
-    QList<QAction*> actions(const KFileItemListProperties& fileItemInfos, QWidget* parentWidget) Q_DECL_OVERRIDE
+    QList<QAction*> actions(const KFileItemListProperties& fileItemInfos, QWidget* parentWidget) override
     {
         auto helper = OwncloudDolphinPluginHelper::instance();
         if (!helper->isConnected() || !fileItemInfos.isLocal())

--- a/src/3rdparty/QProgressIndicator/QProgressIndicator.h
+++ b/src/3rdparty/QProgressIndicator/QProgressIndicator.h
@@ -42,7 +42,7 @@ class QProgressIndicator : public QWidget
     Q_PROPERTY(bool displayedWhenStopped READ isDisplayedWhenStopped WRITE setDisplayedWhenStopped)
     Q_PROPERTY(QColor color READ color WRITE setColor)
 public:
-    QProgressIndicator(QWidget* parent = 0);
+    QProgressIndicator(QWidget* parent = nullptr);
 
     /*! Returns the delay between animation steps.
         \return The number of milliseconds between animation steps. By default, the animation delay is set to 40 milliseconds.

--- a/src/3rdparty/QProgressIndicator/QProgressIndicator.h
+++ b/src/3rdparty/QProgressIndicator/QProgressIndicator.h
@@ -67,8 +67,8 @@ public:
       */
     const QColor & color() const { return m_color; }
 
-    virtual QSize sizeHint() const;
-    int heightForWidth(int w) const;
+    QSize sizeHint() const override;
+    int heightForWidth(int w) const override;
 public slots:
     /*! Starts the spin animation.
         \sa stopAnimation isAnimated
@@ -98,8 +98,8 @@ public slots:
      */
     void setColor(const QColor & color);
 protected:
-    virtual void timerEvent(QTimerEvent * event); 
-    virtual void paintEvent(QPaintEvent * event);
+    void timerEvent(QTimerEvent * event) override; 
+    void paintEvent(QPaintEvent * event) override;
 private:
     int m_angle;
     int m_timerId;

--- a/src/3rdparty/qtlockedfile/qtlockedfile.h
+++ b/src/3rdparty/qtlockedfile/qtlockedfile.h
@@ -57,7 +57,7 @@ public:
 
     QtLockedFile();
     QtLockedFile(const QString &name);
-    ~QtLockedFile();
+    ~QtLockedFile() override;
 
     bool lock(LockMode mode, bool block = true);
     bool unlock();

--- a/src/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -123,7 +123,7 @@ bool QtLocalPeer::sendMessage(const QString &message, int timeout, bool block)
         Sleep(DWORD(ms));
 #else
         struct timespec ts = { ms / 1000, (ms % 1000) * 1000 * 1000 };
-        nanosleep(&ts, NULL);
+        nanosleep(&ts, nullptr);
 #endif
     }
     if (!connOk)

--- a/src/3rdparty/qtsingleapplication/qtlocalpeer.h
+++ b/src/3rdparty/qtsingleapplication/qtlocalpeer.h
@@ -40,7 +40,7 @@ class QtLocalPeer : public QObject
     Q_OBJECT
 
 public:
-    explicit QtLocalPeer(QObject *parent = 0, const QString &appId = QString());
+    explicit QtLocalPeer(QObject *parent = nullptr, const QString &appId = QString());
     bool isClient();
     bool sendMessage(const QString &message, int timeout, bool block);
     QString applicationId() const

--- a/src/3rdparty/qtsingleapplication/qtsingleapplication.cpp
+++ b/src/3rdparty/qtsingleapplication/qtsingleapplication.cpp
@@ -53,7 +53,7 @@ static QString instancesLockFilename(const QString &appSessionId)
 QtSingleApplication::QtSingleApplication(const QString &appId, int &argc, char **argv)
     : QApplication(argc, argv),
       firstPeer(-1),
-      pidPeer(0)
+      pidPeer(nullptr)
 {
     this->appId = appId;
 
@@ -61,7 +61,7 @@ QtSingleApplication::QtSingleApplication(const QString &appId, int &argc, char *
 
     // This shared memory holds a zero-terminated array of active (or crashed) instances
     instances = new QSharedMemory(appSessionId, this);
-    actWin = 0;
+    actWin = nullptr;
     block = false;
 
     // First instance creates the shared memory, later instances attach to it
@@ -71,7 +71,7 @@ QtSingleApplication::QtSingleApplication(const QString &appId, int &argc, char *
             qWarning() << "Failed to initialize instances shared memory: "
                        << instances->errorString();
             delete instances;
-            instances = 0;
+            instances = nullptr;
             return;
         }
     }

--- a/src/3rdparty/qtsingleapplication/qtsingleapplication.h
+++ b/src/3rdparty/qtsingleapplication/qtsingleapplication.h
@@ -44,13 +44,13 @@ class QtSingleApplication : public QApplication
 
 public:
     QtSingleApplication(const QString &id, int &argc, char **argv);
-    ~QtSingleApplication();
+    ~QtSingleApplication() override;
 
     bool isRunning(qint64 pid = -1);
 
     void setActivationWindow(QWidget* aw, bool activateOnMessage = true);
     QWidget* activationWindow() const;
-    bool event(QEvent *event) Q_DECL_OVERRIDE;
+    bool event(QEvent *event) override;
 
     QString applicationId() const;
     void setBlock(bool value);

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -145,7 +145,7 @@ public:
     {
     }
 
-    void askFromUser() Q_DECL_OVERRIDE
+    void askFromUser() override
     {
         _password = ::queryPassword(user());
         _ready = true;
@@ -158,7 +158,7 @@ public:
         _sslTrusted = isTrusted;
     }
 
-    bool sslIsTrusted() Q_DECL_OVERRIDE
+    bool sslIsTrusted() override
     {
         return _sslTrusted;
     }

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -88,7 +88,7 @@ struct CmdOptions
 
 // we can't use csync_set_userdata because the SyncEngine sets it already.
 // So we have to use a global variable
-CmdOptions *opts = 0;
+CmdOptions *opts = nullptr;
 
 class EchoDisabler
 {

--- a/src/cmd/simplesslerrorhandler.h
+++ b/src/cmd/simplesslerrorhandler.h
@@ -28,7 +28,7 @@ namespace OCC {
 class SimpleSslErrorHandler : public OCC::AbstractSslErrorHandler
 {
 public:
-    bool handleErrors(QList<QSslError> errors, const QSslConfiguration &conf, QList<QSslCertificate> *certs, OCC::AccountPtr) Q_DECL_OVERRIDE;
+    bool handleErrors(QList<QSslError> errors, const QSslConfiguration &conf, QList<QSslCertificate> *certs, OCC::AccountPtr) override;
 };
 }
 

--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -377,13 +377,13 @@ QByteArray CSyncChecksumHook::hook(const QByteArray &path, const QByteArray &oth
 {
     QByteArray type = parseChecksumHeaderType(QByteArray(otherChecksumHeader));
     if (type.isEmpty())
-        return NULL;
+        return nullptr;
 
     qCInfo(lcChecksums) << "Computing" << type << "checksum of" << path << "in the csync hook";
     QByteArray checksum = ComputeChecksum::computeNowOnFile(QString::fromUtf8(path), type);
     if (checksum.isNull()) {
         qCWarning(lcChecksums) << "Failed to compute checksum" << type << "for" << path;
-        return NULL;
+        return nullptr;
     }
 
     return makeChecksumHeader(type, checksum);

--- a/src/common/checksums.h
+++ b/src/common/checksums.h
@@ -83,7 +83,7 @@ class OCSYNC_EXPORT ComputeChecksum : public QObject
 {
     Q_OBJECT
 public:
-    explicit ComputeChecksum(QObject *parent = 0);
+    explicit ComputeChecksum(QObject *parent = nullptr);
     ~ComputeChecksum() override;
 
     /**
@@ -143,7 +143,7 @@ class OCSYNC_EXPORT ValidateChecksumHeader : public QObject
 {
     Q_OBJECT
 public:
-    explicit ValidateChecksumHeader(QObject *parent = 0);
+    explicit ValidateChecksumHeader(QObject *parent = nullptr);
 
     /**
      * Check a file's actual checksum against the provided checksumHeader

--- a/src/common/checksums.h
+++ b/src/common/checksums.h
@@ -84,7 +84,7 @@ class OCSYNC_EXPORT ComputeChecksum : public QObject
     Q_OBJECT
 public:
     explicit ComputeChecksum(QObject *parent = 0);
-    ~ComputeChecksum();
+    ~ComputeChecksum() override;
 
     /**
      * Sets the checksum type to be used. The default is empty.

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -91,7 +91,7 @@ namespace FileSystem {
      */
     bool OCSYNC_EXPORT rename(const QString &originFileName,
         const QString &destinationFileName,
-        QString *errorString = NULL);
+        QString *errorString = nullptr);
 
     /**
      * Rename the file \a originFileName to \a destinationFileName, and
@@ -107,7 +107,7 @@ namespace FileSystem {
      * Equivalent to QFile::remove(), except on Windows, where it will also
      * successfully remove read-only files.
      */
-    bool OCSYNC_EXPORT remove(const QString &fileName, QString *errorString = 0);
+    bool OCSYNC_EXPORT remove(const QString &fileName, QString *errorString = nullptr);
 
     /**
      * Move the specified file or folder to the trash. (Only implemented on linux)

--- a/src/common/ownsql.cpp
+++ b/src/common/ownsql.cpp
@@ -44,7 +44,7 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcSql, "sync.database.sql", QtInfoMsg)
 
 SqlDatabase::SqlDatabase()
-    : _db(0)
+    : _db(nullptr)
     , _errId(0)
 {
 }
@@ -57,7 +57,7 @@ SqlDatabase::~SqlDatabase()
 
 bool SqlDatabase::isOpen()
 {
-    return _db != 0;
+    return _db != nullptr;
 }
 
 bool SqlDatabase::openHelper(const QString &filename, int sqliteFlags)
@@ -68,7 +68,7 @@ bool SqlDatabase::openHelper(const QString &filename, int sqliteFlags)
 
     sqliteFlags |= SQLITE_OPEN_NOMUTEX;
 
-    SQLITE_DO(sqlite3_open_v2(filename.toUtf8().constData(), &_db, sqliteFlags, 0));
+    SQLITE_DO(sqlite3_open_v2(filename.toUtf8().constData(), &_db, sqliteFlags, nullptr));
 
     if (_errId != SQLITE_OK) {
         qCWarning(lcSql) << "Error:" << _error << "for" << filename;
@@ -196,7 +196,7 @@ void SqlDatabase::close()
         SQLITE_DO(sqlite3_close(_db));
         if (_errId != SQLITE_OK)
             qCWarning(lcSql) << "Closing database failed" << _error;
-        _db = 0;
+        _db = nullptr;
     }
 }
 
@@ -205,7 +205,7 @@ bool SqlDatabase::transaction()
     if (!_db) {
         return false;
     }
-    SQLITE_DO(sqlite3_exec(_db, "BEGIN", 0, 0, 0));
+    SQLITE_DO(sqlite3_exec(_db, "BEGIN", nullptr, nullptr, nullptr));
     return _errId == SQLITE_OK;
 }
 
@@ -214,7 +214,7 @@ bool SqlDatabase::commit()
     if (!_db) {
         return false;
     }
-    SQLITE_DO(sqlite3_exec(_db, "COMMIT", 0, 0, 0));
+    SQLITE_DO(sqlite3_exec(_db, "COMMIT", nullptr, nullptr, nullptr));
     return _errId == SQLITE_OK;
 }
 
@@ -255,7 +255,7 @@ int SqlQuery::prepare(const QByteArray &sql, bool allow_failure)
         int n = 0;
         int rc;
         do {
-            rc = sqlite3_prepare_v2(_db, _sql.constData(), -1, &_stmt, 0);
+            rc = sqlite3_prepare_v2(_db, _sql.constData(), -1, &_stmt, nullptr);
             if ((rc == SQLITE_BUSY) || (rc == SQLITE_LOCKED)) {
                 n++;
                 OCC::Utility::usleep(SQLITE_SLEEP_TIME_USEC);
@@ -483,7 +483,7 @@ void SqlQuery::finish()
     if (!_stmt)
         return;
     SQLITE_DO(sqlite3_finalize(_stmt));
-    _stmt = 0;
+    _stmt = nullptr;
     if (_sqldb) {
         _sqldb->_queries.remove(this);
     }

--- a/src/common/plugin.h
+++ b/src/common/plugin.h
@@ -26,7 +26,7 @@ namespace OCC {
 class OCSYNC_EXPORT PluginFactory
 {
 public:
-    ~PluginFactory();
+    virtual ~PluginFactory();
     virtual QObject* create(QObject* parent) = 0;
 };
 

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -45,7 +45,7 @@ class OCSYNC_EXPORT SyncJournalDb : public QObject
     Q_OBJECT
 public:
     explicit SyncJournalDb(const QString &dbFilePath, QObject *parent = 0);
-    virtual ~SyncJournalDb();
+    ~SyncJournalDb() override;
 
     /// Create a journal path for a specific configuration
     static QString makeDbName(const QString &localPath,

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -44,7 +44,7 @@ class OCSYNC_EXPORT SyncJournalDb : public QObject
 {
     Q_OBJECT
 public:
-    explicit SyncJournalDb(const QString &dbFilePath, QObject *parent = 0);
+    explicit SyncJournalDb(const QString &dbFilePath, QObject *parent = nullptr);
     ~SyncJournalDb() override;
 
     /// Create a journal path for a specific configuration

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -304,7 +304,7 @@ namespace {
 
         QString description(quint64 value) const
         {
-            return QCoreApplication::translate("Utility", name, 0, value);
+            return QCoreApplication::translate("Utility", name, nullptr, value);
         }
     };
 // QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate
@@ -319,7 +319,7 @@ namespace {
         { QT_TRANSLATE_NOOP("Utility", "%n hour(s)", 0, _), 3600 * 1000LL },
         { QT_TRANSLATE_NOOP("Utility", "%n minute(s)", 0, _), 60 * 1000LL },
         { QT_TRANSLATE_NOOP("Utility", "%n second(s)", 0, _), 1000LL },
-        { 0, 0 }
+        { nullptr, 0 }
     };
 } // anonymous namespace
 
@@ -398,7 +398,7 @@ QString Utility::platformName()
 
 void Utility::crash()
 {
-    volatile int *a = (int *)(NULL);
+    volatile int *a = (int *)nullptr;
     *a = 1;
 }
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -191,7 +191,7 @@ namespace Utility {
 
     /**  Returns a new settings pre-set in a specific group.  The Settings will be created
          with the given parent. If no parent is specified, the caller must destroy the settings */
-    OCSYNC_EXPORT std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = 0);
+    OCSYNC_EXPORT std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = nullptr);
 
     /** Sanitizes a string that shall become part of a filename.
      *

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -110,7 +110,7 @@ public:
 
 public:
     explicit Vfs(QObject* parent = nullptr);
-    virtual ~Vfs();
+    ~Vfs() override;
 
     virtual Mode mode() const = 0;
 
@@ -275,7 +275,7 @@ class OCSYNC_EXPORT VfsOff : public Vfs
 
 public:
     VfsOff(QObject* parent = nullptr);
-    virtual ~VfsOff();
+    ~VfsOff() override;
 
     Mode mode() const override { return Vfs::Off; }
 

--- a/src/csync/csync_exclude.h
+++ b/src/csync/csync_exclude.h
@@ -70,7 +70,7 @@ public:
     typedef std::tuple<int, int, int> Version;
 
     ExcludedFiles();
-    ~ExcludedFiles();
+    ~ExcludedFiles() override;
 
     /**
      * Adds a new path to a file containing exclude patterns.

--- a/src/csync/csync_util.cpp
+++ b/src/csync/csync_util.cpp
@@ -58,7 +58,7 @@ static const _instr_code_struct _instr[] =
   { "INSTRUCTION_ERROR", CSYNC_INSTRUCTION_ERROR },
   { "INSTRUCTION_TYPE_CHANGE", CSYNC_INSTRUCTION_TYPE_CHANGE },
   { "INSTRUCTION_UPDATE_METADATA", CSYNC_INSTRUCTION_UPDATE_METADATA },
-  { NULL, CSYNC_INSTRUCTION_ERROR }
+  { nullptr, CSYNC_INSTRUCTION_ERROR }
 };
 
 struct csync_memstat_s {
@@ -75,7 +75,7 @@ const char *csync_instruction_str(enum csync_instructions_e instr)
 {
   int idx = 0;
 
-  while (_instr[idx].instr_str != NULL) {
+  while (_instr[idx].instr_str != nullptr) {
     if (_instr[idx].instr_code == instr) {
       return _instr[idx].instr_str;
     }
@@ -93,7 +93,7 @@ void csync_memstat_check(void) {
 
   /* get process memory stats */
   fp = fopen("/proc/self/statm","r");
-  if (fp == NULL) {
+  if (fp == nullptr) {
     return;
   }
   s = fscanf(fp, "%d%d%d%d%d%d%d", &m.size, &m.resident, &m.shared, &m.trs,

--- a/src/csync/std/c_utf8.cpp
+++ b/src/csync/std/c_utf8.cpp
@@ -42,7 +42,7 @@
 /* Convert a locale String to UTF8 */
 QByteArray c_utf8_from_locale(const mbchar_t *wstr)
 {
-  if (wstr == NULL) {
+  if (wstr == nullptr) {
     return QByteArray();
   }
 
@@ -86,8 +86,8 @@ extern "C" {
 /* Convert a an UTF8 string to locale */
 mbchar_t* c_utf8_string_to_locale(const char *str)
 {
-    if (str == NULL ) {
-        return NULL;
+    if (str == nullptr ) {
+        return nullptr;
     }
 #ifdef _WIN32
     mbchar_t *dst = NULL;
@@ -110,8 +110,8 @@ mbchar_t* c_utf8_string_to_locale(const char *str)
 
  mbchar_t* c_utf8_path_to_locale(const char *str)
  {
-     if( str == NULL ) {
-         return NULL;
+     if( str == nullptr ) {
+         return nullptr;
      } else {
  #ifdef _WIN32
          QByteArray unc_str = OCC::FileSystem::pathtoUNC(QByteArray::fromRawData(str, strlen(str)));

--- a/src/csync/vio/csync_vio_local_unix.cpp
+++ b/src/csync/vio/csync_vio_local_unix.cpp
@@ -74,12 +74,12 @@ int csync_vio_local_closedir(csync_vio_handle_t *dhandle) {
 
 std::unique_ptr<csync_file_stat_t> csync_vio_local_readdir(csync_vio_handle_t *handle, OCC::Vfs *vfs) {
 
-  struct _tdirent *dirent = NULL;
+  struct _tdirent *dirent = nullptr;
   std::unique_ptr<csync_file_stat_t> file_stat;
 
   do {
       dirent = _treaddir(handle->dh);
-      if (dirent == NULL)
+      if (dirent == nullptr)
           return {};
   } while (qstrcmp(dirent->d_name, ".") == 0 || qstrcmp(dirent->d_name, "..") == 0);
 

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -28,7 +28,7 @@ class AccountManager : public QObject
     Q_OBJECT
 public:
     static AccountManager *instance();
-    ~AccountManager() {}
+    ~AccountManager() override {}
 
     /**
      * Saves the accounts to a given settings file

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -225,7 +225,7 @@ void AccountSettings::slotOpenAccountWizard()
     if (qgetenv("QT_QPA_PLATFORMTHEME") == "appmenu-qt5" || QSystemTrayIcon::isSystemTrayAvailable()) {
         topLevelWidget()->close();
     }
-    OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)), 0);
+    OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)), nullptr);
 }
 
 void AccountSettings::slotToggleSignInState()
@@ -713,7 +713,7 @@ void AccountSettings::slotEnableCurrentFolder()
                 QWidget *parent = this;
                 Qt::WindowFlags flags = Qt::Sheet;
 #else
-                QWidget *parent = 0;
+                QWidget *parent = nullptr;
                 Qt::WindowFlags flags = Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint; // default flags
 #endif
                 QMessageBox msgbox(QMessageBox::Question, tr("Sync Running"),
@@ -1078,7 +1078,7 @@ void AccountSettings::slotDeleteAccount()
     }
 
     // Else it might access during destruction. This should be better handled by it having a QSharedPointer
-    _model->setAccountState(0);
+    _model->setAccountState(nullptr);
 
     auto manager = AccountManager::instance();
     manager->deleteAccount(_accountState);

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -53,7 +53,7 @@ class AccountSettings : public QWidget
     Q_PROPERTY(AccountState* accountState MEMBER _accountState)
 
 public:
-    explicit AccountSettings(AccountState *accountState, QWidget *parent = 0);
+    explicit AccountSettings(AccountState *accountState, QWidget *parent = nullptr);
     ~AccountSettings() override;
     QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -54,8 +54,8 @@ class AccountSettings : public QWidget
 
 public:
     explicit AccountSettings(AccountState *accountState, QWidget *parent = 0);
-    ~AccountSettings();
-    QSize sizeHint() const Q_DECL_OVERRIDE { return ownCloudGui::settingsDialogSize(); }
+    ~AccountSettings() override;
+    QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 
 
 signals:
@@ -97,7 +97,7 @@ protected slots:
 private:
     void showConnectionLabel(const QString &message,
         QStringList errors = QStringList());
-    bool event(QEvent *) Q_DECL_OVERRIDE;
+    bool event(QEvent *) override;
     void createAccountToolbox();
 
     /// Returns the alias of the selected folder, empty string if none

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -350,7 +350,7 @@ void AccountState::slotCredentialsAsked(AbstractCredentials *credentials)
         // When new credentials become available we always want to restart the
         // connection validation, even if it's currently running.
         _connectionValidator->deleteLater();
-        _connectionValidator = 0;
+        _connectionValidator = nullptr;
     }
 
     checkConnectivity();

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -78,7 +78,7 @@ public:
 
     /// Use the account as parent
     explicit AccountState(AccountPtr account);
-    ~AccountState();
+    ~AccountState() override;
 
     /** Creates an account state from settings and an Account object.
      *

--- a/src/gui/activityitemdelegate.h
+++ b/src/gui/activityitemdelegate.h
@@ -35,10 +35,10 @@ public:
         PointInTimeRole,
         AccountConnectedRole };
 
-    void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const Q_DECL_OVERRIDE;
-    QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const Q_DECL_OVERRIDE;
+    void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const override;
+    QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option,
-        const QModelIndex &index) Q_DECL_OVERRIDE;
+        const QModelIndex &index) override;
 
     static int rowHeight();
     static int iconHeight();

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -38,7 +38,7 @@ class ActivityListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    explicit ActivityListModel(QWidget *parent = 0);
+    explicit ActivityListModel(QWidget *parent = nullptr);
 
     QVariant data(const QModelIndex &index, int role) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -40,11 +40,11 @@ class ActivityListModel : public QAbstractListModel
 public:
     explicit ActivityListModel(QWidget *parent = 0);
 
-    QVariant data(const QModelIndex &index, int role) const Q_DECL_OVERRIDE;
-    int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    QVariant data(const QModelIndex &index, int role) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    bool canFetchMore(const QModelIndex &) const Q_DECL_OVERRIDE;
-    void fetchMore(const QModelIndex &) Q_DECL_OVERRIDE;
+    bool canFetchMore(const QModelIndex &) const override;
+    void fetchMore(const QModelIndex &) override;
 
     ActivityList activityList() { return _finalList; }
 

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -258,7 +258,7 @@ void ActivityWidget::slotBuildNotificationDisplay(const ActivityList &list)
             continue;
         }
 
-        NotificationWidget *widget = 0;
+        NotificationWidget *widget = nullptr;
 
         if (_widgetForNotifId.contains(activity.ident())) {
             widget = _widgetForNotifId[activity.ident()];

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -58,7 +58,7 @@ class ActivityWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ActivityWidget(QWidget *parent = 0);
+    explicit ActivityWidget(QWidget *parent = nullptr);
     ~ActivityWidget() override;
     QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
     void storeActivityList(QTextStream &ts);
@@ -130,7 +130,7 @@ class ActivitySettings : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ActivitySettings(QWidget *parent = 0);
+    explicit ActivitySettings(QWidget *parent = nullptr);
     ~ActivitySettings() override;
     QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -59,8 +59,8 @@ class ActivityWidget : public QWidget
     Q_OBJECT
 public:
     explicit ActivityWidget(QWidget *parent = 0);
-    ~ActivityWidget();
-    QSize sizeHint() const Q_DECL_OVERRIDE { return ownCloudGui::settingsDialogSize(); }
+    ~ActivityWidget() override;
+    QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
     void storeActivityList(QTextStream &ts);
 
     /**
@@ -131,8 +131,8 @@ class ActivitySettings : public QWidget
     Q_OBJECT
 public:
     explicit ActivitySettings(QWidget *parent = 0);
-    ~ActivitySettings();
-    QSize sizeHint() const Q_DECL_OVERRIDE { return ownCloudGui::settingsDialogSize(); }
+    ~ActivitySettings() override;
+    QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 
 public slots:
     void slotRefresh(AccountState *ptr);
@@ -153,7 +153,7 @@ signals:
     void guiLog(const QString &, const QString &);
 
 private:
-    bool event(QEvent *e) Q_DECL_OVERRIDE;
+    bool event(QEvent *e) override;
 
     QTabWidget *_tab;
     int _activityTabId;

--- a/src/gui/addcertificatedialog.h
+++ b/src/gui/addcertificatedialog.h
@@ -34,7 +34,7 @@ class AddCertificateDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit AddCertificateDialog(QWidget *parent = 0);
+    explicit AddCertificateDialog(QWidget *parent = nullptr);
     ~AddCertificateDialog() override;
     QString getCertificatePath();
     QString getCertificatePasswd();

--- a/src/gui/addcertificatedialog.h
+++ b/src/gui/addcertificatedialog.h
@@ -35,7 +35,7 @@ class AddCertificateDialog : public QDialog
 
 public:
     explicit AddCertificateDialog(QWidget *parent = 0);
-    ~AddCertificateDialog();
+    ~AddCertificateDialog() override;
     QString getCertificatePath();
     QString getCertificatePasswd();
     void showErrorMessage(const QString message);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -163,7 +163,7 @@ bool Application::configVersionMigration()
 
 Application::Application(int &argc, char **argv)
     : SharedTools::QtSingleApplication(Theme::instance()->appName(), argc, argv)
-    , _gui(0)
+    , _gui(nullptr)
     , _theme(Theme::instance())
     , _helpOnly(false)
     , _versionOnly(false)
@@ -295,7 +295,7 @@ Application::Application(int &argc, char **argv)
         if (!AccountManager::instance()->restore()) {
             qCCritical(lcApplication) << "Could not read the account settings, quitting";
             QMessageBox::critical(
-                0,
+                nullptr,
                 tr("Error accessing the configuration file"),
                 tr("There was an error while accessing the configuration "
                    "file at %1.")

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -57,7 +57,7 @@ class Application : public SharedTools::QtSingleApplication
     Q_OBJECT
 public:
     explicit Application(int &argc, char **argv);
-    ~Application();
+    ~Application() override;
 
     bool giveHelp();
     void showHelp();
@@ -87,7 +87,7 @@ protected:
     void parseOptions(const QStringList &);
     void setupTranslations();
     void setupLogging();
-    bool event(QEvent *event);
+    bool event(QEvent *event) override;
 
 signals:
     void folderRemoved();

--- a/src/gui/authenticationdialog.h
+++ b/src/gui/authenticationdialog.h
@@ -29,7 +29,7 @@ class AuthenticationDialog : public QDialog
 {
     Q_OBJECT
 public:
-    AuthenticationDialog(const QString &realm, const QString &domain, QWidget *parent = 0);
+    AuthenticationDialog(const QString &realm, const QString &domain, QWidget *parent = nullptr);
 
     QString user() const;
     QString password() const;

--- a/src/gui/clientproxy.h
+++ b/src/gui/clientproxy.h
@@ -53,7 +53,7 @@ class SystemProxyRunnable : public QObject, public QRunnable
     Q_OBJECT
 public:
     SystemProxyRunnable(const QUrl &url);
-    void run();
+    void run() override;
 signals:
     void systemProxyLookedUp(const QNetworkProxy &url);
 

--- a/src/gui/clientproxy.h
+++ b/src/gui/clientproxy.h
@@ -36,7 +36,7 @@ class ClientProxy : public QObject
 {
     Q_OBJECT
 public:
-    explicit ClientProxy(QObject *parent = 0);
+    explicit ClientProxy(QObject *parent = nullptr);
 
     static bool isUsingSystemDefault();
     static void lookupSystemProxyAsync(const QUrl &url, QObject *dst, const char *slot);

--- a/src/gui/connectionvalidator.h
+++ b/src/gui/connectionvalidator.h
@@ -79,7 +79,7 @@ class ConnectionValidator : public QObject
 {
     Q_OBJECT
 public:
-    explicit ConnectionValidator(AccountPtr account, QObject *parent = 0);
+    explicit ConnectionValidator(AccountPtr account, QObject *parent = nullptr);
 
     enum Status {
         Undefined,

--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -71,10 +71,10 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
     switch (r) {
     case OAuth::NotSupported:
         showDialog();
-        _asyncAuth.reset(0);
+        _asyncAuth.reset(nullptr);
         return;
     case OAuth::Error:
-        _asyncAuth.reset(0);
+        _asyncAuth.reset(nullptr);
         emit asked();
         return;
     case OAuth::LoggedIn:
@@ -87,7 +87,7 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
     _refreshToken = refreshToken;
     _ready = true;
     persist();
-    _asyncAuth.reset(0);
+    _asyncAuth.reset(nullptr);
     emit asked();
 }
 

--- a/src/gui/creds/httpcredentialsgui.h
+++ b/src/gui/creds/httpcredentialsgui.h
@@ -49,7 +49,7 @@ public:
      * This will query the server and either uses OAuth via _asyncAuth->start()
      * or call showDialog to ask the password
      */
-    void askFromUser() Q_DECL_OVERRIDE;
+    void askFromUser() override;
     /**
      * In case of oauth, return an URL to the link to open the browser.
      * An invalid URL otherwise

--- a/src/gui/elidedlabel.h
+++ b/src/gui/elidedlabel.h
@@ -24,7 +24,7 @@ class ElidedLabel : public QLabel
 {
     Q_OBJECT
 public:
-    explicit ElidedLabel(const QString &text, QWidget *parent = 0);
+    explicit ElidedLabel(const QString &text, QWidget *parent = nullptr);
 
     void setText(const QString &text);
     const QString &text() const { return _text; }

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -632,8 +632,8 @@ void Folder::setSupportsVirtualFiles(bool enabled)
         _vfs->stop();
         _vfs->unregisterFolder();
 
-        disconnect(_vfs.data(), 0, this, 0);
-        disconnect(&_engine->syncFileStatusTracker(), 0, _vfs.data(), 0);
+        disconnect(_vfs.data(), nullptr, this, nullptr);
+        disconnect(&_engine->syncFileStatusTracker(), nullptr, _vfs.data(), nullptr);
 
         _vfs.reset(createVfsFromPlugin(newMode).release());
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -121,7 +121,7 @@ public:
 
     /** Create a new Folder
      */
-    Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> vfs, QObject *parent = 0L);
+    Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> vfs, QObject *parent = nullptr);
 
     ~Folder() override;
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -123,7 +123,7 @@ public:
      */
     Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> vfs, QObject *parent = 0L);
 
-    ~Folder();
+    ~Folder() override;
 
     typedef QMap<QString, Folder *> Map;
     typedef QMapIterator<QString, Folder *> MapIterator;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -43,11 +43,11 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcFolderMan, "gui.folder.manager", QtInfoMsg)
 
-FolderMan *FolderMan::_instance = 0;
+FolderMan *FolderMan::_instance = nullptr;
 
 FolderMan::FolderMan(QObject *parent)
     : QObject(parent)
-    , _currentSyncFolder(0)
+    , _currentSyncFolder(nullptr)
     , _syncEnabled(true)
     , _lockWatcher(new LockWatcher)
     , _navigationPaneHelper(this)
@@ -90,7 +90,7 @@ FolderMan *FolderMan::instance()
 FolderMan::~FolderMan()
 {
     qDeleteAll(_folderMap);
-    _instance = 0;
+    _instance = nullptr;
 }
 
 OCC::Folder::Map FolderMan::map() const
@@ -142,8 +142,8 @@ int FolderMan::unloadAndDeleteAllFolders()
     }
     ASSERT(_folderMap.isEmpty());
 
-    _lastSyncFolder = 0;
-    _currentSyncFolder = 0;
+    _lastSyncFolder = nullptr;
+    _currentSyncFolder = nullptr;
     _scheduledFolders.clear();
     emit folderListChanged(_folderMap);
     emit scheduleQueueChanged();
@@ -350,7 +350,7 @@ bool FolderMan::ensureJournalGone(const QString &journalDbFile)
     // remove the old journal file
     while (QFile::exists(journalDbFile) && !QFile::remove(journalDbFile)) {
         qCWarning(lcFolderMan) << "Could not remove old db file at" << journalDbFile;
-        int ret = QMessageBox::warning(0, tr("Could not reset folder state"),
+        int ret = QMessageBox::warning(nullptr, tr("Could not reset folder state"),
             tr("An old sync journal '%1' was found, "
                "but could not be removed. Please make sure "
                "that no application is currently using it.")
@@ -425,7 +425,7 @@ QString FolderMan::unescapeAlias(const QString &alias)
 // WARNING: Do not remove this code, it is used for predefined/automated deployments (2016)
 Folder *FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountState *accountState)
 {
-    Folder *folder = 0;
+    Folder *folder = nullptr;
 
     qCInfo(lcFolderMan) << "  ` -> setting up:" << file;
     QString escapedAlias(file);
@@ -466,7 +466,7 @@ Folder *FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountStat
 
     if (backend.isEmpty() || backend != QLatin1String("owncloud")) {
         qCWarning(lcFolderMan) << "obsolete configuration of type" << backend;
-        return 0;
+        return nullptr;
     }
 
     // cut off the leading slash, oCUrl always has a trailing.
@@ -476,7 +476,7 @@ Folder *FolderMan::setupFolderFromOldConfigFile(const QString &file, AccountStat
 
     if (!accountState) {
         qCCritical(lcFolderMan) << "can't create folder without an account";
-        return 0;
+        return nullptr;
     }
 
     FolderDefinition folderDefinition;
@@ -537,7 +537,7 @@ Folder *FolderMan::folder(const QString &alias)
             return _folderMap[alias];
         }
     }
-    return 0;
+    return nullptr;
 }
 
 void FolderMan::scheduleAllFolders()
@@ -702,7 +702,7 @@ void FolderMan::setSyncEnabled(bool enabled)
     }
     _syncEnabled = enabled;
     // force a redraw in case the network connect status changed
-    emit(folderSyncStateChange(0));
+    emit(folderSyncStateChange(nullptr));
 }
 
 void FolderMan::startScheduledSyncSoon()
@@ -770,7 +770,7 @@ void FolderMan::slotStartScheduledFolderSync()
     }
 
     // Find the first folder in the queue that can be synced.
-    Folder *folder = 0;
+    Folder *folder = nullptr;
     while (!_scheduledFolders.isEmpty()) {
         Folder *g = _scheduledFolders.dequeue();
         if (g->canSync()) {
@@ -957,7 +957,7 @@ void FolderMan::slotFolderSyncFinished(const SyncResult &)
 
     if (f == _currentSyncFolder) {
         _lastSyncFolder = _currentSyncFolder;
-        _currentSyncFolder = 0;
+        _currentSyncFolder = nullptr;
     }
     if (!isAnySyncRunning())
         startScheduledSyncSoon();
@@ -970,13 +970,13 @@ Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition 
     definition.journalPath = definition.defaultJournalPath(accountState->account());
 
     if (!ensureJournalGone(definition.absoluteJournalPath())) {
-        return 0;
+        return nullptr;
     }
 
     auto vfs = createVfsFromPlugin(folderDefinition.virtualFilesMode);
     if (!vfs) {
         qCWarning(lcFolderMan) << "Could not load plugin for mode" << folderDefinition.virtualFilesMode;
-        return 0;
+        return nullptr;
     }
 
     auto folder = addFolderInternal(definition, accountState, std::move(vfs));
@@ -1058,7 +1058,7 @@ Folder *FolderMan::folderForPath(const QString &path, QString *relativePath)
 
     if (relativePath)
         relativePath->clear();
-    return 0;
+    return nullptr;
 }
 
 QStringList FolderMan::findFileInLocalFolders(const QString &relPath, const AccountPtr acc)
@@ -1071,7 +1071,7 @@ QStringList FolderMan::findFileInLocalFolders(const QString &relPath, const Acco
         serverPath.prepend('/');
 
     foreach (Folder *folder, this->map().values()) {
-        if (acc != 0 && folder->accountState()->account() != acc) {
+        if (acc != nullptr && folder->accountState()->account() != acc) {
             continue;
         }
         if (!serverPath.startsWith(folder->remotePath()))

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -357,7 +357,7 @@ private:
     bool _appRestartRequired;
 
     static FolderMan *_instance;
-    explicit FolderMan(QObject *parent = 0);
+    explicit FolderMan(QObject *parent = nullptr);
     friend class OCC::Application;
     friend class ::TestFolderMan;
 };

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -62,7 +62,7 @@ class FolderMan : public QObject
 {
     Q_OBJECT
 public:
-    ~FolderMan();
+    ~FolderMan() override;
     static FolderMan *instance();
 
     int setupFolders();

--- a/src/gui/folderstatusdelegate.h
+++ b/src/gui/folderstatusdelegate.h
@@ -48,10 +48,10 @@ public:
 
         AddButton // 1 = enabled; 2 = disabled
     };
-    void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const Q_DECL_OVERRIDE;
-    QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const Q_DECL_OVERRIDE;
+    void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const override;
+    QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option,
-        const QModelIndex &index) Q_DECL_OVERRIDE;
+        const QModelIndex &index) override;
 
 
     /**

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -43,7 +43,7 @@ static QString removeTrailingSlash(const QString &s)
 
 FolderStatusModel::FolderStatusModel(QObject *parent)
     : QAbstractItemModel(parent)
-    , _accountState(0)
+    , _accountState(nullptr)
     , _dirty(false)
 {
 }
@@ -105,7 +105,7 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
 Qt::ItemFlags FolderStatusModel::flags(const QModelIndex &index) const
 {
     if (!_accountState) {
-        return 0;
+        return nullptr;
     }
     switch (classify(index)) {
     case AddButton: {
@@ -123,7 +123,7 @@ Qt::ItemFlags FolderStatusModel::flags(const QModelIndex &index) const
     case SubFolder:
         return Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable;
     }
-    return 0;
+    return nullptr;
 }
 
 QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
@@ -387,19 +387,19 @@ FolderStatusModel::ItemType FolderStatusModel::classify(const QModelIndex &index
 FolderStatusModel::SubFolderInfo *FolderStatusModel::infoForIndex(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return 0;
+        return nullptr;
     if (auto parentInfo = static_cast<SubFolderInfo *>(index.internalPointer())) {
         if (parentInfo->hasLabel()) {
-            return 0;
+            return nullptr;
         }
         if (index.row() >= parentInfo->_subs.size()) {
-            return 0;
+            return nullptr;
         }
         return &parentInfo->_subs[index.row()];
     } else {
         if (index.row() >= _folders.count()) {
             // AddButton
-            return 0;
+            return nullptr;
         }
         return const_cast<SubFolderInfo *>(&_folders[index.row()]);
     }

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -40,19 +40,19 @@ class FolderStatusModel : public QAbstractItemModel
     Q_OBJECT
 public:
     FolderStatusModel(QObject *parent = 0);
-    ~FolderStatusModel();
+    ~FolderStatusModel() override;
     void setAccountState(const AccountState *accountState);
 
-    Qt::ItemFlags flags(const QModelIndex &) const Q_DECL_OVERRIDE;
-    QVariant data(const QModelIndex &index, int role) const Q_DECL_OVERRIDE;
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) Q_DECL_OVERRIDE;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
-    int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
-    QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
-    QModelIndex parent(const QModelIndex &child) const Q_DECL_OVERRIDE;
-    bool canFetchMore(const QModelIndex &parent) const Q_DECL_OVERRIDE;
-    void fetchMore(const QModelIndex &parent) Q_DECL_OVERRIDE;
-    bool hasChildren(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
+    Qt::ItemFlags flags(const QModelIndex &) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &child) const override;
+    bool canFetchMore(const QModelIndex &parent) const override;
+    void fetchMore(const QModelIndex &parent) override;
+    bool hasChildren(const QModelIndex &parent = QModelIndex()) const override;
 
     struct SubFolderInfo
     {

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -39,7 +39,7 @@ class FolderStatusModel : public QAbstractItemModel
 {
     Q_OBJECT
 public:
-    FolderStatusModel(QObject *parent = 0);
+    FolderStatusModel(QObject *parent = nullptr);
     ~FolderStatusModel() override;
     void setAccountState(const AccountState *accountState);
 
@@ -57,7 +57,7 @@ public:
     struct SubFolderInfo
     {
         SubFolderInfo()
-            : _folder(0)
+            : _folder(nullptr)
             , _size(0)
             , _isExternal(false)
             , _fetched(false)

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -22,7 +22,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QHash>
 #include <QScopedPointer>
 #include <QSet>
@@ -116,7 +116,7 @@ protected:
 
 private:
     QScopedPointer<FolderWatcherPrivate> _d;
-    QTime _timer;
+    QElapsedTimer _timer;
     QSet<QString> _lastPaths;
     Folder *_folder;
     bool _isReliable = true;

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -51,7 +51,7 @@ class FolderWatcher : public QObject
     Q_OBJECT
 public:
     // Construct, connect signals, call init()
-    explicit FolderWatcher(Folder *folder = 0L);
+    explicit FolderWatcher(Folder *folder = nullptr);
     ~FolderWatcher() override;
 
     /**

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -52,7 +52,7 @@ class FolderWatcher : public QObject
 public:
     // Construct, connect signals, call init()
     explicit FolderWatcher(Folder *folder = 0L);
-    virtual ~FolderWatcher();
+    ~FolderWatcher() override;
 
     /**
      * @param root Path of the root of the folder

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -162,7 +162,7 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
     for (i = 0; i + sizeof(inotify_event) < ulen; i += sizeof(inotify_event) + (event ? event->len : 0)) {
         // cast an inotify_event
         event = (struct inotify_event *)&buffer[i];
-        if (event == NULL) {
+        if (event == nullptr) {
             qCDebug(lcFolderWatcher) << "NULL event";
             continue;
         }

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -37,7 +37,7 @@ class FolderWatcherPrivate : public QObject
 public:
     FolderWatcherPrivate() {}
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
-    ~FolderWatcherPrivate();
+    ~FolderWatcherPrivate() override;
 
     int testWatchCount() const { return _pathToWatch.size(); }
 

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -246,7 +246,7 @@ static QTreeWidgetItem *findFirstChild(QTreeWidgetItem *parent, const QString &t
             return child;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 void FolderWizardRemotePath::recursiveInsert(QTreeWidgetItem *parent, QStringList pathTrail, QString path)
@@ -363,7 +363,7 @@ void FolderWizardRemotePath::slotFolderEntryEdited(const QString &text)
         return;
     }
 
-    _ui.folderTreeWidget->setCurrentItem(0);
+    _ui.folderTreeWidget->setCurrentItem(nullptr);
     _lscolTimer.start(); // avoid sending a request on each keystroke
 }
 
@@ -376,7 +376,7 @@ void FolderWizardRemotePath::slotLsColFolderEntry()
     LsColJob *job = runLsColJob(path);
     // No error handling, no updating, we do this manually
     // because of extra logic in the typed-path case.
-    disconnect(job, 0, this, 0);
+    disconnect(job, nullptr, this, nullptr);
     connect(job, &LsColJob::finishedWithError,
         this, &FolderWizardRemotePath::slotTypedPathError);
     connect(job, &LsColJob::directoryListingSubfolders,
@@ -556,7 +556,7 @@ void FolderWizardSelectiveSync::virtualFilesCheckboxClicked()
 FolderWizard::FolderWizard(AccountPtr account, QWidget *parent)
     : QWizard(parent)
     , _folderWizardSourcePage(new FolderWizardLocalPath(account))
-    , _folderWizardTargetPage(0)
+    , _folderWizardTargetPage(nullptr)
     , _folderWizardSelectiveSyncPage(new FolderWizardSelectiveSync(account))
 {
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -53,11 +53,11 @@ class FolderWizardLocalPath : public FormatWarningsWizardPage
     Q_OBJECT
 public:
     explicit FolderWizardLocalPath(const AccountPtr &account);
-    ~FolderWizardLocalPath();
+    ~FolderWizardLocalPath() override;
 
-    virtual bool isComplete() const Q_DECL_OVERRIDE;
-    void initializePage() Q_DECL_OVERRIDE;
-    void cleanupPage() Q_DECL_OVERRIDE;
+    bool isComplete() const override;
+    void initializePage() override;
+    void cleanupPage() override;
 
     void setFolderMap(const Folder::Map &fm) { _folderMap = fm; }
 protected slots:
@@ -80,12 +80,12 @@ class FolderWizardRemotePath : public FormatWarningsWizardPage
     Q_OBJECT
 public:
     explicit FolderWizardRemotePath(const AccountPtr &account);
-    ~FolderWizardRemotePath();
+    ~FolderWizardRemotePath() override;
 
-    virtual bool isComplete() const Q_DECL_OVERRIDE;
+    bool isComplete() const override;
 
-    virtual void initializePage() Q_DECL_OVERRIDE;
-    virtual void cleanupPage() Q_DECL_OVERRIDE;
+    void initializePage() override;
+    void cleanupPage() override;
 
 protected slots:
 
@@ -123,12 +123,12 @@ class FolderWizardSelectiveSync : public QWizardPage
     Q_OBJECT
 public:
     explicit FolderWizardSelectiveSync(const AccountPtr &account);
-    ~FolderWizardSelectiveSync();
+    ~FolderWizardSelectiveSync() override;
 
-    virtual bool validatePage() Q_DECL_OVERRIDE;
+    bool validatePage() override;
 
-    virtual void initializePage() Q_DECL_OVERRIDE;
-    virtual void cleanupPage() Q_DECL_OVERRIDE;
+    void initializePage() override;
+    void cleanupPage() override;
 
 private slots:
     void virtualFilesCheckboxClicked();
@@ -153,7 +153,7 @@ public:
     };
 
     explicit FolderWizard(AccountPtr account, QWidget *parent = 0);
-    ~FolderWizard();
+    ~FolderWizard() override;
 
     bool eventFilter(QObject *watched, QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -152,7 +152,7 @@ public:
         Page_SelectiveSync
     };
 
-    explicit FolderWizard(AccountPtr account, QWidget *parent = 0);
+    explicit FolderWizard(AccountPtr account, QWidget *parent = nullptr);
     ~FolderWizard() override;
 
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -36,7 +36,7 @@ class GeneralSettings : public QWidget
 
 public:
     explicit GeneralSettings(QWidget *parent = nullptr);
-    ~GeneralSettings();
+    ~GeneralSettings() override;
     QSize sizeHint() const override;
 
 signals:

--- a/src/gui/ignorelisteditor.h
+++ b/src/gui/ignorelisteditor.h
@@ -34,7 +34,7 @@ class IgnoreListEditor : public QDialog
     Q_OBJECT
 
 public:
-    explicit IgnoreListEditor(QWidget *parent = 0);
+    explicit IgnoreListEditor(QWidget *parent = nullptr);
     ~IgnoreListEditor() override;
 
     bool ignoreHiddenFiles();

--- a/src/gui/ignorelisteditor.h
+++ b/src/gui/ignorelisteditor.h
@@ -35,7 +35,7 @@ class IgnoreListEditor : public QDialog
 
 public:
     explicit IgnoreListEditor(QWidget *parent = 0);
-    ~IgnoreListEditor();
+    ~IgnoreListEditor() override;
 
     bool ignoreHiddenFiles();
 

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -389,7 +389,7 @@ void IssuesWidget::slotUpdateFolderFilters()
     if (!account) {
         _ui->filterFolder->setCurrentIndex(0);
     }
-    _ui->filterFolder->setEnabled(account != 0);
+    _ui->filterFolder->setEnabled(account != nullptr);
 
     for (int i = _ui->filterFolder->count() - 1; i >= 1; --i) {
         _ui->filterFolder->removeItem(i);
@@ -505,7 +505,7 @@ void IssuesWidget::addError(const QString &folderAlias, const QString &message,
 
 void IssuesWidget::addErrorWidget(QTreeWidgetItem *item, const QString &message, ErrorCategory category)
 {
-    QWidget *widget = 0;
+    QWidget *widget = nullptr;
     if (category == ErrorCategory::InsufficientRemoteStorage) {
         widget = new QWidget;
         auto layout = new QHBoxLayout;

--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -44,8 +44,8 @@ class IssuesWidget : public QWidget
     Q_OBJECT
 public:
     explicit IssuesWidget(QWidget *parent = 0);
-    ~IssuesWidget();
-    QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
+    ~IssuesWidget() override;
+    QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 
     void storeSyncIssues(QTextStream &ts);
     void showFolderErrors(const QString &folderAlias);
@@ -57,8 +57,8 @@ public slots:
     void slotOpenFile(QTreeWidgetItem *item, int);
 
 protected:
-    void showEvent(QShowEvent *);
-    void hideEvent(QHideEvent *);
+    void showEvent(QShowEvent *) override;
+    void hideEvent(QHideEvent *) override;
 
 signals:
     void copyToClipboard();

--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -43,7 +43,7 @@ class IssuesWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit IssuesWidget(QWidget *parent = 0);
+    explicit IssuesWidget(QWidget *parent = nullptr);
     ~IssuesWidget() override;
     QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 

--- a/src/gui/lockwatcher.h
+++ b/src/gui/lockwatcher.h
@@ -44,7 +44,7 @@ class LockWatcher : public QObject
 {
     Q_OBJECT
 public:
-    explicit LockWatcher(QObject *parent = 0);
+    explicit LockWatcher(QObject *parent = nullptr);
 
     /** Start watching a file.
      *

--- a/src/gui/logbrowser.h
+++ b/src/gui/logbrowser.h
@@ -38,7 +38,7 @@ class LogBrowser : public QDialog
     Q_OBJECT
 public:
     explicit LogBrowser(QWidget *parent = 0);
-    ~LogBrowser();
+    ~LogBrowser() override;
 
     /** Sets Logger settings depending on ConfigFile values.
      *

--- a/src/gui/logbrowser.h
+++ b/src/gui/logbrowser.h
@@ -37,7 +37,7 @@ class LogBrowser : public QDialog
 {
     Q_OBJECT
 public:
-    explicit LogBrowser(QWidget *parent = 0);
+    explicit LogBrowser(QWidget *parent = nullptr);
     ~LogBrowser() override;
 
     /** Sets Logger settings depending on ConfigFile values.

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -35,7 +35,7 @@ using namespace OCC;
 
 void warnSystray()
 {
-    QMessageBox::critical(0, qApp->translate("main.cpp", "System Tray not available"),
+    QMessageBox::critical(nullptr, qApp->translate("main.cpp", "System Tray not available"),
         qApp->translate("main.cpp", "%1 requires on a working system tray. "
                                     "If you are running XFCE, please follow "
                                     "<a href=\"http://docs.xfce.org/xfce/xfce4-panel/systray\">these instructions</a>. "

--- a/src/gui/networksettings.h
+++ b/src/gui/networksettings.h
@@ -33,7 +33,7 @@ class NetworkSettings : public QWidget
     Q_OBJECT
 
 public:
-    explicit NetworkSettings(QWidget *parent = 0);
+    explicit NetworkSettings(QWidget *parent = nullptr);
     ~NetworkSettings() override;
     QSize sizeHint() const override;
 

--- a/src/gui/networksettings.h
+++ b/src/gui/networksettings.h
@@ -34,7 +34,7 @@ class NetworkSettings : public QWidget
 
 public:
     explicit NetworkSettings(QWidget *parent = 0);
-    ~NetworkSettings();
+    ~NetworkSettings() override;
     QSize sizeHint() const override;
 
 private slots:

--- a/src/gui/notificationconfirmjob.cpp
+++ b/src/gui/notificationconfirmjob.cpp
@@ -24,7 +24,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcNotifications)
 
 NotificationConfirmJob::NotificationConfirmJob(AccountPtr account)
     : AbstractNetworkJob(account, "")
-    , _widget(0)
+    , _widget(nullptr)
 {
     setIgnoreCredentialFailure(true);
 }

--- a/src/gui/notificationconfirmjob.h
+++ b/src/gui/notificationconfirmjob.h
@@ -52,7 +52,7 @@ public:
     /**
      * @brief Start the OCS request
      */
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     /**
      * @brief setWidget stores the associated widget to be able to use
@@ -78,7 +78,7 @@ signals:
     void jobFinished(QString reply, int replyCode);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QByteArray _verb;

--- a/src/gui/notificationwidget.h
+++ b/src/gui/notificationwidget.h
@@ -31,7 +31,7 @@ class NotificationWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit NotificationWidget(QWidget *parent = 0);
+    explicit NotificationWidget(QWidget *parent = nullptr);
 
     bool readyToClose();
     Activity activity() const;

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -104,7 +104,7 @@ protected slots:
     /**
      * Start the OCS request
      */
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
 signals:
 
@@ -125,7 +125,7 @@ signals:
     void ocsError(int statusCode, const QString &message);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QByteArray _verb;

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -49,7 +49,7 @@ class ownCloudGui : public QObject
 {
     Q_OBJECT
 public:
-    explicit ownCloudGui(Application *parent = 0);
+    explicit ownCloudGui(Application *parent = nullptr);
     ~ownCloudGui() override;
 
     bool checkAccountExists(bool openSettings);

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -50,7 +50,7 @@ class ownCloudGui : public QObject
     Q_OBJECT
 public:
     explicit ownCloudGui(Application *parent = 0);
-    ~ownCloudGui();
+    ~ownCloudGui() override;
 
     bool checkAccountExists(bool openSettings);
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -62,7 +62,7 @@ OwncloudSetupWizard::~OwncloudSetupWizard()
     _ocWizard->deleteLater();
 }
 
-static QPointer<OwncloudSetupWizard> wiz = 0;
+static QPointer<OwncloudSetupWizard> wiz = nullptr;
 
 void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *parent)
 {
@@ -563,7 +563,7 @@ bool OwncloudSetupWizard::ensureStartFromScratch(const QString &localFolder)
         renameOk = FolderMan::instance()->startFromScratch(localFolder);
         if (!renameOk) {
             QMessageBox::StandardButton but;
-            but = QMessageBox::question(0, tr("Folder rename failed"),
+            but = QMessageBox::question(nullptr, tr("Folder rename failed"),
                 tr("Can't remove and back up the folder because the folder or a file in it is open in another program."
                    " Please close the folder or file and hit retry or cancel the setup."),
                 QMessageBox::Retry | QMessageBox::Abort, QMessageBox::Retry);

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -70,7 +70,7 @@ private slots:
 
 private:
     explicit OwncloudSetupWizard(QObject *parent = 0);
-    ~OwncloudSetupWizard();
+    ~OwncloudSetupWizard() override;
     void startWizard();
     void testOwnCloudConnect();
     void createRemoteFolder();

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -42,7 +42,7 @@ class OwncloudSetupWizard : public QObject
     Q_OBJECT
 public:
     /** Run the wizard */
-    static void runWizard(QObject *obj, const char *amember, QWidget *parent = 0);
+    static void runWizard(QObject *obj, const char *amember, QWidget *parent = nullptr);
     static bool bringWizardToFrontIfVisible();
 signals:
     // overall dialog close signal.
@@ -69,7 +69,7 @@ private slots:
     void slotAssistantFinished(int);
 
 private:
-    explicit OwncloudSetupWizard(QObject *parent = 0);
+    explicit OwncloudSetupWizard(QObject *parent = nullptr);
     ~OwncloudSetupWizard() override;
     void startWizard();
     void testOwnCloudConnect();

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -59,7 +59,7 @@ ProtocolItem *ProtocolItem::create(const QString &folder, const SyncFileItem &it
 {
     auto f = FolderMan::instance()->folder(folder);
     if (!f) {
-        return 0;
+        return nullptr;
     }
 
     QStringList columns;

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -85,7 +85,7 @@ class ProtocolWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ProtocolWidget(QWidget *parent = 0);
+    explicit ProtocolWidget(QWidget *parent = nullptr);
     ~ProtocolWidget() override;
     QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -86,8 +86,8 @@ class ProtocolWidget : public QWidget
     Q_OBJECT
 public:
     explicit ProtocolWidget(QWidget *parent = 0);
-    ~ProtocolWidget();
-    QSize sizeHint() const { return ownCloudGui::settingsDialogSize(); }
+    ~ProtocolWidget() override;
+    QSize sizeHint() const override { return ownCloudGui::settingsDialogSize(); }
 
     void storeSyncActivity(QTextStream &ts);
 
@@ -96,8 +96,8 @@ public slots:
     void slotOpenFile(QTreeWidgetItem *item, int);
 
 protected:
-    void showEvent(QShowEvent *);
-    void hideEvent(QHideEvent *);
+    void showEvent(QShowEvent *) override;
+    void hideEvent(QHideEvent *) override;
 
 private slots:
     void slotItemContextMenu(const QPoint &pos);

--- a/src/gui/proxyauthdialog.h
+++ b/src/gui/proxyauthdialog.h
@@ -34,7 +34,7 @@ class ProxyAuthDialog : public QDialog
 
 public:
     explicit ProxyAuthDialog(QWidget *parent = 0);
-    ~ProxyAuthDialog();
+    ~ProxyAuthDialog() override;
 
     void setProxyAddress(const QString &address);
 

--- a/src/gui/proxyauthdialog.h
+++ b/src/gui/proxyauthdialog.h
@@ -33,7 +33,7 @@ class ProxyAuthDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ProxyAuthDialog(QWidget *parent = 0);
+    explicit ProxyAuthDialog(QWidget *parent = nullptr);
     ~ProxyAuthDialog() override;
 
     void setProxyAddress(const QString &address);

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -83,7 +83,7 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
     }
 
     // Find the responsible QNAM if possible.
-    QNetworkAccessManager *sending_qnam = 0;
+    QNetworkAccessManager *sending_qnam = nullptr;
     QWeakPointer<QNetworkAccessManager> qnam_alive;
     if (Account *account = qobject_cast<Account *>(sender())) {
         // Since we go into an event loop, it's possible for the account's qnam

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -83,14 +83,12 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
     }
 
     // Find the responsible QNAM if possible.
-    QNetworkAccessManager *sending_qnam = nullptr;
-    QWeakPointer<QNetworkAccessManager> qnam_alive;
+    QPointer<QNetworkAccessManager> sending_qnam = nullptr;
     if (Account *account = qobject_cast<Account *>(sender())) {
         // Since we go into an event loop, it's possible for the account's qnam
         // to be destroyed before we get back. We can use this to check for its
         // liveness.
-        qnam_alive = account->sharedNetworkAccessManager();
-        sending_qnam = qnam_alive.data();
+        sending_qnam = account->sharedNetworkAccessManager().data();
     }
     if (!sending_qnam) {
         qCWarning(lcProxy) << "Could not get the sending QNAM for" << sender();
@@ -128,7 +126,6 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
     qCInfo(lcProxy) << "got creds for" << _proxy;
     authenticator->setUser(_username);
     authenticator->setPassword(_password);
-    sending_qnam = qnam_alive.data();
     if (sending_qnam) {
         _gaveCredentialsTo.insert(sending_qnam);
         connect(sending_qnam, &QObject::destroyed,

--- a/src/gui/proxyauthhandler.h
+++ b/src/gui/proxyauthhandler.h
@@ -49,7 +49,7 @@ class ProxyAuthHandler : public QObject
 public:
     static ProxyAuthHandler *instance();
 
-    virtual ~ProxyAuthHandler();
+    ~ProxyAuthHandler() override;
 
 public slots:
     /// Intended for QNetworkAccessManager::proxyAuthenticationRequired()

--- a/src/gui/quotainfo.h
+++ b/src/gui/quotainfo.h
@@ -47,7 +47,7 @@ class QuotaInfo : public QObject
 {
     Q_OBJECT
 public:
-    explicit QuotaInfo(OCC::AccountState *accountState, QObject *parent = 0);
+    explicit QuotaInfo(OCC::AccountState *accountState, QObject *parent = nullptr);
 
     qint64 lastQuotaTotalBytes() const { return _lastQuotaTotalBytes; }
     qint64 lastQuotaUsedBytes() const { return _lastQuotaUsedBytes; }

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    bool operator<(const QTreeWidgetItem &other) const
+    bool operator<(const QTreeWidgetItem &other) const override
     {
         int column = treeWidget()->sortColumn();
         if (column == 1) {

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -139,7 +139,7 @@ static QTreeWidgetItem *findFirstChild(QTreeWidgetItem *parent, const QString &t
             return child;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 void SelectiveSyncWidget::recursiveInsert(QTreeWidgetItem *parent, QStringList pathTrail, QString path, qint64 size)
@@ -431,7 +431,7 @@ qint64 SelectiveSyncWidget::estimatedSize(QTreeWidgetItem *root)
 SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, Folder *folder, QWidget *parent, Qt::WindowFlags f)
     : QDialog(parent, f)
     , _folder(folder)
-    , _okButton(0) // defined in init()
+    , _okButton(nullptr) // defined in init()
 {
     bool ok;
     init(account);
@@ -448,7 +448,7 @@ SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, Folder *folder, QWi
 SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, const QString &folder,
     const QStringList &blacklist, QWidget *parent, Qt::WindowFlags f)
     : QDialog(parent, f)
-    , _folder(0)
+    , _folder(nullptr)
 {
     init(account);
     _selectiveSync->setFolderInfo(folder, folder, blacklist);

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -52,7 +52,7 @@ public:
     void setFolderInfo(const QString &folderPath, const QString &rootName,
         const QStringList &oldBlackList = QStringList());
 
-    QSize sizeHint() const Q_DECL_OVERRIDE;
+    QSize sizeHint() const override;
 
 private slots:
     void slotUpdateDirectories(QStringList);
@@ -94,7 +94,7 @@ public:
     // Dialog for the whole account (Used from the wizard)
     explicit SelectiveSyncDialog(AccountPtr account, const QString &folder, const QStringList &blacklist, QWidget *parent = 0, Qt::WindowFlags f = 0);
 
-    virtual void accept() Q_DECL_OVERRIDE;
+    void accept() override;
 
     QStringList createBlackList() const;
     QStringList oldBlackList() const;

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -35,10 +35,10 @@ class SelectiveSyncWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit SelectiveSyncWidget(AccountPtr account, QWidget *parent = 0);
+    explicit SelectiveSyncWidget(AccountPtr account, QWidget *parent = nullptr);
 
     /// Returns a list of blacklisted paths, each including the trailing /
-    QStringList createBlackList(QTreeWidgetItem *root = 0) const;
+    QStringList createBlackList(QTreeWidgetItem *root = nullptr) const;
 
     /** Returns the oldBlackList passed into setFolderInfo(), except that
      *  a "/" entry is expanded to all top-level folder names.
@@ -46,7 +46,7 @@ public:
     QStringList oldBlackList() const;
 
     // Estimates the total size of checked items (recursively)
-    qint64 estimatedSize(QTreeWidgetItem *root = 0);
+    qint64 estimatedSize(QTreeWidgetItem *root = nullptr);
 
     // oldBlackList is a list of excluded paths, each including a trailing /
     void setFolderInfo(const QString &folderPath, const QString &rootName,
@@ -89,10 +89,10 @@ class SelectiveSyncDialog : public QDialog
     Q_OBJECT
 public:
     // Dialog for a specific folder (used from the account settings button)
-    explicit SelectiveSyncDialog(AccountPtr account, Folder *folder, QWidget *parent = 0, Qt::WindowFlags f = 0);
+    explicit SelectiveSyncDialog(AccountPtr account, Folder *folder, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
     // Dialog for the whole account (Used from the wizard)
-    explicit SelectiveSyncDialog(AccountPtr account, const QString &folder, const QStringList &blacklist, QWidget *parent = 0, Qt::WindowFlags f = 0);
+    explicit SelectiveSyncDialog(AccountPtr account, const QString &folder, const QStringList &blacklist, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
     void accept() override;
 

--- a/src/gui/servernotificationhandler.h
+++ b/src/gui/servernotificationhandler.h
@@ -27,7 +27,7 @@ class ServerNotificationHandler : public QObject
 {
     Q_OBJECT
 public:
-    explicit ServerNotificationHandler(QObject *parent = 0);
+    explicit ServerNotificationHandler(QObject *parent = nullptr);
 
 signals:
     void newNotificationList(ActivityList);

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -399,7 +399,7 @@ public:
     }
 
 
-    QWidget *createWidget(QWidget *parent) Q_DECL_OVERRIDE
+    QWidget *createWidget(QWidget *parent) override
     {
         auto toolbar = qobject_cast<QToolBar *>(parent);
         if (!toolbar) {

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -404,7 +404,7 @@ public:
         auto toolbar = qobject_cast<QToolBar *>(parent);
         if (!toolbar) {
             // this means we are in the extention menu, no special action here
-            return 0;
+            return nullptr;
         }
 
         QToolButton *btn = new QToolButton(parent);

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -50,7 +50,7 @@ class SettingsDialog : public QDialog
 
 public:
     explicit SettingsDialog(ownCloudGui *gui, QWidget *parent = nullptr);
-    ~SettingsDialog();
+    ~SettingsDialog() override;
 
     QWidget* currentPage();
 
@@ -65,9 +65,9 @@ public slots:
     void slotAccountDisplayNameChanged();
 
 protected:
-    void reject() Q_DECL_OVERRIDE;
-    void accept() Q_DECL_OVERRIDE;
-    void changeEvent(QEvent *) Q_DECL_OVERRIDE;
+    void reject() override;
+    void accept() override;
+    void changeEvent(QEvent *) override;
 
 private slots:
     void accountAdded(AccountState *);

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -49,9 +49,9 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     , _maxSharingPermissions(maxSharingPermissions)
     , _privateLinkUrl(accountState->account()->deprecatedPrivateLinkUrl(numericFileId).toString(QUrl::FullyEncoded))
     , _startPage(startPage)
-    , _linkWidget(NULL)
-    , _userGroupWidget(NULL)
-    , _progressIndicator(NULL)
+    , _linkWidget(nullptr)
+    , _userGroupWidget(nullptr)
+    , _progressIndicator(nullptr)
 {
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -244,11 +244,11 @@ void ShareDialog::slotAccountStateChanged(int state)
     bool enabled = (state == AccountState::State::Connected);
     qCDebug(lcSharing) << "Account connected?" << enabled;
 
-    if (_userGroupWidget != NULL) {
+    if (_userGroupWidget != nullptr) {
         _userGroupWidget->setEnabled(enabled);
     }
 
-    if (_linkWidget != NULL) {
+    if (_linkWidget != nullptr) {
         _linkWidget->setEnabled(enabled);
     }
 }

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -47,10 +47,10 @@ public:
         const QByteArray &numericFileId,
         ShareDialogStartPage startPage,
         QWidget *parent = 0);
-    ~ShareDialog();
+    ~ShareDialog() override;
 
 private slots:
-    void done(int r);
+    void done(int r) override;
     void slotPropfindReceived(const QVariantMap &result);
     void slotPropfindError();
     void slotThumbnailFetched(const int &statusCode, const QByteArray &reply);

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -46,7 +46,7 @@ public:
         SharePermissions maxSharingPermissions,
         const QByteArray &numericFileId,
         ShareDialogStartPage startPage,
-        QWidget *parent = 0);
+        QWidget *parent = nullptr);
     ~ShareDialog() override;
 
 private slots:

--- a/src/gui/sharee.cpp
+++ b/src/gui/sharee.cpp
@@ -235,7 +235,7 @@ QVariant ShareeModel::data(const QModelIndex &index, int role) const
 QSharedPointer<Sharee> ShareeModel::getSharee(int at)
 {
     if (at < 0 || at > _sharees.size()) {
-        return QSharedPointer<Sharee>(NULL);
+        return QSharedPointer<Sharee>(nullptr);
     }
 
     return _sharees.at(at);

--- a/src/gui/sharee.h
+++ b/src/gui/sharee.h
@@ -63,7 +63,7 @@ class ShareeModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    explicit ShareeModel(const AccountPtr &account, const QString &type, QObject *parent = 0);
+    explicit ShareeModel(const AccountPtr &account, const QString &type, QObject *parent = nullptr);
 
     typedef QVector<QSharedPointer<Sharee>> ShareeSet; // FIXME: make it a QSet<Sharee> when Sharee can be compared
     void fetch(const QString &search, const ShareeSet &blacklist);

--- a/src/gui/sharee.h
+++ b/src/gui/sharee.h
@@ -67,8 +67,8 @@ public:
 
     typedef QVector<QSharedPointer<Sharee>> ShareeSet; // FIXME: make it a QSet<Sharee> when Sharee can be compared
     void fetch(const QString &search, const ShareeSet &blacklist);
-    int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role) const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
 
     QSharedPointer<Sharee> getSharee(int at);
 

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -54,7 +54,7 @@ public:
         const QString &localPath,
         SharePermissions maxSharingPermissions,
         QWidget *parent = 0);
-    ~ShareLinkWidget();
+    ~ShareLinkWidget() override;
     void getShares();
 
 private slots:

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -53,7 +53,7 @@ public:
         const QString &sharePath,
         const QString &localPath,
         SharePermissions maxSharingPermissions,
-        QWidget *parent = 0);
+        QWidget *parent = nullptr);
     ~ShareLinkWidget() override;
     void getShares();
 

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -57,7 +57,7 @@ public:
         const QString &path,
         const ShareType shareType,
         const Permissions permissions = SharePermissionDefault,
-        const QSharedPointer<Sharee> shareWith = QSharedPointer<Sharee>(NULL));
+        const QSharedPointer<Sharee> shareWith = QSharedPointer<Sharee>(nullptr));
 
     /**
      * The account the share is defined on.
@@ -234,7 +234,7 @@ class ShareManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit ShareManager(AccountPtr _account, QObject *parent = NULL);
+    explicit ShareManager(AccountPtr _account, QObject *parent = nullptr);
 
     /**
      * Tell the manager to create a link share

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -58,7 +58,7 @@ public:
         const QString &localPath,
         SharePermissions maxSharingPermissions,
         const QString &privateLinkUrl,
-        QWidget *parent = 0);
+        QWidget *parent = nullptr);
     ~ShareUserGroupWidget() override;
 
 public slots:
@@ -113,7 +113,7 @@ public:
     explicit ShareUserLine(QSharedPointer<Share> Share,
         SharePermissions maxSharingPermissions,
         bool isFile,
-        QWidget *parent = 0);
+        QWidget *parent = nullptr);
     ~ShareUserLine() override;
 
     QSharedPointer<Share> share() const;

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -59,7 +59,7 @@ public:
         SharePermissions maxSharingPermissions,
         const QString &privateLinkUrl,
         QWidget *parent = 0);
-    ~ShareUserGroupWidget();
+    ~ShareUserGroupWidget() override;
 
 public slots:
     void getShares();
@@ -114,7 +114,7 @@ public:
         SharePermissions maxSharingPermissions,
         bool isFile,
         QWidget *parent = 0);
-    ~ShareUserLine();
+    ~ShareUserLine() override;
 
     QSharedPointer<Share> share() const;
 

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -52,7 +52,7 @@ class SocketApi : public QObject
 
 public:
     explicit SocketApi(QObject *parent = 0);
-    virtual ~SocketApi();
+    ~SocketApi() override;
 
 public slots:
     void slotUpdateFolderView(Folder *f);

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -51,7 +51,7 @@ class SocketApi : public QObject
     Q_OBJECT
 
 public:
-    explicit SocketApi(QObject *parent = 0);
+    explicit SocketApi(QObject *parent = nullptr);
     ~SocketApi() override;
 
 public slots:

--- a/src/gui/sslbutton.h
+++ b/src/gui/sslbutton.h
@@ -35,7 +35,7 @@ class SslButton : public QToolButton
 {
     Q_OBJECT
 public:
-    explicit SslButton(QWidget *parent = 0);
+    explicit SslButton(QWidget *parent = nullptr);
     void updateAccountState(AccountState *accountState);
 
 public slots:

--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -148,7 +148,7 @@ bool SslErrorDialog::checkFailingCertsKnown(const QList<QSslError> &errors)
     }
     msg += QL("</div></body></html>");
 
-    QTextDocument *doc = new QTextDocument(0);
+    QTextDocument *doc = new QTextDocument(nullptr);
     QString style = styleSheet();
     doc->addResource(QTextDocument::StyleSheetResource, QUrl(QL("format.css")), style);
     doc->setHtml(msg);

--- a/src/gui/sslerrordialog.h
+++ b/src/gui/sslerrordialog.h
@@ -37,7 +37,7 @@ namespace Ui {
 class SslDialogErrorHandler : public AbstractSslErrorHandler
 {
 public:
-    bool handleErrors(QList<QSslError> errors, const QSslConfiguration &conf, QList<QSslCertificate> *certs, AccountPtr) Q_DECL_OVERRIDE;
+    bool handleErrors(QList<QSslError> errors, const QSslConfiguration &conf, QList<QSslCertificate> *certs, AccountPtr) override;
 };
 
 /**
@@ -49,7 +49,7 @@ class SslErrorDialog : public QDialog
     Q_OBJECT
 public:
     explicit SslErrorDialog(AccountPtr account, QWidget *parent = 0);
-    ~SslErrorDialog();
+    ~SslErrorDialog() override;
     bool checkFailingCertsKnown(const QList<QSslError> &errors);
     bool trustConnection();
     QList<QSslCertificate> unknownCerts() const { return _unknownCerts; }

--- a/src/gui/sslerrordialog.h
+++ b/src/gui/sslerrordialog.h
@@ -48,7 +48,7 @@ class SslErrorDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit SslErrorDialog(AccountPtr account, QWidget *parent = 0);
+    explicit SslErrorDialog(AccountPtr account, QWidget *parent = nullptr);
     ~SslErrorDialog() override;
     bool checkFailingCertsKnown(const QList<QSslError> &errors);
     bool trustConnection();

--- a/src/gui/synclogdialog.h
+++ b/src/gui/synclogdialog.h
@@ -38,7 +38,7 @@ class SyncLogDialog : public QDialog
 
 public:
     explicit SyncLogDialog(QWidget *parent = 0, ProtocolWidget *protoWidget = 0);
-    ~SyncLogDialog();
+    ~SyncLogDialog() override;
 
 private slots:
 

--- a/src/gui/synclogdialog.h
+++ b/src/gui/synclogdialog.h
@@ -37,7 +37,7 @@ class SyncLogDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SyncLogDialog(QWidget *parent = 0, ProtocolWidget *protoWidget = 0);
+    explicit SyncLogDialog(QWidget *parent = nullptr, ProtocolWidget *protoWidget = nullptr);
     ~SyncLogDialog() override;
 
 private slots:

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -31,7 +31,7 @@ class ThumbnailJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit ThumbnailJob(const QString &path, AccountPtr account, QObject *parent = 0);
+    explicit ThumbnailJob(const QString &path, AccountPtr account, QObject *parent = nullptr);
 public slots:
     void start() override;
 signals:

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -33,7 +33,7 @@ class ThumbnailJob : public AbstractNetworkJob
 public:
     explicit ThumbnailJob(const QString &path, AccountPtr account, QObject *parent = 0);
 public slots:
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 signals:
     /**
      * @param statusCode the HTTP status code
@@ -45,7 +45,7 @@ signals:
      */
     void jobFinished(int statusCode, QByteArray reply);
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 };
 }
 

--- a/src/gui/tooltipupdater.h
+++ b/src/gui/tooltipupdater.h
@@ -40,7 +40,7 @@ public:
     ToolTipUpdater(QTreeView *treeView);
 
 protected:
-    bool eventFilter(QObject *obj, QEvent *ev) Q_DECL_OVERRIDE;
+    bool eventFilter(QObject *obj, QEvent *ev) override;
 
 private slots:
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -105,7 +105,7 @@ bool OCUpdater::performUpdate()
     if (!updateFile.isEmpty() && QFile(updateFile).exists()
         && !updateSucceeded() /* Someone might have run the updater manually between restarts */) {
         const QString name = Theme::instance()->appNameGUI();
-        if (QMessageBox::information(0, tr("New %1 Update Ready").arg(name),
+        if (QMessageBox::information(nullptr, tr("New %1 Update Ready").arg(name),
                 tr("A new update for %1 is about to be installed. The updater may ask\n"
                    "for additional privileges during the process.")
                     .arg(name),

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -103,7 +103,7 @@ public:
 
     bool performUpdate();
 
-    void checkForUpdate() Q_DECL_OVERRIDE;
+    void checkForUpdate() override;
 
     QString statusString() const;
     int downloadState() const;
@@ -119,7 +119,7 @@ public slots:
     void slotStartInstaller();
 
 protected slots:
-    void backgroundCheckForUpdate() Q_DECL_OVERRIDE;
+    void backgroundCheckForUpdate() override;
     void slotOpenUpdateUrl();
 
 private slots:
@@ -149,7 +149,7 @@ class NSISUpdater : public OCUpdater
     Q_OBJECT
 public:
     explicit NSISUpdater(const QUrl &url);
-    bool handleStartup() Q_DECL_OVERRIDE;
+    bool handleStartup() override;
 private slots:
     void slotSetSeenVersion();
     void slotDownloadFinished();
@@ -159,7 +159,7 @@ private:
     void wipeUpdateData();
     void showNoUrlDialog(const UpdateInfo &info);
     void showUpdateErrorDialog(const QString &targetVersion);
-    void versionInfoArrived(const UpdateInfo &info) Q_DECL_OVERRIDE;
+    void versionInfoArrived(const UpdateInfo &info) override;
     QScopedPointer<QTemporaryFile> _file;
     QString _targetFile;
 };
@@ -176,11 +176,11 @@ class PassiveUpdateNotifier : public OCUpdater
     Q_OBJECT
 public:
     explicit PassiveUpdateNotifier(const QUrl &url);
-    bool handleStartup() Q_DECL_OVERRIDE { return false; }
-    void backgroundCheckForUpdate() Q_DECL_OVERRIDE;
+    bool handleStartup() override { return false; }
+    void backgroundCheckForUpdate() override;
 
 private:
-    void versionInfoArrived(const UpdateInfo &info) Q_DECL_OVERRIDE;
+    void versionInfoArrived(const UpdateInfo &info) override;
     QByteArray _runningAppVersion;
 };
 }

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -26,14 +26,14 @@ class SparkleUpdater : public Updater
     Q_OBJECT
 public:
     SparkleUpdater(const QUrl &appCastUrl);
-    ~SparkleUpdater();
+    ~SparkleUpdater() override;
 
     void setUpdateUrl(const QUrl &url);
 
     // unused in this updater
-    void checkForUpdate() Q_DECL_OVERRIDE;
-    void backgroundCheckForUpdate() Q_DECL_OVERRIDE;
-    bool handleStartup() Q_DECL_OVERRIDE { return false; }
+    void checkForUpdate() override;
+    void backgroundCheckForUpdate() override;
+    bool handleStartup() override { return false; }
 
     QString statusString();
 

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -31,7 +31,7 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcUpdater, "gui.updater", QtInfoMsg)
 
-Updater *Updater::_instance = 0;
+Updater *Updater::_instance = nullptr;
 
 Updater *Updater::instance()
 {
@@ -125,7 +125,7 @@ Updater *Updater::create()
     qCDebug(lcUpdater) << url;
     if (url.isEmpty()) {
         qCWarning(lcUpdater) << "Not a valid updater URL, will not do update check";
-        return 0;
+        return nullptr;
     }
 
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)

--- a/src/gui/updater/updater.h
+++ b/src/gui/updater/updater.h
@@ -46,7 +46,7 @@ public:
 protected:
     static QString clientVersion();
     Updater()
-        : QObject(0)
+        : QObject(nullptr)
     {
     }
 

--- a/src/gui/wizard/abstractcredswizardpage.h
+++ b/src/gui/wizard/abstractcredswizardpage.h
@@ -28,7 +28,7 @@ class AbstractCredentials;
 class AbstractCredentialsWizardPage : public QWizardPage
 {
 public:
-    void cleanupPage() Q_DECL_OVERRIDE;
+    void cleanupPage() override;
     virtual AbstractCredentials *getCredentials() const = 0;
 };
 

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -312,7 +312,7 @@ void OwncloudAdvancedSetupPage::setRemoteFolder(const QString &remoteFolder)
 
 void OwncloudAdvancedSetupPage::slotSelectFolder()
 {
-    QString dir = QFileDialog::getExistingDirectory(0, tr("Local Sync Folder"), QDir::homePath());
+    QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Local Sync Folder"), QDir::homePath());
     if (!dir.isEmpty()) {
         _ui.pbSelectLocalFolder->setText(dir);
         wizard()->setProperty("localFolder", dir);

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -35,10 +35,10 @@ class OwncloudAdvancedSetupPage : public QWizardPage
 public:
     OwncloudAdvancedSetupPage();
 
-    virtual bool isComplete() const Q_DECL_OVERRIDE;
-    virtual void initializePage() Q_DECL_OVERRIDE;
-    virtual int nextId() const Q_DECL_OVERRIDE;
-    bool validatePage() Q_DECL_OVERRIDE;
+    bool isComplete() const override;
+    void initializePage() override;
+    int nextId() const override;
+    bool validatePage() override;
     QString localFolder() const;
     QStringList selectiveSyncBlacklist() const;
     bool useVirtualFileSync() const;

--- a/src/gui/wizard/owncloudconnectionmethoddialog.h
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.h
@@ -36,7 +36,7 @@ class OwncloudConnectionMethodDialog : public QDialog
 
 public:
     explicit OwncloudConnectionMethodDialog(QWidget *parent = 0);
-    ~OwncloudConnectionMethodDialog();
+    ~OwncloudConnectionMethodDialog() override;
     enum {
         Closed = 0,
         No_TLS,

--- a/src/gui/wizard/owncloudconnectionmethoddialog.h
+++ b/src/gui/wizard/owncloudconnectionmethoddialog.h
@@ -35,7 +35,7 @@ class OwncloudConnectionMethodDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit OwncloudConnectionMethodDialog(QWidget *parent = 0);
+    explicit OwncloudConnectionMethodDialog(QWidget *parent = nullptr);
     ~OwncloudConnectionMethodDialog() override;
     enum {
         Closed = 0,

--- a/src/gui/wizard/owncloudhttpcredspage.h
+++ b/src/gui/wizard/owncloudhttpcredspage.h
@@ -34,12 +34,12 @@ class OwncloudHttpCredsPage : public AbstractCredentialsWizardPage
 public:
     OwncloudHttpCredsPage(QWidget *parent);
 
-    AbstractCredentials *getCredentials() const Q_DECL_OVERRIDE;
+    AbstractCredentials *getCredentials() const override;
 
-    void initializePage() Q_DECL_OVERRIDE;
-    void cleanupPage() Q_DECL_OVERRIDE;
-    bool validatePage() Q_DECL_OVERRIDE;
-    int nextId() const Q_DECL_OVERRIDE;
+    void initializePage() override;
+    void cleanupPage() override;
+    bool validatePage() override;
+    int nextId() const override;
     void setConnected();
     void setErrorString(const QString &err);
 

--- a/src/gui/wizard/owncloudoauthcredspage.h
+++ b/src/gui/wizard/owncloudoauthcredspage.h
@@ -36,11 +36,11 @@ class OwncloudOAuthCredsPage : public AbstractCredentialsWizardPage
 public:
     OwncloudOAuthCredsPage();
 
-    AbstractCredentials *getCredentials() const Q_DECL_OVERRIDE;
+    AbstractCredentials *getCredentials() const override;
 
-    void initializePage() Q_DECL_OVERRIDE;
+    void initializePage() override;
     void cleanupPage() override;
-    int nextId() const Q_DECL_OVERRIDE;
+    int nextId() const override;
     void setConnected();
     bool isComplete() const override;
 

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -40,7 +40,7 @@ class OwncloudSetupPage : public QWizardPage
 {
     Q_OBJECT
 public:
-    OwncloudSetupPage(QWidget *parent = 0);
+    OwncloudSetupPage(QWidget *parent = nullptr);
     ~OwncloudSetupPage() override;
 
     bool isComplete() const override;

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -41,14 +41,14 @@ class OwncloudSetupPage : public QWizardPage
     Q_OBJECT
 public:
     OwncloudSetupPage(QWidget *parent = 0);
-    ~OwncloudSetupPage();
+    ~OwncloudSetupPage() override;
 
-    virtual bool isComplete() const Q_DECL_OVERRIDE;
-    virtual void initializePage() Q_DECL_OVERRIDE;
-    virtual int nextId() const Q_DECL_OVERRIDE;
+    bool isComplete() const override;
+    void initializePage() override;
+    int nextId() const override;
     void setServerUrl(const QString &);
     void setAllowPasswordStorage(bool);
-    bool validatePage() Q_DECL_OVERRIDE;
+    bool validatePage() override;
     QString url() const;
     QString localFolder() const;
     void setRemoteFolder(const QString &remoteFolder);

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -41,13 +41,13 @@ Q_LOGGING_CATEGORY(lcWizard, "gui.wizard", QtInfoMsg)
 
 OwncloudWizard::OwncloudWizard(QWidget *parent)
     : QWizard(parent)
-    , _account(0)
+    , _account(nullptr)
     , _setupPage(new OwncloudSetupPage(this))
     , _httpCredsPage(new OwncloudHttpCredsPage(this))
     , _browserCredsPage(new OwncloudOAuthCredsPage)
     , _advancedSetupPage(new OwncloudAdvancedSetupPage)
     , _resultPage(new OwncloudWizardResultPage)
-    , _credentialsPage(0)
+    , _credentialsPage(nullptr)
     , _setupLog()
 {
     setObjectName("owncloudWizard");
@@ -232,7 +232,7 @@ AbstractCredentials *OwncloudWizard::getCredentials() const
         return _credentialsPage->getCredentials();
     }
 
-    return 0;
+    return nullptr;
 }
 
 void OwncloudWizard::askExperimentalVirtualFilesFeature(const std::function<void(bool enable)> &callback)

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -50,7 +50,7 @@ public:
         LogParagraph
     };
 
-    OwncloudWizard(QWidget *parent = 0);
+    OwncloudWizard(QWidget *parent = nullptr);
 
     void setAccount(AccountPtr account);
     AccountPtr account() const;

--- a/src/gui/wizard/owncloudwizardresultpage.h
+++ b/src/gui/wizard/owncloudwizardresultpage.h
@@ -31,10 +31,10 @@ class OwncloudWizardResultPage : public QWizardPage
     Q_OBJECT
 public:
     OwncloudWizardResultPage();
-    ~OwncloudWizardResultPage();
+    ~OwncloudWizardResultPage() override;
 
-    bool isComplete() const Q_DECL_OVERRIDE;
-    void initializePage() Q_DECL_OVERRIDE;
+    bool isComplete() const override;
+    void initializePage() override;
     void setRemoteFolder(const QString &remoteFolder);
 
 public slots:

--- a/src/gui/wizard/postfixlineedit.h
+++ b/src/gui/wizard/postfixlineedit.h
@@ -44,7 +44,7 @@ public:
     void setFullText(const QString &text);
 
 protected:
-    void paintEvent(QPaintEvent *pe);
+    void paintEvent(QPaintEvent *pe) override;
 
 private:
     QString _postfix;

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -51,7 +51,7 @@ AbstractNetworkJob::AbstractNetworkJob(AccountPtr account, const QString &path, 
     , _followRedirects(true)
     , _account(account)
     , _ignoreCredentialFailure(false)
-    , _reply(0)
+    , _reply(nullptr)
     , _path(path)
 {
     // Since we hold a QSharedPointer to the account, this makes no sense. (issue #6893)
@@ -334,7 +334,7 @@ QString AbstractNetworkJob::errorStringParsingBody(QByteArray *body)
 
 AbstractNetworkJob::~AbstractNetworkJob()
 {
-    setReply(0);
+    setReply(nullptr);
 }
 
 void AbstractNetworkJob::start()

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -41,7 +41,7 @@ class OWNCLOUDSYNC_EXPORT AbstractNetworkJob : public QObject
     Q_OBJECT
 public:
     explicit AbstractNetworkJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    virtual ~AbstractNetworkJob();
+    ~AbstractNetworkJob() override;
 
     virtual void start();
 

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -40,7 +40,7 @@ class OWNCLOUDSYNC_EXPORT AbstractNetworkJob : public QObject
 {
     Q_OBJECT
 public:
-    explicit AbstractNetworkJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit AbstractNetworkJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     ~AbstractNetworkJob() override;
 
     virtual void start();
@@ -89,7 +89,7 @@ public:
      *
      * Warning: Needs to call reply()->readAll().
      */
-    QString errorStringParsingBody(QByteArray *body = 0);
+    QString errorStringParsingBody(QByteArray *body = nullptr);
 
     /** Make a new request */
     void retry();
@@ -130,14 +130,14 @@ protected:
      */
     QNetworkReply *sendRequest(const QByteArray &verb, const QUrl &url,
         QNetworkRequest req = QNetworkRequest(),
-        QIODevice *requestBody = 0);
+        QIODevice *requestBody = nullptr);
 
     // sendRequest does not take a relative path instead of an url,
     // but the old API allowed that. We have this undefined overload
     // to help catch usage errors
     QNetworkReply *sendRequest(const QByteArray &verb, const QString &relativePath,
         QNetworkRequest req = QNetworkRequest(),
-        QIODevice *requestBody = 0);
+        QIODevice *requestBody = nullptr);
 
     /** Makes this job drive a pre-made QNetworkReply
      *

--- a/src/libsync/accessmanager.h
+++ b/src/libsync/accessmanager.h
@@ -37,7 +37,7 @@ public:
     void setRawCookie(const QByteArray &rawCookie, const QUrl &url);
 
 protected:
-    QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = 0) Q_DECL_OVERRIDE;
+    QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = 0) override;
 };
 
 } // namespace OCC

--- a/src/libsync/accessmanager.h
+++ b/src/libsync/accessmanager.h
@@ -32,12 +32,12 @@ class OWNCLOUDSYNC_EXPORT AccessManager : public QNetworkAccessManager
     Q_OBJECT
 
 public:
-    AccessManager(QObject *parent = 0);
+    AccessManager(QObject *parent = nullptr);
 
     void setRawCookie(const QByteArray &rawCookie, const QUrl &url);
 
 protected:
-    QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = 0) override;
+    QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr) override;
 };
 
 } // namespace OCC

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -147,10 +147,10 @@ AbstractCredentials *Account::credentials() const
 void Account::setCredentials(AbstractCredentials *cred)
 {
     // set active credential manager
-    QNetworkCookieJar *jar = 0;
+    QNetworkCookieJar *jar = nullptr;
     if (_am) {
         jar = _am->cookieJar();
-        jar->setParent(0);
+        jar->setParent(nullptr);
 
         _am = QSharedPointer<QNetworkAccessManager>();
     }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -144,7 +144,7 @@ public:
     QNetworkReply *sendRawRequest(const QByteArray &verb,
         const QUrl &url,
         QNetworkRequest req = QNetworkRequest(),
-        QIODevice *data = 0);
+        QIODevice *data = nullptr);
 
     /** Create and start network job for a simple one-off request.
      *
@@ -153,7 +153,7 @@ public:
     SimpleNetworkJob *sendRequest(const QByteArray &verb,
         const QUrl &url,
         QNetworkRequest req = QNetworkRequest(),
-        QIODevice *data = 0);
+        QIODevice *data = nullptr);
 
     /** The ssl configuration during the first connection */
     QSslConfiguration getOrCreateSslConfig();
@@ -265,7 +265,7 @@ protected Q_SLOTS:
     void slotCredentialsAsked();
 
 private:
-    Account(QObject *parent = 0);
+    Account(QObject *parent = nullptr);
     void setSharedThis(AccountPtr sharedThis);
 
     QWeakPointer<Account> _sharedThis;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -78,7 +78,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
 
 public:
     static AccountPtr create();
-    ~Account();
+    ~Account() override;
 
     AccountPtr sharedFromThis();
 

--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -53,8 +53,8 @@ BandwidthManager::BandwidthManager(OwncloudPropagator *p)
     , _relativeLimitCurrentMeasuredJob(nullptr)
     , _currentDownloadLimit(0)
 {
-    _currentUploadLimit = _propagator->_uploadLimit.fetchAndAddAcquire(0);
-    _currentDownloadLimit = _propagator->_downloadLimit.fetchAndAddAcquire(0);
+    _currentUploadLimit = _propagator->_uploadLimit;
+    _currentDownloadLimit = _propagator->_downloadLimit;
 
     QObject::connect(&_switchingTimer, &QTimer::timeout, this, &BandwidthManager::switchingTimerExpired);
     _switchingTimer.setInterval(10 * 1000);
@@ -337,7 +337,7 @@ void BandwidthManager::relativeDownloadDelayTimerExpired()
 
 void BandwidthManager::switchingTimerExpired()
 {
-    qint64 newUploadLimit = _propagator->_uploadLimit.fetchAndAddAcquire(0);
+    qint64 newUploadLimit = _propagator->_uploadLimit;
     if (newUploadLimit != _currentUploadLimit) {
         qCInfo(lcBandwidthManager) << "Upload Bandwidth limit changed" << _currentUploadLimit << newUploadLimit;
         _currentUploadLimit = newUploadLimit;
@@ -354,7 +354,7 @@ void BandwidthManager::switchingTimerExpired()
             }
         }
     }
-    qint64 newDownloadLimit = _propagator->_downloadLimit.fetchAndAddAcquire(0);
+    qint64 newDownloadLimit = _propagator->_downloadLimit;
     if (newDownloadLimit != _currentDownloadLimit) {
         qCInfo(lcBandwidthManager) << "Download Bandwidth limit changed" << _currentDownloadLimit << newDownloadLimit;
         _currentDownloadLimit = newDownloadLimit;

--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -47,10 +47,10 @@ static qint64 relativeLimitMeasuringTimerIntervalMsec = 1000 * 2;
 BandwidthManager::BandwidthManager(OwncloudPropagator *p)
     : QObject()
     , _propagator(p)
-    , _relativeLimitCurrentMeasuredDevice(0)
+    , _relativeLimitCurrentMeasuredDevice(nullptr)
     , _relativeUploadLimitProgressAtMeasuringRestart(0)
     , _currentUploadLimit(0)
-    , _relativeLimitCurrentMeasuredJob(0)
+    , _relativeLimitCurrentMeasuredJob(nullptr)
     , _currentDownloadLimit(0)
 {
     _currentUploadLimit = _propagator->_uploadLimit.fetchAndAddAcquire(0);
@@ -115,7 +115,7 @@ void BandwidthManager::unregisterUploadDevice(QObject *o)
     _absoluteUploadDeviceList.removeAll(p);
     _relativeUploadDeviceList.removeAll(p);
     if (p == _relativeLimitCurrentMeasuredDevice) {
-        _relativeLimitCurrentMeasuredDevice = 0;
+        _relativeLimitCurrentMeasuredDevice = nullptr;
         _relativeUploadLimitProgressAtMeasuringRestart = 0;
     }
 }
@@ -142,7 +142,7 @@ void BandwidthManager::unregisterDownloadJob(QObject *o)
     GETJob *j = reinterpret_cast<GETJob *>(o); // note, we might already be in the ~QObject
     _downloadJobList.removeAll(j);
     if (_relativeLimitCurrentMeasuredJob == j) {
-        _relativeLimitCurrentMeasuredJob = 0;
+        _relativeLimitCurrentMeasuredJob = nullptr;
         _relativeDownloadLimitProgressAtMeasuringRestart = 0;
     }
 }
@@ -155,7 +155,7 @@ void BandwidthManager::relativeUploadMeasuringTimerExpired()
         _relativeUploadDelayTimer.start();
         return;
     }
-    if (_relativeLimitCurrentMeasuredDevice == 0) {
+    if (_relativeLimitCurrentMeasuredDevice == nullptr) {
         qCDebug(lcBandwidthManager) << "No device set, just waiting 1 sec";
         _relativeUploadDelayTimer.setInterval(1000);
         _relativeUploadDelayTimer.start();
@@ -201,7 +201,7 @@ void BandwidthManager::relativeUploadMeasuringTimerExpired()
         ud->giveBandwidthQuota(quotaPerDevice);
         qCDebug(lcBandwidthManager) << "Gave" << quotaPerDevice / 1024.0 << "kB to" << ud;
     }
-    _relativeLimitCurrentMeasuredDevice = 0;
+    _relativeLimitCurrentMeasuredDevice = nullptr;
 }
 
 void BandwidthManager::relativeUploadDelayTimerExpired()
@@ -249,7 +249,7 @@ void BandwidthManager::relativeDownloadMeasuringTimerExpired()
         _relativeDownloadDelayTimer.start();
         return;
     }
-    if (_relativeLimitCurrentMeasuredJob == 0) {
+    if (_relativeLimitCurrentMeasuredJob == nullptr) {
         qCDebug(lcBandwidthManager) << "No job set, just waiting 1 sec";
         _relativeDownloadDelayTimer.setInterval(1000);
         _relativeDownloadDelayTimer.start();
@@ -295,7 +295,7 @@ void BandwidthManager::relativeDownloadMeasuringTimerExpired()
         gfj->giveBandwidthQuota(quotaPerJob);
         qCDebug(lcBandwidthManager) << "Gave" << quotaPerJob / 1024.0 << "kB to" << gfj;
     }
-    _relativeLimitCurrentMeasuredDevice = 0;
+    _relativeLimitCurrentMeasuredDevice = nullptr;
 }
 
 void BandwidthManager::relativeDownloadDelayTimerExpired()

--- a/src/libsync/bandwidthmanager.h
+++ b/src/libsync/bandwidthmanager.h
@@ -35,7 +35,7 @@ class BandwidthManager : public QObject
     Q_OBJECT
 public:
     BandwidthManager(OwncloudPropagator *p);
-    ~BandwidthManager();
+    ~BandwidthManager() override;
 
     bool usingAbsoluteUploadLimit() { return _currentUploadLimit > 0; }
     bool usingRelativeUploadLimit() { return _currentUploadLimit < 0; }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -188,7 +188,7 @@ public:
 
     /**  Returns a new settings pre-set in a specific group.  The Settings will be created
          with the given parent. If no parent is specified, the caller must destroy the settings */
-    static std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = 0);
+    static std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = nullptr);
 
     /// Add the system and user exclude file path to the ExcludedFiles instance.
     static void setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles);

--- a/src/libsync/cookiejar.h
+++ b/src/libsync/cookiejar.h
@@ -29,7 +29,7 @@ class OWNCLOUDSYNC_EXPORT CookieJar : public QNetworkCookieJar
 {
     Q_OBJECT
 public:
-    explicit CookieJar(QObject *parent = 0);
+    explicit CookieJar(QObject *parent = nullptr);
     ~CookieJar() override;
     bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url) override;
     QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const override;

--- a/src/libsync/cookiejar.h
+++ b/src/libsync/cookiejar.h
@@ -30,9 +30,9 @@ class OWNCLOUDSYNC_EXPORT CookieJar : public QNetworkCookieJar
     Q_OBJECT
 public:
     explicit CookieJar(QObject *parent = 0);
-    ~CookieJar();
-    bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url) Q_DECL_OVERRIDE;
-    QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const Q_DECL_OVERRIDE;
+    ~CookieJar() override;
+    bool setCookiesFromUrl(const QList<QNetworkCookie> &cookieList, const QUrl &url) override;
+    QList<QNetworkCookie> cookiesForUrl(const QUrl &url) const override;
 
     void clearSessionCookies();
 

--- a/src/libsync/creds/abstractcredentials.cpp
+++ b/src/libsync/creds/abstractcredentials.cpp
@@ -24,7 +24,7 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcCredentials, "sync.credentials", QtInfoMsg)
 
 AbstractCredentials::AbstractCredentials()
-    : _account(0)
+    : _account(nullptr)
     , _wasFetched(false)
 {
 }

--- a/src/libsync/creds/dummycredentials.h
+++ b/src/libsync/creds/dummycredentials.h
@@ -26,16 +26,16 @@ class OWNCLOUDSYNC_EXPORT DummyCredentials : public AbstractCredentials
 public:
     QString _user;
     QString _password;
-    QString authType() const Q_DECL_OVERRIDE;
-    QString user() const Q_DECL_OVERRIDE;
-    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
-    bool ready() const Q_DECL_OVERRIDE;
-    bool stillValid(QNetworkReply *reply) Q_DECL_OVERRIDE;
-    void fetchFromKeychain() Q_DECL_OVERRIDE;
-    void askFromUser() Q_DECL_OVERRIDE;
-    void persist() Q_DECL_OVERRIDE;
-    void invalidateToken() Q_DECL_OVERRIDE {}
-    void forgetSensitiveData() Q_DECL_OVERRIDE{};
+    QString authType() const override;
+    QString user() const override;
+    QNetworkAccessManager *createQNAM() const override;
+    bool ready() const override;
+    bool stillValid(QNetworkReply *reply) override;
+    void fetchFromKeychain() override;
+    void askFromUser() override;
+    void persist() override;
+    void invalidateToken() override {}
+    void forgetSensitiveData() override{};
 };
 
 } // namespace OCC

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -61,7 +61,7 @@ public:
     }
 
 protected:
-    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request, QIODevice *outgoingData) Q_DECL_OVERRIDE
+    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request, QIODevice *outgoingData) override
     {
         QNetworkRequest req(request);
         if (!req.attribute(HttpCredentials::DontAddCredentialsAttribute).toBool()) {

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -54,7 +54,7 @@ namespace {
 class HttpCredentialsAccessManager : public AccessManager
 {
 public:
-    HttpCredentialsAccessManager(const HttpCredentials *cred, QObject *parent = 0)
+    HttpCredentialsAccessManager(const HttpCredentials *cred, QObject *parent = nullptr)
         : AccessManager(parent)
         , _cred(cred)
     {

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -83,17 +83,17 @@ public:
     explicit HttpCredentials(const QString &user, const QString &password,
             const QByteArray &clientCertBundle = QByteArray(), const QByteArray &clientCertPassword = QByteArray());
 
-    QString authType() const Q_DECL_OVERRIDE;
-    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
-    bool ready() const Q_DECL_OVERRIDE;
-    void fetchFromKeychain() Q_DECL_OVERRIDE;
-    bool stillValid(QNetworkReply *reply) Q_DECL_OVERRIDE;
-    void persist() Q_DECL_OVERRIDE;
-    QString user() const Q_DECL_OVERRIDE;
+    QString authType() const override;
+    QNetworkAccessManager *createQNAM() const override;
+    bool ready() const override;
+    void fetchFromKeychain() override;
+    bool stillValid(QNetworkReply *reply) override;
+    void persist() override;
+    QString user() const override;
     // the password or token
     QString password() const;
-    void invalidateToken() Q_DECL_OVERRIDE;
-    void forgetSensitiveData() Q_DECL_OVERRIDE;
+    void invalidateToken() override;
+    void forgetSensitiveData() override;
     QString fetchUser();
     virtual bool sslIsTrusted() { return false; }
 
@@ -103,7 +103,7 @@ public:
     bool refreshAccessToken();
 
     // To fetch the user name as early as possible
-    void setAccount(Account *account) Q_DECL_OVERRIDE;
+    void setAccount(Account *account) override;
 
     // Whether we are using OAuth
     bool isUsingOAuth() const { return !_refreshToken.isNull(); }

--- a/src/libsync/creds/oauth.h
+++ b/src/libsync/creds/oauth.h
@@ -57,7 +57,7 @@ public:
     Q_ENUM(Result);
 
     OAuth(Account *account, QObject *parent);
-    ~OAuth();
+    ~OAuth() override;
     void startAuthentication();
     void refreshAuthentication(const QString &refreshToken);
     void openBrowser();

--- a/src/libsync/creds/tokencredentials.h
+++ b/src/libsync/creds/tokencredentials.h
@@ -39,16 +39,16 @@ public:
     TokenCredentials();
     TokenCredentials(const QString &user, const QString &password, const QString &token);
 
-    QString authType() const Q_DECL_OVERRIDE;
-    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
-    bool ready() const Q_DECL_OVERRIDE;
-    void askFromUser() Q_DECL_OVERRIDE;
-    void fetchFromKeychain() Q_DECL_OVERRIDE;
-    bool stillValid(QNetworkReply *reply) Q_DECL_OVERRIDE;
-    void persist() Q_DECL_OVERRIDE;
-    QString user() const Q_DECL_OVERRIDE;
-    void invalidateToken() Q_DECL_OVERRIDE;
-    void forgetSensitiveData() Q_DECL_OVERRIDE;
+    QString authType() const override;
+    QNetworkAccessManager *createQNAM() const override;
+    bool ready() const override;
+    void askFromUser() override;
+    void fetchFromKeychain() override;
+    bool stillValid(QNetworkReply *reply) override;
+    void persist() override;
+    QString user() const override;
+    void invalidateToken() override;
+    void forgetSensitiveData() override;
 
     QString password() const;
 private Q_SLOTS:

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -89,7 +89,7 @@ class DiscoverySingleLocalDirectoryJob : public QObject, public QRunnable
 public:
     explicit DiscoverySingleLocalDirectoryJob(const AccountPtr &account, const QString &localPath, OCC::Vfs *vfs, QObject *parent = 0);
 
-    void run() Q_DECL_OVERRIDE;
+    void run() override;
 signals:
     void finished(QVector<LocalInfo> result);
     void finishedFatalError(QString errorString);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -87,7 +87,7 @@ class DiscoverySingleLocalDirectoryJob : public QObject, public QRunnable
 {
     Q_OBJECT
 public:
-    explicit DiscoverySingleLocalDirectoryJob(const AccountPtr &account, const QString &localPath, OCC::Vfs *vfs, QObject *parent = 0);
+    explicit DiscoverySingleLocalDirectoryJob(const AccountPtr &account, const QString &localPath, OCC::Vfs *vfs, QObject *parent = nullptr);
 
     void run() override;
 signals:
@@ -115,7 +115,7 @@ class DiscoverySingleDirectoryJob : public QObject
 {
     Q_OBJECT
 public:
-    explicit DiscoverySingleDirectoryJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
+    explicit DiscoverySingleDirectoryJob(const AccountPtr &account, const QString &path, QObject *parent = nullptr);
     // Specify that this is the root and we need to check the data-fingerprint
     void setIsRootPath() { _isRootPath = true; }
     void start();

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -18,7 +18,6 @@
 
 #include <QDir>
 #include <QStringList>
-#include <QThread>
 #include <QtGlobal>
 #include <qmetaobject.h>
 
@@ -103,7 +102,6 @@ void Logger::log(Log log)
         msg = log.timeStamp.toString(QLatin1String("MM-dd hh:mm:ss:zzz")) + QLatin1Char(' ');
     }
 
-    msg += QString().sprintf("%p ", (void *)QThread::currentThread());
     msg += log.message;
     // _logs.append(log);
     // std::cout << qPrintable(log.message) << std::endl;

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -152,7 +152,7 @@ void Logger::setLogFile(const QString &name)
 {
     QMutexLocker locker(&_mutex);
     if (_logstream) {
-        _logstream.reset(0);
+        _logstream.reset(nullptr);
         _logFile.close();
     }
 

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -94,7 +94,7 @@ public slots:
 
 private:
     Logger(QObject *parent = 0);
-    ~Logger();
+    ~Logger() override;
     QList<Log> _logs;
     bool _showTime;
     QFile _logFile;

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -93,7 +93,7 @@ public slots:
     void enterNextLogFile();
 
 private:
-    Logger(QObject *parent = 0);
+    Logger(QObject *parent = nullptr);
     ~Logger() override;
     QList<Log> _logs;
     bool _showTime;

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -46,7 +46,7 @@ class OWNCLOUDSYNC_EXPORT EntityExistsJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit EntityExistsJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit EntityExistsJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     void start() override;
 
 signals:
@@ -79,8 +79,8 @@ class OWNCLOUDSYNC_EXPORT LsColJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit LsColJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    explicit LsColJob(AccountPtr account, const QUrl &url, QObject *parent = 0);
+    explicit LsColJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
+    explicit LsColJob(AccountPtr account, const QUrl &url, QObject *parent = nullptr);
     void start() override;
     QHash<QString, qint64> _sizes;
 
@@ -123,7 +123,7 @@ class OWNCLOUDSYNC_EXPORT PropfindJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit PropfindJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit PropfindJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     void start() override;
 
     /**
@@ -139,7 +139,7 @@ public:
 
 signals:
     void result(const QVariantMap &values);
-    void finishedWithError(QNetworkReply *reply = 0);
+    void finishedWithError(QNetworkReply *reply = nullptr);
 
 private slots:
     bool finished() override;
@@ -164,7 +164,7 @@ public:
      * @param userId The user for which to obtain the avatar
      * @param size The size of the avatar (square so size*size)
      */
-    explicit AvatarJob(AccountPtr account, const QString &userId, int size, QObject *parent = 0);
+    explicit AvatarJob(AccountPtr account, const QString &userId, int size, QObject *parent = nullptr);
 
     void start() override;
 
@@ -199,7 +199,7 @@ class OWNCLOUDSYNC_EXPORT ProppatchJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit ProppatchJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit ProppatchJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     void start() override;
 
     /**
@@ -235,9 +235,9 @@ class OWNCLOUDSYNC_EXPORT MkColJob : public AbstractNetworkJob
     QMap<QByteArray, QByteArray> _extraHeaders;
 
 public:
-    explicit MkColJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit MkColJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     explicit MkColJob(AccountPtr account, const QUrl &url,
-        const QMap<QByteArray, QByteArray> &extraHeaders, QObject *parent = 0);
+        const QMap<QByteArray, QByteArray> &extraHeaders, QObject *parent = nullptr);
     void start() override;
 
 signals:
@@ -255,7 +255,7 @@ class OWNCLOUDSYNC_EXPORT CheckServerJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit CheckServerJob(AccountPtr account, QObject *parent = 0);
+    explicit CheckServerJob(AccountPtr account, QObject *parent = nullptr);
     void start() override;
 
     static QString version(const QJsonObject &info);
@@ -312,7 +312,7 @@ class OWNCLOUDSYNC_EXPORT RequestEtagJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit RequestEtagJob(AccountPtr account, const QString &path, QObject *parent = 0);
+    explicit RequestEtagJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
     void start() override;
 
 signals:
@@ -342,7 +342,7 @@ class OWNCLOUDSYNC_EXPORT JsonApiJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit JsonApiJob(const AccountPtr &account, const QString &path, QObject *parent = 0);
+    explicit JsonApiJob(const AccountPtr &account, const QString &path, QObject *parent = nullptr);
 
     /**
      * @brief addQueryParams - add more parameters to the ocs call
@@ -392,7 +392,7 @@ public:
     };
     Q_ENUM(AuthType)
 
-    explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = 0);
+    explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = nullptr);
     void start();
 signals:
     void authType(AuthType);
@@ -411,11 +411,11 @@ class OWNCLOUDSYNC_EXPORT SimpleNetworkJob : public AbstractNetworkJob
 {
     Q_OBJECT
 public:
-    explicit SimpleNetworkJob(AccountPtr account, QObject *parent = 0);
+    explicit SimpleNetworkJob(AccountPtr account, QObject *parent = nullptr);
 
     QNetworkReply *startRequest(const QByteArray &verb, const QUrl &url,
         QNetworkRequest req = QNetworkRequest(),
-        QIODevice *requestBody = 0);
+        QIODevice *requestBody = nullptr);
 
 signals:
     void finishedSignal(QNetworkReply *reply);

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -47,13 +47,13 @@ class OWNCLOUDSYNC_EXPORT EntityExistsJob : public AbstractNetworkJob
     Q_OBJECT
 public:
     explicit EntityExistsJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
 signals:
     void exists(QNetworkReply *);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 };
 
 /**
@@ -81,7 +81,7 @@ class OWNCLOUDSYNC_EXPORT LsColJob : public AbstractNetworkJob
 public:
     explicit LsColJob(AccountPtr account, const QString &path, QObject *parent = 0);
     explicit LsColJob(AccountPtr account, const QUrl &url, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
     QHash<QString, qint64> _sizes;
 
     /**
@@ -102,7 +102,7 @@ signals:
     void finishedWithoutError();
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QList<QByteArray> _properties;
@@ -124,7 +124,7 @@ class OWNCLOUDSYNC_EXPORT PropfindJob : public AbstractNetworkJob
     Q_OBJECT
 public:
     explicit PropfindJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     /**
      * Used to specify which properties shall be retrieved.
@@ -142,7 +142,7 @@ signals:
     void finishedWithError(QNetworkReply *reply = 0);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QList<QByteArray> _properties;
@@ -166,7 +166,7 @@ public:
      */
     explicit AvatarJob(AccountPtr account, const QString &userId, int size, QObject *parent = 0);
 
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     /** The retrieved avatar images don't have the circle shape by default */
     static QImage makeCircularAvatar(const QImage &baseAvatar);
@@ -179,7 +179,7 @@ signals:
     void avatarPixmap(const QImage &);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QUrl _avatarUrl;
@@ -200,7 +200,7 @@ class OWNCLOUDSYNC_EXPORT ProppatchJob : public AbstractNetworkJob
     Q_OBJECT
 public:
     explicit ProppatchJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     /**
      * Used to specify which properties shall be set.
@@ -218,7 +218,7 @@ signals:
     void finishedWithError();
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
 private:
     QMap<QByteArray, QByteArray> _properties;
@@ -238,13 +238,13 @@ public:
     explicit MkColJob(AccountPtr account, const QString &path, QObject *parent = 0);
     explicit MkColJob(AccountPtr account, const QUrl &url,
         const QMap<QByteArray, QByteArray> &extraHeaders, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
 signals:
     void finished(QNetworkReply::NetworkError);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 };
 
 /**
@@ -256,7 +256,7 @@ class OWNCLOUDSYNC_EXPORT CheckServerJob : public AbstractNetworkJob
     Q_OBJECT
 public:
     explicit CheckServerJob(AccountPtr account, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     static QString version(const QJsonObject &info);
     static QString versionString(const QJsonObject &info);
@@ -283,8 +283,8 @@ signals:
     void timeout(const QUrl &url);
 
 private:
-    bool finished() Q_DECL_OVERRIDE;
-    void onTimedOut() Q_DECL_OVERRIDE;
+    bool finished() override;
+    void onTimedOut() override;
 private slots:
     virtual void metaDataChangedSlot();
     virtual void encryptedSlot();
@@ -313,14 +313,14 @@ class OWNCLOUDSYNC_EXPORT RequestEtagJob : public AbstractNetworkJob
     Q_OBJECT
 public:
     explicit RequestEtagJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
 signals:
     void etagRetreived(const QString &etag);
     void finishedWithResult(const HttpResult<QString> &etag);
 
 private slots:
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 };
 
 /**
@@ -357,14 +357,14 @@ public:
     void addQueryParams(const QUrlQuery &params);
 
 public slots:
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
     /**
      * Start which allow to specify a request that might contains already headers or attributes
      */
     void startWithRequest(QNetworkRequest request);
 
 protected:
-    bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 signals:
 
     /**

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -81,8 +81,8 @@ OwncloudPropagator::~OwncloudPropagator()
 
 int OwncloudPropagator::maximumActiveTransferJob()
 {
-    if (_downloadLimit.fetchAndAddAcquire(0) != 0
-        || _uploadLimit.fetchAndAddAcquire(0) != 0
+    if (_downloadLimit != 0
+        || _uploadLimit != 0
         || !_syncOptions._parallelNetworkJobs) {
         // disable parallelism when there is a network limit.
         return 1;
@@ -239,8 +239,8 @@ void PropagateItemJob::done(SyncFileItem::Status statusArg, const QString &error
         }
     }
 
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0) && (_item->_status == SyncFileItem::NormalError
-                                                                   || _item->_status == SyncFileItem::FatalError)) {
+    if (propagator()->_abortRequested && (_item->_status == SyncFileItem::NormalError
+                                          || _item->_status == SyncFileItem::FatalError)) {
         // an abort request is ongoing. Change the status to Soft-Error
         _item->_status = SyncFileItem::SoftError;
     }

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -334,7 +334,7 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
             job->setDeleteExistingFolder(deleteExisting);
             return job;
         } else {
-            PropagateUploadFileCommon *job = 0;
+            PropagateUploadFileCommon *job = nullptr;
             if (item->_size > syncOptions()._initialChunkSize && account()->capabilities().chunkingNg()) {
                 // Item is above _initialChunkSize, thus will be classified as to be chunked
                 job = new PropagateUploadFileNG(this, item);
@@ -354,9 +354,9 @@ PropagateItemJob *OwncloudPropagator::createJob(const SyncFileItemPtr &item)
     case CSYNC_INSTRUCTION_ERROR:
         return new PropagateIgnoreJob(this, item);
     default:
-        return 0;
+        return nullptr;
     }
-    return 0;
+    return nullptr;
 }
 
 qint64 OwncloudPropagator::smallFileSize()

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -184,9 +184,9 @@ public:
         , _item(item)
     {
     }
-    ~PropagateItemJob();
+    ~PropagateItemJob() override;
 
-    bool scheduleSelfOrChild() Q_DECL_OVERRIDE
+    bool scheduleSelfOrChild() override
     {
         if (_state != NotYetStarted) {
             return false;
@@ -225,7 +225,7 @@ public:
     {
     }
 
-    virtual ~PropagatorCompositeJob()
+    ~PropagatorCompositeJob() override
     {
         // Don't delete jobs in _jobsToDo and _runningJobs: they have parents
         // that will be responsible for cleanup. Deleting them here would risk
@@ -238,15 +238,15 @@ public:
         _tasksToDo.append(item);
     }
 
-    virtual bool scheduleSelfOrChild() Q_DECL_OVERRIDE;
-    virtual JobParallelism parallelism() Q_DECL_OVERRIDE;
+    bool scheduleSelfOrChild() override;
+    JobParallelism parallelism() override;
 
     /*
      * Abort synchronously or asynchronously - some jobs
      * require to be finished without immediete abort (abort on job might
      * cause conflicts/duplicated files - owncloud/client/issues/5949)
      */
-    virtual void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE
+    void abort(PropagatorJob::AbortType abortType) override
     {
         if (!_runningJobs.empty()) {
             _abortsCount = _runningJobs.size();
@@ -262,7 +262,7 @@ public:
         }
     }
 
-    qint64 committedDiskSpace() const Q_DECL_OVERRIDE;
+    qint64 committedDiskSpace() const override;
 
 private slots:
     void slotSubJobAbortFinished();
@@ -304,9 +304,9 @@ public:
         _subJobs.appendTask(item);
     }
 
-    virtual bool scheduleSelfOrChild() Q_DECL_OVERRIDE;
-    virtual JobParallelism parallelism() Q_DECL_OVERRIDE;
-    virtual void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE
+    bool scheduleSelfOrChild() override;
+    JobParallelism parallelism() override;
+    void abort(PropagatorJob::AbortType abortType) override
     {
         if (_firstJob)
             // Force first job to abort synchronously
@@ -325,7 +325,7 @@ public:
     }
 
 
-    qint64 committedDiskSpace() const Q_DECL_OVERRIDE
+    qint64 committedDiskSpace() const override
     {
         return _subJobs.committedDiskSpace();
     }
@@ -375,7 +375,7 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
-    void start() Q_DECL_OVERRIDE
+    void start() override
     {
         SyncFileItem::Status status = _item->_status;
         if (status == SyncFileItem::NoStatus) {
@@ -415,7 +415,7 @@ public:
         qRegisterMetaType<PropagatorJob::AbortType>("PropagatorJob::AbortType");
     }
 
-    ~OwncloudPropagator();
+    ~OwncloudPropagator() override;
 
     void start(const SyncFileItemVector &_syncedItems);
 
@@ -625,7 +625,7 @@ public:
     {
     }
 
-    ~CleanupPollsJob();
+    ~CleanupPollsJob() override;
 
     /**
      * Start the job.  After the job is completed, it will emit either finished or aborted, and it

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -422,11 +422,11 @@ public:
     const SyncOptions &syncOptions() const;
     void setSyncOptions(const SyncOptions &syncOptions);
 
-    QAtomicInt _downloadLimit;
-    QAtomicInt _uploadLimit;
+    int _downloadLimit = 0;
+    int _uploadLimit = 0;
     BandwidthManager _bandwidthManager;
 
-    QAtomicInt _abortRequested; // boolean set by the main thread to abort.
+    bool _abortRequested = false;
 
     /** The list of currently active jobs.
         This list contains the jobs that are currently using ressources and is used purely to
@@ -495,8 +495,7 @@ public:
 
     void abort()
     {
-        bool alreadyAborting = _abortRequested.fetchAndStoreOrdered(true);
-        if (alreadyAborting)
+        if (_abortRequested)
             return;
         if (_rootJob) {
             // Connect to abortFinished  which signals that abort has been asynchronously finished

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -615,7 +615,7 @@ class CleanupPollsJob : public QObject
 
 public:
     explicit CleanupPollsJob(const QVector<SyncJournalDb::PollInfo> &pollInfos, AccountPtr account,
-        SyncJournalDb *journal, const QString &localPath, const QSharedPointer<Vfs> &vfs, QObject *parent = 0)
+        SyncJournalDb *journal, const QString &localPath, const QSharedPointer<Vfs> &vfs, QObject *parent = nullptr)
         : QObject(parent)
         , _pollInfos(pollInfos)
         , _account(account)

--- a/src/libsync/owncloudtheme.h
+++ b/src/libsync/owncloudtheme.h
@@ -29,11 +29,11 @@ class ownCloudTheme : public Theme
 public:
     ownCloudTheme();
 #ifndef TOKEN_AUTH_ONLY
-    QVariant customMedia(CustomMediaType type) Q_DECL_OVERRIDE;
+    QVariant customMedia(CustomMediaType type) override;
 
-    QColor wizardHeaderBackgroundColor() const Q_DECL_OVERRIDE;
-    QColor wizardHeaderTitleColor() const Q_DECL_OVERRIDE;
-    QPixmap wizardHeaderLogo() const Q_DECL_OVERRIDE;
+    QColor wizardHeaderBackgroundColor() const override;
+    QColor wizardHeaderTitleColor() const override;
+    QPixmap wizardHeaderLogo() const override;
 #endif
 
     // For owncloud-brandings *do* show the virtual files option.

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -20,7 +20,7 @@
 
 namespace OCC {
 
-ProgressDispatcher *ProgressDispatcher::_instance = 0;
+ProgressDispatcher *ProgressDispatcher::_instance = nullptr;
 
 QString Progress::asResultString(const SyncFileItem &item)
 {

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -296,7 +296,7 @@ class OWNCLOUDSYNC_EXPORT ProgressDispatcher : public QObject
     friend class Folder; // only allow Folder class to access the setting slots.
 public:
     static ProgressDispatcher *instance();
-    ~ProgressDispatcher();
+    ~ProgressDispatcher() override;
 
 signals:
     /**

--- a/src/libsync/progressdispatcher.h
+++ b/src/libsync/progressdispatcher.h
@@ -326,7 +326,7 @@ protected:
     void setProgressInfo(const QString &folder, const ProgressInfo &progress);
 
 private:
-    ProgressDispatcher(QObject *parent = 0);
+    ProgressDispatcher(QObject *parent = nullptr);
 
     QElapsedTimer _timer;
     static ProgressDispatcher *_instance;

--- a/src/libsync/propagatecommonzsync.cpp
+++ b/src/libsync/propagatecommonzsync.cpp
@@ -174,7 +174,7 @@ void ZsyncGenerateRunnable::run()
     zsynctf.close();
 
     /* Ensure that metadata file is not buffered, since we are using handles directly */
-    setvbuf(meta.get(), NULL, _IONBF, 0);
+    setvbuf(meta.get(), nullptr, _IONBF, 0);
 
     qCDebug(lcZsyncGenerate) << "Starting generation of:" << _file;
 
@@ -220,10 +220,10 @@ void ZsyncGenerateRunnable::run()
     if (zsyncfile_write(
             meta.get(), tf.get(),
             rsum_len, checksum_len,
-            0, 0, 0, // recompress
-            0, 0, // fname, mtime
-            0, 0, // urls
-            0, 0, // Uurls
+            0, nullptr, nullptr, // recompress
+            nullptr, 0, // fname, mtime
+            nullptr, 0, // urls
+            nullptr, 0, // Uurls
             state.get())
         != 0) {
         QString error = QString(tr("Failed to write zsync metadata file:")) + _file;

--- a/src/libsync/propagatecommonzsync.h
+++ b/src/libsync/propagatecommonzsync.h
@@ -74,7 +74,7 @@ public:
         , _tmpFilePath(tmpFilePath)
         , _type(type){};
 
-    void run();
+    void run() override;
 
 signals:
     void finishedSignal(void *zs);
@@ -97,7 +97,7 @@ public:
     explicit ZsyncGenerateRunnable(const QString &file)
         : _file(file){};
 
-    void run();
+    void run() override;
 
 signals:
     void finishedSignal(const QString &generatedFileName);

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -346,7 +346,7 @@ QString GETJob::errorString() const
 
 void PropagateDownloadFile::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     qCDebug(lcPropagateDownload) << _item->_file << propagator()->_activeJobList.count();
@@ -444,7 +444,7 @@ void PropagateDownloadFile::conflictChecksumComputed(const QByteArray &checksumT
 
 void PropagateDownloadFile::startDownload()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     // do a klaas' case clash check.

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -36,7 +36,7 @@ protected:
     QPointer<BandwidthManager> _bandwidthManager = nullptr;
 
 public:
-    GETJob(AccountPtr account, const QString &path, QObject *parent = 0)
+    GETJob(AccountPtr account, const QString &path, QObject *parent = nullptr)
         : AbstractNetworkJob(account, path, parent)
     {
     }
@@ -104,7 +104,7 @@ public:
     // DOES NOT take ownership of the device.
     GETFileZsyncJob(OwncloudPropagator *propagator, SyncFileItemPtr &item, const QString &path, QFile *device,
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-        const QByteArray &zsyncData, QObject *parent = 0);
+        const QByteArray &zsyncData, QObject *parent = nullptr);
 
     qint64 currentDownloadPosition() override;
 
@@ -152,11 +152,11 @@ public:
     // DOES NOT take ownership of the device.
     explicit GETFileJob(AccountPtr account, const QString &path, QIODevice *device,
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-        qint64 resumeStart, QObject *parent = 0);
+        qint64 resumeStart, QObject *parent = nullptr);
     // For directDownloadUrl:
     explicit GETFileJob(AccountPtr account, const QUrl &url, QIODevice *device,
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
-        qint64 resumeStart, QObject *parent = 0);
+        qint64 resumeStart, QObject *parent = nullptr);
 
     qint64 currentDownloadPosition() override;
 

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    ~GETJob()
+    ~GETJob() override
     {
         if (_bandwidthManager) {
             _bandwidthManager->unregisterDownloadJob(this);
@@ -62,7 +62,7 @@ public:
     void setChoked(bool c);
     void setBandwidthLimited(bool b);
     void giveBandwidthQuota(qint64 q);
-    void onTimedOut();
+    void onTimedOut() override;
 
 signals:
     void finishedSignal();
@@ -158,10 +158,10 @@ public:
         const QMap<QByteArray, QByteArray> &headers, const QByteArray &expectedEtagForResume,
         qint64 resumeStart, QObject *parent = 0);
 
-    qint64 currentDownloadPosition() Q_DECL_OVERRIDE;
+    qint64 currentDownloadPosition() override;
 
-    void start() Q_DECL_OVERRIDE;
-    bool finished() Q_DECL_OVERRIDE
+    void start() override;
+    bool finished() override
     {
         if (_saveBodyToFile && reply()->bytesAvailable()) {
             return false;
@@ -176,7 +176,7 @@ public:
 
     void newReplyHook(QNetworkReply *reply) override;
 
-    qint64 resumeStart() Q_DECL_OVERRIDE
+    qint64 resumeStart() override
     {
         return _resumeStart;
     }
@@ -257,11 +257,11 @@ public:
         , _deleteExisting(false)
     {
     }
-    void start() Q_DECL_OVERRIDE;
-    qint64 committedDiskSpace() const Q_DECL_OVERRIDE;
+    void start() override;
+    qint64 committedDiskSpace() const override;
 
     // We think it might finish quickly because it is a small file.
-    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < propagator()->smallFileSize(); }
+    bool isLikelyFinishedQuickly() override { return _item->_size < propagator()->smallFileSize(); }
 
     /**
      * Whether an existing folder with the same name may be deleted before
@@ -293,7 +293,7 @@ private slots:
     /// Called when it's time to update the db metadata
     void updateMetadata(bool isConflict);
 
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
+    void abort(PropagatorJob::AbortType abortType) override;
     void slotDownloadProgress(qint64, qint64);
     void slotChecksumFail(const QString &errMsg);
 

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -61,7 +61,7 @@ bool DeleteJob::finished()
 
 void PropagateRemoteDelete::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     qCDebug(lcPropagateRemoteDelete) << _item->_file;

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -27,8 +27,8 @@ class DeleteJob : public AbstractNetworkJob
     Q_OBJECT
     QUrl _url; // Only used if the constructor taking a url is taken.
 public:
-    explicit DeleteJob(AccountPtr account, const QString &path, QObject *parent = 0);
-    explicit DeleteJob(AccountPtr account, const QUrl &url, QObject *parent = 0);
+    explicit DeleteJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
+    explicit DeleteJob(AccountPtr account, const QUrl &url, QObject *parent = nullptr);
 
     void start() override;
     bool finished() override;

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -30,8 +30,8 @@ public:
     explicit DeleteJob(AccountPtr account, const QString &path, QObject *parent = 0);
     explicit DeleteJob(AccountPtr account, const QUrl &url, QObject *parent = 0);
 
-    void start() Q_DECL_OVERRIDE;
-    bool finished() Q_DECL_OVERRIDE;
+    void start() override;
+    bool finished() override;
 
 signals:
     void finishedSignal();
@@ -51,10 +51,10 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
-    void start() Q_DECL_OVERRIDE;
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
+    void start() override;
+    void abort(PropagatorJob::AbortType abortType) override;
 
-    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return !_item->isDirectory(); }
+    bool isLikelyFinishedQuickly() override { return !_item->isDirectory(); }
 
 private slots:
     void slotDeleteJobFinished();

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -28,7 +28,7 @@ Q_LOGGING_CATEGORY(lcPropagateRemoteMkdir, "sync.propagator.remotemkdir", QtInfo
 
 void PropagateRemoteMkdir::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     qCDebug(lcPropagateRemoteMkdir) << _item->_file;
@@ -48,7 +48,7 @@ void PropagateRemoteMkdir::start()
 
 void PropagateRemoteMkdir::slotStartMkcolJob()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     qCDebug(lcPropagateRemoteMkdir) << _item->_file;

--- a/src/libsync/propagateremotemkdir.h
+++ b/src/libsync/propagateremotemkdir.h
@@ -34,11 +34,11 @@ public:
         , _deleteExisting(false)
     {
     }
-    void start() Q_DECL_OVERRIDE;
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
+    void start() override;
+    void abort(PropagatorJob::AbortType abortType) override;
 
     // Creating a directory should be fast.
-    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return true; }
+    bool isLikelyFinishedQuickly() override { return true; }
 
     /**
      * Whether an existing entity with the same name may be deleted before

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -75,7 +75,7 @@ bool MoveJob::finished()
 
 void PropagateRemoteMove::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     QString origin = propagator()->adjustRenamedPath(_item->_file);

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -30,9 +30,9 @@ class MoveJob : public AbstractNetworkJob
     QMap<QByteArray, QByteArray> _extraHeaders;
 
 public:
-    explicit MoveJob(AccountPtr account, const QString &path, const QString &destination, QObject *parent = 0);
+    explicit MoveJob(AccountPtr account, const QString &path, const QString &destination, QObject *parent = nullptr);
     explicit MoveJob(AccountPtr account, const QUrl &url, const QString &destination,
-        QMap<QByteArray, QByteArray> _extraHeaders, QObject *parent = 0);
+        QMap<QByteArray, QByteArray> _extraHeaders, QObject *parent = nullptr);
 
     void start() override;
     bool finished() override;

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -34,8 +34,8 @@ public:
     explicit MoveJob(AccountPtr account, const QUrl &url, const QString &destination,
         QMap<QByteArray, QByteArray> _extraHeaders, QObject *parent = 0);
 
-    void start() Q_DECL_OVERRIDE;
-    bool finished() Q_DECL_OVERRIDE;
+    void start() override;
+    bool finished() override;
 
 signals:
     void finishedSignal();
@@ -55,9 +55,9 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
-    void start() Q_DECL_OVERRIDE;
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
-    JobParallelism parallelism() Q_DECL_OVERRIDE { return _item->isDirectory() ? WaitForFinished : FullParallelism; }
+    void start() override;
+    void abort(PropagatorJob::AbortType abortType) override;
+    JobParallelism parallelism() override { return _item->isDirectory() ? WaitForFinished : FullParallelism; }
 
     /**
      * Rename the directory in the selective sync list

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -187,7 +187,7 @@ void PropagateUploadFileCommon::setDeleteExisting(bool enabled)
 
 void PropagateUploadFileCommon::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0)) {
+    if (propagator()->_abortRequested) {
         return;
     }
 
@@ -225,7 +225,7 @@ void PropagateUploadFileCommon::start()
 
 void PropagateUploadFileCommon::slotComputeContentChecksum()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0)) {
+    if (propagator()->_abortRequested) {
         return;
     }
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -63,7 +63,7 @@ static bool fileIsStillChanging(const SyncFileItem &item)
 PUTFileJob::~PUTFileJob()
 {
     // Make sure that we destroy the QNetworkReply before our _device of which it keeps an internal pointer.
-    setReply(0);
+    setReply(nullptr);
 }
 
 void PUTFileJob::start()

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -37,18 +37,18 @@ class UploadDevice : public QIODevice
     Q_OBJECT
 public:
     UploadDevice(const QString &fileName, qint64 start, qint64 size, BandwidthManager *bwm);
-    ~UploadDevice();
+    ~UploadDevice() override;
 
     bool open(QIODevice::OpenMode mode) override;
     void close() override;
 
-    qint64 writeData(const char *, qint64) Q_DECL_OVERRIDE;
-    qint64 readData(char *data, qint64 maxlen) Q_DECL_OVERRIDE;
-    bool atEnd() const Q_DECL_OVERRIDE;
-    qint64 size() const Q_DECL_OVERRIDE;
-    qint64 bytesAvailable() const Q_DECL_OVERRIDE;
-    bool isSequential() const Q_DECL_OVERRIDE;
-    bool seek(qint64 pos) Q_DECL_OVERRIDE;
+    qint64 writeData(const char *, qint64) override;
+    qint64 readData(char *data, qint64 maxlen) override;
+    bool atEnd() const override;
+    qint64 size() const override;
+    qint64 bytesAvailable() const override;
+    bool isSequential() const override;
+    bool seek(qint64 pos) override;
 
     void setBandwidthLimited(bool);
     bool isBandwidthLimited() { return _bandwidthLimited; }
@@ -115,13 +115,13 @@ public:
     {
         _device->setParent(this);
     }
-    ~PUTFileJob();
+    ~PUTFileJob() override;
 
     int _chunk;
 
-    virtual void start() Q_DECL_OVERRIDE;
+    void start() override;
 
-    virtual bool finished() Q_DECL_OVERRIDE;
+    bool finished() override;
 
     QIODevice *device()
     {
@@ -169,8 +169,8 @@ public:
     {
     }
 
-    void start() Q_DECL_OVERRIDE;
-    bool finished() Q_DECL_OVERRIDE;
+    void start() override;
+    bool finished() override;
 
 signals:
     void finishedSignal();
@@ -231,9 +231,9 @@ public:
      */
     void setDeleteExisting(bool enabled);
 
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
-    bool isLikelyFinishedQuickly() Q_DECL_OVERRIDE { return _item->_size < propagator()->smallFileSize(); }
+    bool isLikelyFinishedQuickly() override { return _item->_size < propagator()->smallFileSize(); }
 
 private slots:
     void slotComputeContentChecksum();
@@ -331,9 +331,9 @@ public:
     {
     }
 
-    void doStartUpload() Q_DECL_OVERRIDE;
+    void doStartUpload() override;
 public slots:
-    void abort(PropagatorJob::AbortType abortType) Q_DECL_OVERRIDE;
+    void abort(PropagatorJob::AbortType abortType) override;
 private slots:
     void startNextChunk();
     void slotPutFinished();
@@ -414,7 +414,7 @@ public:
     {
     }
 
-    void doStartUpload() Q_DECL_OVERRIDE;
+    void doStartUpload() override;
 
 private:
     void doStartUploadNext();
@@ -422,7 +422,7 @@ private:
     void startNextChunk();
     void doFinalMove();
 public slots:
-    void abort(AbortType abortType) Q_DECL_OVERRIDE;
+    void abort(AbortType abortType) override;
 private slots:
     void slotPropfindFinished();
     void slotPropfindFinishedWithError();

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -97,7 +97,7 @@ private:
 
 public:
     explicit PUTFileJob(AccountPtr account, const QString &path, std::unique_ptr<QIODevice> device,
-        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject *parent = 0)
+        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject *parent = nullptr)
         : AbstractNetworkJob(account, path, parent)
         , _device(device.release())
         , _headers(headers)
@@ -106,7 +106,7 @@ public:
         _device->setParent(this);
     }
     explicit PUTFileJob(AccountPtr account, const QUrl &url, std::unique_ptr<QIODevice> device,
-        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject *parent = 0)
+        const QMap<QByteArray, QByteArray> &headers, int chunk, QObject *parent = nullptr)
         : AbstractNetworkJob(account, QString(), parent)
         , _device(device.release())
         , _headers(headers)

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -528,7 +528,7 @@ void PropagateUploadFileNG::doFinalMove()
 
 void PropagateUploadFileNG::startNextChunk()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     ENFORCE(_bytesToUpload >= _sent, "Sent data exceeds file size");

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -73,7 +73,7 @@ void PropagateUploadFileV1::doStartUpload()
 
 void PropagateUploadFileV1::startNextChunk()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     if (!_jobs.isEmpty() && _currentChunk + _startChunk >= _chunkCount - 1) {

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -90,7 +90,7 @@ void PropagateLocalRemove::start()
 {
     _moveToTrash = propagator()->syncOptions()._moveFilesToTrash;
 
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     QString filename = propagator()->_localDir + _item->_file;
@@ -130,7 +130,7 @@ void PropagateLocalRemove::start()
 
 void PropagateLocalMkdir::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     QDir newDir(propagator()->getFilePath(_item->_file));
@@ -195,7 +195,7 @@ void PropagateLocalMkdir::setDeleteExistingFile(bool enabled)
 
 void PropagateLocalRename::start()
 {
-    if (propagator()->_abortRequested.fetchAndAddRelaxed(0))
+    if (propagator()->_abortRequested)
         return;
 
     QString existingFile = propagator()->getFilePath(propagator()->adjustRenamedPath(_item->_file));

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -39,7 +39,7 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
 private:
     bool removeRecursively(const QString &path);
@@ -60,7 +60,7 @@ public:
         , _deleteExistingFile(false)
     {
     }
-    void start() Q_DECL_OVERRIDE;
+    void start() override;
 
     /**
      * Whether an existing file with the same name may be deleted before
@@ -86,7 +86,7 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
-    void start() Q_DECL_OVERRIDE;
-    JobParallelism parallelism() Q_DECL_OVERRIDE { return _item->isDirectory() ? WaitForFinished : FullParallelism; }
+    void start() override;
+    JobParallelism parallelism() override { return _item->isDirectory() ? WaitForFinished : FullParallelism; }
 };
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1004,7 +1004,7 @@ void SyncEngine::abort()
     } else if (_discoveryPhase) {
         // Delete the discovery and all child jobs after ensuring
         // it can't finish and start the propagator
-        disconnect(_discoveryPhase.data(), 0, this, 0);
+        disconnect(_discoveryPhase.data(), nullptr, this, nullptr);
         _discoveryPhase.take()->deleteLater();
 
         syncError(tr("Aborted"));

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -754,11 +754,8 @@ void SyncEngine::setNetworkLimits(int upload, int download)
     _propagator->_uploadLimit = upload;
     _propagator->_downloadLimit = download;
 
-    int propDownloadLimit = _propagator->_downloadLimit.load();
-    int propUploadLimit = _propagator->_uploadLimit.load();
-
-    if (propDownloadLimit != 0 || propUploadLimit != 0) {
-        qCInfo(lcEngine) << "Network Limits (down/up) " << propDownloadLimit << propUploadLimit;
+    if (upload != 0 || download != 0) {
+        qCInfo(lcEngine) << "Network Limits (down/up) " << upload << download;
     }
 }
 

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -59,7 +59,7 @@ class OWNCLOUDSYNC_EXPORT SyncEngine : public QObject
 public:
     SyncEngine(AccountPtr account, const QString &localPath,
         const QString &remotePath, SyncJournalDb *journal);
-    ~SyncEngine();
+    ~SyncEngine() override;
 
     Q_INVOKABLE void startSync();
     void setNetworkLimits(int upload, int download);

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -39,7 +39,7 @@
 
 namespace OCC {
 
-Theme *Theme::_instance = 0;
+Theme *Theme::_instance = nullptr;
 
 Theme *Theme::instance()
 {
@@ -201,7 +201,7 @@ QString Theme::hidpiFileName(const QString &fileName, QPaintDevice *dev)
 #endif
 
 Theme::Theme()
-    : QObject(0)
+    : QObject(nullptr)
     , _mono(false)
 {
 }

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -87,7 +87,7 @@ public:
     virtual QString configFileName() const;
 
 #ifndef TOKEN_AUTH_ONLY
-    static QString hidpiFileName(const QString &fileName, QPaintDevice *dev = 0);
+    static QString hidpiFileName(const QString &fileName, QPaintDevice *dev = nullptr);
 
     /**
       * get an sync state icon

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -47,7 +47,7 @@ public:
     /* returns a singleton instance. */
     static Theme *instance();
 
-    ~Theme();
+    ~Theme() override;
 
     /**
      * @brief appNameGUI - Human readable application name.

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -27,7 +27,7 @@ class VfsSuffix : public Vfs
 
 public:
     explicit VfsSuffix(QObject *parent = nullptr);
-    ~VfsSuffix();
+    ~VfsSuffix() override;
 
     Mode mode() const override;
     QString fileSuffix() const override;

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -270,7 +270,7 @@ public:
             }
             return file;
         }
-        return 0;
+        return nullptr;
     }
 
     FileInfo *createDir(const QString &relativePath) {
@@ -1113,7 +1113,7 @@ public:
 
 protected:
     QNetworkReply *createRequest(Operation op, const QNetworkRequest &request,
-                                         QIODevice *outgoingData = 0) override {
+                                         QIODevice *outgoingData = nullptr) override {
         if (_override) {
             if (auto reply = _override(op, request, outgoingData))
                 return reply;
@@ -1214,7 +1214,7 @@ public:
         auto opts = _syncEngine->syncOptions();
 
         opts._vfs->stop();
-        QObject::disconnect(_syncEngine.get(), 0, opts._vfs.data(), 0);
+        QObject::disconnect(_syncEngine.get(), nullptr, opts._vfs.data(), nullptr);
 
         opts._vfs = vfs;
         _syncEngine->setSyncOptions(opts);

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -1113,7 +1113,7 @@ public:
 
 protected:
     QNetworkReply *createRequest(Operation op, const QNetworkRequest &request,
-                                         QIODevice *outgoingData = 0) {
+                                         QIODevice *outgoingData = 0) override {
         if (_override) {
             if (auto reply = _override(op, request, outgoingData))
                 return reply;
@@ -1154,16 +1154,16 @@ class FakeCredentials : public OCC::AbstractCredentials
     QNetworkAccessManager *_qnam;
 public:
     FakeCredentials(QNetworkAccessManager *qnam) : _qnam{qnam} { }
-    virtual QString authType() const { return "test"; }
-    virtual QString user() const { return "admin"; }
-    virtual QNetworkAccessManager *createQNAM() const { return _qnam; }
-    virtual bool ready() const { return true; }
-    virtual void fetchFromKeychain() { }
-    virtual void askFromUser() { }
-    virtual bool stillValid(QNetworkReply *) { return true; }
-    virtual void persist() { }
-    virtual void invalidateToken() { }
-    virtual void forgetSensitiveData() { }
+    QString authType() const override { return "test"; }
+    QString user() const override { return "admin"; }
+    QNetworkAccessManager *createQNAM() const override { return _qnam; }
+    bool ready() const override { return true; }
+    void fetchFromKeychain() override { }
+    void askFromUser() override { }
+    bool stillValid(QNetworkReply *) override { return true; }
+    void persist() override { }
+    void invalidateToken() override { }
+    void forgetSensitiveData() override { }
 };
 
 class FakeFolder

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -24,7 +24,7 @@ public:
         : HttpCredentials(user, password)
     {}
 
-    void askFromUser() Q_DECL_OVERRIDE {
+    void askFromUser() override {
 
     }
 };

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -292,7 +292,7 @@ private slots:
     {
         // Test that we can send random garbage to the litening socket and it does not prevent the connection
         struct Test : OAuthTestCase {
-            virtual QNetworkReply *createBrowserReply(const QNetworkRequest &request) override {
+            QNetworkReply *createBrowserReply(const QNetworkRequest &request) override {
                 QTimer::singleShot(0, this, [this, request] {
                     auto port = request.url().port();
                     state = CustomState;


### PR DESCRIPTION
Run clang-tidy over the code since we know get warning when there are missing override

Also fix a couple of deprecated warning as more function has been marked as deprecated in Qt 5.14

See individual commit.