### PR TITLE
OAuth: the well-known url is always at the host root

### DIFF
--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -326,7 +326,8 @@ void OAuth::fetchWellKnown()
     }
     else
     {
-        QUrl wellKnownUrl = Utility::concatUrlPath(_account->url(), QStringLiteral("/.well-known/openid-configuration"));
+        QUrl wellKnownUrl = _account->url();
+        wellKnownUrl.setPath(QStringLiteral("/.well-known/openid-configuration"));
         QNetworkRequest req;
         auto job = _account->sendRequest("GET", wellKnownUrl);
         job->setTimeout(qMin(30 * 1000ll, job->timeoutMsec()));

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -133,7 +133,7 @@ public:
         account->setCredentials(new FakeCredentials{fakeQnam});
         fakeQnam->setParent(this);
         fakeQnam->setOverride([this](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *device)  {
-            if (req.url().path().endsWith(".well-known/openid-configuration"))
+            if (req.url().path() == "/.well-known/openid-configuration")
                 return this->wellKnownReply(op, req);
             ASSERT(device);
             ASSERT(device->bytesAvailable()>0); // OAuth2 always sends around POST data.


### PR DESCRIPTION
So this means that even id the owncloud URL is
https://some.server/something/something,
the well-known url should be
https://some.server/.well-known/openid-configuration and not
https://some.server/somethins/somethins/.well-known/openid-configuration