### PR TITLE
Branded no experimental

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -102,6 +102,8 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         _ui->updateChannelLabel->hide();
         _ui->updateChannel->hide();
 #endif
+	// branded clients are never experimental
+        _ui->experimentalGroupBox->hide();
     }
 
     _ui->versionLabel->setText(QStringLiteral("<a href='%1'>%1</a>").arg(MIRALL_VERSION_STRING));


### PR DESCRIPTION
hard coded theme names ownCloud and testpilotcloud
are already used to show crashreporter options. We could do the same for experimental options.