### PR TITLE
OAuth: make sure to encode the '+' in query string

### DIFF
--- a/changelog/unreleased/7762
+++ b/changelog/unreleased/7762
@@ -1,0 +1,7 @@
+Bugfix: Fixed OAuth2 login of user with `+`
+
+Make sure that the `+` in the user name is properly encoded in the URL
+opened by the browser when doing an OAuth2 authentication.
+
+https://github.com/owncloud/client/issues/7762
+

--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -171,6 +171,7 @@ QUrl OAuth::authorisationLink() const
     if (!_expectedUser.isNull())
         query.addQueryItem("user", _expectedUser);
     QUrl url = Utility::concatUrlPath(_account->url(), QLatin1String("/index.php/apps/oauth2/authorize"), query);
+    url.setQuery(url.query(QUrl::FullyEncoded).replace('+', QLatin1String("%2B"))); // Issue #7762
     return url;
 }
 


### PR DESCRIPTION
The server understands '+' as a space.

Issue #7762