### PR TITLE
Don't insert items into the folder model if selectiveSync is not supp…

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -619,6 +619,9 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     if (!parentInfo) {
         return;
     }
+    if (!parentInfo->_folder->supportsSelectiveSync()) {
+        return;
+    }
     ASSERT(parentInfo->_fetchingJob == job);
     ASSERT(parentInfo->_subs.isEmpty());
 


### PR DESCRIPTION
…orted

This fixes an assertion in FolderStatusModel::SubFolderInfo::resetSubs
rowCount reported 0 but we actually had items in the model

I don't know whether we had related crashes.