### PR TITLE
Tests: Fail on error

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_definitions(-DQT_FORCE_ASSERTS)
 find_package(SQLite3 3.8.0 REQUIRED)
 include_directories(${CMAKE_SOURCE_DIR}/src
                     ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer

--- a/test/testsyncvirtualfiles.cpp
+++ b/test/testsyncvirtualfiles.cpp
@@ -55,6 +55,7 @@ void markForDehydration(FakeFolder &folder, const QByteArray &path)
 QSharedPointer<Vfs> setupVfs(FakeFolder &folder)
 {
     auto suffixVfs = QSharedPointer<Vfs>(createVfsFromPlugin(Vfs::WithSuffix).release());
+    Q_ASSERT(suffixVfs);
     folder.switchToVfs(suffixVfs);
 
     // Using this directly doesn't recursively unpin everything and instead leaves


### PR DESCRIPTION
QVERIFY has no effect besides a return outside of the test function itself.

> Note: This macro can only be used in a test function that is invoked by the test framework.

https://doc.qt.io/qt-5/qtest.html#QVERIFY

Therefore use Q_ASSERT in the testing stubs.