### PR TITLE
Cookies: Don't override cookies with outdated values

### DIFF
--- a/changelog/unreleased/7831
+++ b/changelog/unreleased/7831
@@ -1,0 +1,6 @@
+Bugfix: Don't override cookies with old values
+
+We fixed a bug where a client somteimes overrode the content of the cookie jar
+with outdated or corrupted values
+
+https://github.com/owncloud/client/pull/7831

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -49,18 +49,6 @@ AccessManager::AccessManager(QObject *parent)
     setCookieJar(new CookieJar);
 }
 
-void AccessManager::setRawCookie(const QByteArray &rawCookie, const QUrl &url)
-{
-    QNetworkCookie cookie(rawCookie.left(rawCookie.indexOf('=')),
-        rawCookie.mid(rawCookie.indexOf('=') + 1));
-    qCDebug(lcAccessManager) << cookie.name() << cookie.value();
-    QList<QNetworkCookie> cookieList;
-    cookieList.append(cookie);
-
-    QNetworkCookieJar *jar = cookieJar();
-    jar->setCookiesFromUrl(cookieList, url);
-}
-
 static QByteArray generateRequestId()
 {
     // Use a UUID with the starting and ending curly brace removed.
@@ -71,12 +59,6 @@ static QByteArray generateRequestId()
 QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData)
 {
     QNetworkRequest newRequest(request);
-
-    if (newRequest.hasRawHeader("cookie")) {
-        // This will set the cookie into the QNetworkCookieJar which will then override the cookie header
-        setRawCookie(request.rawHeader("cookie"), request.url());
-    }
-
     newRequest.setRawHeader(QByteArray("User-Agent"), Utility::userAgentString());
 
     // Some firewalls reject requests that have a "User-Agent" but no "Accept" header

--- a/src/libsync/accessmanager.h
+++ b/src/libsync/accessmanager.h
@@ -34,8 +34,6 @@ class OWNCLOUDSYNC_EXPORT AccessManager : public QNetworkAccessManager
 public:
     AccessManager(QObject *parent = 0);
 
-    void setRawCookie(const QByteArray &rawCookie, const QUrl &url);
-
 protected:
     QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = 0) Q_DECL_OVERRIDE;
 };

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -874,8 +874,6 @@ void DetermineAuthTypeJob::start()
     req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
     // Don't reuse previous auth credentials
     req.setAttribute(QNetworkRequest::AuthenticationReuseAttribute, QNetworkRequest::Manual);
-    // Don't send cookies, we can't determine the auth type if we're logged in
-    req.setAttribute(QNetworkRequest::CookieLoadControlAttribute, QNetworkRequest::Manual);
 
     auto propfind = _account->sendRequest("PROPFIND", _account->davUrl(), req);
     propfind->setTimeout(30 * 1000);


### PR DESCRIPTION
This code was actually not breaking most cookie handling by accident.
As the raw cookies where not split properly we added cookies with values like
"key: val; key2 = val2; key3 = val3"
When the code was corrected we overwrote the newer values in the jar with
the old ones from a request.