### PR TITLE
Plugins: Add a relative plugin search path on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,16 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
 if(UNIT_TESTING)
     message(DEPRECATION "Setting UNIT_TESTING is deprecated please use BUILD_TESTING")
     set(BUILD_TESTING TRUE)
 endif()
 include(CTest)
 
+
+include(OCConfigPluginDir)
 include("${CMAKE_CURRENT_LIST_DIR}/THEME.cmake")
 
 set(synclib_NAME "${APPLICATION_EXECUTABLE}sync")

--- a/cmake/modules/OCConfigPluginDir.cmake
+++ b/cmake/modules/OCConfigPluginDir.cmake
@@ -1,0 +1,35 @@
+function(IS_SUBDIR ROOT CHILD OUT)
+    file(RELATIVE_PATH REL_PATH "${ROOT}" "${CHILD}")
+    string(REGEX MATCH "^\.\./" NOT_SUBDIR "${REL_PATH}")
+    if (NOT_SUBDIR)
+        set(${OUT} FALSE PARENT_SCOPE)
+    else()
+        set(${OUT} TRUE PARENT_SCOPE)
+    endif()
+endfunction()
+
+
+if (UNIX AND NOT APPLE)
+    set(OC_PLUGIN_DIR ${KDE_INSTALL_FULL_PLUGINDIR})
+    IS_SUBDIR("${CMAKE_INSTALL_PREFIX}" "${OC_PLUGIN_DIR}" _is_subdir)
+    if (NOT _is_subdir)
+        if (KDE_INSTALL_USE_QT_SYS_PATHS)
+            message(FATAL_ERROR "Using KDE_INSTALL_USE_QT_SYS_PATHS with a non bundled Qt is not supported.")
+        else()
+            message(FATAL_ERROR "KDE_INSTALL_PLUGINDIR must be located in CMAKE_INSTALL_PREFIX")
+        endif()
+    endif()
+
+    include(ECMQueryQmake)
+    query_qmake(_qt_plugin_dir QT_INSTALL_PLUGINS TRY)
+    # any sub dir of _qt_plugin_dir is sufficient
+    IS_SUBDIR("${_qt_plugin_dir}" "${OC_PLUGIN_DIR}" _is_subdir)
+    if (_is_subdir)
+        # no need to add a additional plugin dir
+        unset(OC_PLUGIN_DIR)
+    else()
+        # set plugin dir to a path relative to the binary
+        file(RELATIVE_PATH OC_PLUGIN_DIR "${CMAKE_INSTALL_FULL_BINDIR}" "${OC_PLUGIN_DIR}")
+        message(STATUS "Adding additional plugin path: ${OC_PLUGIN_DIR}")
+    endif()
+endif()

--- a/config.h.in
+++ b/config.h.in
@@ -27,6 +27,7 @@
 
 #cmakedefine SYSCONFDIR "@SYSCONFDIR@"
 #cmakedefine SHAREDIR "@SHAREDIR@"
+#cmakedefine OC_PLUGIN_DIR "@OC_PLUGIN_DIR@"
 
 #cmakedefine01 GUI_TESTING
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -263,6 +263,12 @@ Application::Application(int &argc, char **argv)
     if (!AbstractNetworkJob::httpTimeout)
         AbstractNetworkJob::httpTimeout = cfg.timeout();
 
+#if defined(OC_PLUGIN_DIR) && defined(Q_OS_LINUX)
+    const QString extraPluginDir = QDir(QApplication::applicationDirPath()).filePath(QStringLiteral(OC_PLUGIN_DIR));
+    qCInfo(lcApplication) << "Adding extra plugin search path:" << extraPluginDir;
+    this->addLibraryPath(extraPluginDir);
+#endif
+
     // Check vfs plugins
     if (Theme::instance()->showVirtualFilesOption() && bestAvailableVfsMode() == Vfs::Off) {
         qCWarning(lcApplication) << "Theme wants to show vfs mode, but no vfs plugins are available";


### PR DESCRIPTION
This fixes installations where the client is not installed in the same prefix as Qt

The idea is to only conditionally add the plugin search path and only if its inside our installation.
On Windows and mac we create distributables that contain everything in the right place.
On Linux not...

Fixes: #7801