### PR TITLE
Raise the Wizard

### DIFF
--- a/changelog/unreleased/7856
+++ b/changelog/unreleased/7856
@@ -1,0 +1,5 @@
+Change: Wizard is hidden behind the browser
+
+We now raise the wizard after a successful authentication
+
+https://github.com/owncloud/client/issues/7856

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -32,6 +32,7 @@
 #include <QtCore>
 #include <QtGui>
 #include <QMessageBox>
+#include <owncloudgui.h>
 
 #include <stdlib.h>
 
@@ -158,6 +159,7 @@ void OwncloudWizard::successfulStep()
         break;
     }
 
+    ownCloudGui::raiseDialog(this);
     next();
 }
 


### PR DESCRIPTION
The OAuth authentication brings the broweser to the front, once thats done the wizard continues.
But the wizard ist now most probably hidden behind the browser