### PR TITLE
Revert "Gui: Workaround for QScrollArea not getting updated on theme …

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -73,8 +73,6 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     // Create a widget container for the notifications. The ui file defines
     // a scroll area that get a widget with a layout as children
     QWidget *w = new QWidget;
-    // workaround for Qt not updating the background on theme changes
-    w->setAttribute(Qt::WA_OpaquePaintEvent, true);
     _notificationsLayout = new QVBoxLayout;
     w->setLayout(_notificationsLayout);
     _notificationsLayout->setAlignment(Qt::AlignTop);


### PR DESCRIPTION
…change"

While the change seemed to fix a issue with heme switching on mac, it broke
Windows 100% of the time....

This reverts commit 996bedc3aedc0be5882e02741a0745a3c8f6611f.

See https://github.com/owncloud/client/pull/7813#issuecomment-626815221