### PR TITLE
Uploads: correctly handle the bigfilechunking capability

### DIFF
--- a/changelog/unreleased/7862
+++ b/changelog/unreleased/7862
@@ -1,0 +1,5 @@
+Change: The client uploads chunks even though the server repports lack of support
+
+We now correctly handle the bigfilechunking capability
+
+https://github.com/owncloud/client/issues/7862

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -140,12 +140,27 @@ QByteArray Capabilities::uploadChecksumType() const
 
 bool Capabilities::chunkingNg() const
 {
+    if (!bigfilechunkingEnabled())
+    {
+        return false;
+    }
     static const auto chunkng = qgetenv("OWNCLOUD_CHUNKING_NG");
     if (chunkng == "0")
         return false;
     if (chunkng == "1")
         return true;
     return _capabilities.value("dav").toMap().value("chunking").toByteArray() >= "1.0";
+}
+
+bool Capabilities::bigfilechunkingEnabled() const
+{
+    bool ok;
+    const int chunkSize = qEnvironmentVariableIntValue("OWNCLOUD_CHUNK_SIZE", &ok);
+    if (ok && chunkSize == 0)
+    {
+        return false;
+    }
+    return _capabilities.value("files").toMap().value(QStringLiteral("bigfilechunking"), true).toBool();
 }
 
 bool Capabilities::chunkingParallelUploadDisabled() const

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -59,6 +59,9 @@ public:
     bool chunkingNg() const;
     QString zsyncSupportedVersion() const;
 
+    /// Wheter to use chunking
+    bool bigfilechunkingEnabled() const;
+
     /// disable parallel upload in chunking
     bool chunkingParallelUploadDisabled() const;
 

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -38,7 +38,12 @@ namespace OCC {
 
 void PropagateUploadFileV1::doStartUpload()
 {
-    _chunkCount = int(std::ceil(_item->_size / double(chunkSize())));
+    if (!propagator()->account()->capabilities().bigfilechunkingEnabled())
+    {
+        _chunkCount = 1;
+    } else {
+        _chunkCount = int(std::ceil(_item->_size / double(chunkSize())));
+    }
     _startChunk = 0;
     _transferId = uint(qrand()) ^ uint(_item->_modtime) ^ (uint(_item->_size) << 16);
 


### PR DESCRIPTION
The current implementation disables chunking v1 and uses the basic upload.
Is support for unchunked v1 support required?