### PR TITLE
Link tests against a static owncloudCore instead of trying to pick si…

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -161,23 +161,10 @@ if(Qt5LinguistTools_FOUND)
     qt5_add_translation(client_I18N ${TRANSLATIONS})
 endif()
 
-IF( WIN32 )
-    configure_file(
-      ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
-      ${CMAKE_CURRENT_BINARY_DIR}/version.rc
-      @ONLY)
-    set(client_version ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    IF(NOT MSVC)
-        set(client_manifest ${CMAKE_CURRENT_SOURCE_DIR}/manifest-mingw.rc)
-    ENDIF()
-ENDIF()
-
 set( final_src
     ${MIRALL_RC_SRC}
     ${client_SRCS}
     ${client_UI_SRCS}
-    ${client_version}
-    ${client_manifest}
     ${guiMoc}
     ${client_I18N}
     ${3rdparty_SRC}
@@ -197,11 +184,60 @@ if(APPLE)
 endif()
 ecm_add_app_icon(final_src ICONS "${OWNCLOUD_ICONS}" SIDEBAR_ICONS "${OWNCLOUD_SIDEBAR_ICONS}" OUTFILE_BASENAME "${APPLICATION_ICON_NAME}")
 
-add_executable(${APPLICATION_EXECUTABLE} main.cpp ${final_src})
+add_library(owncloudCore STATIC ${final_src})
+set_target_properties(owncloudCore PROPERTIES AUTOUIC ON AUTORCC ON)
+target_link_libraries(owncloudCore PUBLIC Qt5::Widgets Qt5::Network Qt5::Xml
+                                          ${synclib_NAME})
+
+add_library(updater STATIC ${updater_SRCS})
+target_link_libraries(updater ${synclib_NAME} ${updater_DEPS} Qt5::Widgets Qt5::Network Qt5::Xml)
+target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries( owncloudCore PUBLIC updater)
+
+target_include_directories(owncloudCore PUBLIC
+    ${CMAKE_SOURCE_DIR}/src/3rdparty/QProgressIndicator
+    ${CMAKE_SOURCE_DIR}/src/3rdparty/qtlockedfile
+    ${CMAKE_SOURCE_DIR}/src/3rdparty/qtsingleapplication
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+## handle DBUS for Fdo notifications
+if( UNIX AND NOT APPLE )
+    find_package(Qt5 COMPONENTS DBus)
+    target_link_libraries(owncloudCore PUBLIC Qt5::DBus)
+    target_compile_definitions(owncloudCore PUBLIC "USE_FDO_NOTIFICATIONS")
+endif()
+
+if (APPLE)
+    find_package(Qt5 COMPONENTS MacExtras)
+    target_link_libraries(owncloudCore PUBLIC Qt5::MacExtras)
+endif()
+
+if(WITH_CRASHREPORTER)
+    target_link_libraries(owncloudCore PUBLIC crashreporter-handler)
+
+    if(UNIX AND NOT MAC)
+        find_package(Threads REQUIRED)
+        target_link_libraries(owncloudCore PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+    endif()
+endif()
+
+add_executable(${APPLICATION_EXECUTABLE} main.cpp)
 set_target_properties(${APPLICATION_EXECUTABLE} PROPERTIES AUTOUIC ON AUTORCC ON)
+target_link_libraries( ${APPLICATION_EXECUTABLE} owncloudCore )
 
 if(NOT APPLE)
-    if(NOT WIN32)
+    IF( WIN32 )
+        configure_file(
+          ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
+          ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+          @ONLY)
+        target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+        IF(NOT MSVC)
+            target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/manifest-mingw.rc)
+        ENDIF()
+    else()
         file(GLOB _icons "${theme_dir}/colored/*-${APPLICATION_ICON_NAME}-icon.png")
         foreach(_file ${_icons})
             string(REPLACE "${theme_dir}/colored/" "" _res ${_file})
@@ -229,43 +265,6 @@ else()
       )
 
   set_target_properties(${APPLICATION_EXECUTABLE} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/MacOSXBundleInfo.plist)
-endif()
-
-add_library(updater STATIC ${updater_SRCS})
-target_link_libraries(updater ${synclib_NAME} ${updater_DEPS} Qt5::Widgets Qt5::Network Qt5::Xml)
-target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::Widgets Qt5::Network Qt5::Xml)
-target_link_libraries( ${APPLICATION_EXECUTABLE} ${synclib_NAME} )
-target_link_libraries( ${APPLICATION_EXECUTABLE} updater )
-target_link_libraries( ${APPLICATION_EXECUTABLE} ${OS_SPECIFIC_LINK_LIBRARIES} )
-
-target_include_directories(${APPLICATION_EXECUTABLE} PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/3rdparty/QProgressIndicator
-    ${CMAKE_SOURCE_DIR}/src/3rdparty/qtlockedfile
-    ${CMAKE_SOURCE_DIR}/src/3rdparty/qtsingleapplication
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
-
-## handle DBUS for Fdo notifications
-if( UNIX AND NOT APPLE )
-    find_package(Qt5 COMPONENTS DBus)
-    target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::DBus)
-    target_compile_definitions(${APPLICATION_EXECUTABLE} PRIVATE "USE_FDO_NOTIFICATIONS")
-endif()
-
-if (APPLE)
-    find_package(Qt5 COMPONENTS MacExtras)
-    target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::MacExtras)
-endif()
-
-if(WITH_CRASHREPORTER)
-    target_link_libraries(${APPLICATION_EXECUTABLE} crashreporter-handler)
-
-    if(UNIX AND NOT MAC)
-        find_package(Threads REQUIRED)
-        target_link_libraries( ${APPLICATION_EXECUTABLE} ${CMAKE_THREAD_LIBS_INIT})
-    endif()
 endif()
 
 install(TARGETS ${APPLICATION_EXECUTABLE} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -1,11 +1,3 @@
-if ( APPLE )
-    list(APPEND OS_SPECIFIC_LINK_LIBRARIES
-         /System/Library/Frameworks/CoreServices.framework
-         /System/Library/Frameworks/Foundation.framework
-         /System/Library/Frameworks/AppKit.framework
-    )
-endif()
-
 set(libsync_SRCS
     account.cpp
     bandwidthmanager.cpp
@@ -112,10 +104,17 @@ ENDIF(NOT APPLE)
 add_library(${synclib_NAME} SHARED ${libsync_SRCS})
 target_link_libraries(${synclib_NAME} PUBLIC
     "${csync_NAME}"
-    ${OS_SPECIFIC_LINK_LIBRARIES}
     Qt5::Core Qt5::Network
     zsync
 )
+
+if ( APPLE )
+    target_link_libraries(${synclib_NAME} PUBLIC
+         /System/Library/Frameworks/CoreServices.framework
+         /System/Library/Frameworks/Foundation.framework
+         /System/Library/Frameworks/AppKit.framework
+    )
+endif()
 
 if (NOT TOKEN_AUTH_ONLY)
     find_package(Qt5 REQUIRED COMPONENTS Widgets)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,45 +1,19 @@
-include_directories(${CMAKE_SOURCE_DIR}/src
-                    ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer
-                    ${CMAKE_SOURCE_DIR}/src/3rdparty/zsync/c
-                    ${CMAKE_SOURCE_DIR}/src/csync
-                    ${CMAKE_SOURCE_DIR}/src/csync/std
-                    ${CMAKE_SOURCE_DIR}/src/gui
-                    ${CMAKE_SOURCE_DIR}/src/libsync
-                    ${CMAKE_BINARY_DIR}/src/csync
-                    ${CMAKE_BINARY_DIR}/src/libsync
-                    ${CMAKE_CURRENT_SOURCE_DIR}
-                    ${CMAKE_CURRENT_BINARY_DIR}
-                   )
-
 include(owncloud_add_test.cmake)
 
-owncloud_add_test(OwncloudPropagator "")
-owncloud_add_test(Updater "")
+owncloud_add_test(OwncloudPropagator)
+owncloud_add_test(Updater)
 
-SET(FolderWatcher_SRC ../src/gui/folderwatcher.cpp)
+owncloud_add_test(OwnSql)
+owncloud_add_test(SyncJournalDB)
+owncloud_add_test(SyncFileItem)
+owncloud_add_test(ConcatUrl)
+owncloud_add_test(Cookies)
+owncloud_add_test(XmlParse)
+owncloud_add_test(ChecksumValidator)
 
-IF( NOT WIN32 AND NOT APPLE )
-list(APPEND FolderWatcher_SRC  ../src/gui/folderwatcher_linux.cpp)
-ENDIF()
-IF( WIN32 )
-list(APPEND  FolderWatcher_SRC ../src/gui/folderwatcher_win.cpp)
-ENDIF()
-IF( APPLE )
-list(APPEND FolderWatcher_SRC ../src/gui/folderwatcher_mac.cpp)
-list(APPEND FolderWatcher_SRC ../src/gui/socketapisocket_mac.mm)
-ENDIF()
-owncloud_add_test(NetrcParser ../src/cmd/netrcparser.cpp)
-owncloud_add_test(OwnSql "")
-owncloud_add_test(SyncJournalDB "")
-owncloud_add_test(SyncFileItem "")
-owncloud_add_test(ConcatUrl "")
-owncloud_add_test(Cookies "")
-owncloud_add_test(XmlParse "")
-owncloud_add_test(ChecksumValidator "")
+owncloud_add_test(ExcludedFiles)
 
-owncloud_add_test(ExcludedFiles "")
-
-owncloud_add_test(Utility "")
+owncloud_add_test(Utility)
 owncloud_add_test(SyncEngine "syncenginetestutils.h")
 owncloud_add_test(SyncVirtualFiles "syncenginetestutils.h")
 owncloud_add_test(SyncMove "syncenginetestutils.h")
@@ -61,29 +35,17 @@ owncloud_add_test(DatabaseError "syncenginetestutils.h")
 # For unknown reasons the DatabaseErrorTest occasionally aborts during drone execution
 set_tests_properties(DatabaseErrorTest PROPERTIES LABELS "nodrone" )
 
-owncloud_add_test(LockedFiles "syncenginetestutils.h;../src/gui/lockwatcher.cpp")
+owncloud_add_test(LockedFiles "syncenginetestutils.h")
 
-owncloud_add_test(FolderWatcher "${FolderWatcher_SRC}")
+owncloud_add_test(FolderWatcher)
 
 if( UNIX AND NOT APPLE )
-    owncloud_add_test(InotifyWatcher "${FolderWatcher_SRC}")
+    owncloud_add_test(InotifyWatcher)
 endif(UNIX AND NOT APPLE)
 
 owncloud_add_benchmark(LargeSync "syncenginetestutils.h")
 
-SET(FolderMan_SRC ../src/gui/folderman.cpp)
-list(APPEND FolderMan_SRC ../src/gui/folder.cpp )
-list(APPEND FolderMan_SRC ../src/gui/socketapi.cpp )
-list(APPEND FolderMan_SRC ../src/gui/accountstate.cpp )
-list(APPEND FolderMan_SRC ../src/gui/syncrunfilelog.cpp )
-list(APPEND FolderMan_SRC ../src/gui/lockwatcher.cpp )
-list(APPEND FolderMan_SRC ../src/gui/guiutility.cpp )
-list(APPEND FolderMan_SRC ../src/gui/navigationpanehelper.cpp )
-list(APPEND FolderMan_SRC ../src/gui/connectionvalidator.cpp )
-list(APPEND FolderMan_SRC ../src/gui/clientproxy.cpp )
-list(APPEND FolderMan_SRC ${FolderWatcher_SRC})
-list(APPEND FolderMan_SRC stub.cpp )
-owncloud_add_test(FolderMan "${FolderMan_SRC}")
+owncloud_add_test(FolderMan)
 
 owncloud_add_test(OAuth "syncenginetestutils.h")
 

--- a/test/csync/cmdline.c
+++ b/test/csync/cmdline.c
@@ -17,7 +17,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include "config_csync.h"
+#include "csync/config_csync.h"
 #include "torture.h"
 
 #ifdef HAVE_ARGP_H

--- a/test/csync/torture.c
+++ b/test/csync/torture.c
@@ -17,7 +17,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include "config_csync.h"
+#include "csync/config_csync.h"
 
 #include "torture.h"
 

--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -2,17 +2,14 @@ find_package(Qt5 COMPONENTS Core Test Xml Network REQUIRED)
 
 include(ECMAddTests)
 
-function(owncloud_add_test test_class additional_cpp)
+function(owncloud_add_test test_class)
     set(OWNCLOUD_TEST_CLASS ${test_class})
     string(TOLOWER "${OWNCLOUD_TEST_CLASS}" OWNCLOUD_TEST_CLASS_LOWERCASE)
-    list(APPEND additional_cpp test${OWNCLOUD_TEST_CLASS_LOWERCASE}.cpp)
 
-    ecm_add_test("${additional_cpp}"
+    ecm_add_test(test${OWNCLOUD_TEST_CLASS_LOWERCASE}.cpp ${ARGN}
         TEST_NAME "${OWNCLOUD_TEST_CLASS}Test"
         LINK_LIBRARIES
-        updater
-        ${APPLICATION_EXECUTABLE}sync
-        Qt5::Core Qt5::Test Qt5::Xml Qt5::Network
+        owncloudCore Qt5::Test
     )
 
     target_compile_definitions(${OWNCLOUD_TEST_CLASS}Test PRIVATE OWNCLOUD_TEST OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")

--- a/test/stub.cpp
+++ b/test/stub.cpp
@@ -1,7 +1,0 @@
-// stub to prevent linker error
-#include "accountmanager.h"
-OCC::AccountManager *OCC::AccountManager::instance() { static QObject dummy; return reinterpret_cast<AccountManager *>(&dummy); }
-void OCC::AccountManager::saveAccountState(AccountState *) { }
-void OCC::AccountManager::save(bool saveCredentials) { Q_UNUSED(saveCredentials); }
-void OCC::AccountManager::accountRemoved(OCC::AccountState*) { }
-const QMetaObject OCC::AccountManager::staticMetaObject = QObject::staticMetaObject;


### PR DESCRIPTION
…ngle...

files they depend on

This is only a first step and fixes the issue caused by
https://github.com/owncloud/client/blob/master/test/stub.cpp#L3 .
In a next step we should link this libary dynamically to reduce the build
overhead but this will require proper import export macros.