### PR TITLE
Gui: hide the selective sync pop up by default

### DIFF
--- a/changelog/unreleased/7925
+++ b/changelog/unreleased/7925
@@ -1,0 +1,5 @@
+Change: The settings ui shows a prompt for a few seconds
+
+We now hide that prompt by default and only show it if needed.
+
+https://github.com/owncloud/client/pull/7925

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -136,6 +136,8 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     ui->_folderList->setAttribute(Qt::WA_Hover, true);
     ui->_folderList->installEventFilter(mouseCursorChanger);
 
+    ui->selectiveSyncStatus->hide();
+
     createAccountToolbox();
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, &AccountSettings::slotAccountAdded);


### PR DESCRIPTION
This fixes a strange flickering when the client is started with the gui visible.