### PR TITLE
Remove OWNCLOUD_TEST define handling

### DIFF
--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -61,13 +61,10 @@ bool FolderWatcher::pathIsIgnored(const QString &path)
         return true;
     if (!_folder)
         return false;
-
-#ifndef OWNCLOUD_TEST
     if (_folder->isFileExcludedAbsolute(path) && !Utility::isConflictFile(path)) {
         qCDebug(lcFolderWatcher) << "* Ignoring file" << path;
         return true;
     }
-#endif
     return false;
 }
 

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -33,9 +33,7 @@
 #include "capabilities.h"
 #include "common/asserts.h"
 #include "guiutility.h"
-#ifndef OWNCLOUD_TEST
 #include "sharemanager.h"
-#endif
 
 #include <array>
 #include <QBitArray>
@@ -560,9 +558,6 @@ void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listen
     listener->sendMessage(QLatin1String("SHARE_MENU_TITLE:") + tr("Share with %1", "parameter is ownCloud").arg(Theme::instance()->appNameGUI()));
 }
 
-// don't pull the share manager into socketapi unittests
-#ifndef OWNCLOUD_TEST
-
 class GetOrCreatePublicLinkShare : public QObject
 {
     Q_OBJECT
@@ -656,26 +651,6 @@ private:
     ShareManager _shareManager;
     QString _serverPath;
 };
-
-#else
-
-class GetOrCreatePublicLinkShare : public QObject
-{
-    Q_OBJECT
-public:
-    GetOrCreatePublicLinkShare(const AccountPtr &, const QString &, QObject *)
-    {
-    }
-
-    void run()
-    {
-    }
-signals:
-    void done(const QString &link);
-    void error(int code, const QString &message);
-};
-
-#endif
 
 void SocketApi::command_COPY_PUBLIC_LINK(const QString &localFile, SocketListener *)
 {

--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -12,7 +12,7 @@ function(owncloud_add_test test_class)
         owncloudCore Qt5::Test
     )
 
-    target_compile_definitions(${OWNCLOUD_TEST_CLASS}Test PRIVATE OWNCLOUD_TEST OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
+    target_compile_definitions(${OWNCLOUD_TEST_CLASS}Test PRIVATE OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
 
     target_include_directories(${OWNCLOUD_TEST_CLASS}Test PRIVATE "${CMAKE_SOURCE_DIR}/test/")
 endfunction()
@@ -29,5 +29,5 @@ macro(owncloud_add_benchmark test_class additional_cpp)
         ${APPLICATION_EXECUTABLE}sync
         Qt5::Core Qt5::Test Qt5::Xml Qt5::Network
     )
-    target_compile_definitions(${OWNCLOUD_TEST_CLASS}Bench PRIVATE OWNCLOUD_TEST OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
+    target_compile_definitions(${OWNCLOUD_TEST_CLASS}Bench PRIVATE OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
 endmacro()


### PR DESCRIPTION
Since we link the core into the tests the define has no effect.