### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -37,6 +37,7 @@
 #include <QDir>
 #include <QScopedValueRollback>
 #include <QMessageBox>
+#include <QOperatingSystemVersion>
 
 namespace OCC {
 
@@ -70,10 +71,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
 
     // Hide on non-Windows, or WindowsVersion < 10.
     // The condition should match the default value of ConfigFile::showInExplorerNavigationPane.
-#ifdef Q_OS_WIN
-    if (QSysInfo::windowsVersion() < QSysInfo::WV_WINDOWS10)
-#endif
-        _ui->showInExplorerNavigationPaneCheckBox->setVisible(false);
+    _ui->showInExplorerNavigationPaneCheckBox->setVisible(QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows10);
 
     /* Set the left contents margin of the layout to zero to make the checkboxes
      * align properly vertically , fixes bug #3758

--- a/src/gui/openfilemanager.cpp
+++ b/src/gui/openfilemanager.cpp
@@ -88,11 +88,6 @@ static bool checkDolphinCanSelect()
 void showInFileManager(const QString &localPath)
 {
     if (Utility::isWindows()) {
-#ifdef Q_OS_WIN
-        if (QSysInfo::windowsVersion() <= QSysInfo::WV_2003) {
-            return;
-        }
-#endif
         QString explorer = "explorer.exe "; // FIXME: we trust it's in PATH
         QFileInfo fi(localPath);
 


### PR DESCRIPTION
D:\a\client\client\src\gui\generalsettings.cpp(74): warning C4996: 'QSysInfo::windowsVersion': Use QOperatingSystemVersion::current()
C:\CraftMaster\windows-msvc2017_32-cl\include\qt5\QtCore/qsysinfo.h(217): note: see declaration of 'QSysInfo::windowsVersion'