### PR TITLE
Use the servers checksum type by default

### DIFF
--- a/changelog/unreleased/7989
+++ b/changelog/unreleased/7989
@@ -1,0 +1,7 @@
+Change: Use the checksum type specified by the server by default
+
+The default type for computation of the checksum was sha1 independent
+of the type specified by the server.
+Under certain conditions that caused multiple computations of the checksum.
+
+https://github.com/owncloud/client/pull/7989

--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -189,15 +189,6 @@ bool uploadChecksumEnabled()
     return enabled;
 }
 
-QByteArray contentChecksumType()
-{
-    static QByteArray type = qgetenv("OWNCLOUD_CONTENT_CHECKSUM_TYPE");
-    if (type.isNull()) { // can set to "" to disable checksumming
-        type = "SHA1";
-    }
-    return type;
-}
-
 static bool checksumComputationEnabled()
 {
     static bool enabled = qgetenv("OWNCLOUD_DISABLE_CHECKSUM_COMPUTATIONS").isEmpty();

--- a/src/common/checksums.h
+++ b/src/common/checksums.h
@@ -65,9 +65,6 @@ OCSYNC_EXPORT QByteArray parseChecksumHeaderType(const QByteArray &header);
 /// Checks OWNCLOUD_DISABLE_CHECKSUM_UPLOAD
 OCSYNC_EXPORT bool uploadChecksumEnabled();
 
-/// Checks OWNCLOUD_CONTENT_CHECKSUM_TYPE (default: SHA1)
-OCSYNC_EXPORT QByteArray contentChecksumType();
-
 // Exported functions for the tests.
 QByteArray OCSYNC_EXPORT calcMd5(QIODevice *device);
 QByteArray OCSYNC_EXPORT calcSha1(QIODevice *device);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -125,7 +125,9 @@ QList<QByteArray> Capabilities::supportedChecksumTypes() const
 
 QByteArray Capabilities::preferredUploadChecksumType() const
 {
-    return _capabilities.value("checksums").toMap().value("preferredUploadType").toByteArray();
+    return qEnvironmentVariable("OWNCLOUD_CONTENT_CHECKSUM_TYPE",
+                                _capabilities.value(QStringLiteral("checksums")).toMap()
+                                .value(QStringLiteral("preferredUploadType"), QStringLiteral("SHA1")).toString()).toUtf8();
 }
 
 QByteArray Capabilities::uploadChecksumType() const

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -847,7 +847,7 @@ namespace { // Anonymous namespace for the recall feature
 
 void PropagateDownloadFile::transmissionChecksumValidated(const QByteArray &checksumType, const QByteArray &checksum)
 {
-    const auto theContentChecksumType = contentChecksumType();
+    const QByteArray theContentChecksumType = propagator()->account()->capabilities().preferredUploadChecksumType();
 
     // Reuse transmission checksum as content checksum.
     //

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -237,7 +237,7 @@ void PropagateUploadFileCommon::slotComputeContentChecksum()
     // change during the checksum calculation
     _item->_modtime = FileSystem::getModTime(filePath);
 
-    QByteArray checksumType = contentChecksumType();
+    const QByteArray checksumType = propagator()->account()->capabilities().preferredUploadChecksumType();
 
     // Maybe the discovery already computed the checksum?
     QByteArray existingChecksumType, existingChecksum;


### PR DESCRIPTION
Local computation of sha1 checksum
Comparison with the checksum the remote provided after upload (sha256), therefore re computation of local checksum with sha256. 


Related: https://gitea.owncloud.services/client/client-plugin-vfs-win/pulls/11