### PR TITLE
Remove pointless warning

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -485,7 +485,7 @@ bool SyncJournalDb::checkConnect()
                         "name TEXT UNIQUE"
                         ");");
     if (!createQuery.exec()) {
-        return sqlFail(QStringLiteral("Create table version"), createQuery);
+        return sqlFail(QStringLiteral("Create table checksumtype"), createQuery);
     }
 
     // create the datafingerprint table.
@@ -530,8 +530,6 @@ bool SyncJournalDb::checkConnect()
 
     SqlQuery versionQuery("SELECT major, minor, patch FROM version;", _db);
     if (!versionQuery.next().hasData) {
-        // If there was no entry in the table, it means we are likely upgrading from 1.5
-        qCInfo(lcDb) << "possibleUpgradeFromMirall_1_5 detected!";
         forceRemoteDiscovery = true;
 
         createQuery.prepare("INSERT INTO version VALUES (?1, ?2, ?3, ?4);");


### PR DESCRIPTION
We also don't have a version entry in the db if thne db is new.
As I don't expect regular updates from 1.5 this message can just be removed.

Fixes: #8004