### PR TITLE
Don't crash if a delete job marked as ignore is cancelled

### DIFF
--- a/changelog/unreleased/7967
+++ b/changelog/unreleased/7967
@@ -1,0 +1,6 @@
+Bugfix: Don't crash if move is undone due to permissions
+
+We fixed a crash when a file in a folder with certain permissions
+was restored.
+
+https://github.com/owncloud/client/issues/7967

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -160,11 +160,7 @@ QPair<bool, QByteArray> DiscoveryPhase::findAndCancelDeletedJob(const QString &o
     auto it = _deletedItem.find(originalPath);
     if (it != _deletedItem.end()) {
         const SyncInstructions instruction = (*it)->_instruction;
-        if (instruction == CSYNC_INSTRUCTION_IGNORE && (*it)->_type == ItemTypeVirtualFile) {
-            // re-creation of virtual files count as a delete
-            // a file might be in an error state and thus gets marked as CSYNC_INSTRUCTION_IGNORE
-            // after it was initially marked as CSYNC_INSTRUCTION_REMOVE
-            // return true, to not trigger any additional actions on that file that could elad to dataloss
+        if (instruction == CSYNC_INSTRUCTION_IGNORE) {
             result = true;
             oldEtag = (*it)->_etag;
         } else {


### PR DESCRIPTION
Issue: #7967

The enforce was introduced in https://github.com/owncloud/client/commit/4d9748080958aaee55810f52a3e14dda024dffa1