### PR TITLE
[Docs] HTTP logging simplifications

### DIFF
--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -143,7 +143,7 @@ QT_LOGGING_RULES='sync.httplogger=true' \
 ```
 QT_LOGGING_RULES='*=false;sync.httplogger=true' \
   /PATH/TO/CLIENT \
-  --logdebug --logfile <file>
+  --logfile <file>
 ```
 
 === ownCloud server Log File


### PR DESCRIPTION
Just found out,  `--logdebug` doesn't have any value when you want to limit to specific log item category anyway.