### PR TITLE
Remove the theming option `wizardSelectiveSyncDefaultNothing`

### DIFF
--- a/changelog/unreleased/8064
+++ b/changelog/unreleased/8064
@@ -1,0 +1,6 @@
+Change: Remove the branding option `wizardSelectiveSyncDefaultNothing`
+
+The branding option was removed as believe that it did not provide a good user experience.
+We recommend `newBigFolderSizeLimit` together with `wizardHideFolderSizeLimitCheckbox` as a replacement.
+
+https://github.com/owncloud/client/pull/8064

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -508,11 +508,7 @@ void FolderWizardSelectiveSync::initializePage()
     QString alias = QFileInfo(targetPath).fileName();
     if (alias.isEmpty())
         alias = Theme::instance()->appName();
-    QStringList initialBlacklist;
-    if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
-        initialBlacklist = QStringList("/");
-    }
-    _selectiveSync->setFolderInfo(targetPath, alias, initialBlacklist);
+    _selectiveSync->setFolderInfo(targetPath, alias);
     QWizardPage::initializePage();
 }
 

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -153,12 +153,6 @@ void OwncloudAdvancedSetupPage::initializePage()
     connect(quotaJob, &PropfindJob::result, this, &OwncloudAdvancedSetupPage::slotQuotaRetrieved);
     quotaJob->start();
 
-
-    if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
-        _selectiveSyncBlacklist = QStringList("/");
-        QTimer::singleShot(0, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
-    }
-
     ConfigFile cfgFile;
     auto newFolderLimit = cfgFile.newBigFolderSizeLimit();
     _ui.confCheckBoxSize->setChecked(newFolderLimit.first);
@@ -339,8 +333,7 @@ void OwncloudAdvancedSetupPage::slotSelectiveSyncClicked()
     bool updateBlacklist = false;
 
     // We need to update the selective sync blacklist either when the dialog
-    // was accepted, or when it was used in conjunction with the
-    // wizardSelectiveSyncDefaultNothing feature and was cancelled - in that
+    // was accepted in that
     // case the stub blacklist of / was expanded to the actual list of top
     // level folders by the selective sync dialog.
     if (result == QDialog::Accepted) {

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -446,11 +446,6 @@ QPixmap Theme::wizardHeaderBanner(const QSize &size) const
 }
 #endif
 
-bool Theme::wizardSelectiveSyncDefaultNothing() const
-{
-    return false;
-}
-
 QString Theme::webDavPath() const
 {
     return QLatin1String("remote.php/webdav/");

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -224,12 +224,6 @@ public:
     virtual QString updateCheckUrl() const;
 
     /**
-     * When true, the setup wizard will show the selective sync dialog by default and default
-     * to nothing selected
-     */
-    virtual bool wizardSelectiveSyncDefaultNothing() const;
-
-    /**
      * Default option for the newBigFolderSizeLimit.
      * Size in MB of the maximum size of folder before we ask the confirmation.
      * Set -1 to never ask confirmation.  0 to ask confirmation for every folder.


### PR DESCRIPTION
We recommend `newBigFolderSizeLimit` together with `wizardHideFolderSizeLimitCheckbox`
as an alternative