### PR TITLE
Ci: enable packaging on mac

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -77,7 +77,7 @@ General/ABI = windows-msvc2017_32-cl
 
 [macos-64-clang]
 General/ABI = macos-64-clang
-Packager/PackageType = MacPkgPackager
+# Packager/PackageType = MacPkgPackager
 
 [macos-64-clang-debug]
 General/ABI = macos-64-clang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
       run: Invoke-Expression "$env:CRAFT --no-cache --src-dir `"${{ github.workspace }}`" --test owncloud/owncloud-client"
 
     - name: Package
-      run: if (-not $IsMacOS) { Invoke-Expression "$env:CRAFT --no-cache --src-dir `"${{ github.workspace }}`" --package owncloud/owncloud-client" } else {Write-Host "Skip packaging on mac as the build gets stuck when mounting"}
+      run: Invoke-Expression "$env:CRAFT --no-cache --src-dir `"${{ github.workspace }}`" --package owncloud/owncloud-client"
 
     - name: Update shelf
       run: |


### PR DESCRIPTION
Now we have public test builds for all platforms https://github.com/owncloud/client/actions/runs/249605262

The pkg packages gets stuck on github so use the dmg packager for now...