### PR TITLE
Don't clear cookies during oauth

### DIFF
--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -375,7 +375,6 @@ void OAuth::fetchWellKnown()
 
 void OAuth::openBrowser()
 {
-    _account->clearCookieJar(); // #6574
     authorisationLinkAsync([this](const QUrl &link) {
         if (!QDesktopServices::openUrl(link)) {
             qCWarning(lcOauth) << "QDesktopServices::openUrl Failed";


### PR DESCRIPTION
The cookies are required by the load balancer and there for a reason.
Since #6574 we fixed the back button in https://github.com/owncloud/client/pull/8056 .