### PR TITLE
Add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        debug-only: true
+        days-before-stale: -1
+        exempt-issue-labels: "blue-ticket, p1-urgent, p2-high, p3-medium, p4-low"
+        close-issue-message: "The issue was marked as stale for 7 days and closed automatically."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,4 +13,5 @@ jobs:
         debug-only: true
         days-before-stale: -1
         exempt-issue-labels: "blue-ticket, p1-urgent, p2-high, p3-medium, p4-low"
+        days-before-close: 7  
         close-issue-message: "The issue was marked as stale for 7 days and closed automatically."


### PR DESCRIPTION
Currently its in debug mode so it will only perform dry runs.
It is also configured to not mark issues as stale by itself.
Only an issue marked as stale by us will be closed after 7 days.

See https://github.com/actions/stale/blob/main/action.yml