### PR TITLE
Fix ROOT component version in master branch

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: desktop
 title: Desktop Client
-version: '2.7'
+version: 'master'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Like was done in 2019 in PR https://github.com/owncloud/client/pull/7187

The merge of 2.7 to master broke this.

Should fix https://github.com/owncloud/docs/issues/2799