### PR TITLE
Evaluate enableExperimentalFeatures when handling suffix vfs

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -337,11 +337,12 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     }
 
     if (Theme::instance()->showVirtualFilesOption()
-        && !folder->supportsVirtualFiles()
-        && bestAvailableVfsMode() != Vfs::Off
-        && !folder->isVfsOnOffSwitchPending()) {
-        ac = menu->addAction(tr("Enable virtual file support%1...").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr(" (experimental)")));
-        connect(ac, &QAction::triggered, this, &AccountSettings::slotEnableVfsCurrentFolder);
+        && !folder->supportsVirtualFiles()) {
+        const auto mode = bestAvailableVfsMode();
+        if (mode == Vfs::WindowsCfApi || Theme::instance()->enableExperimentalFeatures()) {
+            ac = menu->addAction(tr("Enable virtual file support%1...").arg(mode == Vfs::WindowsCfApi ? QString() : tr(" (experimental)")));
+            connect(ac, &QAction::triggered, this, &AccountSettings::slotEnableVfsCurrentFolder);
+        }
     }
 
 

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -478,13 +478,15 @@ FolderWizardSelectiveSync::FolderWizardSelectiveSync(const AccountPtr &account)
     _selectiveSync = new SelectiveSyncWidget(account, this);
     layout->addWidget(_selectiveSync);
 
-    if (Theme::instance()->showVirtualFilesOption() && bestAvailableVfsMode() != Vfs::Off) {
-        _virtualFilesCheckBox = new QCheckBox(tr("Use virtual files instead of downloading content immediately%1").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr(" (experimental)")));
+    const auto vfsMode = bestAvailableVfsMode();
+    if (Theme::instance()->showVirtualFilesOption() && vfsMode != Vfs::Off && (vfsMode == Vfs::WindowsCfApi || Theme::instance()->enableExperimentalFeatures())) {
+
+        _virtualFilesCheckBox = new QCheckBox(tr("Use virtual files instead of downloading content immediately%1").arg(vfsMode == Vfs::WindowsCfApi ? QString() : tr(" (experimental)")));
         connect(_virtualFilesCheckBox, &QCheckBox::clicked, this, &FolderWizardSelectiveSync::virtualFilesCheckboxClicked);
         connect(_virtualFilesCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
             _selectiveSync->setEnabled(state == Qt::Unchecked);
         });
-        _virtualFilesCheckBox->setChecked(bestAvailableVfsMode() == Vfs::WindowsCfApi);
+        _virtualFilesCheckBox->setChecked(vfsMode == Vfs::WindowsCfApi);
         layout->addWidget(_virtualFilesCheckBox);
     }
 }

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -129,7 +129,8 @@ void OwncloudAdvancedSetupPage::initializePage()
         labelSizeHint.width(),
         qMax<int>(1.3 * labelSizeHint.height(), _progressIndi->height()));
 
-    if (!Theme::instance()->showVirtualFilesOption() || bestAvailableVfsMode() == Vfs::Off) {
+    const auto vfsMode = bestAvailableVfsMode();
+    if (!Theme::instance()->showVirtualFilesOption() || vfsMode == Vfs::Off || (vfsMode != Vfs::WindowsCfApi && Theme::instance()->enableExperimentalFeatures()) ) {
         // If the layout were wrapped in a widget, the auto-grouping of the
         // radio buttons no longer works and there are surprising margins.
         // Just manually hide the button and remove the layout.
@@ -137,10 +138,10 @@ void OwncloudAdvancedSetupPage::initializePage()
         _ui.wSyncStrategy->layout()->removeItem(_ui.lVirtualFileSync);
     } else {
 #ifdef Q_OS_WIN
-    if (bestAvailableVfsMode() == Vfs::WindowsCfApi) {
-        qobject_cast<QVBoxLayout *>(_ui.wSyncStrategy->layout())->insertItem(0, _ui.lVirtualFileSync);
-        setRadioChecked(_ui.rVirtualFileSync);
-    }
+        if (vfsMode == Vfs::WindowsCfApi) {
+            qobject_cast<QVBoxLayout *>(_ui.wSyncStrategy->layout())->insertItem(0, _ui.lVirtualFileSync);
+            setRadioChecked(_ui.rVirtualFileSync);
+        }
 #endif
     }
 


### PR DESCRIPTION
This change kind of decouples the vfs modes a bit.
If enableExperimentalFeatures == false, we will hide the suffix implementation.
showVirtualFilesOption can still be used to completely disable vfs support.

We need to set showVirtualFilesOption to true per default in ownbrander.


WIP because its Friday evening and those conditions are complex....