### PR TITLE
macOS: Fix memory leak in FolderWatcherPrivate::startWatching

### DIFF
--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -101,6 +101,7 @@ void FolderWatcherPrivate::startWatching()
         kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagIgnoreSelf);
 
     CFRelease(pathsToWatch);
+    CFRelease(folderCF);
     FSEventStreamScheduleWithRunLoop(_stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
     FSEventStreamStart(_stream);
 }


### PR DESCRIPTION
Hey,

working on the Mac code recently, I just stumbled upon a missing release call.

Greetings & thx for your work :)