### PR TITLE
Oauth use `prompt=select_account` instead of `consent`

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -28,6 +28,7 @@ namespace {
 static const char urlC[] = "url";
 static const char userC[] = "user";
 static const char httpUserC[] = "http_user";
+
 const QString davUserC()
 {
     return QStringLiteral("dav_user");
@@ -37,6 +38,12 @@ const QString davUserDisplyNameC()
 {
     return QStringLiteral("display-name");
 }
+
+const QString idpUserNameC()
+{
+    return QLatin1String("idpUserName");
+}
+
 static const char caCertsKeyC[] = "CaCertificates";
 static const char accountsC[] = "Accounts";
 static const char versionC[] = "version";
@@ -226,6 +233,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.setValue(QLatin1String(urlC), acc->_url.toString());
     settings.setValue(davUserC(), acc->_davUser);
     settings.setValue(davUserDisplyNameC(), acc->_displayName);
+    settings.setValue(idpUserNameC(), acc->_idpUserName);
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
     if (acc->_credentials) {
         if (saveCredentials) {
@@ -293,6 +301,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     acc->_serverVersion = settings.value(QLatin1String(serverVersionC)).toString();
     acc->_davUser = settings.value(davUserC()).toString();
     acc->_displayName = settings.value(davUserDisplyNameC()).toString();
+    acc->setIdpUserName(settings.value(idpUserNameC()).toString());
 
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -299,13 +299,18 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
 
 void ConnectionValidator::slotUserFetched(const QJsonDocument &json)
 {
-    QString user = json.object().value("ocs").toObject().value("data").toObject().value("id").toString();
+    const auto data = json.object().value("ocs").toObject().value("data").toObject();
+    const QString user = data.value("id").toString();
     if (!user.isEmpty()) {
         _account->setDavUser(user);
     }
-    QString displayName = json.object().value("ocs").toObject().value("data").toObject().value("display-name").toString();
+    const QString displayName = data.value("display-name").toString();
     if (!displayName.isEmpty()) {
         _account->setDavDisplayName(displayName);
+    }
+    const QString userName = data.value("username").toString();
+    if (!userName.isEmpty()) {
+        _account->setIdpUserName(userName);
     }
 #ifndef TOKEN_AUTH_ONLY
     AvatarJob *job = new AvatarJob(_account, _account->davUser(), 128, this);

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -313,8 +313,13 @@ void OwncloudSetupWizard::testOwnCloudConnect()
     auto userJob = new JsonApiJob(account, QStringLiteral("ocs/v2.php/cloud/user"), this);
     connect(userJob, &JsonApiJob::jsonReceived, this, [account](const QJsonDocument &json, int status) {
         if (status == 200) {
-            const QString user = json.object().value(QStringLiteral("ocs")).toObject().value(QStringLiteral("data")).toObject().value(QStringLiteral("display-name")).toString();
-            account->setDavDisplayName(user);
+            const auto data = json.object().value(QStringLiteral("ocs")).toObject().value(QStringLiteral("data")).toObject();
+            const QString userName = data.value(QStringLiteral("username")).toString();
+            const QString displayName = data.value(QStringLiteral("display-name")).toString();
+            account->setDavDisplayName(displayName);
+            if (!userName.isEmpty()) {
+                account->setIdpUserName(userName);
+            }
         }
     });
     userJob->start();

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -78,6 +78,16 @@ void Account::setSharedThis(AccountPtr sharedThis)
     _sharedThis = sharedThis.toWeakRef();
 }
 
+QString Account::idpUserName() const
+{
+    return _idpUserName;
+}
+
+void Account::setIdpUserName(const QString &userName)
+{
+    _idpUserName = userName;
+}
+
 AccountPtr Account::sharedFromThis()
 {
     return _sharedThis.toStrongRef();

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -233,6 +233,13 @@ public:
     /// Called by network jobs on credential errors, emits invalidCredentials()
     void handleInvalidCredentials();
 
+    /**
+     * user name used by the idp to identify the user
+     * this might differ from the dav user
+     **/
+    QString idpUserName() const;
+    void setIdpUserName(const QString &userName);
+
 public slots:
     /// Used when forgetting credentials
     void clearQNAMCache();
@@ -271,6 +278,7 @@ private:
     QString _id;
     QString _davUser;
     QString _displayName;
+    QString _idpUserName;
 #ifndef TOKEN_AUTH_ONLY
     QImage _avatarImg;
 #endif

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -299,17 +299,16 @@ QUrl OAuth::authorisationLink() const
     QUrlQuery query;
     const QByteArray code_challenge = QCryptographicHash::hash(_pkceCodeVerifier, QCryptographicHash::Sha256)
                                           .toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
-    query.setQueryItems({
-        { QStringLiteral("response_type"), QStringLiteral("code") },
+    query.setQueryItems({ { QStringLiteral("response_type"), QStringLiteral("code") },
         { QStringLiteral("client_id"), Theme::instance()->oauthClientId() },
         { QStringLiteral("redirect_uri"), QStringLiteral("http://localhost:%1").arg(QString::number(_server.serverPort())) },
         { QStringLiteral("code_challenge"), QString::fromLatin1(code_challenge) },
         { QStringLiteral("code_challenge_method"), QStringLiteral("S256") },
         { QStringLiteral("scope"), Theme::instance()->openIdConnectScopes() },
-        { QStringLiteral("prompt"), QStringLiteral("consent") },
+        { QStringLiteral("prompt"), QStringLiteral("select_account") },
         { QStringLiteral("state"), QString::fromUtf8(_state) },
-        { QStringLiteral("display"), Theme::instance()->appNameGUI() }
-    });
+        { QStringLiteral("display"), Theme::instance()->appNameGUI() },
+        { QStringLiteral("login_hint"), _account->davUser() } });
     if (!_account->davUser().isNull())
         query.addQueryItem(QStringLiteral("user"), _account->davUser().replace(QLatin1Char('+'), QStringLiteral("%2B"))); // Issue #7762
     const QUrl url = _authEndpoint.isValid()

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -310,7 +310,7 @@ QUrl OAuth::authorisationLink() const
         { QStringLiteral("code_challenge"), QString::fromLatin1(code_challenge) },
         { QStringLiteral("code_challenge_method"), QStringLiteral("S256") },
         { QStringLiteral("scope"), Theme::instance()->openIdConnectScopes() },
-        { QStringLiteral("prompt"), QStringLiteral("select_account") },
+        { QStringLiteral("prompt"), Theme::instance()->openIdConnectPrompt() },
         { QStringLiteral("state"), QString::fromUtf8(_state) },
         { QStringLiteral("display"), Theme::instance()->appNameGUI() },
         { QStringLiteral("login_hint"), _account->idpUserName() } });

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -170,7 +170,12 @@ void OAuth::startAuthentication()
                                 tr("<h1>Login Error</h1><p>Failed to retrieve user info</p>").toUtf8());
                             emit result(Error);
                         } else {
-                            const QString user = json.object().value(QStringLiteral("ocs")).toObject().value(QStringLiteral("data")).toObject().value(QStringLiteral("id")).toString();
+                            const auto data = json.object().value(QStringLiteral("ocs")).toObject().value(QStringLiteral("data")).toObject();
+                            const QString user = data.value(QStringLiteral("id")).toString();
+                            const QString username = data.value(QStringLiteral("username")).toString();
+                            if (!username.isEmpty()) {
+                                _account->setIdpUserName(username);
+                            }
                             finalize(socket, accessToken, refreshToken, user, messageUrl);
                         }
                     });
@@ -308,7 +313,7 @@ QUrl OAuth::authorisationLink() const
         { QStringLiteral("prompt"), QStringLiteral("select_account") },
         { QStringLiteral("state"), QString::fromUtf8(_state) },
         { QStringLiteral("display"), Theme::instance()->appNameGUI() },
-        { QStringLiteral("login_hint"), _account->davUser() } });
+        { QStringLiteral("login_hint"), _account->idpUserName() } });
     if (!_account->davUser().isNull())
         query.addQueryItem(QStringLiteral("user"), _account->davUser().replace(QLatin1Char('+'), QStringLiteral("%2B"))); // Issue #7762
     const QUrl url = _authEndpoint.isValid()

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -539,6 +539,11 @@ QString Theme::openIdConnectScopes() const
     return QStringLiteral("openid offline_access email profile");
 }
 
+QString Theme::openIdConnectPrompt() const
+{
+    return QStringLiteral("select_account");
+}
+
 QString Theme::versionSwitchOutput() const
 {
     return aboutVersions(Theme::VersionFormat::Url);

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -361,6 +361,14 @@ public:
     virtual QString openIdConnectScopes() const;
 
     /**
+     * Returns the openidconnect promt type
+     * It is supposed to be "consent select_account".
+     * For Konnect it currently needs to be select_account,
+     * which is the current default.
+     */
+    virtual QString openIdConnectPrompt() const;
+
+    /**
      * @brief What should be output for the --version command line switch.
      *
      * By default, it's a combination of appName(), version(), the GIT SHA1 and some


### PR DESCRIPTION
The idp will now provide a selection dialog.
This fixes the issue where the login is done with the wrong account.
Also provide `login_hint` so that providers supporting it can skip that dialog.