### PR TITLE
Use platform icon theme only on the unbranded client

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -137,7 +137,7 @@ QIcon Theme::themeIcon(const QString &name, bool sysTray, bool sysTrayMenuVisibl
     QString key = name + QLatin1Char(',') + flavor;
     QIcon &cached = _iconCache[key]; // Take reference, this will also "set" the cache entry
     if (cached.isNull()) {
-        if (QIcon::hasThemeIcon(name)) {
+        if (appName() == QLatin1String("ownCloud") && QIcon::hasThemeIcon(name)) {
             // use from theme
             return cached = QIcon::fromTheme(name);
         }


### PR DESCRIPTION
Fixes: https://github.com/owncloud/ownbrander/issues/715

There are also two other cases where the system style might be used:
```
git grep fromTheme
src/gui/sharelinkwidget.cpp:    auto deleteIcon = QIcon::fromTheme(QStringLiteral("user-trash"),
src/gui/shareusergroupwidget.cpp:    _ui->deleteShareButton->setIcon(QIcon::fromTheme(QStringLiteral("user-trash"),