### PR TITLE
Draw active progressbar

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -317,8 +317,8 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         pBarOpt.progress = overallPercent;
         pBarOpt.orientation = Qt::Horizontal;
         pBarOpt.rect = QStyle::visualRect(option.direction, option.rect, pBRect);
+        QApplication::style()->drawControl(QStyle::CE_ProgressBar, &pBarOpt, painter, option.widget);
 
-        QApplication::style()->drawControl(QStyle::CE_ProgressBar, &pBarOpt, painter);
 
         // Overall Progress Text
         QRect overallProgressRect;


### PR DESCRIPTION
Pass a widget to the progressbar in the folder delegate to draw the correct active state