### PR TITLE
Do not sync core files

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -41,6 +41,5 @@ System Volume Information
 
 My Saved Places.
 
-# do not sync Linux core files. They can come in multiple flavours.
-core
-core.*
+# do not sync Linux core files. We only block the more specific naming with two dots (as seen in Ubuntu) to avoid issues with other tools.
+core.*.*

--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -40,3 +40,7 @@ System Volume Information
 .nfs*
 
 My Saved Places.
+
+# do not sync Linux core files. They can come in multiple flavours.
+core
+core.*


### PR DESCRIPTION
Linux core files can be huge and are not normally meant to sync. 
The syntax here seems to be globbing patterns.
I'd like `core.*` to match e.g. `core.freecad-daily.1604943483` according to Ubuntu default /proc/sys/kernel/core_pattern = `core.%e.%t`