### PR TITLE
Owncloud - virtual files smaller <1KB - problems with syncing

### DIFF
--- a/changelog/unreleased/8248
+++ b/changelog/unreleased/8248
@@ -1,0 +1,6 @@
+Bugfix: Sync small plaintext files with Windows VFS
+
+We fixed a bug where small plaintext files where not synced 
+due to a broken interity check.
+
+https://github.com/owncloud/client/issues/8248

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -190,8 +190,9 @@ void GETFileJob::slotMetaDataChanged()
         return;
     }
 
-    _contentLength = reply()->header(QNetworkRequest::ContentLengthHeader).toLongLong();
-    if (_expectedContentLength != -1 && _contentLength != _expectedContentLength) {
+    bool ok;
+    _contentLength = reply()->header(QNetworkRequest::ContentLengthHeader).toLongLong(&ok);
+    if (ok && _expectedContentLength != -1 && _contentLength != _expectedContentLength) {
         qCWarning(lcGetJob) << "We received a different content length than expected!"
                             << _expectedContentLength << "vs" << _contentLength;
         _errorString = tr("We received an unexpected download Content-Length.");


### PR DESCRIPTION
The issue was caused by gziped responses not providing a
content lenght header.

Fixes: #8248