### PR TITLE
add note to install-doc for windows desktop client

### DIFF
--- a/docs/modules/ROOT/pages/installing.adoc
+++ b/docs/modules/ROOT/pages/installing.adoc
@@ -209,3 +209,6 @@ The client will attempt to connect to your ownCloud server, and when it is succe
 * One to open your local folder.
 
 It will also start synchronizing your files.
+
+
+NOTE: Path to find the autostart settings for the windows desktop client: `Computer\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run`


### PR DESCRIPTION
add note to the installation-doc for windows desktop client, on how to find the path for autostart settings under windows.

(Computer\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)

---

benefit: path will be easier to find for users

From issue: https://github.com/owncloud/docs/issues/2322

backport needed for:

2.7
2.6