### PR TITLE
Fix filename clash detection with virtual files

### DIFF
--- a/changelog/unreleased/8323
+++ b/changelog/unreleased/8323
@@ -1,0 +1,6 @@
+Bugfix: Detect file name clash with VirtualFiles enabled
+
+We fixed an issue where the file name clash detection was not run with
+VirtualFiles enabled.
+
+https://github.com/owncloud/client/issues/8323

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -517,6 +517,7 @@ bool OwncloudPropagator::localFileNameClash(const QString &relFile)
     const QString file(_localDir + relFile);
 
     if (!file.isEmpty() && Utility::fsCasePreserving()) {
+        qCDebug(lcPropagator) << "CaseClashCheck for " << file;
 #ifdef Q_OS_MAC
         QFileInfo fileInfo(file);
         if (!fileInfo.exists()) {
@@ -529,8 +530,6 @@ bool OwncloudPropagator::localFileNameClash(const QString &relFile)
             re = (!equal && !cName.endsWith(relFile, Qt::CaseSensitive));
         }
 #elif defined(Q_OS_WIN)
-        const QString file(_localDir + relFile);
-        qCDebug(lcPropagator) << "CaseClashCheck for " << file;
         WIN32_FIND_DATA FindFileData;
         HANDLE hFind;
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -513,21 +513,23 @@ void OwncloudPropagator::setSyncOptions(const SyncOptions &syncOptions)
 
 bool OwncloudPropagator::localFileNameClash(const QString &relFile)
 {
-    bool re = false;
     const QString file(_localDir + relFile);
+    OC_ASSERT(!file.isEmpty());
 
     if (!file.isEmpty() && Utility::fsCasePreserving()) {
         qCDebug(lcPropagator) << "CaseClashCheck for " << file;
 #ifdef Q_OS_MAC
-        QFileInfo fileInfo(file);
+        const QFileInfo fileInfo(file);
         if (!fileInfo.exists()) {
-            re = false;
             qCWarning(lcPropagator) << "No valid fileinfo";
+            return false;
         } else {
             // Need to normalize to composited form because of QTBUG-39622/QTBUG-55896
             const QString cName = fileInfo.canonicalFilePath().normalized(QString::NormalizationForm_C);
-            bool equal = (file == cName);
-            re = (!equal && !cName.endsWith(relFile, Qt::CaseSensitive));
+            if (file != cName && !cName.endsWith(relFile, Qt::CaseSensitive)) {
+                qCWarning(lcPropagator) << "Detected case clash between" << file << "and" << cName;
+                return true;
+            }
         }
 #elif defined(Q_OS_WIN)
         WIN32_FIND_DATA FindFileData;
@@ -537,12 +539,12 @@ bool OwncloudPropagator::localFileNameClash(const QString &relFile)
         if (hFind == INVALID_HANDLE_VALUE) {
             // returns false.
         } else {
-            QString realFileName = QString::fromWCharArray(FindFileData.cFileName);
+            const QString realFileName = QString::fromWCharArray(FindFileData.cFileName);
             FindClose(hFind);
 
             if (!file.endsWith(realFileName, Qt::CaseSensitive)) {
                 qCWarning(lcPropagator) << "Detected case clash between" << file << "and" << realFileName;
-                re = true;
+                return true;
             }
         }
 #else
@@ -550,13 +552,13 @@ bool OwncloudPropagator::localFileNameClash(const QString &relFile)
         // Just check that there is no other file with the same name and different casing.
         QFileInfo fileInfo(file);
         const QString fn = fileInfo.fileName();
-        QStringList list = fileInfo.dir().entryList(QStringList() << fn);
+        const QStringList list = fileInfo.dir().entryList({ fn });
         if (list.count() > 1 || (list.count() == 1 && list[0] != fn)) {
-            re = true;
+            return true;
         }
 #endif
     }
-    return re;
+    return false;
 }
 
 bool OwncloudPropagator::hasCaseClashAccessibilityProblem(const QString &relfile)

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -381,6 +381,11 @@ void PropagateDownloadFile::start()
     }
     if (_item->_type == ItemTypeVirtualFile) {
         qCDebug(lcPropagateDownload) << "creating virtual file" << _item->_file;
+        // do a klaas' case clash check.
+        if (propagator()->localFileNameClash(_item->_file)) {
+            done(SyncFileItem::NormalError, tr("File %1 can not be downloaded because of a local file name clash!").arg(QDir::toNativeSeparators(_item->_file)));
+            return;
+        }
         auto r = vfs->createPlaceholder(*_item);
         if (!r) {
             done(SyncFileItem::NormalError, r.error());


### PR DESCRIPTION
Bugfix: Detect file name clash with VirtualFiles enabled

We fixed an issue where the file name clash detection was not run with
VirtualFiles enabled.

https://github.com/owncloud/client/issues/8323