### PR TITLE
Properly escape response texts in socket api

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -1106,7 +1106,10 @@ void SocketApi::command_ASYNC_LIST_WIDGETS(const QSharedPointer<SocketApiJob> &j
     for (auto &widget : allObjects(QApplication::allWidgets())) {
         auto objectName = widget->objectName();
         if (!objectName.isEmpty()) {
-            response += objectName + ":" + widget->property("text").toString() + ", ";
+            // Apply urlencoding with escaped ',' and ':', so that the response can be safely split at these.
+            QString encObjectName   = QUrl::toPercentEncoding(objectName,                          " =<>/&@\"", "|,:");
+            QString encTextProperty = QUrl::toPercentEncoding(widget->property("text").toString(), " =<>/&@\"", "|,:");
+            response += encObjectName + ":" + encTextProperty + ", ";
         }
     }
     job->resolve(response);


### PR DESCRIPTION
The characters `|` and `:` are reserved characters in the protocol. In case of the ASYNC_LIST_WIDGETS command, a comma separated list is returned, so `,` is also a reserved character.
With the suggested url-percent-encoding, the replacement sequences for `| : ,` are `%7C %3A %2C`
This also ensures that no unexpected linebreaks or other control characters could violate the protocol.


Fixes #8399 
Other commands may also be affected. Not checked.
