### PR TITLE
Improve Configuration File Document

### DIFF
--- a/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
+++ b/docs/modules/ROOT/pages/advanced_usage/configuration_file.adoc
@@ -2,7 +2,15 @@
 :toc:
 :ini-file-format-url: https://en.wikipedia.org/wiki/INI_file
 
-The ownCloud Client reads a configuration file.
+== Introduction
+
+The ownCloud Client uses a configuration file. It has several sections for particular settings.
+You will find more sections in the configuration file than described here. Do not change any of
+those settings except support advises you to do so. 
+
+== Location of the Configuration File
+ 
+The location of the configuration file depends on the operating system used.
 You can locate this configuration file as follows:
 
 [cols="25%,75%",options="header"]
@@ -18,15 +26,14 @@ You can locate this configuration file as follows:
 |`$HOME/Library/Preferences/ownCloud/owncloud.cfg`
 |===
 
-The configuration file contains settings using {ini-file-format-url}[the Microsoft Windows `.ini` file format].
+The configuration file contains settings using the {ini-file-format-url}[Microsoft Windows .ini file format].
 You can overwrite changes using the ownCloud configuration dialog.
 
-NOTE: Use caution when making changes to the ownCloud Client configuration file. Incorrect settings can produce unintended results.
+WARNING: Use caution when making changes to the ownCloud Client configuration file. Incorrect settings can produce unintended results.
 
-Some interesting values that can be set on the configuration file are:
+== Section `[ownCloud]`
 
-== `[ownCloud]` Section
-
+[width="100%",cols="45%,25%,100%",options="header"]
 |===
 |  Variable | Default | Meaning 
 | `remotePollInterval` 
@@ -46,26 +53,31 @@ Some interesting values that can be set on the configuration file are:
 | Specifies the default interval of checking for new server notifications in milliseconds. 
 |===
 
-== `[General]` Section
+== Section `[General]`
 
+[width="100%",cols="45%,25%,100%",options="header"]
 |===
 | Variable | Default | Meaning 
 
 | `chunkSize` 
-| `10000000` (or 10 MB)
+| `10000000` +
+(or 10 MB)
 | Specifies the initial chunk size of uploaded files in bytes.
 The client will dynamically adjust this size within the maximum and minimum bounds (see below).
 
 | `maxChunkSize`
-| `100000000` (or 100 MB)
+| `100000000` +
+(or 100 MB)
 | Specifies the maximum chunk size of uploaded files in bytes.
 
 | `minChunkSize`
-| `1000000` (or 1 MB)
+| `1000000` +
+(or 1 MB)
 | Specifies the minimum chunk size of uploaded files in bytes.
 
 | `targetChunkUploadDuration`
-| `60000` (1 minute)
+| `60000` +
+(1 minute)
 | Target duration in milliseconds for chunk uploads.
 The client adjusts the chunk size until each chunk upload takes approximately this long.
 Set to 0 to disable dynamic chunk sizing.
@@ -93,9 +105,9 @@ Turning this on does not enable experimental behavior on its own.
 It does enable user interface options that can be used to opt in to experimental features. 
 |===
 
-== `[Proxy]` Section 
+== Section `[Proxy]` 
 
-[cols="2,2,2a"]
+[width="100%",cols="45%,25%,100%",options="header"]
 |===
 | Variable 
 | Default 
@@ -113,9 +125,9 @@ It does enable user interface options that can be used to opt in to experimental
 | `2` 
 |
 
-* `0` for System Proxy. 
-* `1` for SOCKS5 Proxy. 
-* `2` for No Proxy. 
-* `3` for HTTP(S) Proxy.
+* `0` for System Proxy +
+* `1` for SOCKS5 Proxy +
+* `2` for No Proxy +
+* `3` for HTTP(S) Proxy
 
 |===


### PR DESCRIPTION
I was not able to change the base branch from master (#8409) to 2.7 --> new PR

This is an improvement of the configuration file.
The content renders now much better, some text has been improved and added.
When you do a build or render it with a browser antora plugin, it now looks much more professional

Backport to 2.6 and master