### PR TITLE
Always call doLog even if we don't have a file stream

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -206,7 +206,12 @@ void Logger::setLogRules(const QSet<QString> &rules)
 {
     static const QString defaultRule = qEnvironmentVariable("QT_LOGGING_RULES").replace(QLatin1Char(';'), QLatin1Char('\n'));
     _logRules = rules;
-    const QString tmp = rules.toList().join(QLatin1Char('\n')) + QLatin1Char('\n') + defaultRule;
+    QString tmp;
+    QTextStream out(&tmp);
+    for (const auto &p : rules) {
+        out << p << QLatin1Char('\n');
+    }
+    out << defaultRule;
     qDebug() << tmp;
     QLoggingCategory::setFilterRules(tmp);
 }

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -36,29 +36,6 @@ constexpr int CrashLogSize = 20;
 }
 namespace OCC {
 
-static void mirallLogCatcher(QtMsgType type, const QMessageLogContext &ctx, const QString &message)
-{
-    auto logger = Logger::instance();
-    if (!logger->isNoop()) {
-        logger->doLog(qFormatLogMessage(type, ctx, message));
-    }
-    if(type == QtCriticalMsg || type == QtFatalMsg) {
-        std::cerr << qPrintable(qFormatLogMessage(type, ctx, message)) << std::endl;
-    }
-
-    if(type == QtFatalMsg) {
-        if (!logger->isNoop()) {
-            logger->dumpCrashLog();
-            logger->close();
-        }
-#if defined(Q_OS_WIN)
-    // Make application terminate in a way that can be caught by the crash reporter
-        Utility::crash();
-#endif
-    }
-}
-
-
 Logger *Logger::instance()
 {
     static Logger log;
@@ -71,9 +48,9 @@ Logger::Logger(QObject *parent)
     qSetMessagePattern(QStringLiteral("%{time MM-dd hh:mm:ss:zzz} [ %{type} %{category} ]%{if-debug}\t[ %{function} ]%{endif}:\t%{message}"));
     _crashLog.resize(CrashLogSize);
 #ifndef NO_MSG_HANDLER
-    qInstallMessageHandler(mirallLogCatcher);
-#else
-    Q_UNUSED(mirallLogCatcher)
+    qInstallMessageHandler([](QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
+            Logger::instance()->doLog(type, ctx, message);
+        });
 #endif
 }
 
@@ -100,23 +77,15 @@ void Logger::postGuiMessage(const QString &title, const QString &message)
     emit guiMessage(title, message);
 }
 
-/**
- * Returns true if doLog does nothing and need not to be called
- */
-bool Logger::isNoop() const
-{
-    QMutexLocker lock(&_mutex);
-    return !_logstream;
-}
-
 bool Logger::isLoggingToFile() const
 {
     QMutexLocker lock(&_mutex);
     return _logstream;
 }
 
-void Logger::doLog(const QString &msg)
+void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString &message)
 {
+    const QString msg = qFormatLogMessage(type, ctx, message);
     {
         QMutexLocker lock(&_mutex);
         _crashLogIndex = (_crashLogIndex + 1) % CrashLogSize;
@@ -126,13 +95,20 @@ void Logger::doLog(const QString &msg)
             if (_doFileFlush)
                 _logstream->flush();
         }
+        if (type == QtFatalMsg) {
+            close();
+#if defined(Q_OS_WIN)
+            // Make application terminate in a way that can be caught by the crash reporter
+            Utility::crash();
+#endif
+        }
     }
     emit logWindowLog(msg);
 }
 
 void Logger::close()
 {
-    QMutexLocker lock(&_mutex);
+    dumpCrashLog();
     if (_logstream)
     {
         _logstream->flush();

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -36,11 +36,9 @@ class OWNCLOUDSYNC_EXPORT Logger : public QObject
 {
     Q_OBJECT
 public:
-    bool isNoop() const;
     bool isLoggingToFile() const;
 
-    void doLog(const QString &log);
-    void close();
+    void doLog(QtMsgType type, const QMessageLogContext &ctx, const QString &message);
 
     static Logger *instance();
 
@@ -80,8 +78,6 @@ public:
     }
     void setLogRules(const QSet<QString> &rules);
 
-    void dumpCrashLog();
-
 signals:
     void logWindowLog(const QString &);
 
@@ -95,6 +91,10 @@ public slots:
 private:
     Logger(QObject *parent = nullptr);
     ~Logger() override;
+
+    void close();
+    void dumpCrashLog();
+
     QFile _logFile;
     bool _doFileFlush = false;
     std::chrono::hours _logExpire;


### PR DESCRIPTION
The only overhead added is the call to qFormatMessage... and we lock one time less if one is attached.

Depends on #8470