### PR TITLE
Instead of renaming the targets, we rename their output 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/THEME.cmake")
 
 set(synclib_NAME "${APPLICATION_EXECUTABLE}sync")
-set(csync_NAME "${APPLICATION_EXECUTABLE}_csync")
 
 
 # For config.h

--- a/changelog/unreleased/8482
+++ b/changelog/unreleased/8482
@@ -1,0 +1,5 @@
+Bugfix: Fix brandings with space in the name
+
+We fix a build system issue with brandings containing spaces.
+
+https://github.com/owncloud/client/pull/8482

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,24 +1,21 @@
-set(cmd_NAME ${APPLICATION_EXECUTABLE}cmd)
-set(cmd_SRC
-    cmd.cpp
-    simplesslerrorhandler.cpp
-    netrcparser.cpp
-   )
-
-
 if(NOT BUILD_LIBRARIES_ONLY)
-    add_executable(${cmd_NAME}  ${cmd_SRC})
-    ecm_mark_nongui_executable(${cmd_NAME})
+    add_executable(cmd
+        cmd.cpp
+        simplesslerrorhandler.cpp
+        netrcparser.cpp
+    )
+    set_target_properties(cmd PROPERTIES OUTPUT_NAME "${APPLICATION_EXECUTABLE}cmd")
+    ecm_mark_nongui_executable(cmd)
 
-    target_link_libraries(${cmd_NAME} "${csync_NAME}" "${synclib_NAME}" Qt5::Core Qt5::Network)
+    target_link_libraries(cmd csync libsync Qt5::Core Qt5::Network)
 
     # Need tokenizer for netrc parser
-    target_include_directories(${cmd_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer)
+    target_include_directories(cmd PRIVATE ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer)
 
     if(APPLE)
-      install(TARGETS ${cmd_NAME} RUNTIME DESTINATION "${KDE_INSTALL_BUNDLEDIR}/${APPLICATION_EXECUTABLE}.app/Contents/MacOS/")
+      install(TARGETS cmd RUNTIME DESTINATION "${KDE_INSTALL_BUNDLEDIR}/${APPLICATION_EXECUTABLE}.app/Contents/MacOS/")
     else()
-      install(TARGETS ${cmd_NAME} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+      install(TARGETS cmd ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
     endif()
 endif()
 

--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -47,26 +47,26 @@ endif()
 
 configure_file(csync_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/csync_version.h)
 
-add_library("${csync_NAME}" SHARED ${common_SOURCES} ${csync_SRCS})
+add_library(csync SHARED ${common_SOURCES} ${csync_SRCS})
 
 target_include_directories(
-  "${csync_NAME}"
+  csync
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/std
 )
 
-generate_export_header("${csync_NAME}"
+generate_export_header(csync
   EXPORT_MACRO_NAME OCSYNC_EXPORT
   EXPORT_FILE_NAME ocsynclib.h
 )
 
-target_link_libraries("${csync_NAME}"
+target_link_libraries(csync
   ${CSYNC_REQUIRED_LIBRARIES}
   SQLite::SQLite3
   Qt5::Core Qt5::Concurrent
 )
 
 if(ZLIB_FOUND)
-  target_link_libraries("${csync_NAME}" ZLIB::ZLIB)
+  target_link_libraries(csync ZLIB::ZLIB)
 endif(ZLIB_FOUND)
 
 
@@ -74,17 +74,19 @@ endif(ZLIB_FOUND)
 if (APPLE)
     find_library(FOUNDATION_LIBRARY NAMES Foundation)
     find_library(CORESERVICES_LIBRARY NAMES CoreServices)
-    target_link_libraries("${csync_NAME}" ${FOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
+    target_link_libraries(csync ${FOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
 endif()
 
 set_target_properties(
-  "${csync_NAME}"
+  csync
     PROPERTIES
+      OUTPUT_NAME
+        "${APPLICATION_EXECUTABLE}_csync"
       VERSION
         ${LIBRARY_VERSION}
       SOVERSION
         ${LIBRARY_SOVERSION}
 )
-INSTALL(TARGETS "${csync_NAME}" ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+INSTALL(TARGETS csync ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 
 configure_file(config_csync.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config_csync.h)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 add_library(owncloudCore STATIC ${final_src})
 set_target_properties(owncloudCore PROPERTIES AUTOUIC ON AUTORCC ON)
 target_link_libraries(owncloudCore PUBLIC Qt5::Widgets Qt5::Network Qt5::Xml
-                                          ${synclib_NAME})
+                                          libsync)
 
 target_include_directories(owncloudCore PUBLIC
     ${CMAKE_SOURCE_DIR}/src/3rdparty/QProgressIndicator
@@ -189,27 +189,31 @@ if(WITH_CRASHREPORTER)
     endif()
 endif()
 
-add_executable(${APPLICATION_EXECUTABLE} main.cpp)
-set_target_properties(${APPLICATION_EXECUTABLE} PROPERTIES AUTOUIC ON AUTORCC ON)
-target_link_libraries( ${APPLICATION_EXECUTABLE} owncloudCore )
+add_executable(owncloud main.cpp)
+set_target_properties(owncloud PROPERTIES
+    OUTPUT_NAME "${APPLICATION_EXECUTABLE}"
+    AUTOUIC ON
+    AUTORCC ON
+)
+target_link_libraries(owncloud owncloudCore)
 
 
 find_package(Qt5LinguistTools)
 if(Qt5LinguistTools_FOUND)
     qt5_add_translation(client_I18N ${TRANSLATIONS})
-    target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${client_I18N})
+    target_sources(owncloud PRIVATE ${client_I18N})
 endif()
 
 #TODO Move resources files
-target_sources(${APPLICATION_EXECUTABLE} PRIVATE
+target_sources(owncloud PRIVATE
     ${PROJECT_SOURCE_DIR}/client.qrc
     ${PROJECT_SOURCE_DIR}/core_theme.qrc)
 
-generate_theme(${APPLICATION_EXECUTABLE} OWNCLOUD_SIDEBAR_ICONS)
+generate_theme(owncloud OWNCLOUD_SIDEBAR_ICONS)
 MESSAGE(STATUS "OWNCLOUD_SIDEBAR_ICONS: ${APPLICATION_ICON_NAME}: ${OWNCLOUD_SIDEBAR_ICONS}")
 
 ecm_add_app_icon(appIcons ICONS "${OWNCLOUD_ICONS}" SIDEBAR_ICONS "${OWNCLOUD_SIDEBAR_ICONS}" OUTFILE_BASENAME "${APPLICATION_ICON_NAME}")
-target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${appIcons})
+target_sources(owncloud PRIVATE ${appIcons})
 
 if(NOT APPLE)
     if(WIN32)
@@ -217,9 +221,9 @@ if(NOT APPLE)
           ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
           ${CMAKE_CURRENT_BINARY_DIR}/version.rc
           @ONLY)
-        target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+        target_sources(owncloud PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
         if(NOT MSVC)
-            target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/manifest-mingw.rc)
+            target_sources(owncloud PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/manifest-mingw.rc)
         endif()
     else()
         file(GLOB _icons "${OEM_THEME_DIR}/theme/colored/*-${APPLICATION_ICON_NAME}-icon.png")
@@ -234,7 +238,7 @@ if(NOT APPLE)
 
     # we may not add MACOSX_BUNDLE here, if not building one
 else()
-    target_sources(${APPLICATION_EXECUTABLE} PRIVATE ${OWNCLOUD_BUNDLED_RESOURCES})
+    target_sources(owncloud PRIVATE ${OWNCLOUD_BUNDLED_RESOURCES})
 
     set_source_files_properties(
       ${client_I18N}
@@ -248,10 +252,10 @@ else()
       MACOSX_PACKAGE_LOCATION Resources
       )
 
-  set_target_properties(${APPLICATION_EXECUTABLE} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/MacOSXBundleInfo.plist)
+  set_target_properties(owncloud PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/MacOSXBundleInfo.plist)
 endif()
 
-install(TARGETS ${APPLICATION_EXECUTABLE} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+install(TARGETS owncloud ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 
 if(UNIX AND NOT APPLE)
     include(libcloudproviders/libcloudproviders.cmake)

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -75,14 +75,14 @@ IF (NOT APPLE)
     )
 ENDIF(NOT APPLE)
 
-add_library(${synclib_NAME} SHARED ${libsync_SRCS})
-target_link_libraries(${synclib_NAME} PUBLIC
-    "${csync_NAME}"
+add_library(libsync SHARED ${libsync_SRCS})
+target_link_libraries(libsync PUBLIC
+    csync
     Qt5::Core Qt5::Network
 )
 
 if ( APPLE )
-    target_link_libraries(${synclib_NAME} PUBLIC
+    target_link_libraries(libsync PUBLIC
          /System/Library/Frameworks/CoreServices.framework
          /System/Library/Frameworks/Foundation.framework
          /System/Library/Frameworks/AppKit.framework
@@ -91,26 +91,26 @@ endif()
 
 if (NOT TOKEN_AUTH_ONLY)
     find_package(Qt5 REQUIRED COMPONENTS Widgets)
-    target_link_libraries(${synclib_NAME} PUBLIC Qt5::Widgets qt5keychain)
+    target_link_libraries(libsync PUBLIC Qt5::Widgets qt5keychain)
 endif()
 
 if(Inotify_FOUND)
-    target_include_directories(${synclib_NAME} PRIVATE ${Inotify_INCLUDE_DIRS})
-    target_link_libraries(${synclib_NAME} PUBLIC ${Inotify_LIBRARIES} )
+    target_include_directories(libsync PRIVATE ${Inotify_INCLUDE_DIRS})
+    target_link_libraries(libsync PUBLIC ${Inotify_LIBRARIES} )
 endif()
 
-GENERATE_EXPORT_HEADER( ${synclib_NAME}
-        BASE_NAME ${synclib_NAME}
+GENERATE_EXPORT_HEADER(libsync
         EXPORT_MACRO_NAME OWNCLOUDSYNC_EXPORT
         EXPORT_FILE_NAME owncloudlib.h
         STATIC_DEFINE OWNCLOUD_BUILT_AS_STATIC
 )
 
-set_target_properties( ${synclib_NAME}  PROPERTIES
+set_target_properties(libsync PROPERTIES
+        OUTPUT_NAME "${synclib_NAME}"
         VERSION ${MIRALL_VERSION}
         SOVERSION ${MIRALL_SOVERSION}
 )
-install(TARGETS ${synclib_NAME} ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+install(TARGETS libsync ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 
 
 add_subdirectory(vfs)

--- a/src/libsync/vfs/suffix/CMakeLists.txt
+++ b/src/libsync/vfs/suffix/CMakeLists.txt
@@ -1,9 +1,11 @@
-add_library("${synclib_NAME}_vfs_suffix" MODULE
+add_library(owncloud_vfs_suffix MODULE
     vfs_suffix.cpp
 )
 
-target_link_libraries("${synclib_NAME}_vfs_suffix"
-    "${synclib_NAME}"
+set_target_properties(owncloud_vfs_suffix PROPERTIES OUTPUT_NAME "${synclib_NAME}_vfs_suffix")
+
+target_link_libraries(owncloud_vfs_suffix
+    libsync
 )
-INSTALL(TARGETS "${synclib_NAME}_vfs_suffix" DESTINATION "${KDE_INSTALL_PLUGINDIR}")
+INSTALL(TARGETS owncloud_vfs_suffix DESTINATION "${KDE_INSTALL_PLUGINDIR}")
 

--- a/test/csync/CMakeLists.txt
+++ b/test/csync/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(torture STATIC torture.c cmdline.c)
 target_link_libraries(torture ${CMOCKA_LIBRARIES})
 set_target_properties(torture PROPERTIES C_STANDARD 99 AUTOMOC OFF)
 
-set(TEST_TARGET_LIBRARIES torture Qt5::Core "${csync_NAME}")
+set(TEST_TARGET_LIBRARIES torture Qt5::Core csync)
 
 # create tests
 

--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -25,7 +25,7 @@ macro(owncloud_add_benchmark test_class additional_cpp)
     ecm_mark_nongui_executable(${OWNCLOUD_TEST_CLASS}Bench)
 
     target_link_libraries(${OWNCLOUD_TEST_CLASS}Bench
-        ${APPLICATION_EXECUTABLE}sync
+        libsync
         Qt5::Core Qt5::Test Qt5::Xml Qt5::Network
     )
     target_compile_definitions(${OWNCLOUD_TEST_CLASS}Bench PRIVATE OWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")


### PR DESCRIPTION
This fixes brandings with spaces in the name

Do we need a changelog entry for that?