### PR TITLE
Make language configurable

### DIFF
--- a/changelog/unreleased/8466
+++ b/changelog/unreleased/8466
@@ -1,0 +1,10 @@
+Enhancement: Add language picker to general settings
+
+Users can override the automatically chosen language by
+selecting a custom language in a dropdown in the general
+settings.
+Furthermore, a --language CLI parameter was added that
+serves the same purpose.
+
+https://github.com/owncloud/client/issues/8466
+https://github.com/owncloud/client/pull/8493

--- a/docs/modules/ROOT/pages/advanced_usage/command_line_options.adoc
+++ b/docs/modules/ROOT/pages/advanced_usage/command_line_options.adoc
@@ -46,4 +46,7 @@ This command is used with `--logdir`.
 
 | `--confdir <dirname>`
 | Uses the specified configuration directory.
+
+| `--language <locale>`
+| Enforce language specified by given locale in the user interface. Example values: `de_DE`, `en_US`, `nl_NL`
 |===

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -86,6 +86,7 @@ set(client_SRCS
     servernotificationhandler.cpp
     guiutility.cpp
     elidedlabel.cpp
+    translations.cpp
     creds/httpcredentialsgui.cpp
     wizard/postfixlineedit.cpp
     wizard/abstractcredswizardpage.cpp

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -698,11 +698,15 @@ void Application::setupTranslations()
 {
     QStringList uiLanguages = QLocale::system().uiLanguages();
 
+    // the user can also set a locale in the settings, so we need to load the config file
+    ConfigFile cfg;
+
     // allow user and theme to enforce a language via a commandline parameter
     const auto themeEnforcedLocale = Theme::instance()->enforcedLocale();
-    // note that the user enforced language is prioritized over the theme enforced one
+    // note that user-enforced languages are prioritized over the theme enforced one
+    // to make testing easier, --language overrides the setting from the config file
     // as we are prepending to the list of languages, the list passed to the loop must be sorted with ascending priority
-    for (const auto &enforcedLocale : { themeEnforcedLocale, _userEnforcedLanguage }) {
+    for (const auto &enforcedLocale : { themeEnforcedLocale, cfg.uiLanguage(), _userEnforcedLanguage }) {
         if (!enforcedLocale.isEmpty()) {
             uiLanguages.prepend(enforcedLocale);
         }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -42,6 +42,7 @@
 #include "csync_exclude.h"
 #include "common/vfs.h"
 #include "settingsdialog.h"
+#include "translations.h"
 
 #include "config.h"
 
@@ -88,23 +89,6 @@ namespace {
             "  --logdebug           : also output debug-level messages in the log.\n"
             "  --language <locale>  : override UI language\n"
             "  --confdir <dirname>  : Use the given configuration folder.");
-    }
-
-    QString applicationTrPath()
-    {
-        QString devTrPath = qApp->applicationDirPath() + QString::fromLatin1("/../src/gui/");
-        if (QDir(devTrPath).exists()) {
-            // might miss Qt, QtKeyChain, etc.
-            qCWarning(lcApplication) << "Running from build location! Translations may be incomplete!";
-            return devTrPath;
-        }
-#if defined(Q_OS_WIN)
-        return QApplication::applicationDirPath();
-#elif defined(Q_OS_MAC)
-        return QApplication::applicationDirPath() + QLatin1String("/../Resources/Translations"); // path defaults to app dir.
-#elif defined(Q_OS_UNIX)
-        return QString::fromLatin1(SHAREDIR "/" APPLICATION_EXECUTABLE "/i18n/");
-#endif
     }
 }
 
@@ -731,8 +715,8 @@ void Application::setupTranslations()
     foreach (QString lang, uiLanguages) {
         lang.replace(QLatin1Char('-'), QLatin1Char('_')); // work around QTBUG-25973
         lang = substLang(lang);
-        const QString trPath = applicationTrPath();
-        const QString trFile = QLatin1String("client_") + lang;
+        const QString trPath = Translations::applicationTrPath();
+        const QString trFile = Translations::translationsFilePrefix() + lang;
         if (translator->load(trFile, trPath) || lang.startsWith(QLatin1String("en"))) {
             // Permissive approach: Qt and keychain translations
             // may be missing, but Qt translations must be there in order

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -136,6 +136,7 @@ private:
     bool _logDebug;
     bool _userTriggeredConnect;
     bool _debugMode;
+    QString _userEnforcedLanguage;
 
     ClientProxy _proxy;
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -67,8 +67,12 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     connect(_ui->newFolderLimitSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newExternalStorage, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
 
-    connect(_ui->languageDropdown, QOverload<int>::of(&QComboBox::activated), this, [this](int) {
-        this->saveMiscSettings();
+    connect(_ui->languageDropdown, QOverload<int>::of(&QComboBox::activated), this, [this]() {
+        // first, store selected language in config file
+        saveMiscSettings();
+
+        // warn user that a language change requires a restart to take effect
+        QMessageBox::warning(this, tr("Warning"), tr("Language changes require a restart of this application to take effect."), QMessageBox::Ok);
     });
 
     /* handle the hidden file checkbox */

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -53,9 +53,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         this, &GeneralSettings::slotToggleOptionalDesktopNotifications);
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 
-    // needs to be called before settings are loaded
-    loadLanguageNamesIntoDropdown();
-
     reloadConfig();
     loadMiscSettings();
     slotUpdateInfo();
@@ -151,7 +148,9 @@ void GeneralSettings::loadMiscSettings()
     _ui->newExternalStorage->setChecked(cfgFile.confirmExternalStorage());
     _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
 
-    // we assume the language names have been loaded into the dropdown already (by making sure that the corresponding method is called before this one)
+    // the dropdown has to be populated before we can can pick an entry below based on the stored setting
+    loadLanguageNamesIntoDropdown();
+
     const auto &locale = cfgFile.uiLanguage();
 
     // index 0 means "use default", which we use unless the loop below sets another entry
@@ -354,6 +353,7 @@ void GeneralSettings::loadLanguageNamesIntoDropdown()
         localesToLanguageNamesMap.insert(availableLocale, nativeLanguageName);
     }
 
+    // allow method to be called more than once
     _ui->languageDropdown->clear();
 
     // if no option has been chosen explicitly by the user, the first entry shall be used

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -56,6 +56,7 @@ protected:
 
 private:
     void reloadConfig();
+    void loadLanguageNamesIntoDropdown();
 
     Ui::GeneralSettings *_ui;
     QPointer<IgnoreListEditor> _ignoreEditor;

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -15,6 +15,7 @@
 #ifndef MIRALL_GENERALSETTINGS_H
 #define MIRALL_GENERALSETTINGS_H
 
+#include <QMap>
 #include <QWidget>
 #include <QPointer>
 
@@ -61,6 +62,7 @@ private:
     Ui::GeneralSettings *_ui;
     QPointer<IgnoreListEditor> _ignoreEditor;
     bool _currentlyLoading;
+    QMap<QString, QString> localesToLanguageNamesMap;
 };
 
 

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -56,6 +56,39 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="languageLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="locale">
+               <locale language="English" country="UnitedStates"/>
+              </property>
+              <property name="text">
+               <string>Language</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="languageDropdown">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="currentText">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/gui/translations.cpp
+++ b/src/gui/translations.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) by Duncan Mac-Vicar P. <duncan@kde.org>
+ * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ * Copyright (C) by Daniel Molkentin <danimo@owncloud.com>
+ * Copyright (C) by Fabian Müller <fmueller@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "translations.h"
+
+#include "config.h"
+#include "theme.h"
+
+#include <QApplication>
+#include <QLoggingCategory>
+#include <QDir>
+#include <QDirIterator>
+
+namespace OCC {
+
+namespace Translations {
+
+    Q_LOGGING_CATEGORY(lcTranslations, "gui.translations", QtInfoMsg)
+
+    const QString translationsFilePrefix()
+    {
+        return QStringLiteral("client_");
+    }
+
+    const QString translationsFileSuffix()
+    {
+        return QStringLiteral(".qm");
+    }
+
+    QString applicationTrPath()
+    {
+        QString devTrPath = qApp->applicationDirPath() + QString::fromLatin1("/../src/gui/");
+        if (QDir(devTrPath).exists()) {
+            // might miss Qt, QtKeyChain, etc.
+            qCWarning(lcTranslations) << "Running from build location! Translations may be incomplete!";
+            return devTrPath;
+        }
+#if defined(Q_OS_WIN)
+        return QApplication::applicationDirPath();
+#elif defined(Q_OS_MAC)
+        return QApplication::applicationDirPath() + QLatin1String("/../Resources/Translations"); // path defaults to app dir.
+#elif defined(Q_OS_UNIX)
+        return QStringLiteral(SHAREDIR "/" APPLICATION_EXECUTABLE "/i18n/");
+#endif
+    }
+
+    QSet<QString> listAvailableTranslations()
+    {
+        QSet<QString> availableTranslations;
+
+        // calculate a glob pattern which can be used in the iterator below to match only translations files
+        QString pattern = translationsFilePrefix() + "*" + translationsFileSuffix();
+
+        QDirIterator it(Translations::applicationTrPath(), QStringList() << pattern);
+
+        while (it.hasNext()) {
+            // extract locale part from filename
+            // of course, this method relies on the filenames to be accurate
+            const auto fileName = QFileInfo(it.next()).fileName();
+            const auto localePartLength = fileName.length() - translationsFileSuffix().length() - translationsFilePrefix().length();
+            QString localeName = fileName.mid(translationsFilePrefix().length(), localePartLength);
+
+            availableTranslations.insert(localeName);
+        }
+
+        return availableTranslations;
+    }
+
+} // namespace Translations
+
+} // namespace OCC

--- a/src/gui/translations.h
+++ b/src/gui/translations.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) by Fabian Müller <fmueller@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef TRANSLATIONSMANAGER_H
+#define TRANSLATIONSMANAGER_H
+
+#include <QSet>
+#include <QString>
+
+namespace OCC {
+
+namespace Translations {
+
+    /**
+    * @return translation files' filename prefix
+    */
+    const QString translationsFilePrefix();
+
+    /**
+    * @returntranslation files' filename suffix
+    */
+    const QString translationsFileSuffix();
+
+    /**
+     * @return path to translation files
+     */
+    QString applicationTrPath();
+
+    /**
+     * @return list of locales for which translations are available
+     */
+    QSet<QString> listAvailableTranslations();
+
+} // namespace Translations
+
+} // namespace OCC
+
+#endif // TRANSLATIONSMANAGER_H

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -63,6 +63,7 @@ const QString showInExplorerNavigationPaneC() { return QStringLiteral("showInExp
 const QString skipUpdateCheckC() { return QStringLiteral("skipUpdateCheck"); }
 const QString updateCheckIntervalC() { return QStringLiteral("updateCheckInterval"); }
 const QString updateChannelC() { return QStringLiteral("updateChannel"); }
+const QString uiLanguageC() { return QStringLiteral("uiLanguage"); }
 const QString geometryC() { return QStringLiteral("geometry"); }
 const QString timeoutC() { return QStringLiteral("timeout"); }
 const QString chunkSizeC() { return QStringLiteral("chunkSize"); }
@@ -566,6 +567,18 @@ void ConfigFile::setUpdateChannel(const QString &channel)
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(updateChannelC(), channel);
+}
+
+QString ConfigFile::uiLanguage() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(uiLanguageC(), QString()).toString();
+}
+
+void ConfigFile::setUiLanguage(const QString &uiLanguage)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(uiLanguageC(), uiLanguage);
 }
 
 void ConfigFile::setProxyType(int proxyType,

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -171,6 +171,9 @@ public:
     QString updateChannel() const;
     void setUpdateChannel(const QString &channel);
 
+    QString uiLanguage() const;
+    void setUiLanguage(const QString &uiLanguage);
+
     void saveGeometryHeader(QHeaderView *header);
     void restoreGeometryHeader(QHeaderView *header);
 


### PR DESCRIPTION
Closes #8466.

This PR adds two new methods to select the language within the GUI application: a config option in the general settings page, and a `--language` parameter.

![screenshot_2021-03-16_17-29-30](https://user-images.githubusercontent.com/80399010/111347466-267eb380-8677-11eb-809f-befd4900e4c6.png)

The current implementation of listing all available locales relies on the translation file's filenames. It extracts the locale part and tries to resolve the native language name using `QLocale::nativeLanguageName`. This seems to work relatively well, except for one file called `TW`. I suspect we have to rename that file to `tw`.