### PR TITLE
[tests-only] Adds tests for selecting and unselecting password protection checkbox

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -84,3 +84,9 @@ o_treeWidget_Conflict_Server_version_downloaded_local_copy_renamed_and_not_uploa
 qt_tabwidget_stackedwidget_OCC_ProtocolWidget_OCC_ProtocolWidget = {"container": stack_qt_tabwidget_stackedwidget_QStackedWidget, "name": "OCC__ProtocolWidget", "type": "OCC::ProtocolWidget", "visible": 1}
 oCC_ProtocolWidget_treeWidget_QTreeWidget = {"container": qt_tabwidget_stackedwidget_OCC_ProtocolWidget_OCC_ProtocolWidget, "name": "_treeWidget", "type": "QTreeWidget", "visible": 1}
 o_treeWidget_lorem_txt_QModelIndex = {"column": 1, "container": oCC_ProtocolWidget_treeWidget_QTreeWidget, "text": "lorem.txt", "type": "QModelIndex"}
+sharingDialog_qt_tabwidget_tabbar_QTabBar = {"name": "qt_tabwidget_tabbar", "type": "QTabBar", "visible": 1, "window": sharingDialog_OCC_ShareDialog}
+qt_tabwidget_tabbar_Public_Links_TabItem = {"container": sharingDialog_qt_tabwidget_tabbar_QTabBar, "text": "Public Links", "type": "TabItem"}
+qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget = {"container": sharingDialog_qt_tabwidget_stackedwidget_QStackedWidget, "name": "OCC__ShareLinkWidget", "type": "OCC::ShareLinkWidget", "visible": 1}
+oCC_ShareLinkWidget_checkBox_password_QCheckBox = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "checkBox_password", "type": "QCheckBox", "visible": 1}
+oCC_ShareLinkWidget_widget_editing_QWidget = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "widget_editing", "type": "QWidget", "visible": 1}
+oCC_ShareLinkWidget_checkBox_password_QProgressIndicator = {"aboveWidget": oCC_ShareLinkWidget_widget_editing_QWidget, "container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "leftWidget": oCC_ShareLinkWidget_checkBox_password_QCheckBox, "type": "QProgressIndicator", "unnamed": 1, "visible": 1}

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -155,7 +155,7 @@ def executeStepThroughMiddleware(context, step):
     body = {
     "step": step}
     params = json.dumps(body).encode('utf8')
-        
+
     req = urllib.request.Request(
         context.userData['middlewareUrl'] + 'execute',
         data=params,
@@ -185,7 +185,7 @@ def step(context, receiver, resource, permissions):
         clickButton(waitForObject(names.scrollArea_permissionsEdit_QCheckBox))
     if ('share' in permissionsList and shareChecked == False) or ('share' not in permissionsList and shareChecked == True):
         clickButton(waitForObject(names.scrollArea_permissionShare_QCheckBox))
-    
+
     clickButton(waitForObject(names.sharingDialog_Close_QPushButton))
 
 @Then('user "|any|" should be listed in the collaborators list for file "|any|" with permissions "|any|" on the client-UI')
@@ -194,7 +194,7 @@ def step(context, receiver, resource, permissions):
     socketConnect = syncstate.SocketConnect()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
     permissionsList = permissions.split(',')
-    
+
     test.compare(str(waitForObjectExists(names.scrollArea_sharedWith_QLabel).text), receiver)
     test.compare(waitForObjectExists(names.scrollArea_permissionsEdit_QCheckBox).checked, ('edit' in permissionsList))
     test.compare(waitForObjectExists(names.scrollArea_permissionShare_QCheckBox).checked, ('share' in permissionsList))
@@ -332,3 +332,21 @@ def step(context, number):
     # It might take some time for all files to sync except the expected number of unsynced files
     snooze(10)
     clickTab(waitForObject(names.stack_QTabWidget), "Not Synced ({})".format(number))
+
+@When('the user opens the public links dialog of "|any|" using the client-UI')
+def step(context, resource):
+    resource = substituteInLineCodes(context, resource).replace('//','/')
+    waitFor(lambda: isFileSynced(resource), context.userData['clientSyncTimeout'] * 1000)
+    waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
+    mouseClick(waitForObject(names.qt_tabwidget_tabbar_Public_Links_TabItem), 0, 0, Qt.NoModifier, Qt.LeftButton)
+
+@When("the user toggles the password protection using the client-UI")
+def step(context):
+    clickButton(waitForObject(names.oCC_ShareLinkWidget_checkBox_password_QCheckBox))
+
+@Then('the progress indicator should not be visible in the client-UI')
+def step(context):
+    test.compare(
+        waitForObjectExists(names.oCC_ShareLinkWidget_checkBox_password_QProgressIndicator).visible,
+        False
+    )

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -1,5 +1,9 @@
 Feature: Sharing
 
+  	As a user
+  	I want to share files and folders with other users
+  	So that those users can access the files and folders
+
     Scenario: simple sharing
         Given user "Alice" has been created on the server with default attributes
         And user "Brian" has been created on the server with default attributes
@@ -23,3 +27,29 @@ Feature: Sharing
             """
         When the user adds "Brian Murphy" as collaborator of resource "%client_sync_path%/textfile0.txt" with permissions "edit,share" using the client-UI
         Then user "Brian Murphy" should be listed in the collaborators list for file "%client_sync_path%/textfile0.txt" with permissions "edit,share" on the client-UI
+
+    @issue-7459
+    Scenario: Progress indicator should not be visible after unselecting the password protection checkbox while sharing through public link
+        Given user "Alice" has been created on the server with default attributes
+        And user "Alice" has set up a client with these settings and password "1234":
+            """
+            [Accounts]
+            0\Folders\1\ignoreHiddenFiles=true
+            0\Folders\1\localPath=%client_sync_path%
+            0\Folders\1\paused=false
+            0\Folders\1\targetPath=/
+            0\Folders\1\version=2
+            0\Folders\1\virtualFilesMode=off
+            0\dav_user=alice
+            0\display-name=Alice
+            0\http_oauth=false
+            0\http_user=alice
+            0\url=%local_server%
+            0\user=Alice
+            0\version=1
+            version=2
+            """
+        When the user opens the public links dialog of "%client_sync_path%/textfile0.txt" using the client-UI
+        And the user toggles the password protection using the client-UI
+        And the user toggles the password protection using the client-UI
+        Then the progress indicator should not be visible in the client-UI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds UI tests to select and unselect the password protection box while public sharing to see the status of the progress indicator.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/client/issues/7459

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
