### PR TITLE
Remove unnecessary stripping of leading slashes

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -498,9 +498,6 @@ FolderWizardSelectiveSync::~FolderWizardSelectiveSync()
 void FolderWizardSelectiveSync::initializePage()
 {
     QString targetPath = wizard()->property("targetPath").toString();
-    if (targetPath.startsWith('/')) {
-        targetPath = targetPath.mid(1);
-    }
     QString alias = QFileInfo(targetPath).fileName();
     if (alias.isEmpty())
         alias = Theme::instance()->appName();

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -122,10 +122,6 @@ void SelectiveSyncWidget::refreshFolders()
 void SelectiveSyncWidget::setFolderInfo(const QString &folderPath, const QString &rootName, const QStringList &oldBlackList)
 {
     _folderPath = folderPath;
-    if (_folderPath.startsWith(QLatin1Char('/'))) {
-        // remove leading '/'
-        _folderPath = folderPath.mid(1);
-    }
     _rootName = rootName;
     _oldBlackList = oldBlackList;
     refreshFolders();


### PR DESCRIPTION
Once the slash is gone, an assert is triggered, making the software terminate unexpectedly:

```
[...] [ fatal default ]: ASSERT: "relativePath.startsWith(QLatin1Char('/'))" in file .../client/src/libsync/abstractnetworkjob.cpp, line 196
```

This happens when trying to add a directory synchronization, in the second step where the remote directory is selected, once you click on the next button.

Related to #8459.