### PR TITLE
[tests-only] multiple small fixes in UI tests

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -140,6 +140,9 @@ def substituteInLineCodes(context, value):
 
     return value
 
+def sanitizePath(path):
+    return path.replace('//','/')
+
 def shareResource(resource):
     socketConnect = syncstate.SocketConnect()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
@@ -170,7 +173,7 @@ def executeStepThroughMiddleware(context, step):
 
 @When('the user adds "|any|" as collaborator of resource "|any|" with permissions "|any|" using the client-UI')
 def step(context, receiver, resource, permissions):
-    resource = substituteInLineCodes(context, resource).replace('//','/')
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFileSynced(resource), context.userData['clientSyncTimeout'] * 1000)
     waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
 
@@ -342,11 +345,10 @@ def step(context, number):
 
 
 def openPublicLinkDialog(context, resource):
-    resource = substituteInLineCodes(context, resource).replace('//','/')
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFileSynced(resource), context.userData['clientSyncTimeout'] * 1000)
     waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
     mouseClick(waitForObject(names.qt_tabwidget_tabbar_Public_Links_TabItem), 0, 0, Qt.NoModifier, Qt.LeftButton)
-
 
 @When('the user opens the public links dialog of "|any|" using the client-UI')
 def step(context, resource):
@@ -368,7 +370,7 @@ def step(context):
 
 @When('user "|any|" opens the sharing dialog of "|any|" using the client-UI')
 def step(context, receiver, resource):
-    resource = substituteInLineCodes(context, resource).replace('//','/')
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFolderSynced(resource), context.userData['clientSyncTimeout'] * 1000)
 
 

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -385,6 +385,7 @@ def step(context, resource):
     openPublicLinkDialog(context, resource)
     test.compare(str(waitForObjectExists(names.sharingDialog_label_name_QLabel).text), resource.replace(context.userData['clientSyncPath'], ''))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
+    waitFor(lambda: (waitForObject(names.linkShares_0_0_QModelIndex).displayText == "Public link"))
 
 
 @When('the user creates a new public link for file "|any|" with password "|any|" using the client-UI')
@@ -396,3 +397,4 @@ def step(context, resource, password):
     mouseClick(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), 0, 0, Qt.NoModifier, Qt.LeftButton)
     type(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), password)
     clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
+    waitFor(lambda: (findObject(names.linkShares_0_0_QModelIndex).displayText == "Public link"))

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -236,7 +236,7 @@ def step(context, stepPart1, stepPart2):
     )
 
 
-@Then(r"^(.*) on the server", regexp=True)
+@Then(r"^(.*) on the server$", regexp=True)
 def step(context, stepPart1):
     executeStepThroughMiddleware(
         context,

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -381,14 +381,16 @@ def step(context, fileShareContext):
 
 @When('the user creates a new public link for file "|any|" without password using the client-UI')
 def step(context, resource):
-    resource = openPublicLinkDialog(context, resource)
+    resource = sanitizePath(substituteInLineCodes(context, resource))
+    openPublicLinkDialog(context, resource)
     test.compare(str(waitForObjectExists(names.sharingDialog_label_name_QLabel).text), resource.replace(context.userData['clientSyncPath'], ''))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
 
 
 @When('the user creates a new public link for file "|any|" with password "|any|" using the client-UI')
 def step(context, resource, password):
-    resource = openPublicLinkDialog(context, resource)
+    resource = sanitizePath(substituteInLineCodes(context, resource))
+    openPublicLinkDialog(context, resource)
     test.compare(str(waitForObjectExists(names.sharingDialog_label_name_QLabel).text), resource.replace(context.userData['clientSyncPath'], ''))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_checkBox_password_QCheckBox))
     mouseClick(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), 0, 0, Qt.NoModifier, Qt.LeftButton)


### PR DESCRIPTION
multiple small issues fixed in the GUI tests:
- move path sanitization to own function
- don't rely on `openPublicLinkDialog` to sanitize path - that function should only do its own thing
- wait till the public share is created
- avoid that multiple matching step definitions
