### PR TITLE
Make crash report IDs easy to copy

### DIFF
--- a/changelog/unreleased/8130
+++ b/changelog/unreleased/8130
@@ -1,0 +1,9 @@
+Enhancement: Make crash report IDs easy to copy
+
+Users can now click on crash report IDs to copy them to
+their personal clipboard. This way, they can easily
+reference them in bug reports.
+
+https://github.com/dschmidt/libcrashreporter-qt/pull/25
+https://github.com/owncloud/client/issues/8130
+https://github.com/owncloud/client/pull/8540

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ if (NOT BUILD_LIBRARIES_ONLY)
     add_subdirectory(cmd)
 
     if (WITH_CRASHREPORTER)
-        add_subdirectory(3rdparty/libcrashreporter-qt)
+        add_subdirectory(3rdparty/libcrashreporter-qt EXCLUDE_FROM_ALL)
         add_subdirectory(crashreporter)
     endif()
 endif(NOT BUILD_LIBRARIES_ONLY)


### PR DESCRIPTION
Closes #8130.

Updates libcrashreporter-qt submodule to the latest commit to include https://github.com/dschmidt/libcrashreporter-qt/pull/25.

Also makes building `all` targets a little faster by excluding all targets from libcrashreporter-qt which are not explicitly linked by any other target. (They can still be buillt manually.)