### PR TITLE
Set up default locale correctly

### DIFF
--- a/changelog/unreleased/8367
+++ b/changelog/unreleased/8367
@@ -1,0 +1,8 @@
+Bugfix: Set up default locale correctly
+
+Fixes the formatting in locale-dependent widgets,
+e.g., date pickers, like the one in the "share
+link" window.
+
+https://github.com/owncloud/client/issues/8367
+https://github.com/owncloud/client/pull/8541

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -749,6 +749,10 @@ void Application::setupTranslations()
                 installTranslator(qtTranslator);
             if (!qtkeychainTranslator->isEmpty())
                 installTranslator(qtkeychainTranslator);
+
+            // makes sure widgets with locale-dependent formatting, e.g., QDateEdit, display the correct formatting
+            QLocale::setDefault(QLocale{lang});
+
             break;
         }
         if (property("ui_lang").isNull())

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -751,7 +751,7 @@ void Application::setupTranslations()
                 installTranslator(qtkeychainTranslator);
 
             // makes sure widgets with locale-dependent formatting, e.g., QDateEdit, display the correct formatting
-            QLocale::setDefault(QLocale{lang});
+            QLocale::setDefault(QLocale(lang));
 
             break;
         }


### PR DESCRIPTION
Some widgets, e.g., `QDateEdit`, use locale-dependent formatting to display its results. Setting the default locale correctly makes sure these widgets respect the user-selected language.

Fixes #8367.