### PR TITLE
[tests-only]password protection public link share for folder

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -101,3 +101,6 @@ oCC_ShareLinkWidget_qt_calendar_prevmonth_QPrevNextCalButton = {"container": qt_
 oCC_ShareLinkWidget_qt_calendar_calendarview_QCalendarView = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "qt_calendar_calendarview", "type": "QCalendarView", "visible": 1}
 oCC_ShareLinkWidget_qt_spinbox_lineedit_QLineEdit = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "qt_spinbox_lineedit", "type": "QLineEdit", "visible": 1}
 linkShares_0_0_QModelIndex = {"column": 0, "container": oCC_ShareLinkWidget_linkShares_QTableWidget, "row": 0, "type": "QModelIndex"}
+oCC_ShareLinkWidget_radio_readOnly_QRadioButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "radio_readOnly", "type": "QRadioButton", "visible": 1}
+oCC_ShareLinkWidget_radio_readWrite_QRadioButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "radio_readWrite", "type": "QRadioButton", "visible": 1}
+oCC_ShareLinkWidget_radio_uploadOnly_QRadioButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "radio_uploadOnly", "type": "QRadioButton", "visible": 1}

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -416,3 +416,32 @@ def step(context, publicLinkName, resource):
     type(waitForObject(names.oCC_ShareLinkWidget_calendar_QDateEdit), expDate[1])
     type(waitForObject(names.oCC_ShareLinkWidget_calendar_QDateEdit), expDate[2])
     type(waitForObject(names.oCC_ShareLinkWidget_calendar_QDateEdit), expYear)
+    
+    
+@When('the user creates a new public link with permissions "|any|" for folder "|any|" without password using the client-UI')
+def step(context, permissions, resource):
+    resource = sanitizePath(substituteInLineCodes(context, resource))
+    openPublicLinkDialog(context, resource)
+    radioObjectName = ''
+    if permissions == 'Download / View':
+        radioObjectName = name.oCC_ShareLinkWidget_radio_readOnly_QRadioButton
+    elif permissions == 'Download / View / Edit':
+        radioObjectName = names.oCC_ShareLinkWidget_radio_readWrite_QRadioButton
+    elif permissions == 'Upload only (File Drop)':
+        radioObjectName = names.oCC_ShareLinkWidget_radio_uploadOnly_QRadioButton   
+    test.compare(str(waitForObjectExists(radioObjectName).text), permissions)
+
+    clickButton(waitForObject(radioObjectName))
+    clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
+
+
+@When('the user creates a new public link with permissions "|any|" for folder "|any|" with password "|any|" using the client-UI')
+def step(context, permissions, resource, password):
+    resource = sanitizePath(substituteInLineCodes(context, resource))
+    openPublicLinkDialog(context, resource)
+    clickButton(waitForObject(names.oCC_ShareLinkWidget_checkBox_password_QCheckBox))
+    mouseClick(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), 0, 0, Qt.NoModifier, Qt.LeftButton)
+    type(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), password)
+    clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
+    waitFor(lambda: (findObject(names.linkShares_0_0_QModelIndex).displayText == "Public link"))
+

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -168,3 +168,53 @@ Feature: Sharing
             | expireDate | 2038-07-21 |
         Then the fields of the last public link share response of user "Alice" should include on the server
             | expireDate | 2038-07-21 |
+
+
+	Scenario: simple sharing of a folder by public link without password
+        Given user "Alice" has been created on the server with default attributes
+        And user "Alice" has set up a client with these settings and password "1234":
+            """
+            [Accounts]
+            0\Folders\1\ignoreHiddenFiles=true
+            0\Folders\1\localPath=%client_sync_path%
+            0\Folders\1\paused=false
+            0\Folders\1\targetPath=/
+            0\Folders\1\version=2
+            0\Folders\1\virtualFilesMode=off
+            0\dav_user=alice
+            0\display-name=Alice
+            0\http_oauth=false
+            0\http_user=alice
+            0\url=%local_server%
+            0\user=Alice
+            0\version=1
+            version=2
+            """
+        When the user creates a new public link with permissions "Download / View" for folder "%client_sync_path%/simple-folder" without password using the client-UI
+        Then as user "Alice" the folder "simple-folder" should have a public link on the server
+        And the public should be able to download the folder "lorem.txt" without password from the last created public link by "Alice" on the server
+
+
+	Scenario: simple sharing of a folder by public link with password
+        Given user "Alice" has been created on the server with default attributes
+        And user "Alice" has set up a client with these settings and password "1234":
+            """
+            [Accounts]
+            0\Folders\1\ignoreHiddenFiles=true
+            0\Folders\1\localPath=%client_sync_path%
+            0\Folders\1\paused=false
+            0\Folders\1\targetPath=/
+            0\Folders\1\version=2
+            0\Folders\1\virtualFilesMode=off
+            0\dav_user=alice
+            0\display-name=Alice
+            0\http_oauth=false
+            0\http_user=alice
+            0\url=%local_server%
+            0\user=Alice
+            0\version=1
+            version=2
+            """
+        When the user creates a new public link with permissions "Download / View " for folder "%client_sync_path%/simple-folder" with password "pass123" using the client-UI
+        Then as user "Alice" the folder "simple-folder" should have a public link on the server
+        And the public should be able to download the folder "lorem.txt" with password "pass123" from the last created public link by "Alice" on the server


### PR DESCRIPTION
### Description
This PR adds tests for sharing folder using public link:
- with password protection
- without password protection

### Related Issue
https://github.com/owncloud/client/issues/8501