### PR TITLE
Make sure share names are in sync with server

### DIFF
--- a/changelog/unreleased/7549
+++ b/changelog/unreleased/7549
@@ -1,0 +1,9 @@
+Bugfix: Keep share link names in sync with server
+
+When the name of a share link is changed, e.g., to an
+empty string, the server may not apply this, but assign
+a fallback value (e.g., the link ID). The client therefore
+needs to re-check the name after sending a change request.
+
+https://github.com/owncloud/client/issues/7549
+https://github.com/owncloud/client/pull/8546

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -452,6 +452,11 @@ void ShareLinkWidget::slotNameEdited(QTableWidgetItem *item)
     auto share = item->data(Qt::UserRole).value<QSharedPointer<LinkShare>>();
     if (share && newName != share->getName() && newName != share->getToken()) {
         share->setName(newName);
+
+        // the server doesn't necessarily apply the desired name but may assign a different one
+        // for instance, when the user removes a custom name by emptying the field, the server assigns the ID as name
+        // therefore, we need to fetch the name(s) from the server again to display accurate information
+        getShares();
     }
 }
 


### PR DESCRIPTION
Removing the name of a share link does not yield an error, but causes the server to automatically assign the link ID. The UI so far didn't show this, however. Rather than disallowing empty link names in the UI, we'll follow a "server makes it right" approach and trust it to either return an error or accept the request. In the latter case (which is what is experienced when emptying the name), to show up-to-date information client side, we have to re-fetch the share names from the server to show accurate information.

Fixes #7549.