### PR TITLE
Prevent GitHub actions from aborting remaining jobs on single failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     name: Build ownCloud
     runs-on: ${{ matrix.os }}
     strategy:
+        fail-fast: false
         matrix:
             include:
             - target: windows-msvc2017_32-cl


### PR DESCRIPTION
Sometimes, builds for single OSes might fail because of issues unrelated to a PR. In that case, it makes sense to have the CI finish the remaining jobs in order to be able to see whether these would have failed, too, or finished normally.