### PR TITLE
[tests-only]refactor tests to stop using skeleton files

### DIFF
--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -4,9 +4,12 @@ Feature: adding accounts
     I want to be able join multiple owncloud servers to the client
     So that I can sync data with various organisations
 
+
+	Background:
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+
     Scenario: Adding normal Account
-        Given user "Alice" has been created on the server with default attributes
-        And the user has started the client
+        Given the user has started the client
         When the user adds the first account with
             | server      | %local_server%     |
             | user        | Alice              |
@@ -14,9 +17,9 @@ Feature: adding accounts
             | localfolder | %client_sync_path% |
         Then an account should be displayed with the displayname Alice Hansen and host %local_server_hostname%
 
+
      Scenario: Adding multiple accounts
-        Given user "Brian" has been created on the server with default attributes
-        And user "Alice" has been created on the server with default attributes
+        Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice Hansen" has set up a client with default settings and password "1234"
         When the user adds an account with
             | server      | %local_server%     |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -4,16 +4,20 @@ Feature: Sharing
     I want to share files and folders with other users
     So that those users can access the files and folders
 
+
+	Background:
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+
     Scenario: simple sharing
-        Given user "Alice" has been created on the server with default attributes
-        And user "Brian" has been created on the server with default attributes
+        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user adds "Brian Murphy" as collaborator of resource "%client_sync_path%/textfile0.txt" with permissions "edit,share" using the client-UI
         Then user "Brian Murphy" should be listed in the collaborators list for file "%client_sync_path%/textfile0.txt" with permissions "edit,share" on the client-UI
 
     @issue-7459
     Scenario: Progress indicator should not be visible after unselecting the password protection checkbox while sharing through public link
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user opens the public links dialog of "%client_sync_path%/textfile0.txt" using the client-UI
         And the user toggles the password protection using the client-UI
@@ -24,9 +28,9 @@ Feature: Sharing
     Scenario: unshare a reshared file
         Given the setting "shareapi_auto_accept_share" on the server of app "core" has been set to "no"
         And the administrator on the server has set the default folder for received shares to "Shares"
-        And user "Alice" has been created on the server with default attributes
-        And user "Brian" has been created on the server with default attributes
-        And user "Carol" has been created on the server with default attributes
+        And user "Alice" has created on the server folder "simple-folder"
+        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Carol" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian"
         And user "Brian" has accepted the share "simple-folder" on the server offered by user "Alice"
         And user "Brian" has shared folder "Shares/simple-folder" on the server with user "Carol"
@@ -37,7 +41,7 @@ Feature: Sharing
 
 
     Scenario: simple sharing of a file by public link without password
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user creates a new public link for file "%client_sync_path%/textfile0.txt" without password using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link on the server
@@ -45,15 +49,15 @@ Feature: Sharing
 
 
     Scenario: simple sharing of a file by public link with password
-        Given user "Alice" has been created on the server with default attributes
-        And user "Alice" has set up a client with default settings and password "1234"
+        Given user "Alice" has set up a client with default settings and password "1234"
+        And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         When the user creates a new public link for file "%client_sync_path%/textfile0.txt" with password "pass123" using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link on the server
         And the public should be able to download the file "textfile0.txt" with password "pass123" from the last created public link by "Alice" on the server
 
 
     Scenario: user changes the expiration date of an already existing public link using webUI
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         And user "Alice" has set up a client with default settings and password "1234"
         And user "Alice" has created a public link on the server with following settings
             | path       | textfile0.txt |
@@ -67,7 +71,7 @@ Feature: Sharing
 
 
 	Scenario: simple sharing of a folder by public link without password
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user creates a new public link with permissions "Download / View" for folder "%client_sync_path%/simple-folder" without password using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link on the server
@@ -75,7 +79,7 @@ Feature: Sharing
 
 
 	Scenario: simple sharing of a folder by public link with password
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user creates a new public link with permissions "Download / View " for folder "%client_sync_path%/simple-folder" with password "pass123" using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link on the server
@@ -83,7 +87,7 @@ Feature: Sharing
 
 
 	Scenario: user changes the expiration date of an already existing public link for folder using client-UI
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" has set up a client with default settings and password "1234"
         And user "Alice" has created a public link on the server with following settings
             | path       | simple-folder |
@@ -98,7 +102,7 @@ Feature: Sharing
 
 
     Scenario Outline: simple sharing of folder by public link with different roles
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" has set up a client with default settings and password "1234"
         When the user creates a new public link for folder "%client_sync_path%/simple-folder" with "<role>" using the client-UI
         Then user "Alice" on the server should have a share with these details:
@@ -116,10 +120,10 @@ Feature: Sharing
 
 
     Scenario: sharing by public link with "Uploader" role
-        Given user "Alice" has been created on the server with default attributes
+        Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" on the server has created file "simple-folder/lorem.txt"
         And user "Alice" has set up a client with default settings and password "1234"
-        When the user creates a new public link for folder "%client_sync_path%/simple-folder" with "Uploader" using the client-UI
+        When the user creates a new public link for folder "%client_sync_path%/simple-folder" with "Contributor" using the client-UI
         Then user "Alice" on the server should have a share with these details:
             | field       | value          |
             | share_type  | public_link    |

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -4,9 +4,11 @@ Feature: Syncing files
     I want to be able to sync my local folders to to my owncloud server
     so that I dont have to upload and download files manually
 
+    Background:
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+
     Scenario: Syncing a file to the server
-        Given user "Alice" has been created on the server with default attributes
-        And user "Alice" has set up a client with default settings and polling interval "5000"
+        Given user "Alice" has set up a client with default settings and polling interval "5000"
         When the user creates a file "lorem-for-upload.txt" with the following content on the file system
             """
             test content
@@ -15,8 +17,7 @@ Feature: Syncing files
         Then as "Alice" the file "lorem-for-upload.txt" on the server should have the content "test content"
 
     Scenario: Syncing a file from the server
-        Given user "Alice" has been created on the server with default attributes
-        And user "Alice" has set up a client with default settings and polling interval "5000"
+        Given user "Alice" has set up a client with default settings and polling interval "5000"
         And user "Alice" has uploaded file on the server with content "test content" to "uploaded-lorem.txt"
         When the user waits for file "uploaded-lorem.txt" to be synced
         Then the file "uploaded-lorem.txt" should exist on the file system with the following content
@@ -25,8 +26,7 @@ Feature: Syncing files
             """
 
     Scenario: Syncing a file from the server and creating a conflict
-        Given user "Alice" has been created on the server with default attributes
-        And user "Alice" has uploaded file on the server with content "server content" to "/conflict.txt"
+        Given user "Alice" has uploaded file on the server with content "server content" to "/conflict.txt"
         And user "Alice" has set up a client with default settings and polling interval "5000"
         And the user has waited for file "conflict.txt" to be synced
         And the user has paused the file sync


### PR DESCRIPTION
### Description 
This PR refactors all tests for client-UI to stop using skeleton files.

### Related Issue
- Fixes https://github.com/owncloud/client/issues/8543