### PR TITLE
[tests-only]refactor tests for file sync conflict

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -323,7 +323,7 @@ def step(context, filePath):
 
 @Given('the user has paused the file sync')
 def step(context):
-    mouseClick(waitForObjectItem(names.stack_folderList_QTreeView, "_1"), 718, 39, Qt.NoModifier, Qt.LeftButton)
+    openContextMenu(waitForObjectItem(names.stack_folderList_QTreeView, "_1"), 0, 0, Qt.NoModifier)
     activateItem(waitForObjectItem(names.settings_QMenu, "Pause sync"))
 
 
@@ -337,7 +337,7 @@ def step(context, filename):
 
 @When('the user resumes the file sync on the client')
 def step(context):
-    mouseClick(waitForObjectItem(names.stack_folderList_QTreeView, "_1"), 719, 38, Qt.NoModifier, Qt.LeftButton)
+    openContextMenu(waitForObjectItem(names.stack_folderList_QTreeView, "_1"), 0, 0, Qt.NoModifier)
     activateItem(waitForObjectItem(names.settings_QMenu, "Resume sync"))
 
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -26,15 +26,15 @@ Feature: Syncing files
 
     Scenario: Syncing a file from the server and creating a conflict
         Given user "Alice" has been created on the server with default attributes
+        And user "Alice" has uploaded file on the server with content "server content" to "/conflict.txt"
         And user "Alice" has set up a client with default settings and polling interval "5000"
-        And user "Alice" has uploaded file on the server with content "test content" to "uploaded-lorem.txt"
         And the user has waited for file "conflict.txt" to be synced
         And the user has paused the file sync
         And the user has changed the content of local file "conflict.txt" to:
             """
             client content
             """
-        And user "Alice" has uploaded file on the server with content "server content" to "uploaded-lorem.txt"
+        And user "Alice" has uploaded file on the server with content "changed server content" to "/conflict.txt"
         When the user resumes the file sync on the client
         And the user clicks on the activity tab
         And the user selects the unsynced files tab with 1 unsynced files
@@ -42,7 +42,7 @@ Feature: Syncing files
         Then the table of conflict warnings should include file "conflict.txt"
         And the file "conflict.txt" should exist on the file system with the following content
             """
-            server content
+            changed server content
             """
         And a conflict file for "conflict.txt" should exist on the file system with the following content
             """


### PR DESCRIPTION
### Description
This PR refactors the following test which creates a conflict and tests the conflict while syncing.  https://github.com/owncloud/client/blob/196c641dbd3a12c441723c6b801cdce7490ca51e/test/gui/tst_syncing/test.feature#L27-L50

The file used to create sync is not in the skeleton directory so we have to create a new file of name `conflict.txt` on the server. Also the file `uploaded-lorem.txt` is not needed here so I have deleted steps related to it.

Finally I have substitute `mouseClick` with `openContextMenu` in step for pausing and resuming the sync because the `mouseClick` doesn't open the menu option for "Pause sync"
