### PR TITLE
Improve VFS context menu of Linux shell integration

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
@@ -80,6 +80,8 @@ public:
                 connect(action, &QAction::triggered, [helper, call, files] {
                     helper->sendCommand(QByteArray(call + ":" + files + "\n"));
                 });
+            } else if (cmd.startsWith("MENU_SEPARATOR:")) {
+                menu->addSeparator();
             }
         });
         QTimer::singleShot(100, &loop, SLOT(quit())); // add a timeout to be sure we don't freeze dolphin

--- a/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
+++ b/shell_integration/dolphin/ownclouddolphinactionplugin.cpp
@@ -84,7 +84,7 @@ public:
                 menu->addSeparator();
             }
         });
-        QTimer::singleShot(100, &loop, SLOT(quit())); // add a timeout to be sure we don't freeze dolphin
+        QTimer::singleShot(500, &loop, SLOT(quit())); // add a timeout to be sure we don't freeze dolphin
         helper->sendCommand(QByteArray("GET_MENU_ITEMS:" + files + "\n"));
         loop.exec(QEventLoop::ExcludeUserInputEvents);
         disconnect(con);

--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -237,7 +237,8 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
 
         done = False
         start = time.time()
-        timeout = 0.1 # 100ms
+        # timeout is specified in seconds
+        timeout = 0.5
         menu_items = []
         while not done:
             dt = time.time() - start

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1103,14 +1103,14 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
 
         // TODO: Should be a submenu, should use icons
         auto makePinContextMenu = [&](bool makeAvailableLocally, bool freeSpace) {
-            listener->sendMessage(QLatin1String("MENU_SEPARATOR:d::"));
-            listener->sendMessage(QLatin1String("MENU_ITEM:CURRENT_PIN:d:")
+            listener->sendMessage(QStringLiteral("MENU_SEPARATOR:d::"));
+            listener->sendMessage(QStringLiteral("MENU_ITEM:CURRENT_PIN:d:")
                 + Utility::vfsCurrentAvailabilityText(*combined));
-            listener->sendMessage(QLatin1String("MENU_ITEM:MAKE_AVAILABLE_LOCALLY:")
-                + (makeAvailableLocally ? QLatin1String(":") : QLatin1String("d:"))
+            listener->sendMessage(QStringLiteral("MENU_ITEM:MAKE_AVAILABLE_LOCALLY:")
+                + (makeAvailableLocally ? QStringLiteral(":") : QStringLiteral("d:"))
                 + Utility::vfsPinActionText());
-            listener->sendMessage(QLatin1String("MENU_ITEM:MAKE_ONLINE_ONLY:")
-                + (freeSpace ? QLatin1String(":") : QLatin1String("d:"))
+            listener->sendMessage(QStringLiteral("MENU_ITEM:MAKE_ONLINE_ONLY:")
+                + (freeSpace ? QStringLiteral(":") : QStringLiteral("d:"))
                 + Utility::vfsFreeSpaceActionText());
         };
 
@@ -1131,7 +1131,7 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
         }
     }
 
-    listener->sendMessage(QString("GET_MENU_ITEMS:END"));
+    listener->sendMessage(QStringLiteral("GET_MENU_ITEMS:END"));
 }
 
 #if GUI_TESTING

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1103,6 +1103,7 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
 
         // TODO: Should be a submenu, should use icons
         auto makePinContextMenu = [&](bool makeAvailableLocally, bool freeSpace) {
+            listener->sendMessage(QLatin1String("MENU_SEPARATOR:d::"));
             listener->sendMessage(QLatin1String("MENU_ITEM:CURRENT_PIN:d:")
                 + Utility::vfsCurrentAvailabilityText(*combined));
             listener->sendMessage(QLatin1String("MENU_ITEM:MAKE_AVAILABLE_LOCALLY:")


### PR DESCRIPTION
This PR introduces a separator between VFS and non-VFS entries in the context menu for Dolphin based file browsers.

![screenshot_2021-04-22_15-52-21](https://user-images.githubusercontent.com/80399010/115726797-936e2300-a372-11eb-9051-bffed56c48f1.png)

For Nautilus based ones, this is unfortunately not possible, as the API doesn't provide any functionality to add such separators. Unfortunately, I only noticed this after cleaning up a bunch of things that would've allowed me to add such separators at all. I think these improvements are worth merging anyway, though.

The changes in the socket API should be backwards compatible. The old clients should just ignore the new entry type.

Partial fix for #7083.

The PR should also fix #8334 by increasing the socket timeout to 500ms, as suggested there.

Fixes #7614.