### PR TITLE
fix language setting in GUI tests

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -72,7 +72,7 @@ def step(context, displayname, host):
         )
 
 def startClient():
-    startApplication("owncloud -s --logfile - --language en_US.utf8 --confdir " + confdir)
+    startApplication("owncloud -s --logfile - --language en_US --confdir " + confdir)
     snooze(1)
 
 def setUpClient(context, username, password, pollingInterval):


### PR DESCRIPTION
The client takes language arguments like `en_US` not `en_US.utf8` see https://github.com/owncloud/client/pull/8572#pullrequestreview-644470076 .
