### PR TITLE
bump antora to 2.8 here

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: desktop
 title: Desktop Client
-version: '2.7'
+version: '2.8'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
@TheOneRing is this correct?

I hope, this cause https://doc.owncloud.com/desktop/2.8 to appear? Or do we need some ansible magic too?