### PR TITLE
[tests-only]implement pageObject model

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -1,11 +1,8 @@
-class SetupClientHelper():
-    def __int__(self):
-        pass
-    
-    def substituteInLineCodes(self, context, value):
-        from urllib.parse import urlparse
-        value = value.replace('%local_server%', context.userData['localBackendUrl'])
-        value = value.replace('%client_sync_path%', context.userData['clientSyncPath'])
-        value = value.replace('%local_server_hostname%', urlparse(context.userData['localBackendUrl']).netloc)
+from urllib.parse import urlparse
 
-        return value
+def substituteInLineCodes(context, value):
+    value = value.replace('%local_server%', context.userData['localBackendUrl'])
+    value = value.replace('%client_sync_path%', context.userData['clientSyncPath'])
+    value = value.replace('%local_server_hostname%', urlparse(context.userData['localBackendUrl']).netloc)
+
+    return value

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -1,0 +1,11 @@
+class SetupClientHelper():
+    def __int__(self):
+        pass
+    
+    def substituteInLineCodes(self, context, value):
+        from urllib.parse import urlparse
+        value = value.replace('%local_server%', context.userData['localBackendUrl'])
+        value = value.replace('%client_sync_path%', context.userData['clientSyncPath'])
+        value = value.replace('%local_server_hostname%', urlparse(context.userData['localBackendUrl']).netloc)
+
+        return value

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -6,3 +6,21 @@ def substituteInLineCodes(context, value):
     value = value.replace('%local_server_hostname%', urlparse(context.userData['localBackendUrl']).netloc)
 
     return value
+
+
+def getClientDetails(context):
+    for row in context.table[0:]:
+        row[1] = substituteInLineCodes(context, row[1])
+        if row[0] == 'server':
+            server = row[1]
+        elif row[0] == 'user':
+            user = row[1]
+        elif row[0] == 'password':
+            password = row[1]
+        elif row[0] == 'localfolder':
+            localfolder = row[1]
+        try:
+            os.makedirs(localfolder, 0o0755)           
+        except:
+            pass
+    return server, user, password, localfolder    

--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -1,0 +1,50 @@
+import names
+import squish
+from helpers.SetupClientHelper import SetupClientHelper
+
+
+class AccountConnectionWizard():
+    SERVER_ADDRESS_BOX = names.leUrl_OCC_PostfixLineEdit
+    NEXT_BUTTON = names.owncloudWizard_qt_passive_wizardbutton1_QPushButton
+    USERNAME_BOX = names.leUsername_QLineEdit
+    PASSWORD_BOX = names.lePassword_QLineEdit
+    SELECT_LOCAL_FOLDER = names.pbSelectLocalFolder_QPushButton
+    DIRECTORY_NAME_BOX = names.fileNameEdit_QLineEdit
+    CHOOSE_BUTTON = names.qFileDialog_Choose_QPushButton
+    CONNECT_BUTTON = names.owncloudWizard_qt_passive_wizardbutton1_QPushButton
+    
+
+    def __init__(self):
+        pass
+
+    def addAccount(self, context):
+        setupClientHelper = SetupClientHelper()
+        
+        for row in context.table[0:]:
+            row[1] = setupClientHelper.substituteInLineCodes(context, row[1])
+            if row[0] == 'server':
+                server = row[1]
+            elif row[0] == 'user':
+                user = row[1]
+            elif row[0] == 'password':
+                password = row[1]
+            elif row[0] == 'localfolder':
+                localfolder = row[1]
+            try:
+                os.makedirs(localfolder, 0o0755)
+            except:
+                pass
+        
+        squish.mouseClick(squish.waitForObject(self.SERVER_ADDRESS_BOX))
+        squish.type(squish.waitForObject(self.SERVER_ADDRESS_BOX), server)
+        squish.clickButton(squish.waitForObject(self.NEXT_BUTTON))
+        squish.mouseClick(squish.waitForObject(self.SERVER_ADDRESS_BOX))
+        squish.type(squish.waitForObject(self.USERNAME_BOX), user)
+        squish.type(squish.waitForObject(self.USERNAME_BOX), "<Tab>")
+        squish.type(squish.waitForObject(self.PASSWORD_BOX), password)
+        squish.clickButton(squish.waitForObject(self.NEXT_BUTTON))
+        squish.clickButton(squish.waitForObject(self.SELECT_LOCAL_FOLDER))
+        squish.mouseClick(squish.waitForObject(self.DIRECTORY_NAME_BOX))
+        squish.type(squish.waitForObject(self.DIRECTORY_NAME_BOX), localfolder)
+        squish.clickButton(squish.waitForObject(self.CHOOSE_BUTTON))
+        squish.clickButton(squish.waitForObject(self.CONNECT_BUTTON))

--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -1,6 +1,6 @@
 import names
 import squish
-from helpers.SetupClientHelper import substituteInLineCodes
+from helpers.SetupClientHelper import getClientDetails
 
 
 class AccountConnectionWizard():
@@ -12,26 +12,13 @@ class AccountConnectionWizard():
     DIRECTORY_NAME_BOX = names.fileNameEdit_QLineEdit
     CHOOSE_BUTTON = names.qFileDialog_Choose_QPushButton
     CONNECT_BUTTON = names.owncloudWizard_qt_passive_wizardbutton1_QPushButton
-    
+
 
     def __init__(self):
         pass
 
-    def addAccount(self, context):    
-        for row in context.table[0:]:
-            row[1] = substituteInLineCodes(context, row[1])
-            if row[0] == 'server':
-                server = row[1]
-            elif row[0] == 'user':
-                user = row[1]
-            elif row[0] == 'password':
-                password = row[1]
-            elif row[0] == 'localfolder':
-                localfolder = row[1]
-            try:
-                os.makedirs(localfolder, 0o0755)
-            except:
-                pass
+    def addAccount(self, context):  
+        server, user, password, localfolder =  getClientDetails(context)
         
         squish.mouseClick(squish.waitForObject(self.SERVER_ADDRESS_BOX))
         squish.type(squish.waitForObject(self.SERVER_ADDRESS_BOX), server)

--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -1,6 +1,6 @@
 import names
 import squish
-from helpers.SetupClientHelper import SetupClientHelper
+from helpers.SetupClientHelper import substituteInLineCodes
 
 
 class AccountConnectionWizard():
@@ -17,11 +17,9 @@ class AccountConnectionWizard():
     def __init__(self):
         pass
 
-    def addAccount(self, context):
-        setupClientHelper = SetupClientHelper()
-        
+    def addAccount(self, context):    
         for row in context.table[0:]:
-            row[1] = setupClientHelper.substituteInLineCodes(context, row[1])
+            row[1] = substituteInLineCodes(context, row[1])
             if row[0] == 'server':
                 server = row[1]
             elif row[0] == 'user':

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -11,7 +11,7 @@ import datetime
 
 from objectmaphelper import RegularExpression
 from pageObjects.AccountConnectionWizard import AccountConnectionWizard
-from helpers.SetupClientHelper import SetupClientHelper
+from helpers.SetupClientHelper import substituteInLineCodes
 
 
 # the script needs to use the system wide python
@@ -66,9 +66,8 @@ def step(context):
 
 @Then('an account should be displayed with the displayname |any| and host |any|')
 def step(context, displayname, host):
-    setupClientHelper = SetupClientHelper()
-    displayname = setupClientHelper.substituteInLineCodes(context, displayname)
-    host = setupClientHelper.substituteInLineCodes(context, host)
+    displayname = substituteInLineCodes(context, displayname)
+    host = substituteInLineCodes(context, host)
     test.compare(
         str(
             waitForObjectExists(
@@ -156,7 +155,7 @@ def step(context):
 
     newAccount = AccountConnectionWizard()
     newAccount.addAccount(context)
-    
+
 
 def isItemSynced(type, itemName):
     if type != 'FILE' and type != 'FOLDER':
@@ -220,8 +219,7 @@ def executeStepThroughMiddleware(context, step):
 
 @When('the user adds "|any|" as collaborator of resource "|any|" with permissions "|any|" using the client-UI')
 def step(context, receiver, resource, permissions):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFileSynced(resource), context.userData['clientSyncTimeout'] * 1000)
     waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
 
@@ -241,8 +239,7 @@ def step(context, receiver, resource, permissions):
 
 @Then('user "|any|" should be listed in the collaborators list for file "|any|" with permissions "|any|" on the client-UI')
 def step(context, receiver, resource, permissions):
-    setupClientHelper = SetupClientHelper()
-    resource = setupClientHelper.substituteInLineCodes(context, resource)
+    resource = substituteInLineCodes(context, resource)
     socketConnect = syncstate.SocketConnect()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
     permissionsList = permissions.split(',')
@@ -395,8 +392,7 @@ def step(context):
 
 
 def openPublicLinkDialog(context, resource):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFileSynced(resource), context.userData['clientSyncTimeout'] * 1000)
     waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
     mouseClick(waitForObject(names.qt_tabwidget_tabbar_Public_Links_TabItem), 0, 0, Qt.NoModifier, Qt.LeftButton)
@@ -425,8 +421,7 @@ def step(context):
 
 @When('user "|any|" opens the sharing dialog of "|any|" using the client-UI')
 def step(context, receiver, resource):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     waitFor(lambda: isFolderSynced(resource), context.userData['clientSyncTimeout'] * 1000)
     waitFor(lambda: shareResource(resource), context.userData['clientSyncTimeout'] * 1000)
 
@@ -438,8 +433,7 @@ def step(context, fileShareContext):
 
 @When('the user creates a new public link for file "|any|" without password using the client-UI')
 def step(context, resource):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     openPublicLinkDialog(context, resource)
     test.compare(str(waitForObjectExists(names.sharingDialog_label_name_QLabel).text), resource.replace(context.userData['clientSyncPath'], ''))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_createShareButton_QPushButton))
@@ -448,8 +442,7 @@ def step(context, resource):
 
 @When('the user creates a new public link for file "|any|" with password "|any|" using the client-UI')
 def step(context, resource, password):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     openPublicLinkDialog(context, resource)
     test.compare(str(waitForObjectExists(names.sharingDialog_label_name_QLabel).text), resource.replace(context.userData['clientSyncPath'], ''))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_checkBox_password_QCheckBox))
@@ -487,8 +480,7 @@ def step(context, publicLinkName, resource):
 
 @When('the user creates a new public link with permissions "|any|" for folder "|any|" without password using the client-UI')
 def step(context, permissions, resource):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     openPublicLinkDialog(context, resource)
     radioObjectName = ''
     if permissions == 'Download / View':
@@ -506,8 +498,7 @@ def step(context, permissions, resource):
 
 @When('the user creates a new public link with permissions "|any|" for folder "|any|" with password "|any|" using the client-UI')
 def step(context, permissions, resource, password):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     openPublicLinkDialog(context, resource)
     clickButton(waitForObject(names.oCC_ShareLinkWidget_checkBox_password_QCheckBox))
     mouseClick(waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit), 0, 0, Qt.NoModifier, Qt.LeftButton)
@@ -517,8 +508,7 @@ def step(context, permissions, resource, password):
 
 
 def createPublicShare(context, resource, role):
-    setupClientHelper = SetupClientHelper()
-    resource = sanitizePath(setupClientHelper.substituteInLineCodes(context, resource))
+    resource = sanitizePath(substituteInLineCodes(context, resource))
     radioObjectName = ''
 
     if role == 'Viewer':


### PR DESCRIPTION
### Description

This PR is a POC for implementing Page Object Model in client test. Currently the PO is only implemented for tests related to adding accounts which is in `tst_addAccount.py`

For this implementation  the folder structure looks like this:
```
test
|
|------>gui	
	|
	|------>shared
	|	|
	|	|------>scripts
	|	|	|
	|	|	|----->helpers
	|	|	|	|
	|	|	|	|---->SetupClientHelper.py
	|	|	|	
	|	|	|------>pageObjects
	|	|	|	|	
	|	|	|	|----->AccountConnectionWizard.py
	|	|	|	
	|	|	|	
	|	|	|------->bdd_hooks.py
	|	|	|	
	|	|	|------->names.py
	|	|
	|	|
	|	|------>steps
	|		|
	|		|
	|		|----->steps.py
	|			
	|
	|------>tst_addAccount
	|
	|------>tst_sharing
	|
	|------>tst_syncing
```


- The `helper` folder contains `SetupClientHelper.py` which contains general helpers functions.
-  The `pageObjects` contains all the stepObject model. For now there is only `AccountConnectionWizard.py`
### Related Issue
https://github.com/owncloud/client/issues/8577