### PR TITLE
wait for all files to be synced before pause the file sync

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -327,6 +327,7 @@ def step(context, filePath):
 
 @Given('the user has paused the file sync')
 def step(context):
+    waitFor(lambda: isFolderSynced(context.userData['clientSyncPath']), context.userData['clientSyncTimeout'] * 1000)
     openContextMenu(waitForObjectItem(names.stack_folderList_QTreeView, "_1"), 0, 0, Qt.NoModifier)
     activateItem(waitForObjectItem(names.settings_QMenu, "Pause sync"))
 


### PR DESCRIPTION
pausing without waiting for all files to be synced results in a pop-up that asks if the current sync should be canceled, that breaks the next steps
as this is a GIVEN step we could add some check in an other PR to see if the sync was really paused
