### PR TITLE
Replace custom argument parsing with QCommandLineParser

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -70,31 +70,6 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcApplication, "gui.application", QtInfoMsg)
 
-namespace {
-
-    const QString optionsC()
-    {
-        return QStringLiteral(
-            "Options:\n"
-            "  -h --help            : show this help screen.\n"
-            "  -s --showsettings    : show the settings dialog while starting.\n"
-            "  -q --quit            : quit the running instance\n"
-            "  --logfile <filename> : write log output to file <filename>.\n"
-            "  --logfile -          : write log output to stdout.\n"
-            "  --logdir <name>      : write each sync log output in a new file\n"
-            "                         in folder <name>.\n"
-            "  --logexpire <hours>  : removes logs older than <hours> hours.\n"
-            "                         (to be used with --logdir)\n"
-            "  --logflush           : flush the log file after every write.\n"
-            "  --logdebug           : also output debug-level messages in the log.\n"
-            "  --language <locale>  : override UI language\n"
-            "  --list-languages     : list available translations (for use with --language)\n"
-            "  --confdir <dirname>  : Use the given configuration folder.");
-    }
-}
-
-// ----------------------------------------------------------------------------------
-
 bool Application::configVersionMigration()
 {
     QStringList deleteKeys, ignoreKeys;
@@ -169,10 +144,7 @@ Application::Application(int &argc, char **argv)
     : SharedTools::QtSingleApplication(Theme::instance()->appName(), argc, argv)
     , _gui(nullptr)
     , _theme(Theme::instance())
-    , _helpOnly(false)
-    , _versionOnly(false)
     , _showLogWindow(false)
-    , _listAvailableTranslationsOnly(false)
     , _logExpire(0)
     , _logFlush(false)
     , _logDebug(false)
@@ -275,10 +247,6 @@ Application::Application(int &argc, char **argv)
         qCInfo(lcApplication) << "VFS windows plugin is available";
     if (isVfsPluginAvailable(Vfs::WithSuffix))
         qCInfo(lcApplication) << "VFS suffix plugin is available";
-
-    //no need to waste time;
-    if (_helpOnly || _versionOnly || _listAvailableTranslationsOnly)
-        return;
 
     if (_quitInstance) {
         QTimer::singleShot(0, qApp, &QApplication::quit);
@@ -564,89 +532,6 @@ void Application::slotParseMessage(const QString &msg, QObject *)
     }
 }
 
-void Application::parseOptions(const QStringList &options)
-{
-    QStringListIterator it(options);
-    // skip file name;
-    if (it.hasNext())
-        it.next();
-
-    //parse options; if help or bad option exit
-    while (it.hasNext()) {
-        QString option = it.next();
-        if (option == QLatin1String("--help") || option == QLatin1String("-h")) {
-            setHelp();
-            break;
-        } else if (option == QLatin1String("--showsettings") || option == QLatin1String("-s")) {
-            _showSettings = true;
-        } else if (option == QLatin1String("--quit") || option == QLatin1String("-q")) {
-            _quitInstance = true;
-        } else if (option == QLatin1String("--logwindow") || option == QLatin1String("-l")) {
-            _showLogWindow = true;
-        } else if (option == QLatin1String("--logfile")) {
-            if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                _logFile = it.next();
-            } else {
-                showHint("Log file not specified");
-            }
-        } else if (option == QLatin1String("--logdir")) {
-            if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                _logDir = it.next();
-            } else {
-                showHint("Log dir not specified");
-            }
-        } else if (option == QLatin1String("--logexpire")) {
-            if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                _logExpire = std::chrono::hours(it.next().toInt());
-            } else {
-                showHint("Log expiration not specified");
-            }
-        } else if (option == QLatin1String("--logflush")) {
-            _logFlush = true;
-        } else if (option == QLatin1String("--logdebug")) {
-            _logDebug = true;
-        } else if (option == QLatin1String("--confdir")) {
-            if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                QString confDir = it.next();
-                if (!ConfigFile::setConfDir(confDir)) {
-                    showHint("Invalid path passed to --confdir");
-                }
-            } else {
-                showHint("Path for confdir not specified");
-            }
-        } else if (option == QLatin1String("--debug")) {
-            _logDebug = true;
-            _debugMode = true;
-        } else if (option == QLatin1String("--version")) {
-            _versionOnly = true;
-        } else if (option == QLatin1String("--language")) {
-            auto showLanguageHint = [this](const QString &message) {
-                showHint(message + " (use --list-languages to get a complete list of supported translations)");
-            };
-
-            if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
-                auto languageParam = it.next();
-
-                // fail if the language is unknown
-                if (!Translations::listAvailableTranslations().contains(languageParam)) {
-                    showLanguageHint("Error: unknown language \"" + languageParam + "\"");
-                } else {
-                    _userEnforcedLanguage = languageParam;
-                }
-            } else {
-                showLanguageHint("Error: --language expects a locale as parameter");
-            }
-        } else if (option == QLatin1String("--list-languages")) {
-            _listAvailableTranslationsOnly = true;
-        } else if (option.endsWith(QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX))) {
-            // virtual file, open it after the Folder were created (if the app is not terminated)
-            QTimer::singleShot(0, this, [this, option] { openVirtualFile(option); });
-        } else {
-            showHint(QStringLiteral("Unrecognized option '%1'").arg(option));
-        }
-    }
-}
-
 // Helpers for displaying messages. Note that there is probably no console on Windows.
 static void displayHelpText(const QString &t, std::ostream &stream = std::cout)
 {
@@ -661,38 +546,124 @@ static void displayHelpText(const QString &t, std::ostream &stream = std::cout)
 #endif
 }
 
-void Application::showHelp()
+void Application::parseOptions(const QStringList &arguments)
 {
-    setHelp();
-    QString helpText;
-    QTextStream stream(&helpText);
-    stream << _theme->appName()
-           << QLatin1String(" version ")
-           << _theme->version() << endl;
+    QCommandLineParser parser;
 
-    stream << QLatin1String("File synchronisation desktop utility.") << endl
-           << endl
-           << optionsC();
+    QString descriptionText;
+    QTextStream descriptionTextStream(&descriptionText);
+
+    descriptionTextStream << _theme->appName() << QStringLiteral(" version ") << _theme->version() << endl;
+    descriptionTextStream << QStringLiteral("File synchronization desktop utility.");
 
     if (_theme->appName() == QLatin1String("ownCloud")) {
-        stream << endl
-               << endl
-               << "For more information, see http://www.owncloud.org";
+        descriptionTextStream << endl
+                              << endl
+                              << "For more information, see http://www.owncloud.org";
     }
 
-    displayHelpText(helpText);
-}
+    parser.setApplicationDescription(descriptionText);
 
-void Application::showVersion()
-{
-    displayHelpText(Theme::instance()->versionSwitchOutput());
-}
+    auto helpOption = parser.addHelpOption();
+    auto versionOption = parser.addVersionOption();
 
-void Application::listAvailableTranslations()
-{
-    auto availableTranslations = Translations::listAvailableTranslations().toList();
-    availableTranslations.sort(Qt::CaseInsensitive);
-    displayHelpText("Available translations: " + availableTranslations.join(", "));
+    // this little snippet saves a few lines below
+    auto addOption = [&parser](const QCommandLineOption &option) {
+        parser.addOption(option);
+        return option;
+    };
+
+    auto showSettingsOption = addOption({ { "s", "showsettings" }, "Show the settings dialog while starting." });
+    auto quitInstanceOption = addOption({ { "q", "quit" }, "Quit the running instance." });
+    auto logFileOption = addOption({ "logfile", "Write log to file (use - to write to stdout).", "filename" });
+    auto logDirOption = addOption({ "logdir", "Write each sync log output in a new file in folder.", "name" });
+    auto logExpireOption = addOption({ "logexpire", "Remove logs older than <hours> hours (to be used with --logdir).", "hours" });
+    auto logFlushOption = addOption({ "logflush", "Flush the log file after every write." });
+    auto logDebugOption = addOption({ "logdebug", "Output debug-level messages in the log." });
+    auto logWindowOption = addOption({ "logwindow", "//TODO//" });
+    auto languageOption = addOption({ "language", "Override UI language.", "language" });
+    auto listLanguagesOption = addOption({ "list-languages", "Override UI language." });
+    auto confDirOption = addOption({ "confdir", "Use the given configuration folder.", "dirname" });
+    auto debugOption = addOption({ "debug", "Enable debug mode." });
+
+    // virtual file system parameters (optional)
+    parser.addPositionalArgument("vfs file", "Virtual file system file to be opened (optional).", { "[<vfs file>]" });
+
+    if (!parser.parse(arguments)) {
+        showHint(parser.errorText());
+    }
+
+    if (parser.isSet(helpOption)) {
+        showHint(parser.helpText());
+    }
+
+    if (parser.isSet(versionOption)) {
+        displayHelpText(_theme->versionSwitchOutput());
+        ::exit(0);
+    }
+
+    // TODO: rename this option (see #8234 for more information)
+    if (parser.isSet(showSettingsOption)) {
+        _showSettings = true;
+    }
+    if (parser.isSet(quitInstanceOption)) {
+        _quitInstance = true;
+    }
+    if (parser.isSet(logWindowOption)) {
+        _showLogWindow = true;
+    }
+    if (parser.isSet(logFileOption)) {
+        _logFile = parser.value(logFileOption);
+    }
+    if (parser.isSet(logDirOption)) {
+        _logDir = parser.value(logDirOption);
+    }
+    if (parser.isSet(logExpireOption)) {
+        _logExpire = std::chrono::hours(parser.value(logExpireOption).toInt());
+    }
+    if (parser.isSet(logFlushOption)) {
+        _logFlush = true;
+    }
+    if (parser.isSet(logDebugOption)) {
+        _logDebug = true;
+    }
+    if (parser.isSet(confDirOption)) {
+        const auto confDir = parser.value(confDirOption);
+        if (!ConfigFile::setConfDir(confDir)) {
+            showHint("Invalid path passed to --confdir");
+        }
+    }
+    if (parser.isSet(debugOption)) {
+        _logDebug = true;
+        _debugMode = true;
+    }
+    if (parser.isSet(languageOption)) {
+        auto showLanguageHint = [this](const QString &message) {
+            showHint(message + " (use --list-languages to get a complete list of supported translations)");
+        };
+
+        const auto languageValue = parser.value(languageOption);
+
+        // fail if the language is unknown
+        if (!Translations::listAvailableTranslations().contains(languageValue)) {
+            showLanguageHint("Error: unknown language \"" + languageValue + "\"");
+        } else {
+            _userEnforcedLanguage = languageValue;
+        }
+    }
+    if (parser.isSet(listLanguagesOption)) {
+        auto availableTranslations = Translations::listAvailableTranslations().toList();
+        availableTranslations.sort(Qt::CaseInsensitive);
+        displayHelpText("Available translations: " + availableTranslations.join(", "));
+        std::exit(0);
+    }
+
+    auto positionalArguments = parser.positionalArguments();
+
+    // ignore any positional arguments beyond the first one
+    if (!positionalArguments.empty()) {
+        QTimer::singleShot(0, this, [this, positionalArguments] { openVirtualFile(positionalArguments.front()); });
+    }
 }
 
 void Application::showHint(const QString &errorHint)
@@ -708,11 +679,6 @@ void Application::showHint(const QString &errorHint)
 bool Application::debugMode()
 {
     return _debugMode;
-}
-
-void Application::setHelp()
-{
-    _helpOnly = true;
 }
 
 QString substLang(const QString &lang)
@@ -810,21 +776,6 @@ void Application::setupTranslations()
             break;
         }
     }
-}
-
-bool Application::giveHelp()
-{
-    return _helpOnly;
-}
-
-bool Application::versionOnly()
-{
-    return _versionOnly;
-}
-
-bool Application::listAvailableTranslationsOnly()
-{
-    return _listAvailableTranslationsOnly;
 }
 
 void Application::showSettingsDialog()

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -582,7 +582,7 @@ void Application::parseOptions(const QStringList &arguments)
     // virtual file system parameters (optional)
     parser.addPositionalArgument("vfs file", tr("Virtual file system file to be opened (optional)."), { tr("[<vfs file>]") });
 
-    parser.process(*this);
+    parser.process(arguments);
 
     // TODO: rename this option (see #8234 for more information)
     if (parser.isSet(showSettingsOption)) {

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -545,13 +545,12 @@ void Application::parseOptions(const QStringList &arguments)
     QString descriptionText;
     QTextStream descriptionTextStream(&descriptionText);
 
-    descriptionTextStream << _theme->appName() << QStringLiteral(" version ") << _theme->version() << endl;
-    descriptionTextStream << QStringLiteral("File synchronization desktop utility.");
+    descriptionTextStream << tr("%1 version %2\r\nFile synchronization desktop utility.").arg(_theme->appName()).arg(_theme->version()) << endl;
 
     if (_theme->appName() == QLatin1String("ownCloud")) {
         descriptionTextStream << endl
                               << endl
-                              << "For more information, see http://www.owncloud.org";
+                              << tr("For more information, see http://www.owncloud.org");
     }
 
     parser.setApplicationDescription(descriptionText);
@@ -565,20 +564,20 @@ void Application::parseOptions(const QStringList &arguments)
         return option;
     };
 
-    auto showSettingsOption = addOption({ { "s", "showsettings" }, "Show the settings dialog while starting." });
-    auto quitInstanceOption = addOption({ { "q", "quit" }, "Quit the running instance." });
-    auto logFileOption = addOption({ "logfile", "Write log to file (use - to write to stdout).", "filename" });
-    auto logDirOption = addOption({ "logdir", "Write each sync log output in a new file in folder.", "name" });
-    auto logExpireOption = addOption({ "logexpire", "Remove logs older than <hours> hours (to be used with --logdir).", "hours" });
-    auto logFlushOption = addOption({ "logflush", "Flush the log file after every write." });
-    auto logDebugOption = addOption({ "logdebug", "Output debug-level messages in the log." });
-    auto languageOption = addOption({ "language", "Override UI language.", "language" });
-    auto listLanguagesOption = addOption({ "list-languages", "Override UI language." });
-    auto confDirOption = addOption({ "confdir", "Use the given configuration folder.", "dirname" });
-    auto debugOption = addOption({ "debug", "Enable debug mode." });
+    auto showSettingsOption = addOption({ { "s", "showsettings" }, tr("Show the settings dialog while starting.") });
+    auto quitInstanceOption = addOption({ { "q", "quit" }, tr("Quit the running instance.") });
+    auto logFileOption = addOption({ "logfile", tr("Write log to file (use - to write to stdout)."), "filename" });
+    auto logDirOption = addOption({ "logdir", tr("Write each sync log output in a new file in folder."), "name" });
+    auto logExpireOption = addOption({ "logexpire", tr("Remove logs older than <hours> hours (to be used with --logdir)."), "hours" });
+    auto logFlushOption = addOption({ "logflush", tr("Flush the log file after every write.") });
+    auto logDebugOption = addOption({ "logdebug", tr("Output debug-level messages in the log.") });
+    auto languageOption = addOption({ "language", tr("Override UI language."), "language" });
+    auto listLanguagesOption = addOption({ "list-languages", tr("Override UI language.") });
+    auto confDirOption = addOption({ "confdir", tr("Use the given configuration folder."), "dirname" });
+    auto debugOption = addOption({ "debug", tr("Enable debug mode.") });
 
     // virtual file system parameters (optional)
-    parser.addPositionalArgument("vfs file", "Virtual file system file to be opened (optional).", { "[<vfs file>]" });
+    parser.addPositionalArgument("vfs file", tr("Virtual file system file to be opened (optional)."), { tr("[<vfs file>]") });
 
     if (!parser.parse(arguments)) {
         showHint(parser.errorText());
@@ -618,7 +617,7 @@ void Application::parseOptions(const QStringList &arguments)
     if (parser.isSet(confDirOption)) {
         const auto confDir = parser.value(confDirOption);
         if (!ConfigFile::setConfDir(confDir)) {
-            showHint("Invalid path passed to --confdir");
+            showHint(tr("Invalid path passed to --confdir"));
         }
     }
     if (parser.isSet(debugOption)) {
@@ -626,15 +625,11 @@ void Application::parseOptions(const QStringList &arguments)
         _debugMode = true;
     }
     if (parser.isSet(languageOption)) {
-        auto showLanguageHint = [this](const QString &message) {
-            showHint(message + " (use --list-languages to get a complete list of supported translations)");
-        };
-
         const auto languageValue = parser.value(languageOption);
 
         // fail if the language is unknown
         if (!Translations::listAvailableTranslations().contains(languageValue)) {
-            showLanguageHint("Error: unknown language \"" + languageValue + "\"");
+            showHint(tr("Error: unknown language \"%1\" (use --list-languages to get a complete list of supported translations)").arg(languageValue));
         } else {
             _userEnforcedLanguage = languageValue;
         }
@@ -642,8 +637,7 @@ void Application::parseOptions(const QStringList &arguments)
     if (parser.isSet(listLanguagesOption)) {
         auto availableTranslations = Translations::listAvailableTranslations().toList();
         availableTranslations.sort(Qt::CaseInsensitive);
-        displayHelpText("Available translations: " + availableTranslations.join(", "));
-        std::exit(0);
+        showHint(tr("Available translations: %1").arg(availableTranslations.join(", ")));
     }
 
     auto positionalArguments = parser.positionalArguments();
@@ -659,7 +653,7 @@ void Application::showHint(const QString &errorHint)
     QString out;
     QTextStream hint(&out);
     hint << errorHint << endl
-         << "Try '" << QFileInfo(QCoreApplication::applicationFilePath()).fileName() << " --help' for more information" << endl;
+         << tr("Try \"%1\" --help' for more information").arg(QFileInfo(QCoreApplication::applicationFilePath()).fileName()) << endl;
     displayHelpText(out, std::cerr);
     std::exit(1);
 }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -144,7 +144,6 @@ Application::Application(int &argc, char **argv)
     : SharedTools::QtSingleApplication(Theme::instance()->appName(), argc, argv)
     , _gui(nullptr)
     , _theme(Theme::instance())
-    , _showLogWindow(false)
     , _logExpire(0)
     , _logFlush(false)
     , _logDebug(false)
@@ -286,9 +285,6 @@ Application::Application(int &argc, char **argv)
     // Setting up the gui class will allow tray notifications for the
     // setup that follows, like folder setup
     _gui = new ownCloudGui(this);
-    if (_showLogWindow) {
-        _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
-    }
     if (_showSettings) {
         _gui->slotShowSettings();
     }
@@ -505,13 +501,9 @@ void Application::slotParseMessage(const QString &msg, QObject *)
     if (msg.startsWith(QLatin1String("MSG_PARSEOPTIONS:"))) {
         const int lengthOfMsgPrefix = 17;
         QStringList options = msg.mid(lengthOfMsgPrefix).split(QLatin1Char('|'));
-        _showLogWindow = false;
         _showSettings = false;
         parseOptions(options);
         setupLogging();
-        if (_showLogWindow) {
-            _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
-        }
         if (_showSettings) {
             _gui->slotShowSettings();
         }
@@ -580,7 +572,6 @@ void Application::parseOptions(const QStringList &arguments)
     auto logExpireOption = addOption({ "logexpire", "Remove logs older than <hours> hours (to be used with --logdir).", "hours" });
     auto logFlushOption = addOption({ "logflush", "Flush the log file after every write." });
     auto logDebugOption = addOption({ "logdebug", "Output debug-level messages in the log." });
-    auto logWindowOption = addOption({ "logwindow", "//TODO//" });
     auto languageOption = addOption({ "language", "Override UI language.", "language" });
     auto listLanguagesOption = addOption({ "list-languages", "Override UI language." });
     auto confDirOption = addOption({ "confdir", "Use the given configuration folder.", "dirname" });
@@ -608,9 +599,6 @@ void Application::parseOptions(const QStringList &arguments)
     }
     if (parser.isSet(quitInstanceOption)) {
         _quitInstance = true;
-    }
-    if (parser.isSet(logWindowOption)) {
-        _showLogWindow = true;
     }
     if (parser.isSet(logFileOption)) {
         _logFile = parser.value(logFileOption);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -548,7 +548,7 @@ void Application::parseOptions(const QStringList &arguments)
     QString descriptionText;
     QTextStream descriptionTextStream(&descriptionText);
 
-    descriptionTextStream << tr("%1 version %2\r\nFile synchronization desktop utility.").arg(_theme->appName()).arg(_theme->version()) << endl;
+    descriptionTextStream << tr("%1 version %2\r\nFile synchronization desktop utility.").arg(_theme->appName(), _theme->version()) << endl;
 
     if (_theme->appName() == QLatin1String("ownCloud")) {
         descriptionTextStream << endl

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -59,14 +59,8 @@ public:
     explicit Application(int &argc, char **argv);
     ~Application() override;
 
-    bool giveHelp();
-    void showHelp();
     void showHint(const QString &errorHint);
     bool debugMode();
-    bool versionOnly(); // only display the version?
-    void showVersion();
-    bool listAvailableTranslationsOnly();
-    void listAvailableTranslations();
 
     void showSettingsDialog();
 
@@ -110,8 +104,6 @@ protected slots:
     void slotSystemOnlineConfigurationChanged(QNetworkConfiguration);
 
 private:
-    void setHelp();
-
     /**
      * Maybe a newer version of the client was used with this config file:
      * if so, backup, confirm with user and remove the config that can't be read.
@@ -121,11 +113,6 @@ private:
     QPointer<ownCloudGui> _gui;
 
     Theme *_theme;
-
-    bool _helpOnly;
-    bool _versionOnly;
-    bool _listAvailableTranslationsOnly;
-
 
 #ifdef Q_OS_LINUX
     QElapsedTimer _startedAt;

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -119,7 +119,6 @@ private:
 #endif
 
     // options from command line:
-    bool _showLogWindow;
     bool _showSettings = false;
     bool _quitInstance = false;
     QString _logFile;

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -59,7 +59,6 @@ public:
     explicit Application(int &argc, char **argv);
     ~Application() override;
 
-    void showHint(const QString &errorHint);
     bool debugMode();
 
     void showSettingsDialog();

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -70,18 +70,6 @@ int main(int argc, char **argv)
 #ifndef Q_OS_WIN
     signal(SIGPIPE, SIG_IGN);
 #endif
-    if (app.giveHelp()) {
-        app.showHelp();
-        return 0;
-    }
-    if (app.versionOnly()) {
-        app.showVersion();
-        return 0;
-    }
-    if (app.listAvailableTranslationsOnly()) {
-        app.listAvailableTranslations();
-        return 0;
-    }
 
 // check a environment variable for core dumps
 #ifdef Q_OS_UNIX


### PR DESCRIPTION
Closes #8603.

The big chain of `if`s could be reduced by using a map and a loop, but it works well.

I could continue to use `showHint`/`displayHelpText` for user feedback, Qt is relatively flexible there. 

Note that #8604 should be rebased once this PR has been merged.