### PR TITLE
Fix network drive detection

### DIFF
--- a/changelog/unreleased/8272
+++ b/changelog/unreleased/8272
@@ -1,0 +1,5 @@
+Bugfix: Correctly detect network drives
+
+We fixed a bug which allowed to use Virtual files on Windows network drives, which is not supported by Windows.
+
+https://github.com/owncloud/client/issues/8272


### PR DESCRIPTION
We can't rely on the file system detection because Windows is reporting the underlying file system.

Fixes: #8272