### PR TITLE
Fix migration of settings

### DIFF
--- a/changelog/unreleased/4597
+++ b/changelog/unreleased/4597
@@ -1,0 +1,5 @@
+Bugfix: Settings migration from v2.4
+
+We fixed the migration of settings of version 2.4 to the current location.
+
+https://github.com/owncloud/enterprise/issues/4597

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -205,7 +205,7 @@ Application::Application(int &argc, char **argv)
     setApplicationName(_theme->appName());
     setWindowIcon(_theme->applicationIcon());
 
-    if (!ConfigFile().exists()) {
+    if (!ConfigFile::exists()) {
         // Migrate from version <= 2.4
         setApplicationName(_theme->appNameGUI());
         // We need to use the deprecated QDesktopServices::storageLocation because of its Qt4
@@ -214,7 +214,7 @@ Application::Application(int &argc, char **argv)
         if (oldDir.endsWith('/')) oldDir.chop(1); // macOS 10.11.x does not like trailing slash for rename/move.
         setApplicationName(_theme->appName());
         if (QFileInfo(oldDir).isDir()) {
-            auto confDir = ConfigFile().configPath();
+            auto confDir = ConfigFile::configPath();
             if (confDir.endsWith('/')) confDir.chop(1);  // macOS 10.11.x does not like trailing slash for rename/move.
             qCInfo(lcApplication) << "Migrating old config from" << oldDir << "to" << confDir;
 
@@ -309,7 +309,7 @@ Application::Application(int &argc, char **argv)
                 tr("Error accessing the configuration file"),
                 tr("There was an error while accessing the configuration "
                    "file at %1.")
-                    .arg(ConfigFile().configFile()),
+                    .arg(ConfigFile::configFile()),
                 tr("Quit ownCloud"));
             QTimer::singleShot(0, qApp, SLOT(quit()));
             return;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -290,9 +290,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
 
 int FolderMan::setupFoldersMigration()
 {
-    ConfigFile cfg;
-    QDir storageDir(cfg.configPath());
-    _folderConfigPath = cfg.configPath() + QLatin1String("folders");
+    _folderConfigPath = ConfigFile::configPath() + QLatin1String("folders");
 
     qCInfo(lcFolderMan) << "Setup folders from " << _folderConfigPath << "(migration)";
 

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -42,7 +42,7 @@ ProxyAuthHandler::ProxyAuthHandler()
     _dialog = new ProxyAuthDialog();
 
     _configFile.reset(new ConfigFile);
-    _settings.reset(new QSettings(_configFile->configFile(), QSettings::IniFormat));
+    _settings.reset(new QSettings(ConfigFile::configFile(), QSettings::IniFormat));
     _settings->beginGroup(QLatin1String("Proxy"));
     _settings->beginGroup(QLatin1String("Credentials"));
 }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -100,8 +100,7 @@ void OCUpdater::setUpdateUrl(const QUrl &url)
 
 bool OCUpdater::performUpdate()
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     QString updateFile = settings.value(updateAvailableC).toString();
     if (!updateFile.isEmpty() && QFile(updateFile).exists()
         && !updateSucceeded() /* Someone might have run the updater manually between restarts */) {
@@ -187,8 +186,7 @@ void OCUpdater::setDownloadState(DownloadState state)
 
 void OCUpdater::slotStartInstaller()
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     QString updateFile = settings.value(updateAvailableC).toString();
     settings.setValue(autoUpdateAttemptedC, true);
     settings.sync();
@@ -209,7 +207,7 @@ void OCUpdater::slotStartInstaller()
             return QDir::toNativeSeparators(path);
         };
 
-        QString msiLogFile = cfg.configPath() + "msi.log";
+        QString msiLogFile = ConfigFile::configPath() + "msi.log";
         QString command = QString("&{msiexec /norestart /passive /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
              .arg(preparePathForPowershell(updateFile))
              .arg(preparePathForPowershell(msiLogFile))
@@ -236,8 +234,7 @@ void OCUpdater::slotOpenUpdateUrl()
 
 bool OCUpdater::updateSucceeded() const
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
 
     qint64 targetVersionInt = Helper::stringVersionToInt(settings.value(updateTargetVersionC).toString());
     qint64 currentVersion = Helper::currentVersionToInt();
@@ -289,8 +286,7 @@ void NSISUpdater::slotWriteFile()
 
 void NSISUpdater::wipeUpdateData()
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     QString updateFileName = settings.value(updateAvailableC).toString();
     if (!updateFileName.isEmpty())
         QFile::remove(updateFileName);
@@ -312,8 +308,7 @@ void NSISUpdater::slotDownloadFinished()
     QUrl url(reply->url());
     _file->close();
 
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
 
     // remove previously downloaded but not used installer
     QFile oldTargetFile(settings.value(updateAvailableC).toString());
@@ -331,8 +326,7 @@ void NSISUpdater::slotDownloadFinished()
 
 void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     qint64 infoVersion = Helper::stringVersionToInt(info.version());
     auto seenString = settings.value(seenVersionC).toString();
     qint64 seenVersion = Helper::stringVersionToInt(seenString);
@@ -357,7 +351,7 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
         if (url.isEmpty()) {
             showNoUrlDialog(info);
         } else {
-            _targetFile = cfg.configPath() + url.mid(url.lastIndexOf('/')+1);
+            _targetFile = ConfigFile::configPath() + url.mid(url.lastIndexOf('/') + 1);
             if (QFile(_targetFile).exists()) {
                 setDownloadState(DownloadComplete);
             } else {
@@ -490,7 +484,7 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 bool NSISUpdater::handleStartup()
 {
     ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     QString updateFileName = settings.value(updateAvailableC).toString();
     // has the previous run downloaded an update?
     if (!updateFileName.isEmpty() && QFile(updateFileName).exists()) {
@@ -520,8 +514,7 @@ bool NSISUpdater::handleStartup()
 
 void NSISUpdater::slotSetSeenVersion()
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
     settings.setValue(seenVersionC, updateInfo().version());
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -268,7 +268,7 @@ QVariant ConfigFile::getPolicySetting(const QString &setting, const QVariant &de
     return defaultValue;
 }
 
-QString ConfigFile::configPath() const
+QString ConfigFile::configPath()
 {
     if (_confDir.isEmpty()) {
         // On Unix, use the AppConfigLocation for the settings, that's configurable with the XDG_CONFIG_HOME env variable.
@@ -371,15 +371,14 @@ QString ConfigFile::backup() const
     return backupFile;
 }
 
-QString ConfigFile::configFile() const
+QString ConfigFile::configFile()
 {
     return configPath() + Theme::instance()->configFileName();
 }
 
 bool ConfigFile::exists()
 {
-    QFile file(configFile());
-    return file.exists();
+    return QFileInfo::exists(configFile());
 }
 
 QString ConfigFile::defaultConnection() const
@@ -871,16 +870,9 @@ void ConfigFile::setClientVersionString(const QString &version)
     settings.setValue(clientVersionC(), version);
 }
 
-Q_GLOBAL_STATIC(QString, g_configFileName)
-
 std::unique_ptr<QSettings> ConfigFile::settingsWithGroup(const QString &group, QObject *parent)
 {
-    if (g_configFileName()->isEmpty()) {
-        // cache file name
-        ConfigFile cfg;
-        *g_configFileName() = cfg.configFile();
-    }
-    std::unique_ptr<QSettings> settings(new QSettings(*g_configFileName(), QSettings::IniFormat, parent));
+    std::unique_ptr<QSettings> settings(new QSettings(ConfigFile::configFile(), QSettings::IniFormat, parent));
     settings->beginGroup(group);
     return settings;
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -39,13 +39,15 @@ class AbstractCredentials;
 class OWNCLOUDSYNC_EXPORT ConfigFile
 {
 public:
+    static QString configPath();
+    static QString configFile();
+    static bool exists();
+
     ConfigFile();
 
     enum Scope { UserScope,
         SystemScope };
 
-    QString configPath() const;
-    QString configFile() const;
     QString excludeFile(Scope scope) const;
     static QString excludeFileFromSystem(); // doesn't access config dir
 
@@ -56,7 +58,6 @@ public:
      */
     QString backup() const;
 
-    bool exists();
 
     QString defaultConnection() const;
 


### PR DESCRIPTION
Don't initialize a settings object just to check whether the file exists.

Fixes: https://github.com/owncloud/enterprise/issues/4597

This is intended to fix one issue, further work is planned in https://github.com/owncloud/client/issues/6213