### PR TITLE
[test-only]fix CI for GUI test run

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -39,7 +39,6 @@ def startClient(context):
         "owncloud -s"
         + " --logfile "
         + context.userData['clientConfigFile']
-        + " --language en_US"
         + " --confdir "
         + confdir
     )


### PR DESCRIPTION
## Description
The master branch have  `--language en_US` to setting language setting in GUI tests due which CI is failing. This PR temporarily fixes CI run for GUI tests. Until https://github.com/owncloud/client/issues/8680 is fixed