### PR TITLE
Destroy UploadDevice instance in case it has not been opened in ReadOnly mode

### DIFF
--- a/src/libsync/propagateuploadtus.cpp
+++ b/src/libsync/propagateuploadtus.cpp
@@ -70,6 +70,7 @@ UploadDevice *PropagateUploadFileTUS::prepareDevice(const quint64 &chunkSize)
         }
         // Soft error because this is likely caused by the user modifying his files while syncing
         abortWithError(SyncFileItem::SoftError, device->errorString());
+        delete device;
         return nullptr;
     }
     return device;


### PR DESCRIPTION
Memory leak occurs when new UploadDevice hasn't been opened in ReadOnly mode.