### PR TITLE
Fix use of deleted function

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -488,7 +488,7 @@ QString ExcludedFiles::convertToRegexpSyntax(QString exclude, bool wildcardsMatc
             // Translate [! to [^
             QString bracketExpr = exclude.mid(i, j - i + 1);
             if (bracketExpr.startsWith(QLatin1String("[!")))
-                bracketExpr[1] = '^';
+                bracketExpr[1] = QLatin1Char('^');
             regex.append(bracketExpr);
             i = j;
             break;


### PR DESCRIPTION
Compilation on void linux (qt 5.15.3+20210429) fails due to implicit cast to QChar
```
[18/326] Building CXX object src/csync/CMakeFiles/csync.dir/csync_exclude.cpp.o
FAILED: src/csync/CMakeFiles/csync.dir/csync_exclude.cpp.o 
/usr/lib/ccache/bin/g++ -DQT_CONCURRENT_LIB -DQT_CORE_LIB -DQT_DEPRECATED_WARNINGS -DQT_MESSAGELOGCONTEXT -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_URL_CAST_FROM_STRING -DQT_USE_QSTRINGBUILDER -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_XOPEN_SOURCE=600 -Dcsync_EXPORTS -Isrc/csync -I../src/csync -Isrc/csync/csync_autogen/include -I. -I../src -Isrc -I../src/csync/std -I /usr/include/qt5 -I /usr/include/qt5/QtCore -I /usr/lib/qt5/mkspecs/linux-g++ -I /usr/include/qt5/QtConcurrent -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -fno-operator-names -fno-exceptions -Wall -Wextra -Wcast-align -Wchar-subscripts -Wformat-security -Wno-long-long -Wpointer-arith -Wundef -Wnon-virtual-dtor -Woverloaded-virtual -Werror=return-type -Wvla -Wdate-time -Wsuggest-override -Wlogical-op -fdiagnostics-color=always -fstack-protector-strong -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -std=gnu++14 -MD -MT src/csync/CMakeFiles/csync.dir/csync_exclude.cpp.o -MF src/csync/CMakeFiles/csync.dir/csync_exclude.cpp.o.d -o src/csync/CMakeFiles/csync.dir/csync_exclude.cpp.o -c ../src/csync/csync_exclude.cpp
../src/csync/csync_exclude.cpp: In static member function 'static QString ExcludedFiles::convertToRegexpSyntax(QString, bool)':
../src/csync/csync_exclude.cpp:489:34: error: use of deleted function 'QCharRef& QCharRef::operator=(char)'
  489 |                 bracketExpr[1] = '^';
      |                                  ^~~
In file included from /usr/include/qt5/QtCore/QString:1,
                 from ../src/common/remotepermissions.h:21,
                 from ../src/csync/csync.h:46,
                 from ../src/csync/csync_exclude.h:26,
                 from ../src/csync/csync_exclude.cpp:30:
/usr/include/qt5/QtCore/qstring.h:1236:15: note: declared here
 1236 |     QCharRef &operator=(char c) = delete;
      |               ^~~~~~~~
ninja: build stopped: subcommand failed.
```

With this trivial fix, tested with 2.8.2, the compilation finishes.