### PR TITLE
Use qEnvironmentVariableIsEmpty instead of qgetenv().isEmpty()

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -204,7 +204,7 @@ bool uploadChecksumEnabled()
 
 static bool checksumComputationEnabled()
 {
-    static bool enabled = qgetenv("OWNCLOUD_DISABLE_CHECKSUM_COMPUTATIONS").isEmpty();
+    static bool enabled = qEnvironmentVariableIsEmpty("OWNCLOUD_DISABLE_CHECKSUM_COMPUTATIONS");
     return enabled;
 }
 


### PR DESCRIPTION
https://doc.qt.io/qt-5/qtglobal.html#qEnvironmentVariableIsEmpty

It's potentially much faster, and can't throw exceptions.