### PR TITLE
[tests-only] Group share tests added

### DIFF
--- a/test/gui/shared/scripts/pageObjects/SharingDialog.py
+++ b/test/gui/shared/scripts/pageObjects/SharingDialog.py
@@ -37,15 +37,15 @@ class SharingDialog:
         "type": "QLabel",
         "visible": 1,
     }
-    ERROR_SHOWN_ON_SHARING_DIALOG = {
+    SHARING_DIALOG = {
         "type": "QLabel",
         "unnamed": 1,
         "visible": 1,
         "window": names.sharingDialog_OCC_ShareDialog,
     }
+    SHARING_DIALOG_ERROR = {"name": "errorLabel", "type": "QLabel", "visible": 1}
 
     def getAvailablePermission(self):
-
         editChecked = squish.waitForObjectExists(self.EDIT_PERMISSIONS_CHECKBOX).checked
         shareChecked = squish.waitForObjectExists(
             self.SHARE_PERMISSIONS_CHECKBOX
@@ -53,25 +53,8 @@ class SharingDialog:
 
         return editChecked, shareChecked
 
-    def addCollaborator(self, receiver, permissions):
-        squish.mouseClick(
-            squish.waitForObject(self.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
-        squish.type(
-            squish.waitForObject(self.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
-            receiver,
-        )
-        squish.mouseClick(
-            squish.waitForObjectItem(self.SUGGESTED_COLLABORATOR, receiver),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+    def addCollaborator(self, receiver, permissions, isGroup=False):
+        self.selectCollaborator(receiver, isGroup)
         permissionsList = permissions.split(",")
 
         editChecked, shareChecked = self.getAvailablePermission()
@@ -87,8 +70,37 @@ class SharingDialog:
 
         squish.clickButton(squish.waitForObject(self.SHARING_DIALOG_CLOSE_BUTTON))
 
+    def getSharingDialogMessage(self):
+        return str(squish.waitForObjectExists(self.SHARING_DIALOG).text)
+
     def getErrorText(self):
-        return str(squish.waitForObjectExists(self.ERROR_SHOWN_ON_SHARING_DIALOG).text)
+        return str(squish.waitForObjectExists(self.SHARING_DIALOG_ERROR).text)
+
+    def selectCollaborator(self, receiver, isGroup=False):
+        postFixInSuggestion = ""
+        if isGroup:
+            postFixInSuggestion = " (group)"
+
+        squish.mouseClick(
+            squish.waitForObject(self.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
+            0,
+            0,
+            squish.Qt.NoModifier,
+            squish.Qt.LeftButton,
+        )
+        squish.type(
+            squish.waitForObject(self.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
+            receiver,
+        )
+        squish.mouseClick(
+            squish.waitForObjectItem(
+                self.SUGGESTED_COLLABORATOR, receiver + postFixInSuggestion
+            ),
+            0,
+            0,
+            squish.Qt.NoModifier,
+            squish.Qt.LeftButton,
+        )
 
     def removePermissions(self, permissions):
         removePermissionsList = permissions.split(",")

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -205,10 +205,31 @@ def step(context, receiver, resource, permissions):
     shareItem.addCollaborator(receiver, permissions)
 
 
+@When(
+    'the user adds group "|any|" as collaborator of resource "|any|" with permissions "|any|" using the client-UI'
+)
+def step(context, receiver, resource, permissions):
+    openSharingDialog(context, resource)
+    shareItem = SharingDialog()
+    shareItem.addCollaborator(receiver, permissions, True)
+
+
 @Then(
     'user "|any|" should be listed in the collaborators list for file "|any|" with permissions "|any|" on the client-UI'
 )
 def step(context, receiver, resource, permissions):
+    collaboratorShouldBeListed(context, receiver, resource, permissions)
+
+
+@Then(
+    'group "|any|" should be listed in the collaborators list for file "|any|" with permissions "|any|" on the client-UI'
+)
+def step(context, receiver, resource, permissions):
+    receiver += " (group)"
+    collaboratorShouldBeListed(context, receiver, resource, permissions)
+
+
+def collaboratorShouldBeListed(context, receiver, resource, permissions):
     resource = substituteInLineCodes(context, resource)
     socketConnect = syncstate.SocketConnect()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
@@ -447,7 +468,7 @@ def step(context, receiver, resource):
 @Then('the error text "|any|" should be displayed in the sharing dialog')
 def step(context, fileShareContext):
     shareItem = SharingDialog()
-    errorText = shareItem.getErrorText()
+    errorText = shareItem.getSharingDialogMessage()
     test.compare(
         errorText,
         fileShareContext,
@@ -687,3 +708,19 @@ def step(context, permissions, user, resource):
 
     if 'share' in permissionsList:
         test.compare(shareChecked, False)
+
+
+@Then('the error "|any|" should be displayed')
+def step(context, errorMessage):
+    sharingDialog = SharingDialog()
+    test.compare(sharingDialog.getErrorText(), errorMessage)
+
+
+@When(
+    'the user tires to share resource "|any|" with the group "|any|" using the client-UI'
+)
+def step(context, resource, group):
+    openSharingDialog(context, resource)
+
+    sharingDialog = SharingDialog()
+    sharingDialog.selectCollaborator(group, True)

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -25,6 +25,35 @@ Feature: Sharing
         And the user toggles the password protection using the client-UI
         Then the password progress indicator should not be visible in the client-UI - expected to fail
 
+
+    Scenario: Collaborator should not see to whom a file is shared.
+        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
+        And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share" permission
+        And user "Brian" has set up a client with default settings
+        When user "Brian" opens the sharing dialog of "%client_sync_path%/textfile0.txt" using the client-UI
+        Then the error text "The item is not shared with any users or groups" should be displayed in the sharing dialog
+
+
+    Scenario: Group sharing
+        Given group "grp1" has been created on the server
+        And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
+        And user "Alice" has set up a client with default settings
+        When the user adds group "grp1" as collaborator of resource "%client_sync_path%/textfile0.txt" with permissions "edit,share" using the client-UI
+        Then group "grp1" should be listed in the collaborators list for file "%client_sync_path%/textfile0.txt" with permissions "edit,share" on the client-UI
+
+
+    Scenario: User (non-author) can not share to a group to which the file is already shared
+        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        And group "grp1" has been created on the server
+        And user "Brian" on the server has been added to group "grp1"
+        And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
+        And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share, update" permission
+        And user "Alice" has shared file "/textfile0.txt" on the server with group "grp1" with "read, share, update" permission
+        And user "Brian" has set up a client with default settings
+        When the user tires to share resource "%client_sync_path%/textfile0.txt" with the group "grp1" using the client-UI
+        Then the error "Path already shared with this group" should be displayed
+
     @issue-7423
     Scenario: unshare a reshared file
         Given the setting "shareapi_auto_accept_share" on the server of app "core" has been set to "no"
@@ -169,6 +198,3 @@ Feature: Sharing
             | edit        | read, share                  | read, share              |
             | share       | read, update, create, delete | read,update              |
             | edit,share  | read                         | read                     |
-
-
-


### PR DESCRIPTION
The following test scenarios have been added:
- Collaborator should not see to whom a file is shared.
- Group sharing
- User (non-author) can not share to a group to which the file is already shared

### Related issues:
- part of https://github.com/owncloud/client/issues/8651