### PR TITLE
Fix deadlock introduced in 8fcc9adcc41f2b46a74b9c0d806d2f4721081f8a

### DIFF
--- a/shell_integration/windows/OCContextMenu/OCClientInterface.cpp
+++ b/shell_integration/windows/OCContextMenu/OCClientInterface.cpp
@@ -80,6 +80,10 @@ pair<wstring, nlohmann::json> parseV2(const wstring &data)
 
 std::shared_ptr<HBITMAP> saveImage(const string &data)
 {
+    ULONG_PTR gdiplusToken = 0;
+    Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+    Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, nullptr);
+
     DWORD size = 2 * 1024;
     std::vector<BYTE> buf(size, 0);
     DWORD skipped;
@@ -99,7 +103,10 @@ std::shared_ptr<HBITMAP> saveImage(const string &data)
         log(L"Failed to get HBITMAP", to_wstring(status));
         return {};
     }
-    return std::shared_ptr<HBITMAP> { new HBITMAP(result), &DeleteObject };
+    return std::shared_ptr<HBITMAP> { new HBITMAP(result), [gdiplusToken](auto o) {
+                                         DeleteObject(o);
+                                         Gdiplus::GdiplusShutdown(gdiplusToken);
+                                     } };
 }
 }
 

--- a/shell_integration/windows/OCContextMenu/dllmain.cpp
+++ b/shell_integration/windows/OCContextMenu/dllmain.cpp
@@ -30,26 +30,19 @@ long        g_cDllRef = 0;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 {
-    static ULONG_PTR gdiplusToken = 0;
     switch (dwReason) {
-    case DLL_PROCESS_ATTACH: {
+    case DLL_PROCESS_ATTACH:
         // Hold the instance of this DLL module, we will use it to get the
         // path of the DLL to register the component.
         g_hInst = hModule;
         DisableThreadLibraryCalls(hModule);
-
-        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
         break;
     }
-        case DLL_THREAD_ATTACH:
-	case DLL_THREAD_DETACH:
-            break;
-        case DLL_PROCESS_DETACH:
-            Gdiplus::GdiplusShutdown(gdiplusToken);
-            break;
-	}
-	return TRUE;
+    return TRUE;
 }
 
 STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, void **ppv)


### PR DESCRIPTION
Microsoft doc:
    Do not call GdiplusStartup or GdiplusShutdown in DllMain or in any function that is called by DllMain