### PR TITLE
[Tests-Only]fix gui tests fail in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -609,7 +609,7 @@ def testMiddleware():
         'image': 'owncloudci/nodejs:14',
         'pull': 'always',
         'environment': {
-            'HOST': 'testmiddleware',
+            'MIDDLEWARE_HOST': 'testmiddleware',
             'BACKEND_HOST': 'http://owncloud'
         },
         'commands': [


### PR DESCRIPTION
## Description
After https://github.com/owncloud/owncloud-test-middleware/pull/44 has been merged  `HOST` has been changed to `MIDDLEWARE_HOST` due to which CI has been failing while running GUI tests.

This PR fixes GUI tests failing on CI