### PR TITLE
Removed obsolete Q_FOREACH macro

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -255,10 +255,8 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
             acc->_credentials->persist();
         }
 
-        auto i = acc->_settingsMap.constBegin();
-        while (i != acc->_settingsMap.constEnd()) {
-            settings.setValue(i.key(), i.value());
-            ++i;
+        for (auto it = acc->_settingsMap.constBegin(); it != acc->_settingsMap.constEnd(); ++it) {
+            settings.setValue(it.key(), it.value());
         }
 
         // HACK: Save http_user also as user

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -254,8 +254,11 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
             // re-persisting them)
             acc->_credentials->persist();
         }
-        Q_FOREACH (QString key, acc->_settingsMap.keys()) {
-            settings.setValue(key, acc->_settingsMap.value(key));
+
+        auto i = acc->_settingsMap.constBegin();
+        while (i != acc->_settingsMap.constEnd()) {
+            settings.setValue(i.key(), i.value());
+            ++i;
         }
 
         // HACK: Save http_user also as user
@@ -266,8 +269,9 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     // Save accepted certificates.
     settings.beginGroup(QLatin1String("General"));
     qCInfo(lcAccountManager) << "Saving " << acc->approvedCerts().count() << " unknown certs.";
+    const auto approvedCerts = acc->approvedCerts();
     QByteArray certs;
-    Q_FOREACH (const QSslCertificate &cert, acc->approvedCerts()) {
+    for (const auto &cert : approvedCerts) {
         certs += cert.toPem() + '\n';
     }
     if (!certs.isEmpty()) {
@@ -317,7 +321,8 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));
     const QString authTypePrefix = QStringLiteral("http_");
-    Q_FOREACH (QString key, settings.childKeys()) {
+    const auto childKeys = settings.childKeys();
+    for (const auto &key : childKeys) {
         if (!key.startsWith(authTypePrefix))
             continue;
         acc->_settingsMap.insert(key, settings.value(key));

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -50,7 +50,7 @@ QString FormatWarningsWizardPage::formatWarnings(const QStringList &warnings) co
         ret = tr("<b>Warning:</b> %1").arg(warnings.first());
     } else if (warnings.count() > 1) {
         ret = tr("<b>Warning:</b>") + " <ul>";
-        Q_FOREACH (QString warning, warnings) {
+        for (const auto &warning : warnings) {
             ret += QString::fromLatin1("<li>%1</li>").arg(warning);
         }
         ret += "</ul>";

--- a/src/gui/ocsjob.cpp
+++ b/src/gui/ocsjob.cpp
@@ -80,7 +80,7 @@ void OcsJob::start()
     } else if (_verb == "POST" || _verb == "PUT") {
         // Url encode the _postParams and put them in a buffer.
         QByteArray postData;
-        Q_FOREACH (auto tmp, _params) {
+        for (const auto &tmp : qAsConst(_params)) {
             if (!postData.isEmpty()) {
                 postData.append("&");
             }

--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -195,7 +195,7 @@ void BandwidthManager::relativeUploadMeasuringTimerExpired()
 
     int deviceCount = _relativeUploadDeviceList.count();
     qint64 quotaPerDevice = relativeLimitProgressDifference * (uploadLimitPercent / 100.0) / deviceCount + 1.0;
-    Q_FOREACH (UploadDevice *ud, _relativeUploadDeviceList) {
+    for (auto *ud : qAsConst(_relativeUploadDeviceList)) {
         ud->setBandwidthLimited(true);
         ud->setChoked(false);
         ud->giveBandwidthQuota(quotaPerDevice);
@@ -230,7 +230,7 @@ void BandwidthManager::relativeUploadDelayTimerExpired()
     _relativeLimitCurrentMeasuredDevice->setChoked(false);
 
     // choke all other UploadDevices
-    Q_FOREACH (UploadDevice *ud, _relativeUploadDeviceList) {
+    for (auto *ud : qAsConst(_relativeUploadDeviceList)) {
         if (ud != _relativeLimitCurrentMeasuredDevice) {
             ud->setBandwidthLimited(true);
             ud->setChoked(true);
@@ -289,7 +289,7 @@ void BandwidthManager::relativeDownloadMeasuringTimerExpired()
         quota -= 20 * 1024;
     }
     qint64 quotaPerJob = quota / jobCount + 1.0;
-    Q_FOREACH (GETJob *gfj, _downloadJobList) {
+    for (auto *gfj : qAsConst(_downloadJobList)) {
         gfj->setBandwidthLimited(true);
         gfj->setChoked(false);
         gfj->giveBandwidthQuota(quotaPerJob);
@@ -323,7 +323,7 @@ void BandwidthManager::relativeDownloadDelayTimerExpired()
     _relativeLimitCurrentMeasuredJob->setChoked(false);
 
     // choke all other download jobs
-    Q_FOREACH (GETJob *gfj, _downloadJobList) {
+    for (auto *gfj : qAsConst(_downloadJobList)) {
         if (gfj != _relativeLimitCurrentMeasuredJob) {
             gfj->setBandwidthLimited(true);
             gfj->setChoked(true);
@@ -341,7 +341,7 @@ void BandwidthManager::switchingTimerExpired()
     if (newUploadLimit != _currentUploadLimit) {
         qCInfo(lcBandwidthManager) << "Upload Bandwidth limit changed" << _currentUploadLimit << newUploadLimit;
         _currentUploadLimit = newUploadLimit;
-        Q_FOREACH (UploadDevice *ud, _relativeUploadDeviceList) {
+        for (auto *ud : qAsConst(_relativeUploadDeviceList)) {
             if (newUploadLimit == 0) {
                 ud->setBandwidthLimited(false);
                 ud->setChoked(false);
@@ -358,7 +358,7 @@ void BandwidthManager::switchingTimerExpired()
     if (newDownloadLimit != _currentDownloadLimit) {
         qCInfo(lcBandwidthManager) << "Download Bandwidth limit changed" << _currentDownloadLimit << newDownloadLimit;
         _currentDownloadLimit = newDownloadLimit;
-        Q_FOREACH (GETJob *j, _downloadJobList) {
+        for (auto *j : qAsConst(_downloadJobList)) {
             if (usingAbsoluteDownloadLimit()) {
                 j->setBandwidthLimited(true);
                 j->setChoked(false);
@@ -378,7 +378,7 @@ void BandwidthManager::absoluteLimitTimerExpired()
     if (usingAbsoluteUploadLimit() && _absoluteUploadDeviceList.count() > 0) {
         qint64 quotaPerDevice = _currentUploadLimit / qMax(1, _absoluteUploadDeviceList.count());
         qCDebug(lcBandwidthManager) << quotaPerDevice << _absoluteUploadDeviceList.count() << _currentUploadLimit;
-        Q_FOREACH (UploadDevice *device, _absoluteUploadDeviceList) {
+        for (auto *device : qAsConst(_absoluteUploadDeviceList)) {
             device->giveBandwidthQuota(quotaPerDevice);
             qCDebug(lcBandwidthManager) << "Gave " << quotaPerDevice / 1024.0 << " kB to" << device;
         }
@@ -386,7 +386,7 @@ void BandwidthManager::absoluteLimitTimerExpired()
     if (usingAbsoluteDownloadLimit() && _downloadJobList.count() > 0) {
         qint64 quotaPerJob = _currentDownloadLimit / qMax(1, _downloadJobList.count());
         qCDebug(lcBandwidthManager) << quotaPerJob << _downloadJobList.count() << _currentDownloadLimit;
-        Q_FOREACH (GETJob *j, _downloadJobList) {
+        for (auto *j : qAsConst(_downloadJobList)) {
             j->giveBandwidthQuota(quotaPerJob);
             qCDebug(lcBandwidthManager) << "Gave " << quotaPerJob / 1024.0 << " kB to" << j;
         }


### PR DESCRIPTION
Note: Since Qt 5.7, the use of this macro is discouraged. It will be removed in a future version of Qt. Please use C++11 range-for, possibly with qAsConst(), as needed.

https://doc.qt.io/qt-5/qtglobal.html#Q_FOREACH