### PR TITLE
 Update translations on stable branch in GitHub actions

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,9 +6,6 @@
 #
 
 def main(ctx):
-    translations_trigger = {
-        "cron": ["translations-2-7"],
-    }
     build_trigger = {
         "ref": [
             "refs/heads/master",
@@ -59,22 +56,6 @@ def main(ctx):
                 "changelog",
                 "gcc-release-make",
                 "clang-debug-ninja",
-            ],
-        ),
-
-        # Sync translations
-        update_translations(
-            ctx,
-            "client",
-            "translations",
-            read_image = "rabits/qt:5.12-desktop",
-            trigger = translations_trigger,
-        ),
-        notification(
-            name = "translations",
-            trigger = translations_trigger,
-            depends_on = [
-                "translations-client",
             ],
         ),
     ]
@@ -300,52 +281,6 @@ def make(target, path, image = "owncloudci/transifex:latest"):
             'cd "' + path + '"',
             "make " + target,
         ],
-    }
-
-def update_translations(ctx, name, path, read_image = "owncloudci/transifex:latest", write_image = "owncloudci/transifex:latest", trigger = {}, depends_on = []):
-    return {
-        "kind": "pipeline",
-        "name": "translations-" + name,
-        "platform": {
-            "os": "linux",
-            "arch": "amd64",
-        },
-        "steps": [
-            make("l10n-read", path, read_image),
-            make("l10n-push", path),
-            make("l10n-pull", path),
-            make("l10n-write", path, write_image),
-            make("l10n-clean", path),
-            # keep time window for commit races as small as possible
-            {
-                "name": "update-repo-before-commit",
-                "image": "docker:git",
-                "commands": [
-                    "git stash",
-                    "git pull --ff-only origin +refs/heads/$${DRONE_BRANCH}",
-                    '[ "$(git stash list)" = "" ] || git stash pop',
-                ],
-            },
-            whenOnline({
-                "name": "commit",
-                "image": "appleboy/drone-git-push",
-                "pull": "always",
-                "settings": {
-                    "ssh_key": from_secret("git_push_ssh_key"),
-                    "author_name": "ownClouders",
-                    "author_email": "devops@owncloud.com",
-                    "remote_name": "origin",
-                    "branch": "${DRONE_BRANCH}",
-                    "empty_commit": False,
-                    "commit": True,
-                    "commit_message": "[tx] updated " + name + " translations from transifex",
-                    "no_verify": True,
-                    "remote": "git@github.com:owncloud/client.git",
-                },
-            }),
-        ],
-        "trigger": trigger,
-        "depends_on": depends_on,
     }
 
 def notification(name, depends_on = [], trigger = {}):

--- a/.github/workflows/run-in-docker.sh
+++ b/.github/workflows/run-in-docker.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+
+image="$1"
+shift
+
+commands="$@"
+
+if [[ "$image" == "" ]] || [[ "${commands[@]}" == "" ]]; then
+    echo "Usage: bash $0 <image> <commands>"
+    exit 1
+fi
+
+set -exo pipefail
+
+extra_args=()
+
+if tty -s; then
+    extra_args+=("-t")
+fi
+
+docker run \
+    --rm \
+    --user "$(id -u)" \
+    -i "${extra_args[@]}" \
+    -e TX_TOKEN \
+    -e HOME \
+    -v "$HOME:$HOME" \
+    -v "$(readlink -f .)":/ws \
+    --entrypoint sh \
+    -w /ws \
+    "$image" \
+    -c "${commands[@]}"

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,49 @@
+name: "Update translations"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  update-translations:
+    runs-on: ubuntu-latest
+
+    env:
+      TX_TOKEN: ${{ secrets.TX_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: l10n-read
+        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws rabits/qt:5.12-desktop sh -c "cd /ws/translations && make l10n-read"
+
+      - name: l10n-push
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-push"
+
+      - name: l10n-pull
+        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-pull"
+
+      - name: l10n-write
+        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-write"
+
+      - name: l10n-clean
+        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-clean"
+
+      - name: update-repo-before-commit
+        run: |
+          git diff
+          git stash
+          git pull --ff-only origin ${{ env.GITHUB_REF }}
+          [[ "$(git stash list)" != "" ]] || git stash pop
+
+      - name: commit and push
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "ownClouders"
+          git config user.email "devops@owncloud.com"
+          git commit -m "[tx] updated " + name + " translations from transifex" .
+          git push

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          ref: 2.8
 
       - name: l10n-read
         run: bash .github/workflows/run-in-docker.sh rabits/qt:5.12-desktop "cd translations && make l10n-read"
@@ -37,7 +38,7 @@ jobs:
         run: |
           git diff
           git stash
-          git pull --ff-only origin ${{ env.GITHUB_REF }}
+          git pull --ff-only origin
           [[ "$(git stash list)" != "" ]] || git stash pop
 
       - name: commit and push

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -18,20 +18,20 @@ jobs:
           submodules: recursive
 
       - name: l10n-read
-        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws rabits/qt:5.12-desktop sh -c "cd /ws/translations && make l10n-read"
+        run: bash .github/workflows/run-in-docker.sh rabits/qt:5.12-desktop "cd translations && make l10n-read"
 
       - name: l10n-push
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-push"
+        run: bash .github/workflows/run-in-docker.sh owncloudci/transifex:latest "cd translations && make l10n-push"
 
       - name: l10n-pull
-        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-pull"
+        run: bash .github/workflows/run-in-docker.sh owncloudci/transifex:latest "cd translations && make l10n-pull"
 
       - name: l10n-write
-        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-write"
+        run: bash .github/workflows/run-in-docker.sh owncloudci/transifex:latest "cd translations && make l10n-write"
 
       - name: l10n-clean
-        run: docker run --user "$(id -u)" --rm -i -e TX_TOKEN -v "$(readlink -f .)":/ws --entrypoint sh owncloudci/transifex:latest -c "cd /ws/translations && make l10n-clean"
+        run: bash .github/workflows/run-in-docker.sh owncloudci/transifex:latest "cd translations && make l10n-clean"
 
       - name: update-repo-before-commit
         run: |

--- a/translations/Makefile
+++ b/translations/Makefile
@@ -17,7 +17,6 @@ l10n-clean:
 
 .PHONY: l10n-read
 l10n-read:
-	sudo chown -R user .
 	cd .. && lupdate src -no-obsolete -ts translations/client_en.ts
 
 .PHONY: l10n-write


### PR DESCRIPTION
Cherry-picked version of #8709 on the `2.8` branch. The original PR operated on the dev branch, but translations shall be updated on the stable branch only.

Original PR reverted in #8712.

Note that we have to update the branch name in this workflow whenever a new minor or major release is published.