### PR TITLE
[Tests-Only]Run smokeTest on CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -50,8 +50,8 @@ def main(ctx):
             "Ninja",
             trigger = build_trigger,
         ),
-        gui_tests(ctx, trigger = build_trigger, filterTags = ["smokeTest"]),
-        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-smokeTest"]),
+        gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"]),
+        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-smokeTest"], filterTags = ["~@smokeTest"]),
         notification(
             name = "build",
             trigger = build_trigger,

--- a/.drone.star
+++ b/.drone.star
@@ -51,7 +51,7 @@ def main(ctx):
             trigger = build_trigger,
         ),
         gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"]),
-        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-smokeTest"], filterTags = ["~@smokeTest"]),
+        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest"]),
         notification(
             name = "build",
             trigger = build_trigger,

--- a/.drone.star
+++ b/.drone.star
@@ -50,7 +50,8 @@ def main(ctx):
             "Ninja",
             trigger = build_trigger,
         ),
-        gui_tests(ctx, trigger = build_trigger),
+        gui_tests(ctx, trigger = build_trigger, filterTags = ["smokeTest"]),
+        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-smokeTest"]),
         notification(
             name = "build",
             trigger = build_trigger,
@@ -167,9 +168,15 @@ def build_and_test_client(ctx, c_compiler, cxx_compiler, build_type, generator, 
         "depends_on": depends_on,
     }
 
-def gui_tests(ctx, trigger = {}, depends_on = []):
+def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = []):
     pipeline_name = "GUI-tests"
     build_dir = "build-" + pipeline_name
+    squish_parameters = "--retry 1"
+
+    if (len(filterTags) > 0):
+        for tags in filterTags:
+            squish_parameters += " --tags " + tags
+            pipeline_name += "-" + tags
 
     return {
         "kind": "pipeline",
@@ -203,7 +210,7 @@ def gui_tests(ctx, trigger = {}, depends_on = []):
                              "MIDDLEWARE_URL": "http://testmiddleware:3000/",
                              "BACKEND_HOST": "http://owncloud/",
                              "SERVER_INI": "/drone/src/test/gui/drone/server.ini",
-                             "SQUISH_PARAMETERS": "--retry 1",
+                             "SQUISH_PARAMETERS": squish_parameters,
                          },
                      },
                  ],

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -8,6 +8,7 @@ Feature: Sharing
     Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
 
+    @smokeTest
     Scenario: simple sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"


### PR DESCRIPTION
## Description
Currently we run all GUI tests in same pipeline name `GUI-tests`. This is a POC PR for running smokeTest in CI.

 Here, we have separated GUI tests run into two pipeline `GUI-tests-@smokeTest` where all tests with tag `@smokeTest`  will run and `GUI-tests-~@smokeTest` where other remaining tests will run. These pipelines does not run parallelly. First `GUI-tests-@smokeTest` will run and on passing  `GUI-tests-~@smokeTest` will run. 

All the normal tests depends on smokeTest. This way we also will be achieving early failure.

## Related Issue
- https://github.com/owncloud/client/issues/8705