### PR TITLE
[Tests-Only] add smokeTest tag

### DIFF
--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -40,7 +40,7 @@ Feature: Sharing
         When user "Brian" opens the sharing dialog of "%client_sync_path%/Shares/simple-folder" using the client-UI
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
 
-
+    @smokeTest
     Scenario: simple sharing of a file by public link without password
         Given user "Alice" has uploaded on the server file with content "ownCloud test text file 0" to "/textfile0.txt"
         And user "Alice" has set up a client with default settings
@@ -70,7 +70,7 @@ Feature: Sharing
         Then the fields of the last public link share response of user "Alice" should include on the server
             | expireDate | 2038-07-21 |
 
-
+    @smokeTest
     Scenario: simple sharing of a folder by public link without password
         Given user "Alice" has created on the server folder "simple-folder"
         And user "Alice" has set up a client with default settings

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -7,6 +7,7 @@ Feature: Syncing files
     Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
 
+    @smokeTest
     Scenario: Syncing a file to the server
         Given user "Alice" has set up a client with default settings
         When the user creates a file "lorem-for-upload.txt" with the following content on the file system


### PR DESCRIPTION
## Description
After https://github.com/owncloud/client/pull/8719 has been merged this PR adds `@smokeTest` tag for already existing tests like for:

- Sync a file to the server
- Create a public link for file/folder

## Related Issue
- https://github.com/owncloud/client/issues/8705

Also see: https://github.com/owncloud/client/issues/8651#issuecomment-857373491
