### PR TITLE
Replaced QFileInfo(file).exists() with a static QFileInfo::exists(file)

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1495,7 +1495,7 @@ QString FolderMan::findGoodPathForNewSyncFolder(const QString &basePath, const Q
     int attempt = 1;
     forever {
         const bool isGood =
-            !QFileInfo(folder).exists()
+            !QFileInfo::exists(folder)
             && FolderMan::instance()->checkPathValidityForNewFolder(folder, serverUrl).isEmpty();
         if (isGood) {
             break;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -267,7 +267,7 @@ void SyncEngine::conflictRecordMaintenance()
     auto conflictRecordPaths = _journal->conflictRecordPaths();
     for (const auto &path : conflictRecordPaths) {
         auto fsPath = _propagator->fullLocalPath(QString::fromUtf8(path));
-        if (!QFileInfo(fsPath).exists()) {
+        if (!QFileInfo::exists(fsPath)) {
             _journal->deleteConflictRecord(path);
         }
     }

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -600,7 +600,7 @@ private slots:
         // We can't depend on currentLocalState for hidden files since
         // it should rightfully skip things like download temporaries
         auto localFileExists = [&](QString name) {
-            return QFileInfo(fakeFolder.localPath() + name).exists();
+            return QFileInfo::exists(fakeFolder.localPath() + name);
         };
 
         fakeFolder.syncEngine().setIgnoreHiddenFiles(true);


### PR DESCRIPTION
https://doc.qt.io/qt-5/qfileinfo.html#exists

Note: Using this function is faster than using QFileInfo(file).exists() for file system access.