### PR TITLE
[Tests-Only] Run GUI tests on nightly

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -13,6 +13,11 @@ def main(ctx):
             "refs/pull/**",
         ],
     }
+    cron_trigger = {
+        "event": [
+            "cron",
+        ],
+    }
     notification_trigger = {
         "ref": [
             "refs/heads/master",
@@ -50,8 +55,8 @@ def main(ctx):
             "Ninja",
             trigger = build_trigger,
         ),
-        gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"]),
-        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest", "~@skip"]),
+        gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"], version = "10.7.0"),
+        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest"], version = "10.7.0"),
         notification(
             name = "build",
             trigger = build_trigger,
@@ -63,8 +68,32 @@ def main(ctx):
             ],
         ),
     ]
+    cron_pipelines = [
+        # Build client
+        build_and_test_client(
+            ctx,
+            "gcc",
+            "g++",
+            "Release",
+            "Unix Makefiles",
+            trigger = cron_trigger,
+        ),
+        build_and_test_client(
+            ctx,
+            "clang",
+            "clang++",
+            "Debug",
+            "Ninja",
+            trigger = cron_trigger,
+        ),
+        gui_tests(ctx, trigger = cron_trigger, filterTags = ["@smokeTest"]),
+        gui_tests(ctx, trigger = cron_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest", "~@skip"]),
+    ]
 
-    return pipelines
+    if ctx.build.event == "cron":
+        return cron_pipelines
+    else:
+        return pipelines
 
 def whenOnline(dict):
     if not "when" in dict:
@@ -168,7 +197,7 @@ def build_and_test_client(ctx, c_compiler, cxx_compiler, build_type, generator, 
         "depends_on": depends_on,
     }
 
-def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = []):
+def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = [], version = "daily-master-qa"):
     pipeline_name = "GUI-tests"
     build_dir = "build-" + pipeline_name
     squish_parameters = "--retry 1"
@@ -194,7 +223,7 @@ def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = []):
                          ],
                      },
                  ] +
-                 installCore("daily-master-qa") +
+                 installCore(version) +
                  setupServerAndApp(2) +
                  fixPermissions() +
                  owncloudLog() +

--- a/.drone.star
+++ b/.drone.star
@@ -55,8 +55,8 @@ def main(ctx):
             "Ninja",
             trigger = build_trigger,
         ),
-        gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"], version = "10.7.0"),
-        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest"], version = "10.7.0"),
+        gui_tests(ctx, trigger = build_trigger, filterTags = ["@smokeTest"], version = "latest"),
+        gui_tests(ctx, trigger = build_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest"], version = "latest"),
         notification(
             name = "build",
             trigger = build_trigger,
@@ -87,7 +87,7 @@ def main(ctx):
             trigger = cron_trigger,
         ),
         gui_tests(ctx, trigger = cron_trigger, filterTags = ["@smokeTest"]),
-        gui_tests(ctx, trigger = cron_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest", "~@skip"]),
+        gui_tests(ctx, trigger = cron_trigger, depends_on = ["GUI-tests-@smokeTest"], filterTags = ["~@smokeTest"]),
     ]
 
     if ctx.build.event == "cron":


### PR DESCRIPTION
### Description
Currently we do not run GUI tests on nightly. So, this PR will run all the GUI tests against the `daily-master-qa` server and  run PRs against a stable server tarball `10.7.0`.

After this PR gets merged we need to change the server version from `10.7.0` to latest stable release when new stable version of core is released.
