### PR TITLE
Fix build warnings

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -81,6 +81,10 @@ struct CmdOptions
 
 struct SyncCTX
 {
+    explicit SyncCTX(const CmdOptions &cmdOptions)
+        : options { cmdOptions }
+    {
+    }
     CmdOptions options;
     QUrl credentialFreeUrl;
     QString folder;

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -114,7 +114,7 @@ void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
 }
 
 
-void sync(const SyncCTX &ctx, int restartCount)
+void sync(const SyncCTX &ctx)
 {
     QStringList selectiveSyncList;
     if (!ctx.options.unsyncedfolders.isEmpty()) {
@@ -537,7 +537,7 @@ int main(int argc, char **argv)
 
             // much lower age than the default since this utility is usually made to be run right after a change in the tests
             SyncEngine::minimumFileAgeForUpload = std::chrono::milliseconds(0);
-            sync(ctx, 0);
+            sync(ctx);
         });
         userJob->start();
     });

--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -65,8 +65,8 @@ Optional<Vfs::Mode> Vfs::modeFromString(const QString &str)
 
 Result<bool, QString> Vfs::checkAvailability(const QString &path)
 {
-    const auto mode = bestAvailableVfsMode();
 #ifdef Q_OS_WIN
+    const auto mode = bestAvailableVfsMode();
     if (mode == Mode::WindowsCfApi) {
         const auto info = QFileInfo(path);
         if (QDir(info.canonicalPath()).isRoot()) {

--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -202,7 +202,7 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(const QStringRef &path, bool ex
 
     /* Do not sync desktop.ini files anywhere in the tree. */
     const auto desktopIniFile = QStringLiteral("desktop.ini");
-    if (blen == static_cast<size_t>(desktopIniFile.length()) && bname.compare(desktopIniFile, Qt::CaseInsensitive) == 0) {
+    if (blen == static_cast<qsizetype>(desktopIniFile.length()) && bname.compare(desktopIniFile, Qt::CaseInsensitive) == 0) {
         return CSYNC_FILE_SILENTLY_EXCLUDED;
     }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -404,8 +404,6 @@ void Folder::createGuiLog(const QString &filename, LogStatus status, int count,
     const QString &renameTarget)
 {
     if (count > 0) {
-        Logger *logger = Logger::instance();
-
         QString file = QDir::toNativeSeparators(filename);
         QString text;
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -51,7 +51,9 @@ GeneralSettings::GeneralSettings(QWidget *parent)
 
     connect(_ui->desktopNotificationsCheckBox, &QAbstractButton::toggled,
         this, &GeneralSettings::slotToggleOptionalDesktopNotifications);
+#ifdef Q_OS_WIN
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
+#endif
 
     reloadConfig();
     loadMiscSettings();
@@ -302,15 +304,15 @@ void GeneralSettings::slotToggleOptionalDesktopNotifications(bool enable)
     cfgFile.setOptionalDesktopNotifications(enable);
 }
 
+#ifdef Q_OS_WIN
 void GeneralSettings::slotShowInExplorerNavigationPane(bool checked)
 {
-#ifdef Q_OS_WIN
     ConfigFile cfgFile;
     cfgFile.setShowInExplorerNavigationPane(checked);
     // Now update the registry with the change.
     FolderMan::instance()->navigationPaneHelper().setShowInExplorerNavigationPane(checked);
-#endif
 }
+#endif
 
 void GeneralSettings::slotIgnoreFilesEditor()
 {

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -46,7 +46,9 @@ private slots:
     void saveMiscSettings();
     void slotToggleLaunchOnStartup(bool);
     void slotToggleOptionalDesktopNotifications(bool);
+#ifdef Q_OS_WIN
     void slotShowInExplorerNavigationPane(bool);
+#endif
     void slotUpdateInfo();
     void slotUpdateChannelChanged(int index);
     void slotIgnoreFilesEditor();

--- a/src/gui/models/activitylistmodel.cpp
+++ b/src/gui/models/activitylistmodel.cpp
@@ -121,7 +121,8 @@ QVariant ActivityListModel::headerData(int section, Qt::Orientation orientation,
             case ActivityRole::ColumnCount:
                 Q_UNREACHABLE();
                 break;
-            };
+            }
+            break;
         case Models::StringFormatWidthRole:
             switch (actionRole) {
             case ActivityRole::Text:
@@ -136,7 +137,8 @@ QVariant ActivityListModel::headerData(int section, Qt::Orientation orientation,
                 Q_UNREACHABLE();
                 break;
             }
-        };
+            break;
+        }
     }
     return QAbstractTableModel::headerData(section, orientation, role);
 }

--- a/src/gui/models/protocolitemmodel.cpp
+++ b/src/gui/models/protocolitemmodel.cpp
@@ -82,6 +82,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
             Q_UNREACHABLE();
             break;
         }
+        break;
     case Qt::DecorationRole:
         if (column == ProtocolItemRole::Action) {
             const auto status = item.status();
@@ -98,6 +99,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
                 //                return Theme::instance()->syncStateIcon(SyncResult::Success);
             }
         }
+        break;
     case Models::UnderlyingDataRole:
         switch (column) {
         case ProtocolItemRole::Time:
@@ -116,6 +118,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
             Q_UNREACHABLE();
             break;
         }
+        break;
     }
     return {};
 }
@@ -142,8 +145,8 @@ QVariant ProtocolItemModel::headerData(int section, Qt::Orientation orientation,
             case ProtocolItemRole::ColumnCount:
                 Q_UNREACHABLE();
                 break;
-            };
-
+            }
+            break;
         case Models::StringFormatWidthRole:
             switch (actionRole) {
             case ProtocolItemRole::Time:
@@ -162,7 +165,8 @@ QVariant ProtocolItemModel::headerData(int section, Qt::Orientation orientation,
                 Q_UNREACHABLE();
                 break;
             }
-        };
+            break;
+        }
     }
     return QAbstractTableModel::headerData(section, orientation, role);
 }

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -225,7 +225,7 @@ bool OwncloudSetupPage::validatePage()
     }
 }
 
-void OwncloudSetupPage::setAuthType(DetermineAuthTypeJob::AuthType type)
+void OwncloudSetupPage::setAuthType()
 {
     _authTypeKnown = true;
     stopSpinner();

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -53,7 +53,7 @@ public:
     QString localFolder() const;
     void setRemoteFolder(const QString &remoteFolder);
     void setMultipleFoldersExist(bool exist);
-    void setAuthType(DetermineAuthTypeJob::AuthType type);
+    void setAuthType();
 
 public slots:
     void setErrorString(const QString &);

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -178,7 +178,7 @@ DetermineAuthTypeJob::AuthType OwncloudWizard::authType() const
 void OwncloudWizard::setAuthType(DetermineAuthTypeJob::AuthType type)
 {
     _authType = type;
-    _setupPage->setAuthType(type);
+    _setupPage->setAuthType();
     if (type == DetermineAuthTypeJob::AuthType::OAuth) {
         _credentialsPage = _oauthCredsPage;
     } else { // try Basic auth even for "Unknown"

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -38,6 +38,9 @@ Q_LOGGING_CATEGORY(lcHttpCredentials, "sync.credentials.http", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcHttpLegacyCredentials, "sync.credentials.http.legacy", QtInfoMsg)
 
 namespace {
+constexpr int CredentialVersion = 1;
+const char authenticationFailedC[] = "owncloud-authentication-failed";
+
 auto isOAuthC()
 {
     return QStringLiteral("oauth");
@@ -61,6 +64,16 @@ auto clientCertBundleKeyC()
 auto clientCertPasswordKeyC()
 {
     return QStringLiteral("clientsideCert/password");
+}
+
+auto CredentialVersionKey()
+{
+    return QStringLiteral("CredentialVersion");
+}
+
+const QString userC()
+{
+    return QStringLiteral("user");
 }
 }
 

--- a/src/libsync/creds/httpcredentials_p.h
+++ b/src/libsync/creds/httpcredentials_p.h
@@ -12,25 +12,12 @@
 #include <qt5keychain/keychain.h>
 
 namespace {
-constexpr int CredentialVersion = 1;
-auto CredentialVersionKey()
-{
-    return QStringLiteral("CredentialVersion");
-}
-
-const QString userC()
-{
-    return QStringLiteral("user");
-}
-const char authenticationFailedC[] = "owncloud-authentication-failed";
-
 void addSettingsToJob(QKeychain::Job *job)
 {
     auto settings = OCC::ConfigFile::settingsWithGroup(OCC::Theme::instance()->appName());
     settings->setParent(job); // make the job parent to make setting deleted properly
     job->setSettings(settings.release());
 }
-
 } // ns
 
 Q_DECLARE_LOGGING_CATEGORY(lcHttpLegacyCredentials)

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -36,19 +36,17 @@
 namespace {
 constexpr int CrashLogSize = 20;
 
+#ifdef Q_OS_WIN
 bool isDebuggerPresent()
 {
-#ifdef Q_OS_WIN
     BOOL debugged;
     if (!CheckRemoteDebuggerPresent(GetCurrentProcess(), &debugged)) {
         const auto error = GetLastError();
         qDebug() << "Failed to detect debugger" << QString::fromWCharArray(_com_error(error).ErrorMessage());
     }
     return debugged;
-#else
-    return false;
-#endif
 }
+#endif
 }
 namespace OCC {
 

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -399,14 +399,14 @@ public:
 public:
     OwncloudPropagator(AccountPtr account, const QString &localDir,
         const QString &remoteFolder, SyncJournalDb *progressDb)
-        : _localDir((localDir.endsWith(QLatin1Char('/'))) ? localDir : localDir + QLatin1Char('/'))
-        , _remoteFolder((remoteFolder.endsWith(QLatin1Char('/'))) ? remoteFolder : remoteFolder + QLatin1Char('/'))
-        , _journal(progressDb)
+        : _journal(progressDb)
         , _finishedEmited(false)
         , _bandwidthManager(this)
         , _anotherSyncNeeded(false)
         , _chunkSize(10 * 1000 * 1000) // 10 MB, overridden in setSyncOptions
         , _account(account)
+        , _localDir((localDir.endsWith(QLatin1Char('/'))) ? localDir : localDir + QLatin1Char('/'))
+        , _remoteFolder((remoteFolder.endsWith(QLatin1Char('/'))) ? remoteFolder : remoteFolder + QLatin1Char('/'))
     {
         qRegisterMetaType<PropagatorJob::AbortType>("PropagatorJob::AbortType");
     }

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -487,8 +487,6 @@ private:
     static void fromDisk(QDir &dir, FileInfo &templateFi);
 };
 
-static FileInfo &findOrCreateDirs(FileInfo &base, PathComponents components);
-
 
 /* Return the FileInfo for a conflict file for the specified relative filename */
 inline const FileInfo *findConflict(FileInfo &dir, const QString &filename)

--- a/test/testcredentialmanager.cpp
+++ b/test/testcredentialmanager.cpp
@@ -81,7 +81,13 @@ private Q_SLOTS:
                 });
             });
         });
-        QTest::qWaitFor([this] { return _finished; });
+#ifdef Q_OS_LINUX
+        // As we have the skip condition on linux the wait might time out here.
+        bool ok = QTest::qWaitFor([this] { return _finished; });
+        Q_UNUSED(ok)
+#else
+        QVERIFY(QTest::qWaitFor([this] { return _finished; }));
+#endif
     }
 
     void testSetGet2()

--- a/test/testjobqueue.cpp
+++ b/test/testjobqueue.cpp
@@ -24,7 +24,7 @@ public:
     {
     }
 
-    void start()
+    void start() override
     {
         QNetworkRequest req;
         req.setRawHeader("Depth", "0");
@@ -44,7 +44,7 @@ public:
     }
 
 protected:
-    bool finished()
+    bool finished() override
     {
         return true;
     }


### PR DESCRIPTION
Fixed the warning messages appeared during build except following:
1) Q_DECL_DEPRECATED_X("Use uuid") QString id() const;
    Not sure whether I can simply replace id() to uuid().
2) Qt deprecation warnings
    If there is a plan to move to Qt6 it would be very useful to fix all warnings in Qt 5.15 to make a migration smoother - can provide a separate PR for that.