### PR TITLE
Poll interval from capabilities

### DIFF
--- a/changelog/unreleased/8780
+++ b/changelog/unreleased/8780
@@ -3,6 +3,7 @@ Enhancement: Consider a remote poll interval coming with the server capabilities
 This way, admins can configure the remote sync poll interval of clients through
 the capabilities settings of the server. Note that the setting in the server
 capabilities needs to be done in milliseconds. Default is 30 seconds.
+
 https://github.com/owncloud/client/issues/5947
 https://github.com/owncloud/client/issues/8780
 https://github.com/owncloud/client/pull/8777

--- a/changelog/unreleased/8780
+++ b/changelog/unreleased/8780
@@ -1,4 +1,4 @@
-Enhancement: Consider a remote poll interval coming with the server capabilities.
+Enhancement: Consider a remote poll interval coming with the server capabilities
 
 This way, admins can configure the remote sync poll interval of clients through
 the capabilities settings of the server. Note that the setting in the server

--- a/changelog/unreleased/8780
+++ b/changelog/unreleased/8780
@@ -1,0 +1,8 @@
+Enhancement: Consider a remote poll interval coming with the server capabilities.
+
+This way, admins can configure the remote sync poll interval of clients through
+the capabilities settings of the server. Note that the setting in the server
+capabilities needs to be done in milliseconds. Default is 30 seconds.
+https://github.com/owncloud/client/issues/5947
+https://github.com/owncloud/client/issues/8780
+https://github.com/owncloud/client/pull/8777

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -266,7 +266,7 @@ void AccountState::checkConnectivity(bool blockJobs)
 
     // IF the account is connected the connection check can be skipped
     // if the last successful etag check job is not so long ago.
-    const auto pta = std::chrono::milliseconds(account()->capabilities().remotePollInterval());
+    const auto pta = account()->capabilities().remotePollInterval();
     const auto polltime = std::chrono::duration_cast<std::chrono::seconds>(ConfigFile().remotePollInterval(pta));
     const auto elapsed = _timeOfLastETagCheck.secsTo(QDateTime::currentDateTimeUtc());
     if (!blockJobs && isConnected() && _timeOfLastETagCheck.isValid()

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -266,7 +266,8 @@ void AccountState::checkConnectivity(bool blockJobs)
 
     // IF the account is connected the connection check can be skipped
     // if the last successful etag check job is not so long ago.
-    const auto polltime = std::chrono::duration_cast<std::chrono::seconds>(ConfigFile().remotePollInterval());
+    const auto pta = std::chrono::milliseconds(account()->capabilities().remotePollInterval());
+    const auto polltime = std::chrono::duration_cast<std::chrono::seconds>(ConfigFile().remotePollInterval(pta));
     const auto elapsed = _timeOfLastETagCheck.secsTo(QDateTime::currentDateTimeUtc());
     if (!blockJobs && isConnected() && _timeOfLastETagCheck.isValid()
         && elapsed <= polltime.count()) {

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -308,8 +308,8 @@ bool Folder::dueToSync() const
     } else {
         // read the account capability - specified in seconds. If there, use it.
         int pta = accountState()->account()->capabilities().remotePollInterval();
-        if (pta > 5) {
-            polltime = std::chrono::milliseconds(pta * 1000);
+        if (pta > 4999) {
+            polltime = std::chrono::milliseconds(pta);
         }
     }
     if (msecSinceLastSync() < polltime) {

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -296,7 +296,7 @@ bool Folder::dueToSync() const
     ConfigFile cfg;
     // the default poll time of 30 seconds as it had been in the client forever.
     // Now with https://github.com/owncloud/client/pull/8777 also the server capabilities are considered.
-    const auto pta = std::chrono::milliseconds(accountState()->account()->capabilities().remotePollInterval());
+    const auto pta = accountState()->account()->capabilities().remotePollInterval();
     const auto polltime = cfg.remotePollInterval(pta);
 
     const auto timeSinceLastSync = std::chrono::milliseconds(_timeSinceLastEtagCheckDone.elapsed());

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -288,10 +288,7 @@ bool Folder::canSync() const
 bool Folder::dueToSync() const
 {
     // conditions taken from previous folderman implementation
-    if (isSyncRunning() ||
-            etagJob()   ||
-            isBusy()    ||
-            !canSync()) {
+    if (isSyncRunning() || etagJob() || isBusy() || !canSync()) {
         return false;
     }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -299,9 +299,7 @@ bool Folder::dueToSync() const
     const auto pta = std::chrono::milliseconds(accountState()->account()->capabilities().remotePollInterval());
     const auto polltime = cfg.remotePollInterval(pta);
 
-    // we add half a second here as estimated duration of the last etag job. That way the wished duration
-    // is met more accurate - which appears to look better in the access log.
-    const auto timeSinceLastSync = std::chrono::milliseconds(500 + _timeSinceLastEtagCheckDone.elapsed());
+    const auto timeSinceLastSync = std::chrono::milliseconds(_timeSinceLastEtagCheckDone.elapsed());
     qCInfo(lcFolder) << "dueToSync:" << alias() << timeSinceLastSync.count() << " < " << polltime.count();
     if (timeSinceLastSync >= polltime) {
         return true;

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -301,7 +301,7 @@ bool Folder::dueToSync() const
 
     // we add half a second here as estimated duration of the last etag job. That way the wished duration
     // is met more accurate - which appears to look better in the access log.
-    const auto timeSinceLastSync = std::chrono::milliseconds(500+_timeSinceLastEtagCheckDone.elapsed());
+    const auto timeSinceLastSync = std::chrono::milliseconds(500 + _timeSinceLastEtagCheckDone.elapsed());
     qCInfo(lcFolder) << "dueToSync:" << alias() << timeSinceLastSync.count() << " < " << polltime.count();
     if (timeSinceLastSync >= polltime) {
         return true;
@@ -367,8 +367,7 @@ void Folder::slotRunEtagJob()
     _requestEtagJob->setTimeout(60 * 1000);
     // check if the etag is different when retrieved
     QObject::connect(_requestEtagJob.data(), &RequestEtagJob::etagRetreived, this, &Folder::etagRetreived);
-    QObject::connect(_requestEtagJob.data(), &RequestEtagJob::finishedWithResult,  this, [=](const HttpResult<QByteArray>)
-    { _timeSinceLastEtagCheckDone.start(); });
+    QObject::connect(_requestEtagJob.data(), &RequestEtagJob::finishedWithResult, this, [=](const HttpResult<QByteArray>) { _timeSinceLastEtagCheckDone.start(); });
     FolderMan::instance()->slotScheduleETagJob(alias(), _requestEtagJob);
     // The _requestEtagJob is auto deleting itself on finish. Our guard pointer _requestEtagJob will then be null.
 }

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -452,6 +452,7 @@ private:
     QScopedPointer<SyncEngine> _engine;
     QPointer<RequestEtagJob> _requestEtagJob;
     QByteArray _lastEtag;
+    QElapsedTimer _timeSinceLastEtagCheckDone;
     QElapsedTimer _timeSinceLastSyncDone;
     QElapsedTimer _timeSinceLastSyncStart;
     QElapsedTimer _timeSinceLastFullLocalDiscovery;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -313,6 +313,8 @@ signals:
 
 public slots:
 
+    void slotRunEtagJob();
+
     /**
        * terminate the current sync run
        */
@@ -379,7 +381,6 @@ private slots:
     void slotTransmissionProgress(const ProgressInfo &pi);
     void slotItemCompleted(const SyncFileItemPtr &);
 
-    void slotRunEtagJob();
     void etagRetreived(const QByteArray &, const QDateTime &tp);
     void etagRetrievedFromSyncEngine(const QByteArray &, const QDateTime &time);
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -183,6 +183,12 @@ public:
      */
     bool canSync() const;
 
+    /**
+     *  Returns true if the folder needs sync poll interval wise, and can
+     *  sync due to its internal state
+     */
+    bool dueToSync() const;
+
     void prepareToSync();
 
     /**
@@ -224,7 +230,7 @@ public:
     SyncEngine &syncEngine() { return *_engine; }
     Vfs &vfs() { return *_vfs; }
 
-    RequestEtagJob *etagJob() { return _requestEtagJob; }
+    RequestEtagJob *etagJob() const { return _requestEtagJob; }
     std::chrono::milliseconds msecSinceLastSync() const { return std::chrono::milliseconds(_timeSinceLastSyncDone.elapsed()); }
     std::chrono::milliseconds msecLastSyncDuration() const { return _lastSyncDuration; }
     int consecutiveFollowUpSyncs() const { return _consecutiveFollowUpSyncs; }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -906,7 +906,7 @@ void FolderMan::slotScheduleFolderByTime()
         auto msecsSinceSync = f->msecSinceLastSync();
 
         // Possibly it's just time for a new sync run
-        const auto pta = std::chrono::milliseconds(f->accountState()->account()->capabilities().remotePollInterval());
+        const auto pta = f->accountState()->account()->capabilities().remotePollInterval();
         bool forceSyncIntervalExpired = msecsSinceSync > ConfigFile().forceSyncInterval(pta);
         if (forceSyncIntervalExpired) {
             qCInfo(lcFolderMan) << "Scheduling folder" << f->alias()

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -115,7 +115,7 @@ FolderMan::FolderMan(QObject *parent)
     // Set the remote poll interval fixed to 10 seconds.
     // That does not mean that it polls every 10 seconds, but it checks every 10 secs
     // if one of the folders is due to sync.
-    _etagPollTimer.setInterval(10000);
+    _etagPollTimer.setInterval(1000);
     QObject::connect(&_etagPollTimer, &QTimer::timeout, this, &FolderMan::slotEtagPollTimerTimeout);
     _etagPollTimer.start();
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -844,7 +844,7 @@ void FolderMan::slotEtagPollTimerTimeout()
             continue;
         }
         if (f->dueToSync()) {
-            QMetaObject::invokeMethod(f, "slotRunEtagJob", Qt::QueuedConnection);
+            QMetaObject::invokeMethod(f, &Folder::slotRunEtagJob, Qt::QueuedConnection);
         }
     }
 }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -906,7 +906,8 @@ void FolderMan::slotScheduleFolderByTime()
         auto msecsSinceSync = f->msecSinceLastSync();
 
         // Possibly it's just time for a new sync run
-        bool forceSyncIntervalExpired = msecsSinceSync > ConfigFile().forceSyncInterval();
+        const auto pta = std::chrono::milliseconds(f->accountState()->account()->capabilities().remotePollInterval());
+        bool forceSyncIntervalExpired = msecsSinceSync > ConfigFile().forceSyncInterval(pta);
         if (forceSyncIntervalExpired) {
             qCInfo(lcFolderMan) << "Scheduling folder" << f->alias()
                                 << "because it has been" << msecsSinceSync.count() << "ms "

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -112,10 +112,10 @@ FolderMan::FolderMan(QObject *parent)
 
     _socketApi.reset(new SocketApi);
 
-    ConfigFile cfg;
-    std::chrono::milliseconds polltime = cfg.remotePollInterval();
-    qCInfo(lcFolderMan) << "setting remote poll timer interval to" << polltime.count() << "msec";
-    _etagPollTimer.setInterval(polltime.count());
+    // Set the remote poll interval fixed to 10 seconds.
+    // That does not mean that it polls every 10 seconds, but it checks every 10 secs
+    // if one of the folders is due to sync.
+    _etagPollTimer.setInterval(10000);
     QObject::connect(&_etagPollTimer, &QTimer::timeout, this, &FolderMan::slotEtagPollTimerTimeout);
     _etagPollTimer.start();
 
@@ -833,14 +833,8 @@ void FolderMan::slotStartScheduledFolderSync()
 
 void FolderMan::slotEtagPollTimerTimeout()
 {
-    ConfigFile cfg;
-    auto polltime = cfg.remotePollInterval();
-
     for (auto *f : qAsConst(_folderMap)) {
         if (!f) {
-            continue;
-        }
-        if (f->isSyncRunning()) {
             continue;
         }
         if (_scheduledFolders.contains(f)) {
@@ -849,13 +843,9 @@ void FolderMan::slotEtagPollTimerTimeout()
         if (_disabledFolders.contains(f)) {
             continue;
         }
-        if (f->etagJob() || f->isBusy() || !f->canSync()) {
-            continue;
+        if (f->dueToSync()) {
+            QMetaObject::invokeMethod(f, "slotRunEtagJob", Qt::QueuedConnection);
         }
-        if (f->msecSinceLastSync() < polltime) {
-            continue;
-        }
-        QMetaObject::invokeMethod(f, "slotRunEtagJob", Qt::QueuedConnection);
     }
 }
 

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -103,6 +103,26 @@ int Capabilities::defaultPermissions() const
     return _fileSharingCapabilities.value(QStringLiteral("default_permissions"), 1).toInt();
 }
 
+int Capabilities::remotePollInterval() const
+{
+    // The default capability is 60, but the clients use 30. If we returned 60 here, the clients
+    // would all jump to 60 seconds, which would be an unepected change from their default.
+    // We only return 60 if the capability was set to 60! to indicate that this is really wanted.
+    // Otherwise 60 is treatet as default.
+    int interval {-1};
+    const QString val = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toString();
+    if (val == QStringLiteral("60!")) {
+        interval = 60;
+    } else {
+        bool ok;
+        int tmpInt = val.toInt(&ok);
+        if (ok && tmpInt != 60)
+            interval = tmpInt;
+    }
+
+    return interval;
+}
+
 bool Capabilities::notificationsAvailable() const
 {
     // We require the OCS style API in 9.x, can't deal with the REST one only found in 8.2

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -105,19 +105,14 @@ int Capabilities::defaultPermissions() const
 
 int Capabilities::remotePollInterval() const
 {
-    // The default capability is 60, but the clients use 30. If we returned 60 here, the clients
-    // would all jump to 60 seconds, which would be an unepected change from their default.
-    // We only return 60 if the capability was set to 60! to indicate that this is really wanted.
-    // Otherwise 60 is treatet as default.
+    // The default of the capability is 60, but the clients use 30.
+    // Values below 5000 are not allowed and fall back to the default.
     int interval {-1};
     const QString val = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toString();
-    if (val == QStringLiteral("60!")) {
-        interval = 60;
-    } else {
-        bool ok;
-        int tmpInt = val.toInt(&ok);
-        if (ok && tmpInt != 60)
-            interval = tmpInt;
+    bool ok;
+    int tmpInt = val.toInt(&ok);
+    if (ok && tmpInt > 4999) { // The minimum is 5 seconds
+        interval = tmpInt;
     }
 
     return interval;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -107,7 +107,7 @@ int Capabilities::remotePollInterval() const
 {
     // The default of the capability is 60, but the clients use 30.
     // Values below 5000 are not allowed and fall back to the default.
-    int interval {-1};
+    int interval { -1 };
     const QString val = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toString();
     bool ok;
     int tmpInt = val.toInt(&ok);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -105,16 +105,7 @@ int Capabilities::defaultPermissions() const
 
 std::chrono::seconds Capabilities::remotePollInterval() const
 {
-    // The default of the capability is 60, but the clients use 30.
-    // Values below 5000 are not allowed and fall back to the default.
-    std::chrono::seconds interval(0);
-    bool ok;
-    int tmpInt = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toInt(&ok);
-    if (ok && tmpInt > 4999) { // The minimum is 5 seconds
-        interval = std::chrono::seconds(tmpInt / 1000);
-    }
-
-    return interval;
+    return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds(_capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toInt()));
 }
 
 bool Capabilities::notificationsAvailable() const

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -103,16 +103,15 @@ int Capabilities::defaultPermissions() const
     return _fileSharingCapabilities.value(QStringLiteral("default_permissions"), 1).toInt();
 }
 
-int Capabilities::remotePollInterval() const
+std::chrono::seconds Capabilities::remotePollInterval() const
 {
     // The default of the capability is 60, but the clients use 30.
     // Values below 5000 are not allowed and fall back to the default.
-    int interval { -1 };
-    const QString val = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toString();
+    std::chrono::seconds interval(0);
     bool ok;
-    int tmpInt = val.toInt(&ok);
+    int tmpInt = _capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("pollinterval")).toInt(&ok);
     if (ok && tmpInt > 4999) { // The minimum is 5 seconds
-        interval = tmpInt;
+        interval = std::chrono::seconds(tmpInt / 1000);
     }
 
     return interval;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -77,7 +77,7 @@ public:
     bool shareResharing() const;
     /** Remote Poll interval.
      *
-     *  returns the requested poll interval to be used by the client in seconds.
+     *  returns the requested poll interval to be used by the client in milliseconds.
      *  If it returns -1 the client default remains unchanged.
      */
     int remotePollInterval() const;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -75,6 +75,12 @@ public:
     bool sharePublicLinkEnforceExpireDate() const;
     bool sharePublicLinkMultiple() const;
     bool shareResharing() const;
+    /** Remote Poll interval.
+     *
+     *  returns the requested poll interval to be used by the client in seconds.
+     *  If it returns -1 the client default remains unchanged.
+     */
+    int remotePollInterval() const;
 
     // TODO: return SharePermission
     int defaultPermissions() const;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -77,8 +77,8 @@ public:
     bool shareResharing() const;
     /** Remote Poll interval.
      *
-     *  returns the requested poll interval to be used by the client in milliseconds.
-     *  If it returns -1 the client default remains unchanged.
+     *  returns the requested poll interval in seconds to be used by the client.
+     *  @returns 0 if no capability is set.
      */
     std::chrono::seconds remotePollInterval() const;
 

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -80,7 +80,7 @@ public:
      *  returns the requested poll interval to be used by the client in milliseconds.
      *  If it returns -1 the client default remains unchanged.
      */
-    int remotePollInterval() const;
+    std::chrono::seconds remotePollInterval() const;
 
     // TODO: return SharePermission
     int defaultPermissions() const;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -412,10 +412,10 @@ chrono::milliseconds ConfigFile::remotePollInterval(const QString &connection) c
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.beginGroup(con);
 
-    auto defaultPollInterval = chrono::milliseconds(DefaultRemotePollInterval);
+    auto defaultPollInterval = DefaultRemotePollInterval;
     auto remoteInterval = millisecondsValue(settings, remotePollIntervalC(), defaultPollInterval);
     if (remoteInterval < chrono::seconds(5)) {
-        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << DefaultRemotePollInterval;
+        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << DefaultRemotePollInterval.count();
         remoteInterval = defaultPollInterval;
     }
     return remoteInterval;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -93,6 +93,7 @@ const QString moveToTrashC() { return QStringLiteral("moveToTrash"); }
 }
 
 QString ConfigFile::_confDir = QString();
+const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in milliseconds
 
 static chrono::milliseconds millisecondsValue(const QSettings &setting, const QString &key,
     chrono::milliseconds defaultValue)
@@ -422,8 +423,8 @@ chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::seconds default
     }
     auto remoteInterval = millisecondsValue(settings, remotePollIntervalC(), defaultPollInterval);
     if (remoteInterval < chrono::seconds(5)) {
-        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << DefaultRemotePollInterval.count();
         remoteInterval = defaultPollInterval;
+        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << remoteInterval.count();
     }
     return remoteInterval;
 }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -403,7 +403,7 @@ bool ConfigFile::dataExists(const QString &group, const QString &key) const
     return settings.contains(key);
 }
 
-chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::milliseconds capabilitiesVal, const QString &connection) const
+chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::seconds defaultVal, const QString &connection) const
 {
     QString con(connection);
     if (connection.isEmpty())
@@ -412,13 +412,13 @@ chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::milliseconds ca
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.beginGroup(con);
 
-    auto defaultPollInterval = DefaultRemotePollInterval;
+    auto defaultPollInterval { DefaultRemotePollInterval };
 
     // The server default-capabilities is set to 60, which is, if interpreted in milliseconds,
     // pretty small. If the value is above 5 seconds, it was set intentionally.
     // Server admins have to set the value in Milliseconds!
-    if (capabilitiesVal > chrono::seconds(5)) {
-        defaultPollInterval = capabilitiesVal;
+    if (defaultVal > chrono::seconds(5)) {
+        defaultPollInterval = defaultVal;
     }
     auto remoteInterval = millisecondsValue(settings, remotePollIntervalC(), defaultPollInterval);
     if (remoteInterval < chrono::seconds(5)) {
@@ -444,7 +444,7 @@ void ConfigFile::setRemotePollInterval(chrono::milliseconds interval, const QStr
     settings.sync();
 }
 
-chrono::milliseconds ConfigFile::forceSyncInterval(std::chrono::milliseconds remoteFromCapabilities, const QString &connection) const
+chrono::milliseconds ConfigFile::forceSyncInterval(std::chrono::seconds remoteFromCapabilities, const QString &connection) const
 {
     auto pollInterval = remotePollInterval(remoteFromCapabilities, connection);
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -40,7 +40,6 @@
 #include <QOperatingSystemVersion>
 #include <QStandardPaths>
 
-#define DEFAULT_REMOTE_POLL_INTERVAL 30000 // default remote poll time in milliseconds
 #define DEFAULT_MAX_LOG_LINES 20000
 
 namespace OCC {
@@ -413,10 +412,10 @@ chrono::milliseconds ConfigFile::remotePollInterval(const QString &connection) c
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.beginGroup(con);
 
-    auto defaultPollInterval = chrono::milliseconds(DEFAULT_REMOTE_POLL_INTERVAL);
+    auto defaultPollInterval = chrono::milliseconds(DefaultRemotePollInterval);
     auto remoteInterval = millisecondsValue(settings, remotePollIntervalC(), defaultPollInterval);
     if (remoteInterval < chrono::seconds(5)) {
-        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << DEFAULT_REMOTE_POLL_INTERVAL;
+        qCWarning(lcConfigFile) << "Remote Interval is less than 5 seconds, reverting to" << DefaultRemotePollInterval;
         remoteInterval = defaultPollInterval;
     }
     return remoteInterval;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -42,6 +42,7 @@ public:
     static QString configPath();
     static QString configFile();
     static bool exists();
+    const int DefaultRemotePollInterval { 30000 }; // default remote poll time in milliseconds
 
     ConfigFile();
 

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -41,9 +41,8 @@ class OWNCLOUDSYNC_EXPORT ConfigFile
 public:
     static QString configPath();
     static QString configFile();
-    static bool exists();
-    const int DefaultRemotePollInterval { 30000 }; // default remote poll time in milliseconds
-
+    static bool exists(); 
+    const std::chrono::milliseconds DefaultRemotePollInterval{30000}; // default remote poll time in milliseconds
     ConfigFile();
 
     enum Scope { UserScope,

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -42,7 +42,7 @@ public:
     static QString configPath();
     static QString configFile();
     static bool exists();
-    const std::chrono::milliseconds DefaultRemotePollInterval { 30000 }; // default remote poll time in milliseconds
+
     ConfigFile();
 
     enum Scope { UserScope,
@@ -64,7 +64,7 @@ public:
     bool passwordStorageAllowed(const QString &connection = QString());
 
     /* Server poll interval in milliseconds */
-    std::chrono::milliseconds remotePollInterval(std::chrono::milliseconds defaultVal, const QString &connection = QString()) const;
+    std::chrono::milliseconds remotePollInterval(std::chrono::seconds defaultVal, const QString &connection = QString()) const;
     /* Set poll interval. Value in milliseconds has to be larger than 5000 */
     void setRemotePollInterval(std::chrono::milliseconds interval, const QString &connection = QString());
 
@@ -72,7 +72,7 @@ public:
     std::chrono::milliseconds notificationRefreshInterval(const QString &connection = QString()) const;
 
     /* Force sync interval, in milliseconds */
-    std::chrono::milliseconds forceSyncInterval(std::chrono::milliseconds remoteFromCapabilities, const QString &connection = QString()) const;
+    std::chrono::milliseconds forceSyncInterval(std::chrono::seconds remoteFromCapabilities, const QString &connection = QString()) const;
 
     /**
      * Interval in milliseconds within which full local discovery is required
@@ -199,6 +199,7 @@ private:
 
 private:
     typedef QSharedPointer<AbstractCredentials> SharedCreds;
+    const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in milliseconds
 
     static QString _oCVersion;
     static QString _confDir;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -199,7 +199,6 @@ private:
 
 private:
     typedef QSharedPointer<AbstractCredentials> SharedCreds;
-    const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in milliseconds
 
     static QString _oCVersion;
     static QString _confDir;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -64,7 +64,7 @@ public:
     bool passwordStorageAllowed(const QString &connection = QString());
 
     /* Server poll interval in milliseconds */
-    std::chrono::milliseconds remotePollInterval(const QString &connection = QString()) const;
+    std::chrono::milliseconds remotePollInterval(std::chrono::milliseconds defaultVal, const QString &connection = QString()) const;
     /* Set poll interval. Value in milliseconds has to be larger than 5000 */
     void setRemotePollInterval(std::chrono::milliseconds interval, const QString &connection = QString());
 
@@ -72,7 +72,7 @@ public:
     std::chrono::milliseconds notificationRefreshInterval(const QString &connection = QString()) const;
 
     /* Force sync interval, in milliseconds */
-    std::chrono::milliseconds forceSyncInterval(const QString &connection = QString()) const;
+    std::chrono::milliseconds forceSyncInterval(std::chrono::milliseconds remoteFromCapabilities, const QString &connection = QString()) const;
 
     /**
      * Interval in milliseconds within which full local discovery is required

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -41,8 +41,8 @@ class OWNCLOUDSYNC_EXPORT ConfigFile
 public:
     static QString configPath();
     static QString configFile();
-    static bool exists(); 
-    const std::chrono::milliseconds DefaultRemotePollInterval{30000}; // default remote poll time in milliseconds
+    static bool exists();
+    const std::chrono::milliseconds DefaultRemotePollInterval { 30000 }; // default remote poll time in milliseconds
     ConfigFile();
 
     enum Scope { UserScope,


### PR DESCRIPTION
With this, admins can configure the remote poll interval via the capabilities of the server.

```
% curl -u admin:admin 'https://demo.owncloud.com/ocs/v1.php/cloud/capabilities?format=json' \
| jq | grep -i -e  poll
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1954  100  1954    0     0   4897      0 --:--:-- --:--:-- --:--:--  4897
          "pollinterval": 60,
```

If the client has no custom interval in the [client config file](https://doc.owncloud.com/desktop/advanced_usage/configuration_file.html) and if the capability is different than the default, the remote poll interval is changed. 

Note: To use 60 seconds, the capability needs to contain the string "60!" for the reason that 60 was the default in the capas, but using that would change the behaviour of all clients which needs to be avoided.