### PR TITLE
Improve handling of Folder removes

### DIFF
--- a/src/common/syncfilestatus.cpp
+++ b/src/common/syncfilestatus.cpp
@@ -82,5 +82,3 @@ QString SyncFileStatus::toSocketAPIString() const
     return statusString;
 }
 }
-
-#include "syncfilestatus.moc"

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -124,10 +124,6 @@ public:
     Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> vfs, QObject *parent = nullptr);
 
     ~Folder() override;
-
-    typedef QMap<QString, Folder *> Map;
-    typedef QMapIterator<QString, Folder *> MapIterator;
-
     /**
      * The account the folder is configured on.
      */

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -25,9 +25,11 @@
 #include "navigationpanehelper.h"
 #include "syncfileitem.h"
 
-class TestFolderMan;
-
 namespace OCC {
+namespace TestUtils {
+    // prototype for test friend
+    FolderMan *folderMan();
+}
 
 class Application;
 class SyncResult;
@@ -99,8 +101,7 @@ public:
      */
     static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
-    const Folder::Map &map() const;
-    QList<Folder *> list() const;
+    const QMap<QString, Folder *> &map() const;
 
     /** Adds a folder for an account, ensures the journal is gone and saves it in the settings.
       */
@@ -216,7 +217,7 @@ public:
     bool isAnySyncRunning() const;
 
     /** Removes all folders */
-    int unloadAndDeleteAllFolders();
+    void unloadAndDeleteAllFolders();
 
     /**
      * If enabled is set to false, no new folders will start to sync.
@@ -252,7 +253,8 @@ signals:
     /**
      * Emitted whenever the list of configured folders changes.
      */
-    void folderListChanged(const Folder::Map &);
+    void folderListChanged(const QMap<QString, Folder *> &);
+    void folderRemoved(Folder *folder);
 
 public slots:
 
@@ -341,7 +343,7 @@ private:
     void setupFoldersHelper(QSettings &settings, AccountStatePtr account, const QStringList &ignoreKeys, bool backwardsCompatible, bool foldersWithPlaceholders);
 
     QSet<Folder *> _disabledFolders;
-    Folder::Map _folderMap;
+    QMap<QString, Folder *> _folderMap;
     QString _folderConfigPath;
     Folder *_currentSyncFolder;
     QPointer<Folder> _lastSyncFolder;
@@ -377,7 +379,7 @@ private:
     static FolderMan *_instance;
     explicit FolderMan(QObject *parent = nullptr);
     friend class OCC::Application;
-    friend class ::TestFolderMan;
+    friend OCC::FolderMan *OCC::TestUtils::folderMan();
 };
 
 } // namespace OCC

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -216,10 +216,8 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
     : _parent(p)
 {
     _thread = new WatcherThread(path);
-    connect(_thread, SIGNAL(changed(const QString &)),
-        _parent, SLOT(changeDetected(const QString &)));
-    connect(_thread, SIGNAL(lostChanges()),
-        _parent, SIGNAL(lostChanges()));
+    connect(_thread, &WatcherThread::changed, _parent, qOverload<const QString &>(&FolderWatcher::changeDetected));
+    connect(_thread, &WatcherThread::lostChanges, _parent, &FolderWatcher::lostChanges);
     connect(_thread, &WatcherThread::ready,
         this, [this]() { _ready = 1; });
     _thread->start();

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -424,10 +424,7 @@ bool FolderWizardRemotePath::isComplete() const
     }
     wizard()->setProperty("targetPath", dir);
 
-    Folder::Map map = FolderMan::instance()->map();
-    Folder::Map::const_iterator i = map.constBegin();
-    for (i = map.constBegin(); i != map.constEnd(); i++) {
-        Folder *f = static_cast<Folder *>(i.value());
+    for (auto *f : qAsConst(FolderMan::instance()->map())) {
         if (f->accountState()->account() != _account) {
             continue;
         }

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -58,14 +58,12 @@ public:
     bool isComplete() const override;
     void initializePage() override;
     void cleanupPage() override;
-
-    void setFolderMap(const Folder::Map &fm) { _folderMap = fm; }
 protected slots:
     void slotChooseLocalFolder();
 
 private:
     Ui_FolderWizardSourcePage _ui;
-    Folder::Map _folderMap;
+    QMap<QString, Folder *> _folderMap;
     AccountPtr _account;
 };
 

--- a/src/gui/models/protocolitemmodel.cpp
+++ b/src/gui/models/protocolitemmodel.cpp
@@ -22,15 +22,6 @@
 
 #include <QIcon>
 
-namespace {
-auto getFolder(const OCC::ProtocolItem &item)
-{
-    auto f = OCC::FolderMan::instance()->folder(item.folderName());
-    OC_ASSERT(f);
-    return f;
-}
-}
-
 using namespace OCC;
 
 ProtocolItemModel::ProtocolItemModel(QObject *parent, bool issueMode)
@@ -69,7 +60,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
         case ProtocolItemRole::Time:
             return item.timestamp();
         case ProtocolItemRole::Folder:
-            return getFolder(item)->shortGuiLocalPath();
+            return item.folder()->shortGuiLocalPath();
         case ProtocolItemRole::Action:
             return item.message();
         case ProtocolItemRole::Size:
@@ -77,7 +68,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
         case ProtocolItemRole::File:
             return Utility::fileNameForGuiUse(item.path());
         case ProtocolItemRole::Account:
-            return getFolder(item)->accountState()->account()->displayName();
+            return item.folder()->accountState()->account()->displayName();
         case ProtocolItemRole::ColumnCount:
             Q_UNREACHABLE();
             break;
@@ -105,7 +96,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
         case ProtocolItemRole::Time:
             return item.timestamp();
         case ProtocolItemRole::Folder:
-            return item.folderName();
+            return item.folder()->path();
         case ProtocolItemRole::Action:
             return item.message();
         case ProtocolItemRole::Size:
@@ -113,7 +104,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
         case ProtocolItemRole::File:
             return item.path();
         case ProtocolItemRole::Account:
-            return getFolder(item)->accountState()->account()->displayName();
+            return item.folder()->accountState()->account()->displayName();
         case ProtocolItemRole::ColumnCount:
             Q_UNREACHABLE();
             break;

--- a/src/gui/protocolitem.cpp
+++ b/src/gui/protocolitem.cpp
@@ -13,6 +13,7 @@
  */
 #include "protocolitem.h"
 
+#include "folderman.h"
 #include "progressdispatcher.h"
 
 #include <QApplication>
@@ -20,11 +21,12 @@
 #include <QMenu>
 #include <QPointer>
 
+
 using namespace OCC;
 
 ProtocolItem::ProtocolItem(const QString &folder, const SyncFileItemPtr &item)
     : _path(item->destination())
-    , _folderName(folder)
+    , _folder(FolderMan::instance()->folder(folder))
     , _size(item->_size)
     , _status(item->_status)
     , _direction(item->_direction)
@@ -46,9 +48,9 @@ QString ProtocolItem::path() const
     return _path;
 }
 
-QString ProtocolItem::folderName() const
+Folder *ProtocolItem::folder() const
 {
-    return _folderName;
+    return _folder;
 }
 
 QDateTime ProtocolItem::timestamp() const

--- a/src/gui/protocolitem.h
+++ b/src/gui/protocolitem.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include "folder.h"
+
 #include "csync/csync.h"
 #include "libsync/syncfileitem.h"
 
@@ -29,7 +31,7 @@ public:
 
     QString path() const;
 
-    QString folderName() const;
+    Folder *folder() const;
 
     QDateTime timestamp() const;
 
@@ -45,7 +47,7 @@ public:
 
 private:
     QString _path;
-    QString _folderName;
+    Folder *_folder;
     QDateTime _timestamp;
     qint64 _size;
     SyncFileItem::Status _status BITFIELD(4);
@@ -53,6 +55,8 @@ private:
 
     QString _message;
     bool _sizeIsRelevant;
+
+    friend class TestProtocolModel;
 };
 
 }

--- a/src/gui/protocolwidget.ui
+++ b/src/gui/protocolwidget.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="_headerLabel">
      <property name="text">
-      <string>TextLabel</string>
+      <string>Local sync protocol</string>
      </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(owncloud_add_test.cmake)
 
-add_library(syncenginetestutils STATIC syncenginetestutils.cpp)
+add_library(syncenginetestutils STATIC testutils/syncenginetestutils.cpp testutils/testutils.cpp)
 target_link_libraries(syncenginetestutils PUBLIC owncloudCore Qt5::Test)
 
 owncloud_add_test(OwncloudPropagator)

--- a/test/benchmarks/benchlargesync.cpp
+++ b/test/benchmarks/benchlargesync.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/modeltests/testactivitymodel.cpp
+++ b/test/modeltests/testactivitymodel.cpp
@@ -9,6 +9,8 @@
 #include "gui/models/activitylistmodel.h"
 #include "gui/accountmanager.h"
 
+#include "testutils/testutils.h"
+
 #include <QTest>
 #include <QAbstractItemModelTester>
 
@@ -25,19 +27,8 @@ private Q_SLOTS:
 
         new QAbstractItemModelTester(model, this);
 
-        auto manager = AccountManager::instance();
-
-        auto createAcc = [&] {
-            // don't use the account manager to create the account, it would try to use widgets
-            auto acc = Account::create();
-            acc->setUrl(QUrl(QStringLiteral("http://admin:admin@localhost/owncloud")));
-            acc->setDavDisplayName(QStringLiteral("fakename") + acc->uuid().toString());
-            acc->setServerVersion(QStringLiteral("10.0.0"));
-            manager->addAccount(acc);
-            return acc;
-        };
-        auto acc1 = createAcc();
-        auto acc2 = createAcc();
+        auto acc1 = TestUtils::createDummyAccount();
+        auto acc2 = TestUtils::createDummyAccount();
 
         model->setActivityList({
             Activity { Activity::ActivityType, 1, acc1, "test", "test", "foo.cpp", QUrl::fromUserInput("https://owncloud.com"), QDateTime::currentDateTime() },
@@ -49,7 +40,7 @@ private Q_SLOTS:
             Activity { Activity::ActivityType, 2, acc1, "test", "test", "foo.cpp", QUrl::fromUserInput("https://owncloud.com"), QDateTime::currentDateTime() },
             Activity { Activity::ActivityType, 4, acc2, "test", "test", "foo.cpp", QUrl::fromUserInput("https://owncloud.com"), QDateTime::currentDateTime() },
         });
-        model->slotRemoveAccount(manager->accounts().first().data());
+        model->slotRemoveAccount(AccountManager::instance()->accounts().first().data());
     }
 };
 }

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -8,10 +8,15 @@
 #include "syncenginetestutils.h"
 #include "httplogger.h"
 #include "accessmanager.h"
+#include "libsync/configfile.h"
+
 
 namespace {
 void setupLogger()
 {
+    static QTemporaryDir dir;
+    OCC::ConfigFile::setConfDir(dir.path()); // we don't want to pollute the user's config file
+
     OCC::Logger::instance()->setLogFile(QStringLiteral("-"));
     OCC::Logger::instance()->addLogRule({ QStringLiteral("sync.httplogger=true") });
 }

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testblacklist.cpp
+++ b/test/testblacklist.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testcredentialmanager.cpp
+++ b/test/testcredentialmanager.cpp
@@ -7,7 +7,7 @@
 #include "account.h"
 #include "libsync/creds/credentialmanager.h"
 
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 
 #include <QTest>
 

--- a/test/testdatabaseerror.cpp
+++ b/test/testdatabaseerror.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 #include <owncloudpropagator.h>
 

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -51,7 +51,6 @@ private slots:
         Utility::NtfsPermissionLookupRAII ntfs_perm;
 #endif
         QTemporaryDir dir;
-        ConfigFile::setConfDir(dir.path()); // we don't want to pollute the user's config file
         QVERIFY(dir.isValid());
         QDir dir2(dir.path());
         QVERIFY(dir2.mkpath("sub/ownCloud1/folder/f"));

--- a/test/testjobqueue.cpp
+++ b/test/testjobqueue.cpp
@@ -9,7 +9,7 @@
 #include "abstractnetworkjob.h"
 #include "account.h"
 
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 
 #include <QTest>
 

--- a/test/testlocaldiscovery.cpp
+++ b/test/testlocaldiscovery.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 #include <localdiscoverytracker.h>
 

--- a/test/testlockedfiles.cpp
+++ b/test/testlockedfiles.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include "lockwatcher.h"
 #include <syncengine.h>
 #include <localdiscoverytracker.h>

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -9,7 +9,7 @@
 #include <QDesktopServices>
 
 #include "libsync/creds/oauth.h"
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include "theme.h"
 #include "common/asserts.h"
 

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 #include "common/ownsql.h"
 

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 #include <localdiscoverytracker.h>
 

--- a/test/testselectivesync.cpp
+++ b/test/testselectivesync.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testsyncdelete.cpp
+++ b/test/testsyncdelete.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include "csync_exclude.h"
 
 using namespace OCC;

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 
 using namespace OCC;

--- a/test/testsyncvirtualfiles.cpp
+++ b/test/testsyncvirtualfiles.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include "common/vfs.h"
 #include "config.h"
 #include <syncengine.h>

--- a/test/testuploadreset.cpp
+++ b/test/testuploadreset.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <QtTest>
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include <syncengine.h>
 #include <common/syncjournaldb.h>
 

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -5,7 +5,7 @@
  *
  */
 
-#include "syncenginetestutils.h"
+#include "testutils/syncenginetestutils.h"
 #include "httplogger.h"
 #include "accessmanager.h"
 #include "libsync/configfile.h"
@@ -346,7 +346,8 @@ FakePropfindReply::FakePropfindReply(FileInfo &remoteRootFileInfo, QNetworkAcces
         xml.writeTextElement(davUri, QStringLiteral("getlastmodified"), stringDate);
         xml.writeTextElement(davUri, QStringLiteral("getcontentlength"), QString::number(fileInfo.size));
         xml.writeTextElement(davUri, QStringLiteral("getetag"), QStringLiteral("\"%1\"").arg(QString::fromLatin1(fileInfo.etag)));
-        xml.writeTextElement(ocUri, QStringLiteral("permissions"), !fileInfo.permissions.isNull() ? QString(fileInfo.permissions.toString()) : fileInfo.isShared ? QStringLiteral("SRDNVCKW") : QStringLiteral("RDNVCKW"));
+        xml.writeTextElement(ocUri, QStringLiteral("permissions"), !fileInfo.permissions.isNull() ? QString(fileInfo.permissions.toString()) : fileInfo.isShared ? QStringLiteral("SRDNVCKW")
+                                                                                                                                                                 : QStringLiteral("RDNVCKW"));
         xml.writeTextElement(ocUri, QStringLiteral("id"), QString::fromUtf8(fileInfo.fileId));
         xml.writeTextElement(ocUri, QStringLiteral("checksums"), QString::fromUtf8(fileInfo.checksums));
         buffer.write(fileInfo.extraDavProperties);

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -1,0 +1,59 @@
+#include "testutils.h"
+
+#include "creds/httpcredentials.h"
+#include "gui/accountmanager.h"
+
+#include <QCoreApplication>
+
+namespace {
+class HttpCredentialsTest : public OCC::HttpCredentials
+{
+public:
+    HttpCredentialsTest(const QString &user, const QString &password)
+        : HttpCredentials(OCC::DetermineAuthTypeJob::AuthType::Basic, user, password)
+    {
+    }
+
+    void askFromUser() override
+    {
+    }
+};
+}
+
+namespace OCC {
+
+namespace TestUtils {
+    AccountPtr createDummyAccount()
+    {
+        // don't use the account manager to create the account, it would try to use widgets
+        auto acc = Account::create();
+        HttpCredentialsTest *cred = new HttpCredentialsTest("testuser", "secret");
+        acc->setCredentials(cred);
+        acc->setUrl(QUrl(QStringLiteral("http://localhost/owncloud")));
+        acc->setDavDisplayName(QStringLiteral("fakename") + acc->uuid().toString());
+        acc->setServerVersion(QStringLiteral("10.0.0"));
+        OCC::AccountManager::instance()->addAccount(acc);
+        return acc;
+    }
+
+    FolderDefinition createDummyFolderDefinition(const QString &path)
+    {
+        OCC::FolderDefinition d;
+        d.localPath = path;
+        d.targetPath = path;
+        d.alias = path;
+        return d;
+    }
+
+    FolderMan *folderMan()
+    {
+        static FolderMan *man = [] {
+            auto man = new FolderMan;
+            QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, man, &FolderMan::deleteLater);
+            return man;
+        }();
+        return man;
+    }
+
+}
+}

--- a/test/testutils/testutils.h
+++ b/test/testutils/testutils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "account.h"
+#include "folder.h"
+#include "folderman.h"
+
+namespace OCC {
+
+namespace TestUtils {
+    FolderMan *folderMan();
+    FolderDefinition createDummyFolderDefinition(const QString &path);
+    AccountPtr createDummyAccount();
+}
+}


### PR DESCRIPTION
As Folder objects where directly removed without any heads up the handling of removed Folders was quite complicated.
The change  allow to directly work on a folder object instead of needing to look up the folder by its path every time it is used and then checking whether the object is still valid.
