### PR TITLE
Use const iterators

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -105,7 +105,7 @@ void GETFileJob::start()
     }
 
     QNetworkRequest req;
-    for (QMap<QByteArray, QByteArray>::const_iterator it = _headers.begin(); it != _headers.end(); ++it) {
+    for (auto it = _headers.cbegin(); it != _headers.cend(); ++it) {
         req.setRawHeader(it.key(), it.value());
     }
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -70,7 +70,7 @@ PUTFileJob::~PUTFileJob()
 void PUTFileJob::start()
 {
     QNetworkRequest req;
-    for (QMap<QByteArray, QByteArray>::const_iterator it = _headers.begin(); it != _headers.end(); ++it) {
+    for (auto it = _headers.cbegin(); it != _headers.cend(); ++it) {
         req.setRawHeader(it.key(), it.value());
     }
 


### PR DESCRIPTION
 There were mixed const and non-const iterators.

It is generally good practice to use const_iterator on a non-const container as well, unless you need to change the one through the iterator. Const iterators are slightly faster, and can improve code readability.