### PR TITLE
Bundle translations using Qt resources system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(CTest)
 
 
 include(OCConfigPluginDir)
-include(OCGenerateTheme)
+include(OCBundleResources)
 
 if (EXISTS "${PROJECT_SOURCE_DIR}/branding")
     set(OEM_THEME_DIR "${PROJECT_SOURCE_DIR}/branding" CACHE STRING "The directory containing a custom theme")
@@ -167,11 +167,6 @@ if( WIN32 )
     add_definitions(-DWINVER=0x0600)
     add_definitions(-DNTDDI_VERSION=0x0A000003)
 endif()
-
-# Handle Translations, pick all client_* files from trans directory.
-file( GLOB TRANS_FILES ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
-set(TRANSLATIONS ${TRANS_FILES})
-
 
 file(GLOB_RECURSE OWNCLOUD_ICONS "${OEM_THEME_DIR}/theme/colored/*-${APPLICATION_ICON_NAME}-icon.png")
 if (NOT OWNCLOUD_ICONS)

--- a/cmake/modules/OCBundleResources.cmake
+++ b/cmake/modules/OCBundleResources.cmake
@@ -9,19 +9,19 @@ function(__addIcon THEME ICON_NAME)
     endif()
 
     set(icon "theme/${_ICON_SRC_PATH}/${ICON_NAME}.svg")
-    set(iconAlias "theme/${THEME}/${ICON_NAME}.svg")
+    set(iconAlias "${APPLICATION_SHORTNAME}/theme/${THEME}/${ICON_NAME}.svg")
     if (EXISTS ${OEM_THEME_DIR}/${icon})
         file(APPEND "${QRC}" "<file alias=\"${iconAlias}\">${OEM_THEME_DIR}/${icon}</file>\n")
     else()
         set(icon "theme/${_ICON_SRC_PATH}/${ICON_NAME}.png")
-        set(iconAlias "theme/${THEME}/${ICON_NAME}.png")
+        set(iconAlias "${APPLICATION_SHORTNAME}/theme/${THEME}/${ICON_NAME}.png")
         if (EXISTS ${OEM_THEME_DIR}/${icon})
             file(APPEND "${QRC}" "<file alias=\"${iconAlias}\">${OEM_THEME_DIR}/${icon}</file>\n")
         else()
             set(SIZES "16;22;32;48;64;128;256;512;1024")
             foreach(size ${SIZES})
                 set(icon "theme/${_ICON_SRC_PATH}/${ICON_NAME}-${size}.png")
-                set(iconAlias "theme/${THEME}/${ICON_NAME}-${size}.png")
+                set(iconAlias "${APPLICATION_SHORTNAME}/theme/${THEME}/${ICON_NAME}-${size}.png")
                 if (EXISTS ${OEM_THEME_DIR}/${icon})
                     file(APPEND "${QRC}" "<file alias=\"${iconAlias}\">${OEM_THEME_DIR}/${icon}</file>\n")
                 endif()
@@ -30,10 +30,20 @@ function(__addIcon THEME ICON_NAME)
     endif()
 endfunction()
 
+function(__write_qrc_file_header QRC_PATH FILES_PREFIX)
+    file(WRITE ${QRC_PATH} "<RCC>\n")
+    file(APPEND ${QRC_PATH} "    <qresource prefix=\"/client/\">\n")
+endfunction()
+
+function(__write_qrc_file_footer QRC)
+    file(APPEND ${QRC} "    </qresource>\n")
+    file(APPEND ${QRC} "</RCC>\n")
+endfunction()
+
 function(generate_theme TARGET OWNCLOUD_SIDEBAR_ICONS_OUT)
     if(NOT "${OEM_THEME_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
         set(QRC ${CMAKE_BINARY_DIR}/theme.qrc)
-        file(WRITE "${QRC}" "<RCC>\n<qresource prefix=\"/client/${APPLICATION_SHORTNAME}\">\n")
+        __write_qrc_file_header(${QRC} theme)
         __addIcon("universal" "${APPLICATION_ICON_NAME}-icon" SRC_PATH "colored")
         __addIcon("universal" "wizard_logo" SRC_PATH "colored")
 
@@ -44,7 +54,7 @@ function(generate_theme TARGET OWNCLOUD_SIDEBAR_ICONS_OUT)
                 __addIcon(${theme} "state-${state}")
             endforeach()
         endforeach()
-        file(APPEND "${QRC}" "</qresource>\n</RCC>\n")
+        __write_qrc_file_footer(${QRC})
         target_sources(${TARGET} PRIVATE ${QRC})
         # add executable icon on windows and osx
         file(GLOB_RECURSE OWNCLOUD_SIDEBAR_ICONS "${OEM_THEME_DIR}/theme/colored/*-${APPLICATION_ICON_NAME}-sidebar.png")
@@ -66,4 +76,57 @@ function(generate_legacy_icons theme_dir OUT)
         list(APPEND OWNCLOUD_ICONS ${out_name})
     endforeach()
     set(${OUT} ${OWNCLOUD_ICONS} PARENT_SCOPE)
+endfunction()
+
+function(generate_qrc_file)
+    set(options "")
+    set(oneValueArgs QRC_PATH PREFIX)
+    set(multiValueArgs FILES)
+    cmake_parse_arguments(GENERATE_QRC_FILE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    foreach(param ${oneValueArgs} ${multiValueArgs})
+        if(NOT GENERATE_QRC_FILE_${param})
+            message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}: Argument missing: ${param}")
+        endif()
+    endforeach()
+
+    __write_qrc_file_header(${GENERATE_QRC_FILE_QRC_PATH} ${GENERATE_QRC_FILE_PREFIX})
+
+    foreach(file ${FILES})
+        get_filename_component(file_name ${file} NAME)
+        if(PREFIX)
+            set(file_alias ${PREFIX}/${file_name})
+        elseif()
+            set(file_alias ${file_name})
+        endif()
+        file(APPEND ${GENERATE_QRC_FILE_QRC_PATH} "        <file alias=\"${file_alias}\">${file}</file>\n")
+    endforeach()
+
+    __write_qrc_file_footer(${GENERATE_QRC_FILE_QRC_PATH})
+endfunction()
+
+# add resources to a target using the Qt resources system
+# parameters:
+#   - TARGET: the target to bundle the resources with
+#   - PREFIX: virtual "subdirectory" the files will be available from
+#   - FILES: the files to bundle
+function(add_resources_to_target)
+    set(options "")
+    set(oneValueArgs TARGET PREFIX)
+    set(multiValueArgs FILES)
+    cmake_parse_arguments(ADD_RESOURCES_TO_TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    foreach(param ${oneValueArgs} ${multiValueArgs})
+        if(NOT ADD_RESOURCES_TO_TARGET_${param})
+            message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}: Argument missing: ${param}")
+        endif()
+    endforeach()
+
+    set(qrc_path ${CMAKE_CURRENT_BINARY_DIR}/${ADD_RESOURCES_TO_TARGET_TARGET}-${ADD_RESOURCES_TO_TARGET_PREFIX}.qrc)
+    generate_qrc_file(
+        QRC_PATH ${qrc_path}
+        PREFIX ${ADD_RESOURCES_TO_TARGET_PREFIX}
+        FILES "${ADD_RESOURCES_TO_TARGET_FILES}"
+    )
+    target_sources(${ADD_RESOURCES_TO_TARGET_TARGET} PRIVATE ${qrc_path})
 endfunction()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -204,8 +204,15 @@ target_link_libraries(owncloud owncloudCore)
 
 find_package(Qt5LinguistTools)
 if(Qt5LinguistTools_FOUND)
-    qt5_add_translation(client_I18N ${TRANSLATIONS})
-    target_sources(owncloud PRIVATE ${client_I18N})
+    # Handle Translations, pick all client_* files from trans directory.
+    file(GLOB client_translations ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
+    qt5_add_translation(client_compiled_translations ${client_translations})
+    target_sources(owncloud PRIVATE ${client_compiled_translations})
+    add_resources_to_target(
+        TARGET owncloud
+        PREFIX translations
+        FILES "${client_compiled_translations}"
+    )
 endif()
 
 #TODO Move resources files
@@ -238,17 +245,9 @@ if(NOT APPLE)
         endforeach(_file)
     endif()
 
-    install(FILES ${client_I18N} DESTINATION ${DATA_INSTALL_DIR}/${APPLICATION_NAME}/i18n)
-
     # we may not add MACOSX_BUNDLE here, if not building one
 else()
     target_sources(owncloud PRIVATE ${OWNCLOUD_BUNDLED_RESOURCES})
-
-    set_source_files_properties(
-      ${client_I18N}
-      PROPERTIES
-      MACOSX_PACKAGE_LOCATION Resources/Translations
-      )
 
     set_source_files_properties(
       ${OWNCLOUD_BUNDLED_RESOURCES}

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -665,11 +665,8 @@ QString substLang(const QString &lang)
 
 void Application::setupTranslations()
 {
-    const QString trPath = Translations::applicationTrPath();
-    if (trPath.isEmpty()) {
-        qCWarning(lcApplication) << "Failed to find translations";
-        return;
-    }
+    const auto trPath = Translations::translationsDirectoryPath();
+
     QStringList uiLanguages = QLocale::system().uiLanguages();
 
     // the user can also set a locale in the settings, so we need to load the config file

--- a/src/gui/translations.cpp
+++ b/src/gui/translations.cpp
@@ -42,20 +42,9 @@ namespace Translations {
         return QStringLiteral(".qm");
     }
 
-    QString applicationTrPath()
+    QString translationsDirectoryPath()
     {
-        const auto devTrPath = QDir(qApp->applicationDirPath() + QStringLiteral("/../src/gui/"));
-        if (devTrPath.exists()) {
-            // might miss Qt, QtKeyChain, etc.
-            qCWarning(lcTranslations) << "Running from build location! Translations may be incomplete!";
-            return devTrPath.absolutePath();
-        }
-#ifdef Q_OS_MAC
-        const auto translationDir = QStringLiteral("Translations");
-#else
-        const auto translationDir = QStringLiteral("i18n");
-#endif
-        return QStandardPaths::locate(QStandardPaths::AppDataLocation, translationDir, QStandardPaths::LocateDirectory);
+        return QStringLiteral(":/client/translations/");
     }
 
     QSet<QString> listAvailableTranslations()
@@ -65,7 +54,7 @@ namespace Translations {
         // calculate a glob pattern which can be used in the iterator below to match only translations files
         QString pattern = translationsFilePrefix() + "*" + translationsFileSuffix();
 
-        QDirIterator it(Translations::applicationTrPath(), QStringList() << pattern);
+        QDirIterator it(Translations::translationsDirectoryPath(), QStringList() << pattern);
 
         while (it.hasNext()) {
             // extract locale part from filename

--- a/src/gui/translations.h
+++ b/src/gui/translations.h
@@ -35,7 +35,7 @@ namespace Translations {
     /**
      * @return path to translation files
      */
-    QString applicationTrPath();
+    QString translationsDirectoryPath();
 
     /**
      * @return list of locales for which translations are available


### PR DESCRIPTION
Contributes to #8822.

This PR replaces the existing translations deployment in "guessable" directories. They are now bundled in the binary using the [Qt resources system](https://doc.qt.io/qt-5/resources.html). This is going to be a lot more reliable and also faster than the old system. The only disadvantage is that the binaries will become a little larger.