### PR TITLE
Wizard: Display sync root issues as dialog

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -163,38 +163,21 @@ void OwncloudAdvancedSetupPage::updateStatus()
     QString errorStr = FolderMan::instance()->checkPathValidityForNewFolder(locFolder, serverUrl());
     _localFolderValid = errorStr.isEmpty();
 
-    QString t;
-
     _ui.pbSelectLocalFolder->setText(QDir::toNativeSeparators(locFolder));
-    if (dataChanged()) {
-        if (_remoteFolder.isEmpty() || _remoteFolder == QLatin1String("/")) {
-            t = "";
-        } else {
-            t = Utility::escape(tr("%1 folder '%2' is synced to local folder '%3'")
-                                    .arg(Theme::instance()->appName(), _remoteFolder,
-                                        QDir::toNativeSeparators(locFolder)));
-            _ui.rSyncEverything->setText(tr("Sync the folder '%1'").arg(_remoteFolder));
-        }
-
-        const bool dirNotEmpty(QDir(locFolder).entryList(QDir::AllEntries | QDir::NoDotAndDotDot).count() > 0);
-        if (dirNotEmpty) {
-            t += tr("<p><small><strong>Warning:</strong> The local folder is not empty. "
-                    "Pick a resolution!</small></p>");
-            _ui.resolutionStackedWidget->setCurrentIndex(1);
-        } else {
-            _ui.resolutionStackedWidget->setCurrentIndex(0);
-        }
+    if (!_remoteFolder.isEmpty() && _remoteFolder != QLatin1String("/")) {
+        _ui.rSyncEverything->setText(tr("Sync the folder '%1'").arg(_remoteFolder));
     }
 
-    _ui.syncModeLabel->setText(t);
+    if (!QDir(locFolder).entryList(QDir::AllEntries | QDir::NoDotAndDotDot).isEmpty()) {
+        _ui.syncModeLabel->setText(tr("<p><strong>Warning:</strong> The local folder is not empty. "
+                                      "Pick a resolution!</p>"));
+        _ui.resolutionStackedWidget->setCurrentIndex(1);
+    } else {
+        _ui.resolutionStackedWidget->setCurrentIndex(0);
+    }
+
     setErrorString(errorStr);
     emit completeChanged();
-}
-
-/* obsolete */
-bool OwncloudAdvancedSetupPage::dataChanged()
-{
-    return true;
 }
 
 void OwncloudAdvancedSetupPage::startSpinner()

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -63,8 +63,6 @@ private slots:
 
 private:
     void setRadioChecked(QRadioButton *radio);
-
-    void setupCustomization();
     void updateStatus();
     bool dataChanged();
     void startSpinner();

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -64,7 +64,6 @@ private slots:
 private:
     void setRadioChecked(QRadioButton *radio);
     void updateStatus();
-    bool dataChanged();
     void startSpinner();
     void stopSpinner();
     QUrl serverUrl() const;

--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -443,9 +443,25 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
           <widget class="QWidget" name="page"/>
-          <widget class="QWidget" name="resolutionStackedWidgetPage1" native="true">
+          <widget class="QWidget" name="resolutionStackedWidgetPage1">
            <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QLabel" name="syncModeLabel">
+              <property name="text">
+               <string notr="true">Status message</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::RichText</enum>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QRadioButton" name="radioButton">
               <property name="text">
@@ -469,6 +485,19 @@
               </property>
              </widget>
             </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
          </widget>
@@ -476,22 +505,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="syncModeLabel">
-     <property name="text">
-      <string>Status message</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
   </layout>

--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -21,28 +21,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QLabel" name="topLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QWidget" name="syncTypeWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_9">
       <item>
@@ -458,38 +436,41 @@
          </layout>
         </item>
         <item>
-         <widget class="QWidget" name="resolutionWidget" native="true">
+         <widget class="QStackedWidget" name="resolutionStackedWidget">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_8">
-           <item>
-            <widget class="QRadioButton" name="radioButton">
-             <property name="text">
-              <string>&amp;Keep local data</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="cbSyncFromScratch">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, existing content in the local folder will be erased to start a clean sync from the server.&lt;/p&gt;&lt;p&gt;Do not check this if the local content should be uploaded to the servers folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Start a &amp;clean sync (Erases the local folder!)</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <widget class="QWidget" name="page"/>
+          <widget class="QWidget" name="resolutionStackedWidgetPage1" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QRadioButton" name="radioButton">
+              <property name="text">
+               <string>&amp;Keep local data</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="cbSyncFromScratch">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this box is checked, existing content in the local folder will be erased to start a clean sync from the server.&lt;/p&gt;&lt;p&gt;Do not check this if the local content should be uploaded to the servers folder.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Start a &amp;clean sync (Crreate a backup and rrases the local folder!)</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
        </layout>
@@ -513,66 +494,6 @@
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QScrollArea" name="errorScroll">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="errorScrollContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>782</width>
-        <height>148</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="errorLabel">
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="bottomLabel">
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -584,6 +505,7 @@
   <tabstop>rVirtualFileSync</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../client.qrc"/>
   <include location="../../../client.qrc"/>
  </resources>
  <connections/>

--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -61,14 +61,6 @@ OwncloudHttpCredsPage::OwncloudHttpCredsPage(QWidget *parent)
 
     _ui.resultLayout->addWidget(_progressIndi);
     stopSpinner();
-    setupCustomization();
-}
-
-void OwncloudHttpCredsPage::setupCustomization()
-{
-    // set defaults for the customize labels.
-    _ui.topLabel->hide();
-    _ui.bottomLabel->hide();
 }
 
 void OwncloudHttpCredsPage::initializePage()

--- a/src/gui/wizard/owncloudhttpcredspage.h
+++ b/src/gui/wizard/owncloudhttpcredspage.h
@@ -49,8 +49,6 @@ Q_SIGNALS:
 private:
     void startSpinner();
     void stopSpinner();
-    void setupCustomization();
-
     Ui_OwncloudHttpCredsPage _ui;
     bool _connected;
     QProgressIndicator *_progressIndi;

--- a/src/gui/wizard/owncloudhttpcredspage.ui
+++ b/src/gui/wizard/owncloudhttpcredspage.ui
@@ -15,22 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="topLabel">
-     <property name="text">
-      <string notr="true">TextLabel</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QLabel" name="tokenLabel">
      <property name="text">
       <string notr="true">TextLabel</string>
@@ -108,16 +92,6 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="resultLayout"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="bottomLabel">
-     <property name="text">
-      <string notr="true">TextLabel</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/200626/127622722-fb29e4fc-3e2b-4efe-ac2d-654e448fa3e3.png)

The commit also removes some unused labels and uses a stack widget instead of hiding/showing widgets during runtime which messed up the layout.

Old:
![image](https://user-images.githubusercontent.com/200626/127622617-5acf397e-dcac-4f2f-89e0-699f9f7a6015.png)
