### PR TITLE
Use ignore list for all NormalErrors

### DIFF
--- a/changelog/unreleased/8672
+++ b/changelog/unreleased/8672
@@ -1,0 +1,5 @@
+Bugfix: Ignore consecutive errors for a pereiode of time
+
+We fixed a bug where certain errors caused a sync run every 30 seconds
+
+https://github.com/owncloud/client/issues/8672

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -193,13 +193,11 @@ static void blacklistUpdate(SyncJournalDb *journal, SyncFileItem &item)
 {
     SyncJournalErrorBlacklistRecord oldEntry = journal->errorBlacklistEntry(item._file);
 
-    bool mayBlacklist =
-        item._errorMayBeBlacklisted // explicitly flagged for blacklisting
-        || ((item._status == SyncFileItem::NormalError
-                || item._status == SyncFileItem::SoftError
-                || item._status == SyncFileItem::DetailError)
-               && item._httpErrorCode != 0 // or non-local error
-               );
+    const bool mayBlacklist = ((item._status == SyncFileItem::NormalError
+                                   || item._status == SyncFileItem::SoftError
+                                   || item._status == SyncFileItem::DetailError)
+        && item._httpErrorCode != 0 // or non-local error
+    );
 
     // No new entry? Possibly remove the old one, then done.
     if (!mayBlacklist) {

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -193,11 +193,11 @@ static void blacklistUpdate(SyncJournalDb *journal, SyncFileItem &item)
 {
     SyncJournalErrorBlacklistRecord oldEntry = journal->errorBlacklistEntry(item._file);
 
-    const bool mayBlacklist = ((item._status == SyncFileItem::NormalError
-                                   || item._status == SyncFileItem::SoftError
-                                   || item._status == SyncFileItem::DetailError)
-        && item._httpErrorCode != 0 // or non-local error
-    );
+    const bool mayBlacklist = (item._status == SyncFileItem::NormalError)
+        || ((item._status == SyncFileItem::SoftError
+                || item._status == SyncFileItem::DetailError)
+            && item._httpErrorCode != 0 // or non-local error
+        );
 
     // No new entry? Possibly remove the old one, then done.
     if (!mayBlacklist) {

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -104,7 +104,6 @@ public:
         , _direction(None)
         , _serverHasIgnoredFiles(false)
         , _hasBlacklistEntry(false)
-        , _errorMayBeBlacklisted(false)
         , _status(NoStatus)
         , _isRestoration(false)
         , _isSelectiveSync(false)
@@ -233,13 +232,6 @@ public:
     /// Note: that entry may have retries left, so this can be true
     /// without the status being FileIgnored.
     bool _hasBlacklistEntry BITFIELD(1);
-
-    /** If true and NormalError, this error may be blacklisted
-     *
-     * Note that non-local errors (httpErrorCode!=0) may also be
-     * blacklisted independently of this flag.
-     */
-    bool _errorMayBeBlacklisted BITFIELD(1);
 
     // Variables useful to report to the user
     Status _status BITFIELD(4);

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -448,6 +448,7 @@ private slots:
 
         // A follow-up sync will restore allowed/file and allowed/sub2 and maintain the nocreatedir/file errors
         completeSpy.clear();
+        QCOMPARE(fakeFolder.syncJournal().wipeErrorBlacklist(), 4);
         QVERIFY(!fakeFolder.syncOnce());
 
         QVERIFY(itemInstruction(completeSpy, "nocreatefile/file", CSYNC_INSTRUCTION_ERROR));


### PR DESCRIPTION
This fixes the issue that a CaseClash caused a resync every 30s.