### PR TITLE
Align sync status and icon

### DIFF
--- a/changelog/unreleased/7715
+++ b/changelog/unreleased/7715
@@ -1,0 +1,13 @@
+Enhancement: Display the information state in case we encountered ignored errors
+
+If syncing a file fails multiple times we mark it as ignored to skip it for a certain amount of time.
+If we have ignored files we are not in sync, we now don't display the green icon.
+
+Additionally this change aligns the icon displayed in the system tray with the icon displayed in the app.
+
+https://github.com/owncloud/client/issues/7715
+https://github.com/owncloud/client/issues/7365
+https://github.com/owncloud/client/issues/7200
+https://github.com/owncloud/client/issues/5860
+
+https://github.com/owncloud/client/pull/8858

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -46,6 +46,7 @@ void TrayOverallStatusResult::addResult(const SyncResult &result)
 {
     _overallStatus._numNewConflictItems += result._numNewConflictItems;
     _overallStatus._numErrorItems += result._numErrorItems;
+    _overallStatus._numBlacklistErrors += result._numBlacklistErrors;
 
     switch (result.status()) {
     case SyncResult::Success:

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -43,9 +43,13 @@ class LockWatcher;
 class TrayOverallStatusResult
 {
 public:
-    SyncResult::Status overallStatus;
-    bool hasUnresolvedConflicts;
     QDateTime lastSyncDone;
+
+    void addResult(const SyncResult &result);
+    const SyncResult &overallStatus() const;
+
+private:
+    SyncResult _overallStatus;
 };
 
 /**
@@ -145,7 +149,7 @@ public:
     bool startFromScratch(const QString &);
 
     /// Produce text for use in the tray tooltip
-    static QString trayTooltipStatusString(SyncResult::Status syncStatus, bool hasUnresolvedConflicts, bool paused);
+    static QString trayTooltipStatusString(const SyncResult &result, bool paused);
 
     /**
      * Compute status summarizing multiple folders

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -239,28 +239,10 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
     case FolderStatusDelegate::FolderStatusIconRole:
         if (accountConnected) {
             auto theme = Theme::instance();
-            auto status = f->syncResult().status();
             if (f->syncPaused()) {
                 return theme->folderDisabledIcon();
             } else {
-                if (status == SyncResult::SyncPrepare) {
-                    return theme->syncStateIcon(SyncResult::SyncRunning);
-                } else if (status == SyncResult::Undefined) {
-                    return theme->syncStateIcon(SyncResult::SyncRunning);
-                } else {
-                    // The "Problem" *result* just means some files weren't
-                    // synced, so we show "Success" in these cases. But we
-                    // do use the "Problem" *icon* for unresolved conflicts.
-                    if (status == SyncResult::Success || status == SyncResult::Problem) {
-                        if (f->syncResult().hasUnresolvedConflicts()) {
-                            return theme->syncStateIcon(SyncResult::Problem);
-                        } else {
-                            return theme->syncStateIcon(SyncResult::Success);
-                        }
-                    } else {
-                        return theme->syncStateIcon(status);
-                    }
-                }
+                return theme->syncStateIcon(f->syncResult().status());
             }
         } else {
             return Theme::instance()->folderOfflineIcon();

--- a/src/gui/libcloudproviders/libcloudproviders.cpp
+++ b/src/gui/libcloudproviders/libcloudproviders.cpp
@@ -213,8 +213,7 @@ void LibCloudProvidersPrivate::updateFolderExport()
             status = CLOUD_PROVIDERS_ACCOUNT_STATUS_ERROR;
 
         auto message = FolderMan::trayTooltipStatusString(
-            syncResult.status(),
-            syncResult.hasUnresolvedConflicts(),
+            syncResult,
             folder->syncPaused());
 
         cloud_providers_account_exporter_set_status(folderExport._exporter, status);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -265,32 +265,19 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
     auto trayOverallStatusResult = FolderMan::trayOverallStatus(map.values());
 
-    // If the sync succeeded but there are unresolved conflicts,
-    // show the problem icon!
-    auto iconStatus = trayOverallStatusResult.overallStatus;
-    if (iconStatus == SyncResult::Success && trayOverallStatusResult.hasUnresolvedConflicts) {
-        iconStatus = SyncResult::Problem;
-    }
-
-    // If we don't get a status for whatever reason, that's a Problem
-    if (iconStatus == SyncResult::Undefined) {
-        iconStatus = SyncResult::Problem;
-    }
-
-    QIcon statusIcon = Theme::instance()->syncStateIcon(iconStatus, true, contextMenuVisible());
+    const QIcon statusIcon = Theme::instance()->syncStateIcon(trayOverallStatusResult.overallStatus(), true, contextMenuVisible());
     _tray->setIcon(statusIcon);
 
     // create the tray blob message, check if we have an defined state
     if (map.count() > 0) {
 #ifdef Q_OS_WIN
         // Windows has a 128-char tray tooltip length limit.
-        trayMessage = FolderMan::instance()->trayTooltipStatusString(trayOverallStatusResult.overallStatus, trayOverallStatusResult.hasUnresolvedConflicts, false);
+        trayMessage = FolderMan::instance()->trayTooltipStatusString(trayOverallStatusResult.overallStatus(), false);
 #else
         QStringList allStatusStrings;
         for (auto *folder : map) {
             QString folderMessage = FolderMan::trayTooltipStatusString(
-                folder->syncResult().status(),
-                folder->syncResult().hasUnresolvedConflicts(),
+                folder->syncResult(),
                 folder->syncPaused());
             allStatusStrings += tr("Folder %1: %2").arg(folder->shortGuiLocalPath(), folderMessage);
         }
@@ -298,9 +285,11 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 #endif
         _tray->setToolTip(trayMessage);
 
-        if (trayOverallStatusResult.overallStatus == SyncResult::Success || trayOverallStatusResult.overallStatus == SyncResult::Problem) {
-            if (trayOverallStatusResult.hasUnresolvedConflicts) {
-                setStatusText(tr("Unresolved conflicts"));
+        if (trayOverallStatusResult.overallStatus().status() == SyncResult::Success || trayOverallStatusResult.overallStatus().status() == SyncResult::Problem) {
+            if (trayOverallStatusResult.overallStatus().hasUnresolvedConflicts()) {
+                setStatusText(tr("Unresolved %1 conflicts").arg(QString::number(trayOverallStatusResult.overallStatus().numNewConflictItems())));
+            } else if (trayOverallStatusResult.overallStatus().numErrorItems() != 0) {
+                setStatusText(tr("Errors %1").arg(QString::number(trayOverallStatusResult.overallStatus().numErrorItems())));
             } else {
                 QString lastSyncDoneString;
 
@@ -313,7 +302,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
                 setStatusText(tr("Up to date (%1)").arg(lastSyncDoneString));
             }
-        } else if (trayOverallStatusResult.overallStatus == SyncResult::Paused) {
+        } else if (trayOverallStatusResult.overallStatus().status() == SyncResult::Paused) {
             setStatusText(tr("Synchronization is paused"));
         } else {
             setStatusText(tr("Error during synchronization"));

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -288,8 +288,8 @@ void ownCloudGui::slotComputeOverallSyncStatus()
         if (trayOverallStatusResult.overallStatus().status() == SyncResult::Success || trayOverallStatusResult.overallStatus().status() == SyncResult::Problem) {
             if (trayOverallStatusResult.overallStatus().hasUnresolvedConflicts()) {
                 setStatusText(tr("Unresolved %1 conflicts").arg(QString::number(trayOverallStatusResult.overallStatus().numNewConflictItems())));
-            } else if (trayOverallStatusResult.overallStatus().numErrorItems() != 0) {
-                setStatusText(tr("Errors %1").arg(QString::number(trayOverallStatusResult.overallStatus().numErrorItems())));
+            } else if (trayOverallStatusResult.overallStatus().numBlacklistErrors() != 0) {
+                setStatusText(tr("Ignored errors %1").arg(QString::number(trayOverallStatusResult.overallStatus().numBlacklistErrors())));
             } else {
                 QString lastSyncDoneString;
 

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -178,9 +178,17 @@ void SyncResult::processCompletedItem(const SyncFileItemPtr &item)
                 break;
             }
         } else if (item->_instruction == CSYNC_INSTRUCTION_IGNORE) {
+            if (item->_hasBlacklistEntry) {
+                _numBlacklistErrors++;
+            }
             _foundFilesNotSynced = true;
         }
     }
+}
+
+int SyncResult::numBlacklistErrors() const
+{
+    return _numBlacklistErrors;
 }
 
 } // ns mirall

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -14,23 +14,15 @@
 
 #include "syncresult.h"
 #include "progressdispatcher.h"
+#include "theme.h"
 
 namespace OCC {
 
-SyncResult::SyncResult()
-    : _status(Undefined)
-    , _foundFilesNotSynced(false)
-    , _folderStructureWasChanged(false)
-    , _numNewItems(0)
-    , _numRemovedItems(0)
-    , _numUpdatedItems(0)
-    , _numRenamedItems(0)
-    , _numNewConflictItems(0)
-    , _numOldConflictItems(0)
-    , _numErrorItems(0)
-
+SyncResult::SyncResult(Status status)
+    : _status(status)
 {
 }
+
 
 SyncResult::Status SyncResult::status() const
 {

--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -46,7 +46,8 @@ public:
     };
     Q_ENUM(Status);
 
-    SyncResult();
+    SyncResult() = default;
+    explicit SyncResult(Status status);
     void reset();
 
     void appendErrorString(const QString &);
@@ -84,7 +85,7 @@ public:
     void processCompletedItem(const SyncFileItemPtr &item);
 
 private:
-    Status _status;
+    Status _status = Undefined;
     SyncFileItemSet _syncItems;
     QDateTime _syncTime;
     QString _folder;
@@ -92,17 +93,17 @@ private:
      * when the sync tool support this...
      */
     QStringList _errors;
-    bool _foundFilesNotSynced;
-    bool _folderStructureWasChanged;
+    bool _foundFilesNotSynced = false;
+    bool _folderStructureWasChanged = false;
 
     // count new, removed and updated items
-    int _numNewItems;
-    int _numRemovedItems;
-    int _numUpdatedItems;
-    int _numRenamedItems;
-    int _numNewConflictItems;
-    int _numOldConflictItems;
-    int _numErrorItems;
+    int _numNewItems = 0;
+    int _numRemovedItems = 0;
+    int _numUpdatedItems = 0;
+    int _numRenamedItems = 0;
+    int _numNewConflictItems = 0;
+    int _numOldConflictItems = 0;
+    int _numErrorItems = 0;
 
     SyncFileItemPtr _firstItemNew;
     SyncFileItemPtr _firstItemDeleted;
@@ -110,6 +111,8 @@ private:
     SyncFileItemPtr _firstItemRenamed;
     SyncFileItemPtr _firstNewConflictItem;
     SyncFileItemPtr _firstItemError;
+
+    friend class TrayOverallStatusResult;
 };
 }
 

--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -84,6 +84,8 @@ public:
 
     void processCompletedItem(const SyncFileItemPtr &item);
 
+    int numBlacklistErrors() const;
+
 private:
     Status _status = Undefined;
     SyncFileItemSet _syncItems;
@@ -101,6 +103,7 @@ private:
     int _numRemovedItems = 0;
     int _numUpdatedItems = 0;
     int _numRenamedItems = 0;
+    int _numBlacklistErrors = 0;
     int _numNewConflictItems = 0;
     int _numOldConflictItems = 0;
     int _numErrorItems = 0;

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -477,33 +477,41 @@ bool Theme::aboutShowCopyright() const
 #ifndef TOKEN_AUTH_ONLY
 QIcon Theme::syncStateIcon(SyncResult::Status status, bool sysTray, bool sysTrayMenuVisible) const
 {
-    // FIXME: Mind the size!
+    return syncStateIcon(SyncResult { status }, sysTray, sysTrayMenuVisible);
+}
+QIcon Theme::syncStateIcon(const SyncResult &result, bool sysTray, bool sysTrayMenuVisible) const
+{
     QString statusIcon;
 
-    switch (status) {
-    case SyncResult::Undefined:
-        // this can happen if no sync connections are configured.
-        statusIcon = QStringLiteral("state-information");
-        break;
+    switch (result.status()) {
     case SyncResult::NotYetStarted:
+        Q_FALLTHROUGH();
     case SyncResult::SyncRunning:
         statusIcon = QStringLiteral("state-sync");
         break;
     case SyncResult::SyncAbortRequested:
+        Q_FALLTHROUGH();
     case SyncResult::Paused:
         statusIcon = QStringLiteral("state-pause");
         break;
     case SyncResult::SyncPrepare:
+        Q_FALLTHROUGH();
     case SyncResult::Success:
+        if (result.hasUnresolvedConflicts()) {
+            return syncStateIcon(SyncResult { SyncResult::Problem }, sysTray, sysTrayMenuVisible);
+        }
         statusIcon = QStringLiteral("state-ok");
         break;
     case SyncResult::Problem:
+        Q_FALLTHROUGH();
+    case SyncResult::Undefined:
+        // this can happen if no sync connections are configured.
         statusIcon = QStringLiteral("state-information");
         break;
     case SyncResult::Error:
+        Q_FALLTHROUGH();
     case SyncResult::SetupError:
     // FIXME: Use state-problem once we have an icon.
-    default:
         statusIcon = QStringLiteral("state-error");
     }
     if (sysTray) {

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -101,7 +101,9 @@ public:
     /**
       * get an sync state icon
       */
-    virtual QIcon syncStateIcon(SyncResult::Status, bool sysTray = false, bool sysTrayMenuVisible = false) const;
+    QIcon syncStateIcon(const SyncResult &status, bool sysTray = false, bool sysTrayMenuVisible = false) const;
+    QIcon syncStateIcon(SyncResult::Status result, bool sysTray = false, bool sysTrayMenuVisible = false) const;
+
 
     virtual QIcon folderDisabledIcon() const;
     virtual QIcon folderOfflineIcon(bool sysTray = false, bool sysTrayMenuVisible = false) const;


### PR DESCRIPTION
With this change we will display the problem state if we have blacklisted errors.
This change also aligns the icon in the tray icon with the icon displayed for the folder state.

![image](https://user-images.githubusercontent.com/200626/127869675-7f68ec0a-70e9-423e-998b-467ec22dfc2f.png)
