### PR TITLE
Wait longer before we assume the client to be ready

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -733,10 +733,10 @@ def step(context, resource, content):
 
     # overwriting the file immediately after it has been synced from the server seems to have some problem.
     # The client does not see the change although the changes have already been made thus we are having a race condition
-    # So for now we add 3sec static wait
+    # So for now we add 5sec static wait
     # an issue https://github.com/owncloud/client/issues/8832 has been created for it
 
-    snooze(3)
+    snooze(5)
 
     f = open(context.userData['clientSyncPath'] + resource, "w")
     f.write(content)


### PR DESCRIPTION
5s seems to be the default snooze time and it seems to fix the test (that now fails since 3 weeks)