### PR TITLE
Folder delegate: Don't display `Synchronizing with`

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -149,8 +149,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     const QIcon statusIcon = qvariant_cast<QIcon>(index.data(FolderStatusIconRole));
     const QString aliasText = qvariant_cast<QString>(index.data(HeaderRole));
-    const QString pathText = qvariant_cast<QString>(index.data(FolderPathRole));
-    const QString remotePath = qvariant_cast<QString>(index.data(FolderSecondPathRole));
     const QStringList conflictTexts = qvariant_cast<QStringList>(index.data(FolderConflictMsg));
     const QStringList errorTexts = qvariant_cast<QStringList>(index.data(FolderErrorMsg));
     const QStringList infoTexts = qvariant_cast<QStringList>(index.data(FolderInfoMsg));
@@ -244,15 +242,11 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     const bool showProgess = !overallString.isEmpty() || !itemString.isEmpty();
     if (!showProgess) {
         painter->setFont(subFont);
-        QString elidedRemotePathText = subFm.elidedText(
+        const QString elidedRemotePathText = subFm.elidedText(
             syncText,
             Qt::ElideRight, remotePathRect.width());
         painter->drawText(QStyle::visualRect(option.direction, option.rect, remotePathRect),
             textAlign, elidedRemotePathText);
-
-        QString elidedPathText = subFm.elidedText(pathText, Qt::ElideMiddle, localPathRect.width());
-        painter->drawText(QStyle::visualRect(option.direction, option.rect, localPathRect),
-            textAlign, elidedPathText);
     }
 
     int h = iconRect.bottom() + margin;

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -256,11 +256,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
     case FolderStatusDelegate::SyncProgressOverallString:
         return progress._overallSyncString;
     case FolderStatusDelegate::FolderSyncText:
-        if (f->virtualFilesEnabled()) {
-            return tr("Synchronizing VirtualFiles with local folder");
-        } else {
-            return tr("Synchronizing with local folder");
-        }
+        return tr("Local folder: %1").arg(f->shortGuiLocalPath());
     }
     return QVariant();
 }


### PR DESCRIPTION
We are a sync client mentioning that we sync is pointless.
Also remove `Synchronizing VirtualFiles` with placeholders we still display a banner.
On Windows VirtualFiles are the standard.

New:
![image](https://user-images.githubusercontent.com/200626/129021621-2753d5ef-7f22-4df6-a2d5-e14c02277f21.png)
Old:
![image](https://user-images.githubusercontent.com/200626/129021672-955601fc-5d16-4599-82de-04f24912d4e1.png)



Fixes: #8871