### PR TITLE
Remove leftover debug line

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -300,7 +300,6 @@ bool Folder::dueToSync() const
     const auto polltime = cfg.remotePollInterval(pta);
 
     const auto timeSinceLastSync = std::chrono::milliseconds(_timeSinceLastEtagCheckDone.elapsed());
-    qCInfo(lcFolder) << "dueToSync:" << alias() << timeSinceLastSync.count() << " < " << polltime.count();
     if (timeSinceLastSync >= polltime) {
         return true;
     }


### PR DESCRIPTION
08-17 11:30:56:139 [ info gui.folder ]:	dueToSync: "1" 9626  <  30000
08-17 11:30:56:139 [ info gui.folder ]:	dueToSync: "2" 9483  <  30000
08-17 11:30:57:140 [ info gui.folder ]:	dueToSync: "1" 10626  <  30000
08-17 11:30:57:140 [ info gui.folder ]:	dueToSync: "2" 10484  <  30000
08-17 11:30:58:140 [ info gui.folder ]:	dueToSync: "1" 11627  <  30000
08-17 11:30:58:141 [ info gui.folder ]:	dueToSync: "2" 11484  <  30000
08-17 11:30:59:139 [ info gui.folder ]:	dueToSync: "1" 12626  <  30000
08-17 11:30:59:140 [ info gui.folder ]:	dueToSync: "2" 12484  <  30000