### PR TITLE
Don't tread local system reserved file names as an issue

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -263,6 +263,10 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const QString &loc
                     item->_errorString = tr("File name contains at least one invalid character");
                 } else {
                     item->_errorString = tr("The file name is a reserved name on this file system.");
+                    if (!localName.isEmpty()) {
+                        // The file is indeed a system file and that we don't upload it is no problem
+                        item->_status = SyncFileItem::Excluded;
+                    }
                 }
             }
             break;


### PR DESCRIPTION
If the file $RECYCLE.BIN is on the local file system there is no reason
we should not mark the sync as success.

If for some reason there is a file with such a name on the server we do need to warn,
as we can't download that file. Thus the sync is incomplete.