### PR TITLE
Running sync takes precedence over Success in overall state

### DIFF
--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -32,12 +32,15 @@ class OWNCLOUDSYNC_EXPORT SyncResult
 {
     Q_GADGET
 public:
+    // the order of the values markes their importance
+    // higher values take prcedence when computing the
+    // overall status
     enum Status {
         Undefined,
         NotYetStarted,
+        Success,
         SyncPrepare,
         SyncRunning,
-        Success,
         SyncAbortRequested,
         Paused,
         Problem,


### PR DESCRIPTION
Fixes: #8933

https://github.com/owncloud/client/blob/2.8/src/gui/folderman.cpp#L1312