### PR TITLE
Sharedialog preview be more resilient

### DIFF
--- a/changelog/unreleased/8938
+++ b/changelog/unreleased/8938
@@ -1,0 +1,7 @@
+Change: Make sharedialog preview be more resilient
+
+We no longer enforce png thumbnails.
+We no longer replace the file icon if the thumbnail is invalid.
+
+https://github.com/owncloud/client/issues/8938
+https://github.com/owncloud/client/pull/8939

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -73,9 +73,9 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     // Set icon
     QFileInfo f_info(_localPath);
     QFileIconProvider icon_provider;
-    QIcon icon = icon_provider.icon(f_info);
-    auto pixmap = icon.pixmap(thumbnailSize, thumbnailSize);
-    if (pixmap.width() > 0) {
+    const QIcon icon = icon_provider.icon(f_info);
+    if (!icon.isNull()) {
+        auto pixmap = icon.pixmap(thumbnailSize, thumbnailSize);
         _ui->label_icon->setPixmap(pixmap);
     } else {
         _ui->label_icon->hide();
@@ -213,16 +213,17 @@ QSize ShareDialog::minimumSizeHint() const
     return ocApp()->gui()->settingsDialog()->sizeHintForChild();
 }
 
-void ShareDialog::slotThumbnailFetched(const int &statusCode, const QByteArray &reply)
+void ShareDialog::slotThumbnailFetched(const int &statusCode, const QPixmap &reply)
 {
     if (statusCode != 200) {
         qCWarning(lcSharing) << "Thumbnail status code: " << statusCode;
         return;
     }
-
-    QPixmap p;
-    p.loadFromData(reply, "PNG");
-    p = p.scaledToHeight(thumbnailSize, Qt::SmoothTransformation);
+    if (reply.isNull()) {
+        qCWarning(lcSharing) << "Invalid pixmap";
+        return;
+    }
+    const auto p = reply.scaledToHeight(thumbnailSize, Qt::SmoothTransformation);
     _ui->label_icon->setPixmap(p);
     _ui->label_icon->show();
 }

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -53,7 +53,7 @@ public:
 private slots:
     void slotPropfindReceived(const QMap<QString, QString> &result);
     void slotPropfindError();
-    void slotThumbnailFetched(const int &statusCode, const QByteArray &reply);
+    void slotThumbnailFetched(const int &statusCode, const QPixmap &reply);
     void slotAccountStateChanged(int state);
 
 private:

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -32,7 +32,15 @@ void ThumbnailJob::start()
 
 bool ThumbnailJob::finished()
 {
-    emit jobFinished(reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), reply()->readAll());
+    const auto result = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    QPixmap p;
+    if (result == 200) {
+        p.loadFromData(reply()->readAll());
+        if (p.isNull()) {
+            qWarning() << Q_FUNC_INFO << "Invalid thumbnail";
+        }
+    }
+    emit jobFinished(result, p);
     return true;
 }
 }

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -39,11 +39,10 @@ signals:
      * @param statusCode the HTTP status code
      * @param reply the content of the reply
      *
-     * Signal that the job is done. If the statusCode is 200 (success) reply
-     * will contain the image data in PNG. If the status code is different the content
-     * of reply is undefined.
+     * Signal that the job is done. If the statusCode is 200 (success).
+     * If the status code is different the content is invalid.
      */
-    void jobFinished(int statusCode, QByteArray reply);
+    void jobFinished(int statusCode, QPixmap reply);
 private slots:
     bool finished() override;
 };


### PR DESCRIPTION
The api currently does respond with non png icons, determine the image type based on the content.
Don't override the system icon if we got a null icon.


Fixes: #8938