### PR TITLE
Accept aborted delete if is ignored due to _hasBlacklistEntry

### DIFF
--- a/changelog/unreleased/8837
+++ b/changelog/unreleased/8837
@@ -1,3 +1,5 @@
 Bugfix: Don't crash if a certain move is undone
 
 https://github.com/owncloud/client/issues/8837
+https://github.com/owncloud/client/pull/8863
+https://github.com/owncloud/client/pull/8958

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -172,13 +172,17 @@ QPair<bool, QByteArray> DiscoveryPhase::findAndCancelDeletedJob(const QString &o
             if (!(instruction == CSYNC_INSTRUCTION_REMOVE
                     // re-creation of virtual files count as a delete
                     || (item->_type == ItemTypeVirtualFile && instruction == CSYNC_INSTRUCTION_NEW)
-                    || (item->_isRestoration && instruction & (CSYNC_INSTRUCTION_NEW | CSYNC_INSTRUCTION_IGNORE)))) {
+                    || (item->_isRestoration && instruction == CSYNC_INSTRUCTION_NEW)
+                    // we encountered an ignored error
+                    || (item->_hasBlacklistEntry && instruction == CSYNC_INSTRUCTION_IGNORE))) {
                 qCWarning(lcDiscovery) << "OC_ENFORCE(FAILING)" << originalPath;
                 qCWarning(lcDiscovery) << "instruction == CSYNC_INSTRUCTION_REMOVE" << (instruction == CSYNC_INSTRUCTION_REMOVE);
                 qCWarning(lcDiscovery) << "(item->_type == ItemTypeVirtualFile && instruction == CSYNC_INSTRUCTION_NEW)"
                                        << (item->_type == ItemTypeVirtualFile && instruction == CSYNC_INSTRUCTION_NEW);
-                qCWarning(lcDiscovery) << "(item->_isRestoration && instruction & (CSYNC_INSTRUCTION_NEW | CSYNC_INSTRUCTION_IGNORE)"
-                                       << (item->_isRestoration && instruction & (CSYNC_INSTRUCTION_NEW | CSYNC_INSTRUCTION_IGNORE));
+                qCWarning(lcDiscovery) << "(item->_isRestoration && instruction == CSYNC_INSTRUCTION_NEW)"
+                                       << (item->_isRestoration && instruction == CSYNC_INSTRUCTION_NEW);
+                qCWarning(lcDiscovery) << "(item->_hasBlacklistEntry && instruction == CSYNC_INSTRUCTION_IGNORE)"
+                                       << (item->_hasBlacklistEntry && instruction == CSYNC_INSTRUCTION_IGNORE);
                 qCWarning(lcDiscovery) << "instruction" << instruction;
                 qCWarning(lcDiscovery) << "item->_type" << item->_type;
                 qCWarning(lcDiscovery) << "item->_isRestoration " << item->_isRestoration;


### PR DESCRIPTION
To reproduce the issue:
- Take two existing files A, B
- Rename B to a

The client will detect the move from B to a, as after the first occurance of the issue
the action is ignored, we will encounter the enforce.

```
08-26 17:07:45:901 [ warning sync.discovery ]:	OC_ENFORCE(FAILING) "Photos/Teotihuacan.jpg"
08-26 17:07:46:323 [ warning sync.discovery ]:	instruction == CSYNC_INSTRUCTION_REMOVE false
08-26 17:07:46:610 [ warning sync.discovery ]:	(item->_type == ItemTypeVirtualFile && instruction == CSYNC_INSTRUCTION_NEW) false
08-26 17:07:46:880 [ warning sync.discovery ]:	(item->_isRestoration && instruction & (CSYNC_INSTRUCTION_NEW | CSYNC_INSTRUCTION_IGNORE) false
08-26 17:07:47:319 [ warning sync.discovery ]:	instruction SyncInstruction(CSYNC_INSTRUCTION_IGNORE)
08-26 17:07:47:745 [ warning sync.discovery ]:	item->_type CSyncEnums::ItemTypeFile
08-26 17:07:48:144 [ warning sync.discovery ]:	item->_isRestoration  false
08-26 17:07:48:586 [ warning sync.discovery ]:	item->_remotePerm "WDNVR"
```