### PR TITLE
Fix multiple authenticaions at the same time

### DIFF
--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -238,7 +238,13 @@ bool HttpCredentials::refreshAccessToken()
 {
     if (_refreshToken.isEmpty())
         return false;
-    _ready = false;
+    if (_isRenewingOAuthToken) {
+        return true;
+    }
+    _isRenewingOAuthToken = true;
+
+    // don't touch _ready or the account state will start a new authentication
+    // _ready = false;
 
     OAuth *oauth = new OAuth(_account, this);
     connect(oauth, &OAuth::refreshError, this, [oauth, this](QNetworkReply::NetworkError error, const QString &errorString) {
@@ -297,7 +303,6 @@ bool HttpCredentials::refreshAccessToken()
         emit fetched();
     });
     oauth->refreshAuthentication(_refreshToken);
-    _isRenewingOAuthToken = true;
     Q_EMIT authenticationStarted();
     return true;
 }


### PR DESCRIPTION
Under certain conditions it was possible that the client started multiple authentications at the same time, resulting in a logout.