### PR TITLE
Tweak the settings dialog size to correctly show the wizards

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -57,12 +57,19 @@ void setActivationPolicy(ActivationPolicy policy);
 namespace {
 auto minimumSizeHint(const QWidget *w)
 {
-    const QSize min { 800, 600 };
+    const QSize min { 800, 700 }; // When changing this, please check macOS: widgets there have larger insets, so they take up more space.
     const auto screen = w->windowHandle() ? w->windowHandle()->screen() : QApplication::screenAt(QCursor::pos());
     if (screen) {
         const auto availableSize = screen->availableSize();
         if (availableSize.isValid()) {
-            return min.boundedTo(availableSize * 0.75);
+            // Assume we can use at least 90% of the screen, if the screen is smaller than 800x700 pixels.
+            //
+            // Note: this means that the wizards have even less space: with the style we use, the
+            // wizard tries to fit inside the window. So, if this is a common case that users have
+            // such small screens, and the contents of the wizard screen are squashed together (or
+            // not shown due to lack of space), we should consider putting that content in a
+            // scroll-view.
+            return min.boundedTo(availableSize * 0.9);
         }
     }
     return min;

--- a/src/gui/wizard/owncloudadvancedsetuppage.ui
+++ b/src/gui/wizard/owncloudadvancedsetuppage.ui
@@ -384,7 +384,7 @@
           <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
-            <height>40</height>
+            <height>10</height>
            </size>
           </property>
          </spacer>
@@ -484,7 +484,7 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>10</height>
                </size>
               </property>
              </spacer>


### PR DESCRIPTION
On macOS, with the style we use, the wizard fits into the settings
dialog, and it will also be restrainded to the size of the settings
dialog.

This change makes sure that on macOS, the settings dialog has enough
(vertical) space to show all the widgets in all pages. If there is not
enough space, widgets might overlapped by other widgets (or disappear
behind them).

Fixes: #8919