### PR TITLE
Fix crash #8916

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -174,6 +174,8 @@ void FolderMan::unloadFolder(Folder *f)
         _socketApi.data(), &SocketApi::broadcastStatusPushMessage);
     disconnect(f, &Folder::watchedFileChangedExternally,
         &f->syncEngine().syncFileStatusTracker(), &SyncFileStatusTracker::slotPathTouched);
+
+    f->syncEngine().disconnect(f);
 }
 
 void FolderMan::unloadAndDeleteAllFolders()


### PR DESCRIPTION
When a folder is removed we remove all associated items from the protocol widgets.
The folder however coninues to announce new items slotItemCompleted.
If one of the items is accessed after the folder object is deleted we got a crash.

Fixes: #8916