### PR TITLE
[CI] fix push trigger for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -21,7 +21,7 @@ def main(ctx):
     }
     pipelines = [
         # check the format of gui test code
-        gui_tests_format(),
+        gui_tests_format(build_trigger),
         # Check starlark
         check_starlark(
             ctx,
@@ -266,7 +266,7 @@ def build_client(ctx, c_compiler, cxx_compiler, build_type, generator, build_com
         },
     ]
 
-def gui_tests_format():
+def gui_tests_format(trigger):
     return {
         "kind": "pipeline",
         "type": "docker",
@@ -282,6 +282,7 @@ def gui_tests_format():
                 ],
             },
         ],
+        "trigger": trigger,
     }
 
 def changelog(ctx, trigger = {}, depends_on = []):


### PR DESCRIPTION
Currently pushing into a branch triggers a build that only runs gui test linting which is not really necessary as same pipeline runs after creating the PR.