### PR TITLE
Display the local time not utc time

### DIFF
--- a/changelog/unreleased/9006
+++ b/changelog/unreleased/9006
@@ -1,0 +1,5 @@
+Bugfix: Tables now display local time
+
+We fixed a bug where the sync tables where displaying utc time for some items.
+
+https://github.com/owncloud/client/issues/9006

--- a/src/gui/models/protocolitemmodel.cpp
+++ b/src/gui/models/protocolitemmodel.cpp
@@ -58,7 +58,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
         switch (column) {
         case ProtocolItemRole::Time:
-            return item.timestamp();
+            return item.timestamp().toLocalTime();
         case ProtocolItemRole::Folder:
             return item.folder()->shortGuiLocalPath();
         case ProtocolItemRole::Action:

--- a/src/gui/protocolitem.cpp
+++ b/src/gui/protocolitem.cpp
@@ -37,7 +37,7 @@ ProtocolItem::ProtocolItem(Folder *folder, const SyncFileItemPtr &item)
     if (!item->_responseTimeStamp.isEmpty()) {
         _timestamp = QDateTime::fromString(QString::fromUtf8(item->_responseTimeStamp), Qt::RFC2822Date);
     } else {
-        _timestamp = QDateTime::currentDateTime();
+        _timestamp = QDateTime::currentDateTimeUtc();
     }
     if (_message.isEmpty()) {
         _message = Progress::asResultString(*item);

--- a/src/gui/protocolitem.h
+++ b/src/gui/protocolitem.h
@@ -34,6 +34,9 @@ public:
 
     Folder *folder() const;
 
+    /**
+     * UTC Time
+     */
     QDateTime timestamp() const;
 
     qint64 size() const;


### PR DESCRIPTION
Copying to clipboard will still display utc time (raw data)

Fixes: #9006