### PR TITLE
Work around compiler bug in old GCC versions

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -273,12 +273,6 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
     {
         return QMetaEnum::fromType<E>().valueToKeys(value);
     }
-    template <class E = void>
-    QString enumDisplayName(E)
-    {
-        static_assert(std::is_same<E, void>::value, "Not implemented");
-        Q_UNREACHABLE();
-    }
 }
 /** @} */ // \addtogroup
 

--- a/src/gui/models/protocolitemmodel.cpp
+++ b/src/gui/models/protocolitemmodel.cpp
@@ -70,7 +70,7 @@ QVariant ProtocolItemModel::data(const QModelIndex &index, int role) const
         case ProtocolItemRole::Account:
             return item.folder()->accountState()->account()->displayName();
         case ProtocolItemRole::Status:
-            return Utility::enumDisplayName(item.status());
+            return SyncFileItem::statusEnumDisplayName(item.status());
         case ProtocolItemRole::ColumnCount:
             Q_UNREACHABLE();
             break;

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -75,8 +75,7 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
     return item;
 }
 
-template <>
-QString Utility::enumDisplayName(SyncFileItem::Status s)
+QString SyncFileItem::statusEnumDisplayName(Status s)
 {
     switch (s) {
     case SyncFileItem::NoStatus:

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -95,6 +95,8 @@ public:
     };
     Q_ENUM(Status)
 
+    static QString statusEnumDisplayName(Status s);
+
     SyncJournalFileRecord toSyncJournalFileRecordWithInode(const QString &localFileName) const;
 
     /** Creates a basic SyncFileItem from a DB record
@@ -275,11 +277,6 @@ public:
     QString _directDownloadUrl;
     QString _directDownloadCookies;
 };
-
-
-template <>
-OWNCLOUDSYNC_EXPORT QString Utility::enumDisplayName(SyncFileItem::Status s);
-
 
 inline bool operator<(const SyncFileItemPtr &item1, const SyncFileItemPtr &item2)
 {


### PR DESCRIPTION
The previous use of template specialisation triggered a compiler bug on
Debian 9 and CentOS 7, which use gcc 5.4 or earlier. As there is just
one specialisation, the work-around is to change the function to be a
static member function of the wrapping class of the enum.

See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480