### PR TITLE
Used make_unique instead of direct unique_ptr construction

### DIFF
--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -205,7 +205,7 @@ Vfs::Mode OCC::bestAvailableVfsMode()
 std::unique_ptr<Vfs> OCC::createVfsFromPlugin(Vfs::Mode mode)
 {
     if (mode == Vfs::Off)
-        return std::unique_ptr<Vfs>(new VfsOff);
+        return std::make_unique<VfsOff>();
 
     auto name = modeToPluginName(mode);
     if (name.isEmpty())

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -155,7 +155,7 @@ bool AccountManager::restoreFromLegacySettings()
 
         QFileInfo fi(oCCfgFile);
         if (fi.isReadable()) {
-            std::unique_ptr<QSettings> oCSettings(new QSettings(oCCfgFile, QSettings::IniFormat));
+            auto oCSettings = std::make_unique<QSettings>(oCCfgFile, QSettings::IniFormat);
             oCSettings->beginGroup(QLatin1String("ownCloud"));
 
             // Check the theme url to see if it is the same url that the oC config was for

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -846,9 +846,9 @@ void ConfigFile::setClientVersionString(const QString &version)
     settings.setValue(clientVersionC(), version);
 }
 
-std::unique_ptr<QSettings> ConfigFile::settingsWithGroup(const QString &group, QObject *parent)
+std::unique_ptr<QSettings> ConfigFile::settingsWithGroup(const QString &group)
 {
-    std::unique_ptr<QSettings> settings(new QSettings(ConfigFile::configFile(), QSettings::IniFormat, parent));
+    auto settings = std::make_unique<QSettings>(ConfigFile::configFile(), QSettings::IniFormat);
     settings->beginGroup(group);
     return settings;
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -179,9 +179,8 @@ public:
     QString clientVersionString() const;
     void setClientVersionString(const QString &version);
 
-    /**  Returns a new settings pre-set in a specific group.  The Settings will be created
-         with the given parent. If no parent is specified, the caller must destroy the settings */
-    static std::unique_ptr<QSettings> settingsWithGroup(const QString &group, QObject *parent = nullptr);
+    /**  Returns a new settings pre-set in a specific group. */
+    static std::unique_ptr<QSettings> settingsWithGroup(const QString &group);
 
     /// Add the system and user exclude file path to the ExcludedFiles instance.
     static void setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles);

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -383,8 +383,8 @@ void PropagateUploadFileNG::startNextChunk()
         abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(fileName));
         return;
     }
-    auto device = std::unique_ptr<UploadDevice>(new UploadDevice(
-            fileName, _currentChunkOffset, _currentChunkSize, &propagator()->_bandwidthManager));
+    auto device = std::make_unique<UploadDevice>(fileName, _currentChunkOffset, _currentChunkSize,
+        &propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadNG) << "Could not prepare upload device: " << device->errorString();
         // Soft error because this is likely caused by the user modifying his files while syncing

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -137,8 +137,8 @@ void PropagateUploadFileV1::startNextChunk()
         abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(fileName));
         return;
     }
-    auto device = std::unique_ptr<UploadDevice>(new UploadDevice(
-            fileName, chunkStart, currentChunkSize, &propagator()->_bandwidthManager));
+    auto device = std::make_unique<UploadDevice>(fileName, chunkStart, currentChunkSize,
+        &propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadV1) << "Could not prepare upload device: " << device->errorString();
         // Soft error because this is likely caused by the user modifying his files while syncing

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -175,7 +175,7 @@ public:
         OC_ASSERT(op == QNetworkAccessManager::PostOperation);
         OC_ASSERT(req.url().toString().startsWith(sOAuthTestServer.toString()));
         OC_ASSERT(req.url().path() == sOAuthTestServer.path() + "/index.php/apps/oauth2/api/v1/token");
-        std::unique_ptr<QBuffer> payload(new QBuffer());
+        auto payload = std::make_unique<QBuffer>();
         payload->setData(tokenReplyPayload());
         return new FakePostReply(op, req, std::move(payload), fakeQnam);
     }
@@ -187,7 +187,7 @@ public:
         OC_ASSERT(op == QNetworkAccessManager::GetOperation);
         OC_ASSERT(req.url().toString().startsWith(sOAuthTestServer.toString()));
         OC_ASSERT(req.url().path() == sOAuthTestServer.path() + "/status.php");
-        std::unique_ptr<QBuffer> payload(new QBuffer());
+        auto payload = std::make_unique<QBuffer>();
         payload->setData(statusPhpPayload());
         return new FakePostReply(op, req, std::move(payload), fakeQnam);
     }
@@ -290,7 +290,7 @@ private slots:
                 OC_ASSERT(state == BrowserOpened);
                 state = TokenAsked;
 
-                std::unique_ptr<QBuffer> payload(new QBuffer);
+                auto payload = std::make_unique<QBuffer>();
                 payload->setData(tokenReplyPayload());
                 return new SlowFakePostReply(op, req, std::move(payload), fakeQnam);
             }


### PR DESCRIPTION
Use make_unique to create an object that isn’t shared (at least not yet), unless you need a custom deleter or are adopting a raw pointer from elsewhere. 