### PR TITLE
Turn raw QSettings pointer into a reference in the CredentialManager

### DIFF
--- a/src/libsync/creds/credentialmanager.h
+++ b/src/libsync/creds/credentialmanager.h
@@ -34,7 +34,7 @@ public:
     const Account *account() const;
 
 private:
-    QSettings *credentialsList() const;
+    QSettings &credentialsList() const;
 
     // TestCredentialManager
     QStringList knownKeys(const QString &group = {}) const;


### PR DESCRIPTION
The underlying object is managed by a std::unique_ptr. So accidentally
setting a parent, or managing it somewhere else, will result in a
double-free. Returning a reference is slightly more safe, and has the
added benefit that it communicates the fact that it will never be a
nullptr.