### PR TITLE
Fix copy private link url

### DIFF
--- a/changelog/unreleased/9048
+++ b/changelog/unreleased/9048
@@ -1,0 +1,5 @@
+Bugfix: Fix copy url location for private links
+
+We fixed a bug where a placholder was copied to the clipboard instead of the url.
+
+https://github.com/owncloud/client/issues/9048

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -90,6 +90,9 @@ ShareUserGroupWidget::ShareUserGroupWidget(AccountPtr account,
     connect(_ui->shareeLineEdit, &QLineEdit::returnPressed, this, &ShareUserGroupWidget::slotLineEditReturn);
     connect(_ui->privateLinkText, &QLabel::linkActivated, this, &ShareUserGroupWidget::slotPrivateLinkShare);
 
+    _ui->privateLinkText->setText(tr("You can direct people to this shared file or folder %1 by giving them a private link")
+                                      .arg(QStringLiteral("<a href=\"%1\"><span style=\"text-decoration: underline\">").arg(_privateLinkUrl)));
+
     // By making the next two QueuedConnections we can override
     // the strings the completer sets on the line edit.
     connect(_completer, qOverload<const QModelIndex &>(&QCompleter::activated), this, &ShareUserGroupWidget::slotCompleterActivated,

--- a/src/gui/shareusergroupwidget.ui
+++ b/src/gui/shareusergroupwidget.ui
@@ -94,8 +94,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>371</width>
-        <height>148</height>
+        <width>377</width>
+        <height>185</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3"/>
@@ -105,7 +105,7 @@
    <item>
     <widget class="QLabel" name="privateLinkText">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You can direct people to this shared file or folder &lt;a href=&quot;private link menu&quot;&gt;&lt;span style=&quot; text-decoration: underline&quot;&gt;by giving them a private link&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string notr="true"/>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
Due to the prominent string change this goes to 2.10
Fixes: #9048