### PR TITLE
Allow up to 20000 sync issues

### DIFF
--- a/src/common/fixedsizeringbuffer.h
+++ b/src/common/fixedsizeringbuffer.h
@@ -24,20 +24,23 @@ namespace OCC {
 /**
  * A Fixed sized ring buffer optimized on continouous insertion
  */
-template <typename TYPE, size_t _Size>
+template <typename TYPE>
 class FixedSizeRingBuffer
 {
 public:
-    FixedSizeRingBuffer() = default;
+    FixedSizeRingBuffer(size_t size)
+        : _data(size, TYPE())
+    {
+    }
 
     constexpr size_t capacity() const
     {
-        return _Size;
+        return _data.size();
     }
 
     constexpr bool isFull() const
     {
-        return size() >= _Size;
+        return size() >= _data.size();
     }
 
     constexpr size_t size() const
@@ -79,7 +82,7 @@ public:
         Q_ASSERT(_start < _end);
         // adjust offset to prevent overflow
         const auto s = size();
-        _start %= _Size;
+        _start %= _data.size();
         _end = _start + s;
     }
 
@@ -102,7 +105,7 @@ public:
     void remove_if(const std::function<bool(const TYPE &)> &f)
     {
         // filter and sort the data
-        FixedSizeRingBuffer<TYPE, _Size> tmp;
+        FixedSizeRingBuffer<TYPE> tmp(_data.size());
         const auto start = convertToIndex(0);
         for (auto it = begin() + start; it != end(); ++it) {
             if (!f(*it)) {
@@ -119,14 +122,14 @@ public:
 
     void reset(std::vector<TYPE> &&data)
     {
-        Q_ASSERT(data.size() <= _Size);
+        Q_ASSERT(data.size() <= _data.size());
         _start = 0;
         _end = data.size();
         std::move(data.begin(), data.end(), _data.begin());
     }
 
 private:
-    std::array<TYPE, _Size> _data;
+    std::vector<TYPE> _data;
 
     // the sliding window of the ring buffer
     size_t _start = 0;
@@ -135,7 +138,7 @@ private:
     // converts an array index to the underlying array index
     constexpr size_t convertToIndex(size_t i) const
     {
-        return (_start + i) % _Size;
+        return (_start + i) % _data.size();
     }
 };
 

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -87,7 +87,7 @@ IssuesWidget::IssuesWidget(QWidget *parent)
         _model->addProtocolItem(ProtocolItem { f, item });
     });
 
-    _model = new ProtocolItemModel(this);
+    _model = new ProtocolItemModel(20000, true, this);
     _sortModel = new QSortFilterProxyModel(this);
     _sortModel->setSourceModel(_model);
     _ui->_tableView->setModel(_sortModel);

--- a/src/gui/models/protocolitemmodel.cpp
+++ b/src/gui/models/protocolitemmodel.cpp
@@ -24,8 +24,9 @@
 
 using namespace OCC;
 
-ProtocolItemModel::ProtocolItemModel(QObject *parent, bool issueMode)
+ProtocolItemModel::ProtocolItemModel(size_t size, bool issueMode, QObject *parent)
     : QAbstractTableModel(parent)
+    , _data(size)
     , _issueMode(issueMode)
 {
 }

--- a/src/gui/models/protocolitemmodel.h
+++ b/src/gui/models/protocolitemmodel.h
@@ -42,7 +42,7 @@ public:
      * @param parent
      * @param issueMode Whether we are tracking all synced items or issues
      */
-    ProtocolItemModel(QObject *parent = nullptr, bool issueMode = false);
+    ProtocolItemModel(size_t size, bool issueMode, QObject *parent = nullptr);
 
     int rowCount(const QModelIndex &parent = {}) const override;
     int columnCount(const QModelIndex &parent = {}) const override;
@@ -70,7 +70,7 @@ public:
     void remove_if(const std::function<bool(const ProtocolItem &)> &filter);
 
 private:
-    FixedSizeRingBuffer<ProtocolItem, 2000> _data;
+    FixedSizeRingBuffer<ProtocolItem> _data;
     bool _issueMode;
     int _maxLogSize;
 

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -48,7 +48,7 @@ ProtocolWidget::ProtocolWidget(QWidget *parent)
 
     connect(_ui->_tableView, &QTreeWidget::customContextMenuRequested, this, &ProtocolWidget::slotItemContextMenu);
 
-    _model = new ProtocolItemModel(this);
+    _model = new ProtocolItemModel(2000, false, this);
     _sortModel = new QSortFilterProxyModel(this);
     _sortModel->setSourceModel(_model);
     _sortModel->setSortRole(Models::UnderlyingDataRole);

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -394,7 +394,7 @@ void SyncEngine::startSync()
             finalize(false);
             return;
         } else {
-            qCInfo(lcEngine) << "There are" << freeBytes << "bytes available at" << _localPath;
+            qCInfo(lcEngine) << "There are" << Utility::octetsToString(freeBytes) << "available at" << _localPath;
         }
     } else {
         qCWarning(lcEngine) << "Could not determine free space available at" << _localPath;

--- a/test/modeltests/testprotocolmodel.cpp
+++ b/test/modeltests/testprotocolmodel.cpp
@@ -26,7 +26,7 @@ class TestProtocolModel : public QObject
 private Q_SLOTS:
     void testInsertAndRemove()
     {
-        auto model = new ProtocolItemModel(this, false);
+        auto model = new ProtocolItemModel(300, false, this);
 
         new QAbstractItemModelTester(model, this);
 


### PR DESCRIPTION
People might have a suboptimal setup with lots of ignored files.
The historic maximum we displayed was 2000 issues, we now allow 20000, while we keep the old value for the protocol view.

The underlying data structure was selected with the protocol widget in mind, so many continual inserts.

The issue widget however resets the model on every single sync, deletes all issues associated with an account, to then fill in the new issues. We should try to create a more clever approach.... 