### PR TITLE
Fix wrong status displayed for files moved on the server

### DIFF
--- a/changelog/unreleased/9071
+++ b/changelog/unreleased/9071
@@ -1,0 +1,5 @@
+Bugfix: A folder moved on the server was displayed as outdated
+
+We fixed a bug where a folder moved on the server was displayed as outdated.
+
+https://github.com/owncloud/client/issues/9071

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -83,6 +83,7 @@ bool FileSystem::setModTime(const QString &filename, time_t modTime)
     if (rc != 0) {
         qCWarning(lcFileSystem) << "Error setting mtime for" << filename
                                 << "failed: rc" << rc << ", errno:" << errno;
+        Q_ASSERT(false);
         return false;
     }
     return true;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -742,6 +742,13 @@ void SyncEngine::setNetworkLimits(int upload, int download)
 
 void SyncEngine::slotItemCompleted(const SyncFileItemPtr &item)
 {
+    Q_ASSERT([&] {
+        // ensure the item is not marked as finished twice
+        const bool finished = item->_finished;
+        item->_finished = true;
+        return !finished;
+    }());
+
     _progressInfo->setProgressComplete(*item);
 
     emit transmissionProgress(*_progressInfo);

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -106,3 +106,15 @@ QString SyncFileItem::statusEnumDisplayName(Status s)
     Q_UNREACHABLE();
 }
 }
+
+QDebug operator<<(QDebug debug, const OCC::SyncFileItem *item)
+{
+    if (!item) {
+        debug << "OCC::SyncFileItem(0x0)";
+    } else {
+        QDebugStateSaver saver(debug);
+        debug.setAutoInsertSpaces(false);
+        debug << "OCC::SyncFileItem(destination=" << item->destination() << ", type=" << item->_type << ", status=" << item->_status << ")";
+    }
+    return debug;
+}

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -127,6 +127,7 @@ public:
         , _inode(0)
         , _previousSize(0)
         , _previousModtime(0)
+        , _relevantDirectoyInstruction(false)
     {
     }
 
@@ -280,6 +281,9 @@ public:
 
     QString _directDownloadUrl;
     QString _directDownloadCookies;
+
+    bool _relevantDirectoyInstruction = false;
+    bool _finished = false;
 };
 
 inline bool operator<(const SyncFileItemPtr &item1, const SyncFileItemPtr &item2)
@@ -293,6 +297,12 @@ using SyncFileItemSet = std::set<SyncFileItemPtr>;
 Q_DECLARE_METATYPE(OCC::SyncFileItemSet)
 Q_DECLARE_METATYPE(OCC::SyncFileItem)
 Q_DECLARE_METATYPE(OCC::SyncFileItemPtr)
+
+OWNCLOUDSYNC_EXPORT QDebug operator<<(QDebug debug, const OCC::SyncFileItem *item);
+inline QDebug operator<<(QDebug debug, const OCC::SyncFileItemPtr &item)
+{
+    return debug << item.data();
+}
 
 
 #endif // SYNCFILEITEM_H

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -14,12 +14,14 @@ using namespace OCC;
 bool itemSuccessful(const ItemCompletedSpy &spy, const QString &path, const SyncInstructions instr)
 {
     auto item = spy.findItem(path);
+    Q_ASSERT(item);
     return item->_status == SyncFileItem::Success && item->_instruction == instr;
 }
 
 bool itemConflict(const ItemCompletedSpy &spy, const QString &path)
 {
     auto item = spy.findItem(path);
+    Q_ASSERT(item);
     return item->_status == SyncFileItem::Conflict && item->_instruction == CSYNC_INSTRUCTION_CONFLICT;
 }
 

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -148,16 +148,16 @@ private slots:
         statusSpy.clear();
         fakeFolder.execUntilItemCompleted("D");
         verifyThatPushMatchesPull(fakeFolder, statusSpy);
-        QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusNone));
-        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusNone));
-        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusNone));
+        QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
 
         statusSpy.clear();
         fakeFolder.execUntilFinished();
         verifyThatPushMatchesPull(fakeFolder, statusSpy);
         QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusUpToDate));
-        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
-        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusNone));
+        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusNone));
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
@@ -178,16 +178,16 @@ private slots:
         statusSpy.clear();
         fakeFolder.execUntilItemCompleted("D");
         verifyThatPushMatchesPull(fakeFolder, statusSpy);
-        QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusNone));
-        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusNone));
-        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusNone));
+        QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
 
         statusSpy.clear();
         fakeFolder.execUntilFinished();
         verifyThatPushMatchesPull(fakeFolder, statusSpy);
         QCOMPARE(statusSpy.statusOf(""), SyncFileStatus(SyncFileStatus::StatusUpToDate));
-        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
-        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusUpToDate));
+        QCOMPARE(statusSpy.statusOf("D"), SyncFileStatus(SyncFileStatus::StatusNone));
+        QCOMPARE(statusSpy.statusOf("D/d0"), SyncFileStatus(SyncFileStatus::StatusNone));
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }

--- a/test/testsyncvirtualfiles.cpp
+++ b/test/testsyncvirtualfiles.cpp
@@ -127,7 +127,8 @@ private slots:
         QCOMPARE(QFileInfo(fakeFolder.localPath() + "A/a1" DVSUFFIX).lastModified(), someDate);
         QVERIFY(fakeFolder.currentRemoteState().find("A/a1"));
         QCOMPARE(dbRecord(fakeFolder, "A/a1" DVSUFFIX)._type, ItemTypeVirtualFile);
-        QVERIFY(completeSpy.isEmpty());
+        QVERIFY(completeSpy.findItem("A"));
+        QVERIFY2(completeSpy.size() == 1, "Only the meta data of A was updated");
         cleanup();
 
         // Neither does a remote change


### PR DESCRIPTION
Completed was emitted before the database entry was created in PropagateDirectory::slotSubJobsFinished.