### PR TITLE
 Fix dehydration of read only files

### DIFF
--- a/changelog/unreleased/9093
+++ b/changelog/unreleased/9093
@@ -1,0 +1,6 @@
+Bugfix: Dehydrating placeholders failed if the file is read only
+
+We fixed a bug where dehydrating a read only file failed without any apparent reason.
+
+https://github.com/owncloud/client/issues/9093
+https://gitea.owncloud.services/client/client-plugin-vfs-win/pulls/33

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -199,9 +199,6 @@ bool FileSystem::uncheckedRenameReplace(const QString &originFileName,
 #else //Q_OS_WIN
     // You can not overwrite a read-only file on windows.
 
-    Utility::NtfsPermissionLookupRAII ntfs_perm;
-    // Warning: This function does not manipulate ACLs, which may limit its effectiveness.
-    // this renders this check kind of pointless
     if (!QFileInfo(destinationFileName).isWritable()) {
         setFileReadOnly(destinationFileName, false);
     }
@@ -368,9 +365,6 @@ bool FileSystem::remove(const QString &fileName, QString *errorString)
     // You cannot delete a read-only file on windows, but we want to
     // allow that.
 
-    Utility::NtfsPermissionLookupRAII ntfs_perm;
-    // Warning: This function does not manipulate ACLs, which may limit its effectiveness.
-    // this renders this check kind of pointless
     if (!QFileInfo(fileName).isWritable()) {
         setFileReadOnly(fileName, false);
     }

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -374,6 +374,7 @@ bool FileSystem::remove(const QString &fileName, QString *errorString)
         if (errorString) {
             *errorString = f.errorString();
         }
+        qCWarning(lcFileSystem) << "Failed to delete:" << fileName << "Error:" << f.errorString();
         return false;
     }
     return true;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -958,7 +958,7 @@ void SyncEngine::wipeVirtualFiles(const QString &localPath, SyncJournalDb &journ
         QString localFile = localPath + QString::fromUtf8(rec._path);
         if (QFile::exists(localFile) && vfs.isDehydratedPlaceholder(localFile)) {
             qCDebug(lcEngine) << "Removing local dehydrated placeholder" << rec._path;
-            QFile::remove(localFile);
+            FileSystem::remove(localFile);
         }
     });
 


### PR DESCRIPTION
This enables us to dehydrate read only files.
Side note the read only flag won't be re applied after the dehydration...

Please also review https://gitea.owncloud.services/client/client-plugin-vfs-win/pulls/33

Issue: https://github.com/owncloud/client/issues/9093