### PR TITLE
Allow to remove broken sync folder connections

### DIFF
--- a/changelog/unreleased/9099
+++ b/changelog/unreleased/9099
@@ -1,0 +1,6 @@
+Enhancement: Allow to remove broken sync folders
+
+In case a folder is no longer available it was not possible to remove the folder.
+We now made the remove action available in that case.
+
+https://github.com/owncloud/client/pull/9099

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -240,9 +240,18 @@ void AccountSettings::doExpand()
 
 void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
 {
+    const auto removeFolderAction = [this](QMenu *menu) {
+        return menu->addAction(tr("Remove folder sync connection"), this, &AccountSettings::slotRemoveCurrentFolder);
+    };
     QTreeView *tv = ui->_folderList;
     QModelIndex index = tv->indexAt(pos);
-    if (!index.isValid() || !(index.flags() & Qt::ItemIsEnabled)) {
+    if (!index.isValid()) {
+        return;
+    } else if (!(index.flags() & Qt::ItemIsEnabled)) {
+        QMenu *menu = new QMenu(tv);
+        menu->setAttribute(Qt::WA_DeleteOnClose);
+        removeFolderAction(menu);
+        menu->popup(QCursor::pos());
         return;
     }
 
@@ -270,7 +279,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
         });
 
 
-        menu->popup(tv->mapToGlobal(pos));
+        menu->popup(QCursor::pos());
         return;
     }
 
@@ -312,8 +321,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     ac = menu->addAction(folderPaused ? tr("Resume sync") : tr("Pause sync"));
     connect(ac, &QAction::triggered, this, &AccountSettings::slotEnableCurrentFolder);
 
-    ac = menu->addAction(tr("Remove folder sync connection"));
-    connect(ac, &QAction::triggered, this, &AccountSettings::slotRemoveCurrentFolder);
+    removeFolderAction(menu);
 
     if (folder->virtualFilesEnabled()) {
         auto availabilityMenu = menu->addMenu(tr("Availability"));
@@ -348,7 +356,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     }
 
 
-    menu->popup(tv->mapToGlobal(pos));
+    menu->popup(QCursor::pos());
 }
 
 void AccountSettings::slotFolderListClicked(const QModelIndex &indx)


### PR DESCRIPTION
Allows to remove broken folders without removal of the whole account.
Should go to rc2
![image](https://user-images.githubusercontent.com/200626/135286056-168476e9-b392-4ac4-8b79-d5a4c995ccce.png)
