### PR TITLE
Ci: Better logging in squish test

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -44,6 +44,8 @@ def startClient(context):
         "owncloud -s"
         + " --logfile "
         + context.userData['clientConfigFile']
+        + " --logdebug"
+        + " --logflush"
         + " --confdir "
         + confdir
     )


### PR DESCRIPTION
I also tried to set `os.environ["QT_LOGGING_RULES"] = "sync.httplogger=true"`
But that seemed to have no effect on the test.
See https://doc.owncloud.com/desktop/2.9/appendices/troubleshooting.html for context.