### PR TITLE
[tests-only] Bump middleware commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # To run the GUI tests we use owncloud-test-middleware(https://github.com/owncloud/owncloud-test-middleware)
 # Set the commit id to use the correct version of the middleware
 
-MIDDLEWARE_COMMITID=7adeb56a999a70aa6108cbbcc70dc37071cbc1f9
+MIDDLEWARE_COMMITID=00651e51294a89e464385c903064340e3b700737


### PR DESCRIPTION
This PR bumps middleware commit id for tests (but not to the latest commit id)
