### PR TITLE
Always build with cloudproviders

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -252,7 +252,7 @@ def build_client(ctx, c_compiler, cxx_compiler, build_type, generator, build_com
             "commands": [
                 'mkdir -p "' + build_dir + '"',
                 'cd "' + build_dir + '"',
-                'cmake -G"' + generator + '" -DCMAKE_C_COMPILER="' + c_compiler + '" -DCMAKE_CXX_COMPILER="' + cxx_compiler + '" -DCMAKE_BUILD_TYPE="' + build_type + '" -DBUILD_TESTING=1 ..',
+                'cmake -G"' + generator + '" -DCMAKE_C_COMPILER="' + c_compiler + '" -DCMAKE_CXX_COMPILER="' + cxx_compiler + '" -DCMAKE_BUILD_TYPE="' + build_type + '" -DBUILD_TESTING=1 -DWITH_LIBCLOUDPROVIDERS=ON -S ..',
             ],
         },
         {


### PR DESCRIPTION
Camke will fail if the dependency is missing