### PR TITLE
Fix warnings for using deprecated Qt API

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -434,7 +434,6 @@ int main(int argc, char **argv)
     QString opensslConf = QCoreApplication::applicationDirPath() + QString("/openssl.cnf");
     qputenv("OPENSSL_CONF", opensslConf.toLocal8Bit());
 #endif
-    qsrand(std::random_device()());
     SyncCTX ctx { parseOptions(app.arguments()) };
 
     if (ctx.options.silent) {

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -23,21 +23,20 @@
 #include "version.h"
 
 // Note:  This file must compile without QtGui
+#include <QCollator>
 #include <QCoreApplication>
-#include <QSettings>
-#include <QTextStream>
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
-#include <QUrl>
-#include <QProcess>
 #include <QObject>
-#include <QThread>
-#include <QDateTime>
-#include <QSysInfo>
+#include <QProcess>
+#include <QRandomGenerator>
+#include <QSettings>
 #include <QStandardPaths>
-#include <QCollator>
 #include <QSysInfo>
-
+#include <QTextStream>
+#include <QThread>
+#include <QUrl>
 
 #ifdef Q_OS_UNIX
 #include <sys/statvfs.h>
@@ -45,9 +44,9 @@
 #include <unistd.h>
 #endif
 
+#include <cstring>
 #include <math.h>
 #include <stdarg.h>
-#include <cstring>
 
 namespace OCC {
 
@@ -55,15 +54,16 @@ Q_LOGGING_CATEGORY(lcUtility, "sync.utility")
 
 bool Utility::writeRandomFile(const QString &fname, int size)
 {
-    int maxSize = 10 * 10 * 1024;
-    qsrand(QDateTime::currentMSecsSinceEpoch());
+    auto rg = QRandomGenerator::global();
 
-    if (size == -1)
-        size = qrand() % maxSize;
+    const int maxSize = 10 * 10 * 1024;
+    if (size == -1) {
+        size = static_cast<int>(rg->generate() % maxSize);
+    }
 
     QString randString;
     for (int i = 0; i < size; i++) {
-        int r = qrand() % 128;
+        int r = static_cast<int>(rg->generate() % 128);
         randString.append(QChar(r));
     }
 

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -23,10 +23,11 @@
 #include "settingsdialog.h"
 #include "theme.h"
 
+#include <QFontMetrics>
 #include <QMessageBox>
+#include <QRandomGenerator>
 #include <QSettings>
 #include <QTimer>
-#include <qfontmetrics.h>
 
 namespace OCC {
 
@@ -82,7 +83,7 @@ AccountState::AccountState(AccountPtr account)
     , _state(AccountState::Disconnected)
     , _connectionStatus(ConnectionValidator::Undefined)
     , _waitingForNewCredentials(false)
-    , _maintenanceToConnectedDelay(60000 + (qrand() % (4 * 60000))) // 1-5min delay
+    , _maintenanceToConnectedDelay(60000 + (QRandomGenerator::global()->generate() % (4 * 60000))) // 1-5min delay
 {
     qRegisterMetaType<AccountState *>("AccountState*");
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -220,8 +220,6 @@ Application::Application(int &argc, char **argv)
     , _userTriggeredConnect(false)
     , _debugMode(false)
 {
-    qsrand(std::random_device()());
-
 #ifdef Q_OS_WIN
     // Ensure OpenSSL config file is only loaded from app directory
     const QString opensslConf = QCoreApplication::applicationDirPath() + QString("/openssl.cnf");

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -270,7 +270,7 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
     if (auto job = qobject_cast<AbstractNetworkJob *>(sender())) {
         if (auto reply = job->reply()) {
             _account->setHttp2Supported(
-                reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool());
+                reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool());
         }
     }
     return true;

--- a/src/gui/openfilemanager.cpp
+++ b/src/gui/openfilemanager.cpp
@@ -108,7 +108,7 @@ void showInFileManager(const QString &localPath)
             // only around the path. Use setNativeArguments to bypass this logic.
             p.setNativeArguments(nativeArgs);
 #endif
-            p.start(explorer);
+            p.start(explorer, QStringList());
             p.waitForFinished(5000);
         }
     } else if (Utility::isMac()) {

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -206,8 +206,7 @@ void AbstractNetworkJob::slotFinished()
     const auto maxHttp2Resends = 3;
     QByteArray verb = HttpLogger::requestVerb(*reply());
     if (_reply->error() == QNetworkReply::ContentReSendError
-        && _reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()) {
-
+        && _reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool()) {
         if ((_requestBody && !_requestBody->isSequential()) || verb.isEmpty()) {
             qCWarning(lcNetworkJob) << "Can't resend HTTP2 request, verb or body not suitable"
                                     << _reply->request().url() << verb << _requestBody;
@@ -220,8 +219,8 @@ void AbstractNetworkJob::slotFinished()
 
             resetTimeout();
             if (_requestBody) {
-                if(!_requestBody->isOpen())
-                   _requestBody->open(QIODevice::ReadOnly);
+                if (!_requestBody->isOpen())
+                    _requestBody->open(QIODevice::ReadOnly);
                 _requestBody->seek(0);
             }
             sendRequest(

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -75,7 +75,7 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         // http2 seems to cause issues, as with our recommended server setup we don't support http2, disable it by default for now
         static const bool http2EnabledEnv = qEnvironmentVariableIntValue("OWNCLOUD_HTTP2_ENABLED") == 1;
 
-        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, http2EnabledEnv);
+        newRequest.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2EnabledEnv);
     }
 
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -234,7 +234,8 @@ TusSupport::TusSupport(const QVariantMap &tus_support)
     }
     version = QVersionNumber::fromString(tus_support.value(QStringLiteral("version")).toString());
     resumable = QVersionNumber::fromString(tus_support.value(QStringLiteral("resumable")).toString());
-    extensions = tus_support.value(QStringLiteral("extension")).toString().split(QLatin1Char(','), QString::SkipEmptyParts);
+
+    extensions = tus_support.value(QStringLiteral("extension")).toString().split(QLatin1Char(','), Qt::SkipEmptyParts);
     max_chunk_size = tus_support.value(QStringLiteral("max_chunk_size")).value<quint64>();
     http_method_override = tus_support.value(QStringLiteral("http_method_override")).toString();
 }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -27,9 +27,11 @@
 #include "propagateremotedelete.h"
 #include "common/asserts.h"
 
-#include <QNetworkAccessManager>
-#include <QFileInfo>
 #include <QDir>
+#include <QFileInfo>
+#include <QNetworkAccessManager>
+#include <QRandomGenerator>
+
 #include <cmath>
 #include <cstring>
 #include <memory>
@@ -45,7 +47,7 @@ void PropagateUploadFileV1::doStartUpload()
         _chunkCount = int(std::ceil(_item->_size / double(chunkSize())));
     }
     _startChunk = 0;
-    _transferId = uint(qrand()) ^ uint(_item->_modtime) ^ (uint(_item->_size) << 16);
+    _transferId = uint(QRandomGenerator::global()->generate()) ^ uint(_item->_modtime) ^ (uint(_item->_size) << 16);
 
     const SyncJournalDb::UploadInfo progressInfo = propagator()->_journal->getUploadInfo(_item->_file);
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -643,14 +643,14 @@ void SyncEngine::slotDiscoveryFinished()
 
         // post update phase script: allow to tweak stuff by a custom script in debug mode.
         if (!qEnvironmentVariableIsEmpty("OWNCLOUD_POST_UPDATE_SCRIPT")) {
-    #ifndef NDEBUG
+#ifndef NDEBUG
             const QString script = qEnvironmentVariable("OWNCLOUD_POST_UPDATE_SCRIPT");
 
             qCDebug(lcEngine) << "Post Update Script: " << script;
-            QProcess::execute(script);
-    #else
+            QProcess::execute(script, {});
+#else
             qCWarning(lcEngine) << "**** Attention: POST_UPDATE_SCRIPT installed, but not executed because compiled with NDEBUG";
-    #endif
+#endif
         }
 
         // do a database commit

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -319,7 +319,7 @@ SyncFileStatus SyncFileStatusTracker::resolveSyncAndErrorStatus(const QString &r
 
 void SyncFileStatusTracker::invalidateParentPaths(const QString &path)
 {
-    QStringList splitPath = path.split(QLatin1Char('/'), QString::SkipEmptyParts);
+    QStringList splitPath = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
     for (int i = 0; i < splitPath.size(); ++i) {
         QString parentPath = QStringList(splitPath.mid(0, i)).join(QLatin1Char('/'));
         emit fileStatusChanged(getSystemDestination(parentPath), fileStatus(parentPath));

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -224,7 +224,7 @@ private slots:
             if (op == QNetworkAccessManager::GetOperation && request.url().path().endsWith("A/resendme") && resendActual < resendExpected) {
                 auto errorReply = new FakeErrorReply(op, request, this, 400, "ignore this body");
                 errorReply->setError(QNetworkReply::ContentReSendError, serverMessage);
-                errorReply->setAttribute(QNetworkRequest::HTTP2WasUsedAttribute, true);
+                errorReply->setAttribute(QNetworkRequest::Http2WasUsedAttribute, true);
                 errorReply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, QVariant());
                 resendActual += 1;
                 return errorReply;

--- a/test/testexcludedfiles.cpp
+++ b/test/testexcludedfiles.cpp
@@ -74,7 +74,7 @@ private slots:
             Q_ASSERT(tmp.isValid());
 
             auto createTree = [&](const QString &path) {
-                auto parts = path.split(QLatin1Char('/'), QString::SkipEmptyParts);
+                auto parts = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
                 const auto fileName = parts.back();
                 parts.pop_back(); // remove file name
                 QString workPath = tmp.path() + QLatin1Char('/');

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -104,7 +104,6 @@ class TestFolderWatcher : public QObject
 
 public:
     TestFolderWatcher() {
-        qsrand(QTime::currentTime().msec());
         QDir rootDir(_root.path());
         _rootPath = rootDir.canonicalPath();
         qDebug() << "creating test directory tree in " << _rootPath;

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -54,8 +54,7 @@ private slots:
 
     void testLaunchOnStartup()
     {
-        qsrand(QDateTime::currentDateTime().toTime_t());
-        QString postfix = QString::number(qrand());
+        QString postfix = QString::number(QRandomGenerator::global()->generate());
 
         const QString appName = QString::fromLatin1("testLaunchOnStartup.%1").arg(postfix);
         const QString guiName = "LaunchOnStartup GUI Name";

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -17,7 +17,7 @@ PathComponents::PathComponents(const char *path)
 }
 
 PathComponents::PathComponents(const QString &path)
-    : QStringList { path.split(QLatin1Char('/'), QString::SkipEmptyParts) }
+    : QStringList { path.split(QLatin1Char('/'), Qt::SkipEmptyParts) }
 {
 }
 

--- a/test/testutils/syncenginetestutils.h
+++ b/test/testutils/syncenginetestutils.h
@@ -50,11 +50,11 @@ inline QString getFilePathFromUrl(const QUrl &url)
 
 inline QByteArray generateEtag()
 {
-    return QByteArray::number(QDateTime::currentDateTimeUtc().toMSecsSinceEpoch(), 16) + QByteArray::number(qrand(), 16);
+    return QByteArray::number(QDateTime::currentDateTimeUtc().toMSecsSinceEpoch(), 16) + QByteArray::number(QRandomGenerator::global()->generate(), 16);
 }
 inline QByteArray generateFileId()
 {
-    return QByteArray::number(qrand(), 16);
+    return QByteArray::number(QRandomGenerator::global()->generate(), 16);
 }
 
 class PathComponents : public QStringList


### PR DESCRIPTION
This patch only fixes those warnings that we can still build on top of
Qt 5.12.