### PR TITLE
Fix installation of libcloudproviders files

### DIFF
--- a/src/gui/libcloudproviders/libcloudproviders.cmake
+++ b/src/gui/libcloudproviders/libcloudproviders.cmake
@@ -32,7 +32,7 @@ if(WITH_LIBCLOUDPROVIDERS)
     configure_file(libcloudproviders/cloud-provider.ini.in ${CMAKE_CURRENT_BINARY_DIR}/${APPLICATION_CLOUDPROVIDERS_DBUS_NAME}.ini)
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/${APPLICATION_CLOUDPROVIDERS_DBUS_NAME}.ini
-        DESTINATION "${DATADIR}/cloud-providers")
+        DESTINATION "${DATA_INSTALL_DIR}/cloud-providers")
 
     message("Building with libcloudproviders")
 elseif(UNIX AND NOT APPLE)


### PR DESCRIPTION
This commit fixes the installation of the INI file that belongs to libcloudproviders. I suppose the intention was to use CMake's `GNUInstallDirs` due to the variable name. The variable was unset, thus the file was installed to /cloud-providers instead of share/cloud-providers, causing the RPM builds to complain.

@TheOneRing are you aware of any KF5 macros that could replace `GNUInstallDirs`? We use KF5 elsewhere, too...