### PR TITLE
Fix icon name in desktop file with ownBrander themes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,9 @@ if(BUILD_CLIENT)
     find_package(SQLite3 3.9.0 REQUIRED)
 endif()
 
+# in the ownBrander themes, the icon files are named after the shortname
+# the theme included in this repository defines a custom icon name, therefore we set the shortname as a fallback if the
+# theme does not define the variable
 if (NOT DEFINED APPLICATION_ICON_NAME)
     set(APPLICATION_ICON_NAME "${APPLICATION_SHORTNAME}")
 endif()

--- a/changelog/unreleased/9150
+++ b/changelog/unreleased/9150
@@ -1,0 +1,7 @@
+Bugfix: Fix icon name in desktop file with ownBrander themes
+
+Fixes broken icon reference in desktop entries for some branded build themes.
+
+https://github.com/owncloud/client/issues/8992
+https://github.com/owncloud/client/pull/9150
+

--- a/mirall.desktop.in
+++ b/mirall.desktop.in
@@ -5,7 +5,7 @@ Exec=@APPLICATION_EXECUTABLE@ --showsettings
 Name=@APPLICATION_NAME@ desktop sync client
 Comment=@APPLICATION_NAME@ desktop synchronization client
 GenericName=Folder Sync
-Icon=@APPLICATION_EXECUTABLE@
+Icon=@APPLICATION_ICON_NAME@
 Keywords=@APPLICATION_NAME@;syncing;file;sharing;
 X-GNOME-Autostart-Delay=3
 MimeType=application/vnd.@APPLICATION_EXECUTABLE@;
@@ -210,9 +210,9 @@ Icon[lb]=@APPLICATION_EXECUTABLE@
 [Desktop Action Settings]
 Exec=@APPLICATION_EXECUTABLE@ --showsettings
 Name=Show @APPLICATION_NAME@ settings
-Icon=@APPLICATION_EXECUTABLE@
+Icon=@APPLICATION_ICON_NAME@
 
 [Desktop Action Quit]
 Exec=@APPLICATION_EXECUTABLE@ --quit
 Name=Quit @APPLICATION_NAME@
-Icon=@APPLICATION_EXECUTABLE@
+Icon=@APPLICATION_ICON_NAME@


### PR DESCRIPTION
The icon files in the ownBrander themes are not named by the executable name, but by the short name. The theme included in this repository defines a custom icon name.

Related: https://github.com/owncloud/client/issues/8992 (might even be closed)