### PR TITLE
macOS: Fix warnings in socketapisocket_mac.mm

### DIFF
--- a/src/gui/socketapi/socketapisocket_mac.h
+++ b/src/gui/socketapi/socketapisocket_mac.h
@@ -26,7 +26,7 @@ class SocketApiSocket : public QIODevice
     Q_OBJECT
 public:
     SocketApiSocket(QObject *parent, SocketApiSocketPrivate *p);
-    ~SocketApiSocket();
+    ~SocketApiSocket() override;
 
     qint64 readData(char *data, qint64 maxlen) override;
     qint64 writeData(const char *data, qint64 len) override;
@@ -50,7 +50,7 @@ class SocketApiServer : public QObject
     Q_OBJECT
 public:
     SocketApiServer();
-    ~SocketApiServer();
+    ~SocketApiServer() override;
 
     void close();
     bool listen(const QString &name);


### PR DESCRIPTION
This includes bounds checks on integers, because there are a lot of
32<->64 bit and signed<->unsigned conversions happening.