### PR TITLE
Fix gcc format string error

### DIFF
--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -199,7 +199,7 @@ private slots:
 
         const auto add = [](const QString &child, const QString &parent, bool result, bool casePreserving = true) {
             const auto title = QStringLiteral("CasePreserving %1: %2 is %3 child of %4").arg(casePreserving ? QStringLiteral("yes") : QStringLiteral("no"), child, result ? QString() : QStringLiteral("not"), parent);
-            QTest::addRow(qUtf8Printable(title)) << child << parent << result << casePreserving;
+            QTest::addRow("%s", qUtf8Printable(title)) << child << parent << result << casePreserving;
         };
         add(QStringLiteral("/A/a"), QStringLiteral("/A"), true);
         add(QStringLiteral("/A/a"), QStringLiteral("/A/a"), true);


### PR DESCRIPTION
Use non-literal format string will make recent gcc fail to compile. This
commit address the issue to make gcc happy.