### PR TITLE
Remove version defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,6 @@ if(BUILD_TESTING)
 endif()
 
 configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
-configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -1,6 +1,7 @@
 # Just list files to build as part of the csync dynamic lib.
 # Essentially they could be in the same directory but are separate to
 # help keep track of the different code licenses.
+configure_file(${CMAKE_CURRENT_LIST_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY)
 set(common_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/checksums.cpp
     ${CMAKE_CURRENT_LIST_DIR}/filesystembase.cpp
@@ -14,7 +15,10 @@ set(common_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/pinstate.cpp
     ${CMAKE_CURRENT_LIST_DIR}/plugin.cpp
     ${CMAKE_CURRENT_LIST_DIR}/syncfilestatus.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
 )
+
+
 
 if(WIN32)
     list(APPEND common_SOURCES

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -26,12 +26,13 @@
 #include <sqlite3.h>
 #include <cstring>
 
-#include "common/syncjournaldb.h"
-#include "version.h"
-#include "filesystembase.h"
 #include "common/asserts.h"
 #include "common/checksums.h"
 #include "common/preparedsqlquerymanager.h"
+#include "common/syncjournaldb.h"
+#include "common/version.h"
+#include "filesystembase.h"
+#include "version.h"
 
 #include "common/c_jhash.h"
 
@@ -515,10 +516,10 @@ bool SyncJournalDb::checkConnect()
         forceRemoteDiscovery = true;
 
         createQuery.prepare("INSERT INTO version VALUES (?1, ?2, ?3, ?4);");
-        createQuery.bindValue(1, MIRALL_VERSION_MAJOR);
-        createQuery.bindValue(2, MIRALL_VERSION_MINOR);
-        createQuery.bindValue(3, MIRALL_VERSION_PATCH);
-        createQuery.bindValue(4, MIRALL_VERSION_BUILD);
+        createQuery.bindValue(1, OCC::Version::major());
+        createQuery.bindValue(2, OCC::Version::minor());
+        createQuery.bindValue(3, OCC::Version::patch());
+        createQuery.bindValue(4, OCC::Version::buildNumber());
         if (!createQuery.exec()) {
             return sqlFail(QStringLiteral("Update version"), createQuery);
         }
@@ -543,13 +544,13 @@ bool SyncJournalDb::checkConnect()
         }
 
         // Not comparing the BUILD id here, correct?
-        if (!(major == MIRALL_VERSION_MAJOR && minor == MIRALL_VERSION_MINOR && patch == MIRALL_VERSION_PATCH)) {
+        if (!(major == OCC::Version::major() && minor == OCC::Version::minor() && patch == OCC::Version::patch())) {
             createQuery.prepare("UPDATE version SET major=?1, minor=?2, patch =?3, custom=?4 "
                                 "WHERE major=?5 AND minor=?6 AND patch=?7;");
-            createQuery.bindValue(1, MIRALL_VERSION_MAJOR);
-            createQuery.bindValue(2, MIRALL_VERSION_MINOR);
-            createQuery.bindValue(3, MIRALL_VERSION_PATCH);
-            createQuery.bindValue(4, MIRALL_VERSION_BUILD);
+            createQuery.bindValue(1, OCC::Version::major());
+            createQuery.bindValue(2, OCC::Version::minor());
+            createQuery.bindValue(3, OCC::Version::patch());
+            createQuery.bindValue(4, OCC::Version::buildNumber());
             createQuery.bindValue(5, major);
             createQuery.bindValue(6, minor);
             createQuery.bindValue(7, patch);

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -140,7 +140,7 @@ QByteArray Utility::userAgentString()
 {
     return QStringLiteral("Mozilla/5.0 (%1) mirall/%2 (%3, %4-%5 ClientArchitecture: %6 OsArchitecture: %7)")
         .arg(platform(),
-            QStringLiteral(MIRALL_VERSION_STRING),
+            OCC::Version::string(),
             // accessing the theme to fetch the string is rather difficult
             // since this is only needed server-side to identify clients, the app name (as of 2.9, the short name) is good enough
             qApp->applicationName(),

--- a/src/common/version.cpp.in
+++ b/src/common/version.cpp.in
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "common/version.h"
+
+QString OCC::Version::string()
+{
+    return QStringLiteral("@MIRALL_VERSION_STRING@");
+}
+
+int OCC::Version::major()
+{
+    return @MIRALL_VERSION_MAJOR@;
+}
+
+int OCC::Version::minor()
+{
+    return @MIRALL_VERSION_MINOR@;
+}
+
+int OCC::Version::patch()
+{
+    return @MIRALL_VERSION_PATCH@;
+}
+
+int OCC::Version::buildNumber()
+{
+    return @MIRALL_VERSION_BUILD@;
+}
+
+QString OCC::Version::gitSha()
+{
+    return QStringLiteral("@GIT_SHA1@");
+}
+
+QString OCC::Version::suffix()
+{
+    return QStringLiteral("@MIRALL_VERSION_SUFFIX@");
+}
+
+
+

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -15,28 +15,32 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#pragma once
 
-#ifndef VERSION_H
-#define VERSION_H
+#include "ocsynclib.h"
 
 #include <QString>
-// TODO: use namespace and functions
-#cmakedefine GIT_SHA1 "@GIT_SHA1@"
 
-/* MIRALL version */
-#define MIRALL_VERSION_MAJOR @MIRALL_VERSION_MAJOR@
-#define MIRALL_VERSION_MINOR @MIRALL_VERSION_MINOR@
-#define MIRALL_VERSION_PATCH @MIRALL_VERSION_PATCH@
-#define MIRALL_VERSION_BUILD @MIRALL_VERSION_BUILD@
+namespace OCC {
+namespace Version {
+    /**
+  * "Major.Minor.Patch"
+  */
+    QString OCSYNC_EXPORT string();
+    int OCSYNC_EXPORT major();
+    int OCSYNC_EXPORT minor();
+    int OCSYNC_EXPORT patch();
+    int OCSYNC_EXPORT buildNumber();
 
-inline auto MIRALL_VERSION_SUFFIX() {
-    return QStringLiteral("@MIRALL_VERSION_SUFFIX@");
+    /**
+ * git, rc1, rc2
+ * Empty in releases
+ */
+    QString OCSYNC_EXPORT suffix();
+    /**
+ * The commit id
+ */
+    QString OCSYNC_EXPORT gitSha();
 }
 
-inline auto MIRALL_VERSION_FULL() {
-    return QStringLiteral("@MIRALL_VERSION_FULL@");
 }
-
-#define MIRALL_VERSION_STRING "@MIRALL_VERSION_STRING@"
-
-#endif // VERSION_H

--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -182,7 +182,7 @@ bool OCC::isVfsPluginAvailable(Vfs::Mode mode)
         qCWarning(lcPlugin) << "Plugin has wrong type" << loader.fileName() << metadata[QStringLiteral("type")];
         return false;
     }
-    if (metadata[QStringLiteral("version")].toString() != QStringLiteral(MIRALL_VERSION_STRING)) {
+    if (metadata[QStringLiteral("version")].toString() != OCC::Version::string()) {
         qCWarning(lcPlugin) << "Plugin has wrong version" << loader.fileName() << metadata[QStringLiteral("version")];
         return false;
     }

--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -30,9 +30,9 @@
 
 #include "csync_exclude.h"
 
-#include "../version.h"
 #include "common/filesystembase.h"
 #include "common/utility.h"
+#include "common/version.h"
 
 #include <QString>
 #include <QFileInfo>
@@ -238,7 +238,7 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(const QStringRef &path, bool ex
 using namespace OCC;
 
 ExcludedFiles::ExcludedFiles()
-    : _clientVersion(MIRALL_VERSION_MAJOR, MIRALL_VERSION_MINOR, MIRALL_VERSION_PATCH)
+    : _clientVersion(OCC::Version::major(), OCC::Version::minor(), OCC::Version::patch())
 {
     // Windows used to use PathMatchSpec which allows *foo to match abc/deffoo.
     _wildcardsMatchSlash = Utility::isWindows();

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -19,30 +19,30 @@
 #include <iostream>
 #include <random>
 
-#include "config.h"
-#include "common/asserts.h"
 #include "account.h"
+#include "accountmanager.h"
 #include "accountstate.h"
+#include "clientproxy.h"
+#include "common/asserts.h"
+#include "common/version.h"
+#include "common/vfs.h"
+#include "config.h"
+#include "configfile.h"
 #include "connectionvalidator.h"
+#include "creds/abstractcredentials.h"
+#include "csync_exclude.h"
 #include "folder.h"
 #include "folderman.h"
-#include "logger.h"
 #include "logbrowser.h"
-#include "configfile.h"
+#include "logger.h"
+#include "owncloudsetupwizard.h"
+#include "settingsdialog.h"
+#include "sharedialog.h"
 #include "socketapi/socketapi.h"
 #include "sslerrordialog.h"
 #include "theme.h"
-#include "clientproxy.h"
-#include "sharedialog.h"
-#include "accountmanager.h"
-#include "creds/abstractcredentials.h"
-#include "updater/ocupdater.h"
-#include "owncloudsetupwizard.h"
-#include "version.h"
-#include "csync_exclude.h"
-#include "common/vfs.h"
-#include "settingsdialog.h"
 #include "translations.h"
+#include "updater/ocupdater.h"
 
 #include "config.h"
 
@@ -150,7 +150,7 @@ bool Application::configVersionMigration()
 
     // Did the client version change?
     // (The client version is adjusted further down)
-    bool versionChanged = configFile.clientVersionString() != MIRALL_VERSION_STRING;
+    bool versionChanged = configFile.clientVersionString() != OCC::Version::string();
 
     // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
@@ -196,7 +196,7 @@ bool Application::configVersionMigration()
             settings->remove(badKey);
     }
 
-    configFile.setClientVersionString(MIRALL_VERSION_STRING);
+    configFile.setClientVersionString(OCC::Version::string());
     return true;
 }
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -15,13 +15,12 @@
 #include "generalsettings.h"
 #include "ui_generalsettings.h"
 
-#include "theme.h"
-#include "version.h"
-#include "configfile.h"
+#include "accountmanager.h"
 #include "application.h"
+#include "common/version.h"
 #include "configfile.h"
 #include "owncloudsetupwizard.h"
-#include "accountmanager.h"
+#include "theme.h"
 
 #include "updater/updater.h"
 #include "updater/ocupdater.h"

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -19,24 +19,23 @@
 
 #include "socketapi/socketuploadjob.h"
 
-#include "config.h"
-#include "configfile.h"
-#include "folderman.h"
-#include "folder.h"
-#include "theme.h"
-#include "common/syncjournalfilerecord.h"
-#include "syncengine.h"
-#include "syncfileitem.h"
-#include "filesystem.h"
-#include "version.h"
-#include "account.h"
-#include "accountstate.h"
 #include "account.h"
 #include "accountmanager.h"
+#include "accountstate.h"
 #include "capabilities.h"
 #include "common/asserts.h"
+#include "common/syncjournalfilerecord.h"
+#include "common/version.h"
+#include "config.h"
+#include "configfile.h"
+#include "filesystem.h"
+#include "folder.h"
+#include "folderman.h"
 #include "guiutility.h"
 #include "sharemanager.h"
+#include "syncengine.h"
+#include "syncfileitem.h"
+#include "theme.h"
 
 #include <array>
 #include <QBitArray>
@@ -576,7 +575,7 @@ void SocketApi::command_MANAGE_PUBLIC_LINKS(const QString &localFile, SocketList
 
 void SocketApi::command_VERSION(const QString &, SocketListener *listener)
 {
-    listener->sendMessage(QLatin1String("VERSION:" MIRALL_VERSION_STRING ":" MIRALL_SOCKET_API_VERSION));
+    listener->sendMessage(QStringLiteral("VERSION:%1:%2").arg(OCC::Version::string(), QStringLiteral(MIRALL_SOCKET_API_VERSION)));
 }
 
 void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listener)

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -20,10 +20,10 @@
 #include "updater/sparkleupdater.h"
 #include "updater/ocupdater.h"
 
-#include "theme.h"
 #include "common/utility.h"
-#include "version.h"
+#include "common/version.h"
 #include "configfile.h"
+#include "theme.h"
 
 #include "config.h"
 
@@ -91,7 +91,7 @@ QUrlQuery Updater::getQueryParams()
     query.addQueryItem(QStringLiteral("buildArch"), QSysInfo::buildCpuArchitecture());
     query.addQueryItem(QStringLiteral("currentArch"), QSysInfo::currentCpuArchitecture());
 
-    query.addQueryItem(QStringLiteral("versionsuffix"), MIRALL_VERSION_SUFFIX());
+    query.addQueryItem(QStringLiteral("versionsuffix"), OCC::Version::suffix());
 
     auto channel = ConfigFile().updateChannel();
     if (channel != QLatin1String("stable")) {
@@ -148,8 +148,8 @@ qint64 Updater::Helper::versionToInt(qint64 major, qint64 minor, qint64 patch, q
 
 qint64 Updater::Helper::currentVersionToInt()
 {
-    return versionToInt(MIRALL_VERSION_MAJOR, MIRALL_VERSION_MINOR,
-        MIRALL_VERSION_PATCH, MIRALL_VERSION_BUILD);
+    return versionToInt(OCC::Version::major(), OCC::Version::minor(),
+        OCC::Version::patch(), OCC::Version::buildNumber());
 }
 
 qint64 Updater::Helper::stringVersionToInt(const QString &version)
@@ -164,7 +164,7 @@ qint64 Updater::Helper::stringVersionToInt(const QString &version)
 
 QString Updater::clientVersion()
 {
-    return MIRALL_VERSION_FULL();
+    return QStringLiteral("%1.%2.%3.%4").arg(QString::number(Version::major()), QString::number(Version::minor()), QString::number(Version::patch()), QString::number(Version::buildNumber()));
 }
 
 } // namespace OCC

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -14,12 +14,12 @@
 
 #include "config.h"
 
-#include "common/utility.h"
 #include "common/asserts.h"
+#include "common/utility.h"
+#include "common/version.h"
 #include "configfile.h"
 #include "logger.h"
 #include "theme.h"
-#include "version.h"
 
 #include "creds/abstractcredentials.h"
 
@@ -539,7 +539,7 @@ void ConfigFile::setSkipUpdateCheck(bool skip, const QString &connection)
 QString ConfigFile::updateChannel() const
 {
     QString defaultUpdateChannel = QStringLiteral("stable");
-    const QString suffix = MIRALL_VERSION_SUFFIX();
+    const QString suffix = OCC::Version::suffix();
     if (suffix.startsWith(QLatin1String("daily"))
         || suffix.startsWith(QLatin1String("nightly"))
         || suffix.startsWith(QLatin1String("alpha"))

--- a/src/libsync/owncloudtheme.cpp
+++ b/src/libsync/owncloudtheme.cpp
@@ -22,9 +22,9 @@
 #endif
 #include <QCoreApplication>
 
-#include "config.h"
 #include "common/utility.h"
-#include "version.h"
+#include "common/version.h"
+#include "config.h"
 
 namespace OCC {
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -13,12 +13,12 @@
  */
 
 #include "theme.h"
-#include "config.h"
 #include "common/depreaction.h"
 #include "common/utility.h"
-#include "version.h"
-#include "configfile.h"
+#include "common/version.h"
 #include "common/vfs.h"
+#include "config.h"
+#include "configfile.h"
 
 #include <QtCore>
 #ifndef TOKEN_AUTH_ONLY
@@ -143,7 +143,7 @@ QString Theme::appName() const
 
 QString Theme::version() const
 {
-    return QStringLiteral(MIRALL_VERSION_STRING);
+    return OCC::Version::string();
 }
 
 QString Theme::configFileName() const
@@ -301,7 +301,7 @@ QString Theme::defaultServerFolder() const
 
 QString Theme::helpUrl() const
 {
-    return QStringLiteral("https://doc.owncloud.org/desktop/%1.%2/").arg(MIRALL_VERSION_MAJOR).arg(MIRALL_VERSION_MINOR);
+    return QStringLiteral("https://doc.owncloud.org/desktop/%1.%2/").arg(OCC::Version::major()).arg(OCC::Version::minor());
 }
 
 QString Theme::conflictHelpUrl() const


### PR DESCRIPTION
Moving the generated values to a cpp means that we won't need to recompile
all files including the version.h