### PR TITLE
[tests-only] add tests for public share

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # To run the GUI tests we use owncloud-test-middleware(https://github.com/owncloud/owncloud-test-middleware)
 # Set the commit id to use the correct version of the middleware
 
-MIDDLEWARE_COMMITID=baf3e5c6308fac641c120e53add2e5ce87a32743
+MIDDLEWARE_COMMITID=078c01157006d4fc1bb7a4d466b6a93af9a47d1b

--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -112,3 +112,6 @@ choose_What_to_Sync_OCC_SelectiveSyncDialog = {"type": "OCC::SelectiveSyncDialog
 choose_What_to_Sync_Deselect_remote_folders_you_do_not_wish_to_synchronize_QLabel = {"text": "Deselect remote folders you do not wish to synchronize.", "type": "QLabel", "unnamed": 1, "visible": 1, "window": choose_What_to_Sync_OCC_SelectiveSyncDialog}
 choose_What_To_Synchronize_QTreeWidget = {"aboveWidget": choose_What_to_Sync_Deselect_remote_folders_you_do_not_wish_to_synchronize_QLabel, "type": "QTreeWidget", "unnamed": 1, "visible": 1, "window": choose_What_to_Sync_OCC_SelectiveSyncDialog}
 deselect_remote_folders_you_do_not_wish_to_synchronize_QHeaderView = {"container": choose_What_To_Synchronize_QTreeWidget, "orientation": 1, "type": "QHeaderView", "unnamed": 1, "visible": 1}
+linkShares_QToolButton_2 = {"container": oCC_ShareLinkWidget_linkShares_QTableWidget, "occurrence": 2, "type": "QToolButton", "unnamed": 1, "visible": 1}
+oCC_ShareLinkWidget_Delete_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "text": "Delete", "type": "QPushButton", "unnamed": 1, "visible": 1}
+oCC_ShareLinkWidget_pushButton_setPassword_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "pushButton_setPassword", "type": "QPushButton", "visible": 1}

--- a/test/gui/shared/scripts/pageObjects/PublicLinkDialog.py
+++ b/test/gui/shared/scripts/pageObjects/PublicLinkDialog.py
@@ -172,3 +172,25 @@ class PublicLinkDialog:
                 == "Public link"
             )
         )
+
+    def changePassword(self, publicLinkName, password):
+        test.compare(
+            str(squish.waitForObjectExists(self.PUBLIC_LINK_NAME).text),
+            publicLinkName,
+        )
+        squish.mouseClick(
+            squish.waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit),
+            0,
+            0,
+            squish.Qt.NoModifier,
+            squish.Qt.LeftButton,
+        )
+        squish.type(
+            squish.waitForObject(names.oCC_ShareLinkWidget_lineEdit_password_QLineEdit),
+            password,
+        )
+        squish.clickButton(
+            squish.waitForObject(
+                names.oCC_ShareLinkWidget_pushButton_setPassword_QPushButton
+            )
+        )

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1082,3 +1082,25 @@ def step(context):
         test.compare(actualFolder, expectedFolder)
 
         rowIndex += 1
+
+
+@When('the user deletes the public link for file "|any|"')
+def step(context, resource):
+    openSharingDialog(context, resource)
+    publicLinkDialog = PublicLinkDialog()
+    publicLinkDialog.openPublicLinkDialog()
+
+    test.compare(
+        str(waitForObjectExists(publicLinkDialog.ITEM_TO_SHARE).text),
+        resource.replace(context.userData['currentUserSyncPath'], ''),
+    )
+    clickButton(waitForObject(names.linkShares_QToolButton_2))
+    clickButton(waitForObject(names.oCC_ShareLinkWidget_Delete_QPushButton))
+
+
+@When(
+    'the user changes the password of public link "|any|" to "|any|" using the client-UI'
+)
+def step(context, publicLinkName, password):
+    publicLinkDialog = PublicLinkDialog()
+    publicLinkDialog.changePassword(publicLinkName, password)

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -131,12 +131,39 @@ Feature: Sharing
         And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" on the server
 
 
-    Scenario: simple sharing of a file by public link with password
+    Scenario: sharing of a file by public link and deleting the link
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has set up a client with default settings
+        And user "Alice" has created a public link on the server with following settings
+            | path     | textfile0.txt |
+            | name     | Public-link   |
+        When the user deletes the public link for file "textfile0.txt"
+        Then as user "Alice" the file "/textfile0.txt" should not have any public link on the server
+
+
+    Scenario Outline: simple sharing of a file by public link with password
         Given user "Alice" has set up a client with default settings
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        When the user creates a new public link for file "textfile0.txt" with password "pass123" using the client-UI
+        When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link on the server
-        And the public should be able to download the file "textfile0.txt" with password "pass123" from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" on the server
+        Examples:
+            | password |
+            | p@$s!23  |
+
+
+    Scenario: sharing of a file by public link with password and changing the password
+        Given user "Alice" has set up a client with default settings
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has created a public link on the server with following settings
+            | path     | textfile0.txt |
+            | name     | Public-link   |
+            | password | 1234          |
+        When the user opens the public links dialog of "textfile0.txt" using the client-UI
+        And the user changes the password of public link "Public-link" to "password1234" using the client-UI
+        Then as user "Alice" the file "textfile0.txt" should have a public link on the server
+        And the public should be able to download the file "textfile0.txt" with password "password1234" from the last created public link by "Alice" on the server
+
 
     @issue-8733
     Scenario: user changes the expiration date of an already existing public link using webUI

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -148,8 +148,9 @@ Feature: Sharing
         Then as user "Alice" the file "textfile0.txt" should have a public link on the server
         And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" on the server
         Examples:
-            | password |
-            | p@$s!23  |
+            | password   |
+            |password1234|
+            | p@$s!23    |
 
 
     Scenario: sharing of a file by public link with password and changing the password


### PR DESCRIPTION
### Description
add tests for public link 
- Public link to a file and set a password with special characters
- Public link to a file and disable it after | use the sharing menu to delete the public link
- Public link to a file and set a password. Modify Password Policies and retry

### Related Issue
https://github.com/owncloud/client/issues/8971#issuecomment-909885070