### PR TITLE
Ensure we only update the clients url after the sync was stopped

### DIFF
--- a/changelog/unreleased/9202
+++ b/changelog/unreleased/9202
@@ -1,0 +1,6 @@
+Bugfix: The client no longer idles after a minor url change
+
+When the client detects a change of the url we ask the user to accept
+the change or if it was only representational change (demo.com vs demo.com/) we directly accept the change.
+Due to a bug the we aborted the sync only after we updated the url.
+This caused the client to idle for one minute.

--- a/changelog/unreleased/9202
+++ b/changelog/unreleased/9202
@@ -4,3 +4,5 @@ When the client detects a change of the url we ask the user to accept
 the change or if it was only representational change (demo.com vs demo.com/) we directly accept the change.
 Due to a bug the we aborted the sync only after we updated the url.
 This caused the client to idle for one minute.
+
+https://github.com/owncloud/client/pull/9202

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -100,6 +100,12 @@ AccountState::AccountState(AccountPtr account)
     connect(this, &AccountState::urlUpdated, this, [this] {
         checkConnectivity(false);
     });
+    connect(account.data(), &Account::requestUrlUpdate, this, &AccountState::updateUrlDialog, Qt::QueuedConnection);
+    connect(
+        this, &AccountState::urlUpdated, this, [this] {
+            checkConnectivity(false);
+        },
+        Qt::QueuedConnection);
 }
 
 AccountState::~AccountState()


### PR DESCRIPTION
When the client detects a change of the url we ask the user to accept
the change or if it was only representational change we directly accept the change.
Due to a bug the we aborted the sync only after we updated the url.
This caused the client to idle for one minute.