### PR TITLE
[gui-tests-only] Fix intermittent test fails

### DIFF
--- a/test/gui/shared/scripts/pageObjects/SharingDialog.py
+++ b/test/gui/shared/scripts/pageObjects/SharingDialog.py
@@ -5,6 +5,12 @@ import test
 
 class SharingDialog:
 
+    ITEM_TO_SHARE = {
+        "name": "label_name",
+        "type": "QLabel",
+        "visible": 1,
+        "window": names.sharingDialog_OCC_ShareDialog,
+    }
     SHARE_WITH_COLLABORATOR_INPUT_FIELD = {
         "container": names.qt_tabwidget_stackedwidget_SharingDialogUG_OCC_ShareUserGroupWidget,
         "name": "shareeLineEdit",
@@ -118,3 +124,9 @@ class SharingDialog:
             squish.clickButton(
                 squish.waitForObject(names.scrollArea_permissionsEdit_QCheckBox)
             )
+
+    def verifyResource(self, resource):
+        test.compare(
+            str(squish.waitForObjectExists(self.ITEM_TO_SHARE).text),
+            resource,
+        )

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -826,6 +826,7 @@ def step(context, permissions, user, resource):
     permissionsList = permissions.split(',')
 
     shareItem = SharingDialog()
+    shareItem.verifyResource(resource)
     editChecked, shareChecked = shareItem.getAvailablePermission()
 
     if 'edit' in permissionsList:

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -679,13 +679,6 @@ def step(context, resource):
         createPublicShareWithRole(context, resource, role)
 
 
-@When(
-    'the user creates a new public link for folder "|any|" with "|any|" using the client-UI'
-)
-def step(context, resource, role):
-    createPublicShareWithRole(context, resource, role)
-
-
 @When('the user logs out of the client-UI')
 def step(context):
     accountStatus = AccountStatus()

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -207,7 +207,7 @@ Feature: Sharing
         Given user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created file "simple-folder/lorem.txt" on the server
         And user "Alice" has set up a client with default settings
-        When the user creates a new public link for folder "%client_sync_path_user1%/simple-folder" using the client-UI with these details:
+        When the user creates a new public link for folder "simple-folder" using the client-UI with these details:
             | role | Contributor |
         Then user "Alice" on the server should have a share with these details:
             | field       | value          |
@@ -220,17 +220,19 @@ Feature: Sharing
 
 
     Scenario Outline: change collaborator permissions of a file & folder
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given the setting "shareapi_auto_accept_share" on the server of app "core" has been set to "yes"
+        And the administrator on the server has set the default folder for received shares to "Shares"
+        And user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created file "lorem.txt" on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "lorem.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user removes permissions "<permissions>" for user "Brian Murphy" of resource "simple-folder" using the client-UI
-        And the user closes the sharing dialog
-        And the user removes permissions "<permissions>" for user "Brian Murphy" of resource "lorem.txt" using the client-UI
         Then "<permissions>" permissions should not be displayed for user "Brian Murphy" for resource "simple-folder" on the client-UI
-        And "<permissions>" permissions should not be displayed for user "Brian Murphy" for resource "lorem.txt" on the client-UI
+        When the user closes the sharing dialog
+        And the user removes permissions "<permissions>" for user "Brian Murphy" of resource "lorem.txt" using the client-UI
+        Then "<permissions>" permissions should not be displayed for user "Brian Murphy" for resource "lorem.txt" on the client-UI
         And user "Alice" on the server should have a share with these details:
             | field       | value                        |
             | uid_owner   | Alice                        |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -207,7 +207,8 @@ Feature: Sharing
         Given user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created file "simple-folder/lorem.txt" on the server
         And user "Alice" has set up a client with default settings
-        When the user creates a new public link for folder "simple-folder" with "Contributor" using the client-UI
+        When the user creates a new public link for folder "%client_sync_path_user1%/simple-folder" using the client-UI with these details:
+            | role | Contributor |
         Then user "Alice" on the server should have a share with these details:
             | field       | value          |
             | share_type  | public_link    |


### PR DESCRIPTION
Gui test scenario: `change collaborator permissions of a file & folder` was failing intermittently because the expected share field `file_target` was different for some unknown reason.
Expected `file_target: '/Shares/simple-folder'` but sometime it was `file_target: '/simple-folder'`
I have added some fixes for that and I am not getting any previous errors now.

For other failing tests, I didn't find anything. I suspect these fails are caused by the above test fail.
Fixes #9206 