### PR TITLE
macOS: change SOCKETAPI_TEAM_IDENTIFIER_PREFIX concatenation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ option(BUILD_GUI "BUILD_GUI" ON)
 set(VIRTUAL_FILE_SYSTEM_PLUGINS suffix win CACHE STRING "Name of internal plugin in src/libsync/vfs or the locations of virtual file plugins")
 
 if(APPLE)
-  set( SOCKETAPI_TEAM_IDENTIFIER_PREFIX "" CACHE STRING "SocketApi prefix (including a following dot) that must match the codesign key's TeamIdentifier/Organizational Unit" )
+  set( SOCKETAPI_TEAM_IDENTIFIER_PREFIX "" CACHE STRING "SocketApi prefix (without a following dot) that must match the codesign key's TeamIdentifier/Organizational Unit" )
 endif()
 
 if(BUILD_CLIENT)

--- a/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/FinderSyncExt.entitlements
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/FinderSyncExt.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>$(OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX)$(OC_APPLICATION_REV_DOMAIN)</string>
+		<string>$(OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX).$(OC_APPLICATION_REV_DOMAIN)</string>
 	</array>
 </dict>
 </plist>

--- a/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/Info.plist
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SocketApiPrefix</key>
-	<string>$(OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX)$(OC_APPLICATION_REV_DOMAIN)</string>
+	<string>$(OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX).$(OC_APPLICATION_REV_DOMAIN)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/src/gui/guiutility_mac.mm
+++ b/src/gui/guiutility_mac.mm
@@ -56,7 +56,7 @@ QString Utility::socketApiSocketPath()
     // This must match the code signing Team setting of the extension
     // Example for developer builds (with ad-hoc signing identity): "" "com.owncloud.desktopclient" ".socketApi"
     // Example for official signed packages: "9B5WD74GWJ." "com.owncloud.desktopclient" ".socketApi"
-    return QLatin1String(SOCKETAPI_TEAM_IDENTIFIER_PREFIX APPLICATION_REV_DOMAIN ".socketApi");
+    return QLatin1String(SOCKETAPI_TEAM_IDENTIFIER_PREFIX "." APPLICATION_REV_DOMAIN ".socketApi");
 }
 
 } // namespace OCC


### PR DESCRIPTION
Previously, the socket api prefix was created by concatenating
SOCKETAPI_TEAM_IDENTIFIER_PREFIX and OC_APPLICATION_REV_DOMAIN together,
so the first variable had to end in a "." to get the correct result.
This change moves adding that period from configuration to the places
where the concatenation happens.