### PR TITLE
Fix values in sync item

### DIFF
--- a/changelog/unreleased/7348
+++ b/changelog/unreleased/7348
@@ -1,0 +1,6 @@
+Fix: Add request time and other missing data to .owncloudsync.log
+
+Some parameters were missing for some operations. This fix makes the 
+log more complete and more useful as a result.
+
+https://github.com/owncloud/client/issues/7348

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -222,14 +222,12 @@ void PropagateUploadFileNG::slotPropfindFinished()
 void PropagateUploadFileNG::slotPropfindFinishedWithError()
 {
     auto job = qobject_cast<LsColJob *>(sender());
-    auto httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    _item->_httpErrorCode = httpErrorCode;
+    auto httpErrorCode = _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     _item->_responseTimeStamp = job->responseTimestamp();
     _item->_requestId = job->requestId();
     slotJobDestroyed(job); // remove it from the _jobs list
 
     QNetworkReply::NetworkError err = job->reply()->error();
-    job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     auto status = classifyError(err, httpErrorCode, &propagator()->_anotherSyncNeeded);
     if (status == SyncFileItem::FatalError) {
         propagator()->_activeJobList.removeOne(this);

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -222,12 +222,16 @@ void PropagateUploadFileNG::slotPropfindFinished()
 void PropagateUploadFileNG::slotPropfindFinishedWithError()
 {
     auto job = qobject_cast<LsColJob *>(sender());
-    slotJobDestroyed(job); // remove it from the _jobs list
-    QNetworkReply::NetworkError err = job->reply()->error();
     auto httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    _item->_httpErrorCode = httpErrorCode;
+    _item->_responseTimeStamp = job->responseTimestamp();
+    _item->_requestId = job->requestId();
+    slotJobDestroyed(job); // remove it from the _jobs list
+
+    QNetworkReply::NetworkError err = job->reply()->error();
+    job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     auto status = classifyError(err, httpErrorCode, &propagator()->_anotherSyncNeeded);
     if (status == SyncFileItem::FatalError) {
-        _item->_requestId = job->requestId();
         propagator()->_activeJobList.removeOne(this);
         abortWithError(status, job->errorStringParsingBody());
         return;
@@ -239,14 +243,16 @@ void PropagateUploadFileNG::slotDeleteJobFinished()
 {
     auto job = qobject_cast<DeleteJob *>(sender());
     OC_ASSERT(job);
-    _jobs.remove(_jobs.indexOf(job));
+    _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    _item->_responseTimeStamp = job->responseTimestamp();
+    _item->_requestId = job->requestId();
+    slotJobDestroyed(job);
 
     QNetworkReply::NetworkError err = job->reply()->error();
     if (err != QNetworkReply::NoError && err != QNetworkReply::ContentNotFoundError) {
         const int httpStatus = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         SyncFileItem::Status status = classifyError(err, httpStatus);
         if (status == SyncFileItem::FatalError) {
-            _item->_requestId = job->requestId();
             abortWithError(status, job->errorString());
             return;
         } else {
@@ -305,10 +311,12 @@ void PropagateUploadFileNG::slotMkColFinished()
 {
     propagator()->_activeJobList.removeOne(this);
     auto job = qobject_cast<MkColJob *>(sender());
-    slotJobDestroyed(job); // remove it from the _jobs list
-    QNetworkReply::NetworkError err = job->reply()->error();
     _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    _item->_responseTimeStamp = job->responseTimestamp();
+    _item->_requestId = job->requestId();
+    slotJobDestroyed(job); // remove it from the _jobs list
 
+    QNetworkReply::NetworkError err = job->reply()->error();
     if (err != QNetworkReply::NoError || _item->_httpErrorCode != 201) {
         _item->_requestId = job->requestId();
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
@@ -416,6 +424,10 @@ void PropagateUploadFileNG::slotPutFinished()
     PUTFileJob *job = qobject_cast<PUTFileJob *>(sender());
     OC_ASSERT(job);
 
+    _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    _item->_responseTimeStamp = job->responseTimestamp();
+    _item->_requestId = job->requestId();
+
     slotJobDestroyed(job); // remove it from the _jobs list
 
     propagator()->_activeJobList.removeOne(this);
@@ -428,8 +440,6 @@ void PropagateUploadFileNG::slotPutFinished()
     QNetworkReply::NetworkError err = job->reply()->error();
 
     if (err != QNetworkReply::NoError) {
-        _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        _item->_requestId = job->requestId();
         commonErrorHandling(job);
         return;
     }

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -222,13 +222,13 @@ void PropagateUploadFileNG::slotPropfindFinished()
 void PropagateUploadFileNG::slotPropfindFinishedWithError()
 {
     auto job = qobject_cast<LsColJob *>(sender());
-    auto httpErrorCode = _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    _item->_httpErrorCode = job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     _item->_responseTimeStamp = job->responseTimestamp();
     _item->_requestId = job->requestId();
     slotJobDestroyed(job); // remove it from the _jobs list
 
     QNetworkReply::NetworkError err = job->reply()->error();
-    auto status = classifyError(err, httpErrorCode, &propagator()->_anotherSyncNeeded);
+    auto status = classifyError(err, _item->_httpErrorCode, &propagator()->_anotherSyncNeeded);
     if (status == SyncFileItem::FatalError) {
         propagator()->_activeJobList.removeOne(this);
         abortWithError(status, job->errorStringParsingBody());


### PR DESCRIPTION
Always set the request time, response value and request Id in the SyncFileItem.
    
These values are written to the .owncloudsync.log file which is useful for debugging. For some operations, some data is missing. This PR fixes that. 
Fixes: #7348