### PR TITLE
Branding option to disable the multiple db files warning

### DIFF
--- a/changelog/unreleased/9216
+++ b/changelog/unreleased/9216
@@ -1,0 +1,7 @@
+Enhancement: Branding option to disable warning for multiple sync_journal.db's
+
+We added a branding option that disables the `Multiple accounts are sharing the folder` warning.
+In previous client versions a bug caused the creation of new sync journals, causing false positives in the detection.
+While this can be handled by the individual user, companies with multiple hundreds of users may opt to disable the warning.
+
+https://github.com/owncloud/client/pull/9216

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1535,10 +1535,17 @@ Result<void, QString> FolderMan::unsupportedConfiguration(const QString &path) c
     if (it == _unsupportedConfigurationError.end()) {
         it = _unsupportedConfigurationError.insert(path, [&]() -> Result<void, QString> {
             if (numberOfSyncJournals(path) > 1) {
-                return tr("Multiple accounts are sharing the folder %1.\n"
-                          "This configuration is know to lead to dataloss and is no longer supported.\n"
-                          "Please consider removing this folder from the account and adding it again.")
-                    .arg(path);
+                const QString error = tr("Multiple accounts are sharing the folder %1.\n"
+                                         "This configuration is know to lead to dataloss and is no longer supported.\n"
+                                         "Please consider removing this folder from the account and adding it again.")
+                                          .arg(path);
+                if (Theme::instance()->warnOnMultipleDb()) {
+                    qCWarning(lcFolderMan) << error;
+                    return error;
+                } else {
+                    qCWarning(lcFolderMan) << error << "this error is not displayed to the user as this is a branded"
+                                           << "client and the error itself might be a false positive caused by a previous broken migration";
+                }
             }
             return {};
         }());

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1531,13 +1531,19 @@ void FolderMan::restartApplication()
 
 Result<void, QString> FolderMan::unsupportedConfiguration(const QString &path) const
 {
-    if (numberOfSyncJournals(path) > 1) {
-        return tr("Multiple accounts are sharing the folder %1.\n"
-                  "This configuration is know to lead to dataloss and is no longer supported.\n"
-                  "Please consider removing this folder from the account and adding it again.")
-            .arg(path);
+    auto it = _unsupportedConfigurationError.find(path);
+    if (it == _unsupportedConfigurationError.end()) {
+        it = _unsupportedConfigurationError.insert(path, [&]() -> Result<void, QString> {
+            if (numberOfSyncJournals(path) > 1) {
+                return tr("Multiple accounts are sharing the folder %1.\n"
+                          "This configuration is know to lead to dataloss and is no longer supported.\n"
+                          "Please consider removing this folder from the account and adding it again.")
+                    .arg(path);
+            }
+            return {};
+        }());
     }
-    return {};
+    return *it;
 }
 
 bool FolderMan::checkVfsAvailability(const QString &path, Vfs::Mode mode) const

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -385,6 +385,8 @@ private:
 
     bool _appRestartRequired;
 
+    mutable QMap<QString, Result<void, QString>> _unsupportedConfigurationError;
+
     static FolderMan *_instance;
     explicit FolderMan(QObject *parent = nullptr);
     friend class OCC::Application;

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -683,4 +683,9 @@ bool Theme::enableSocketApiIconSupport() const
     return true;
 }
 
+bool Theme::warnOnMultipleDb() const
+{
+    return isVanilla();
+}
+
 } // end namespace client

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -435,6 +435,13 @@ public:
     virtual bool enableSocketApiIconSupport() const;
 
 
+    /**
+     * Warn if we find multiple db files in the sync root.
+     * This can indicate that the sync dir is shared between multiple clients or accounts
+     */
+    virtual bool warnOnMultipleDb() const;
+
+
 protected:
 #ifndef TOKEN_AUTH_ONLY
     QIcon themeUniversalIcon(const QString &name, IconType iconType = IconType::BrandedIcon) const;


### PR DESCRIPTION
Also cache error message to prevent unnecessary listing of sync root.