### PR TITLE
Rename stop and unregisterFolder methods

### DIFF
--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -142,11 +142,11 @@ public:
      */
     void start(const VfsSetupParams &params);
 
-    /// Stop interaction with VFS provider. Like when the client application quits.
-    virtual void stop() = 0;
+    /// Stop interaction with VFS provider, because the client is going to quit.
+    virtual void stopForExit() = 0;
 
-    /// Deregister the folder with the sync provider, like when a folder is removed.
-    virtual void unregisterFolder() = 0;
+    /// Stop and deregister the folder with the sync provider, like when a folder is removed.
+    virtual void stopAndUnregisterFolder() = 0;
 
 
     /** Whether the socket api should show pin state options
@@ -285,8 +285,8 @@ public:
 
     QString fileSuffix() const override { return QString(); }
 
-    void stop() override {}
-    void unregisterFolder() override {}
+    void stopForExit() override { }
+    void stopAndUnregisterFolder() override { }
 
     bool socketApiPinStateActionsShown() const override { return false; }
     bool isHydrating() const override { return false; }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -458,7 +458,7 @@ void AccountSettings::slotFolderWizardAccepted()
 
 #ifdef Q_OS_WIN
     if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
-        definition.navigationPaneClsid = QUuid::createUuid();
+        definition.isInNavigationPane = true;
 #endif
 
     auto selectiveSyncBlackList = folderWizard->property("selectiveSyncBlackList").toStringList();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -175,8 +175,9 @@ Folder::Folder(const FolderDefinition &definition,
 Folder::~Folder()
 {
     // If wipeForRemoval() was called the vfs has already shut down.
-    if (_vfs)
-        _vfs->stop();
+    if (_vfs) {
+        _vfs->stopForExit();
+    }
 
     // Reset then engine first as it will abort and try to access members of the Folder
     _engine.reset();
@@ -709,8 +710,7 @@ void Folder::setVirtualFilesEnabled(bool enabled)
         // TODO: Must wait for current sync to finish!
         SyncEngine::wipeVirtualFiles(path(), _journal, *_vfs);
 
-        _vfs->stop();
-        _vfs->unregisterFolder();
+        _vfs->stopAndUnregisterFolder();
 
         disconnect(_vfs.data(), nullptr, this, nullptr);
         disconnect(&_engine->syncFileStatusTracker(), nullptr, _vfs.data(), nullptr);
@@ -852,8 +852,7 @@ void Folder::wipeForRemoval()
     QFile::remove(stateDbFile + "-wal");
     QFile::remove(stateDbFile + "-journal");
 
-    _vfs->stop();
-    _vfs->unregisterFolder();
+    _vfs->stopAndUnregisterFolder();
     _vfs.reset(nullptr); // warning: folder now in an invalid state
 }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1337,54 +1337,55 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     }
 }
 
-bool FolderDefinition::load(const QSettings &settings, const QString &alias, FolderDefinition *folder)
+FolderDefinition FolderDefinition::load(const QSettings &settings, const QString &alias)
 {
-    folder->alias = FolderMan::unescapeAlias(alias);
-    folder->localPath = settings.value(localPathC).toString();
-    folder->journalPath = settings.value(journalPathC).toString();
-    folder->targetPath = settings.value(targetPathC).toString();
-    folder->paused = settings.value(pausedC).toBool();
-    folder->ignoreHiddenFiles = settings.value(ignoreHiddenFilesC, QVariant(true)).toBool();
-    folder->isInNavigationPane = settings.value(isInNavigationPaneC, QVariant(true)).toBool();
+    FolderDefinition folder;
+    folder.alias = FolderMan::unescapeAlias(alias);
+    folder.localPath = settings.value(localPathC).toString();
+    folder.journalPath = settings.value(journalPathC).toString();
+    folder.targetPath = settings.value(targetPathC).toString();
+    folder.paused = settings.value(pausedC).toBool();
+    folder.ignoreHiddenFiles = settings.value(ignoreHiddenFilesC, QVariant(true)).toBool();
+    folder.isInNavigationPane = settings.value(isInNavigationPaneC, QVariant(true)).toBool();
 
     if (settings.contains(uuidC)) {
-        folder->uuid = settings.value(uuidC).toUuid();
+        folder.uuid = settings.value(uuidC).toUuid();
     } else if (settings.contains(navigationPaneClsidC)) {
         // For backwards compatibility, will be changed when saved:
-        folder->uuid = settings.value(navigationPaneClsidC).toUuid();
-        if (!folder->isInNavigationPane) {
-            folder->isInNavigationPane = true;
+        folder.uuid = settings.value(navigationPaneClsidC).toUuid();
+        if (!folder.isInNavigationPane) {
+            folder.isInNavigationPane = true;
         }
     }
 
     // Sanity check:
-    if (folder->uuid.isNull()) {
-        folder->uuid = QUuid::createUuid();
+    if (folder.uuid.isNull()) {
+        folder.uuid = QUuid::createUuid();
     }
 
-    folder->virtualFilesMode = Vfs::Off;
+    folder.virtualFilesMode = Vfs::Off;
     QString vfsModeString = settings.value(virtualFilesModeC).toString();
     if (!vfsModeString.isEmpty()) {
         if (auto mode = Vfs::modeFromString(vfsModeString)) {
-            folder->virtualFilesMode = *mode;
+            folder.virtualFilesMode = *mode;
         } else {
             qCWarning(lcFolder) << "Unknown virtualFilesMode:" << vfsModeString << "assuming 'off'";
         }
     } else {
         if (settings.value(usePlaceholdersC).toBool()) {
-            folder->virtualFilesMode = Vfs::WithSuffix;
-            folder->upgradeVfsMode = true; // maybe winvfs is available?
+            folder.virtualFilesMode = Vfs::WithSuffix;
+            folder.upgradeVfsMode = true; // maybe winvfs is available?
         }
     }
 
     // Old settings can contain paths with native separators. In the rest of the
     // code we assume /, so clean it up now.
-    folder->localPath = prepareLocalPath(folder->localPath);
+    folder.localPath = prepareLocalPath(folder.localPath);
 
     // Target paths also have a convention
-    folder->targetPath = prepareTargetPath(folder->targetPath);
+    folder.targetPath = prepareTargetPath(folder.targetPath);
 
-    return true;
+    return folder;
 }
 
 QString FolderDefinition::prepareLocalPath(const QString &path)

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -85,8 +85,7 @@ public:
     static void save(QSettings &settings, const FolderDefinition &folder);
 
     /// Reads a folder definition from the current settings group.
-    static bool load(const QSettings &settings, const QString &alias,
-        FolderDefinition *folder);
+    static FolderDefinition load(const QSettings &settings, const QString &alias);
 
     /** The highest version in the settings that load() can read
      *

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -71,8 +71,12 @@ public:
     bool ignoreHiddenFiles;
     /// Which virtual files setting the folder uses
     Vfs::Mode virtualFilesMode = Vfs::Off;
-    /// The CLSID where this folder appears in registry for the Explorer navigation pane entry.
-    QUuid navigationPaneClsid;
+
+    /// The (always valid) UUID for the folder. This can be overwritten when read from the settings.
+    QUuid uuid = QUuid::createUuid();
+
+    /// Is shown in Windows Explorer navigation pane
+    bool isInNavigationPane = false;
 
     /// Whether the vfs mode shall silently be updated if possible
     bool upgradeVfsMode = false;
@@ -81,7 +85,7 @@ public:
     static void save(QSettings &settings, const FolderDefinition &folder);
 
     /// Reads a folder definition from the current settings group.
-    static bool load(QSettings &settings, const QString &alias,
+    static bool load(const QSettings &settings, const QString &alias,
         FolderDefinition *folder);
 
     /** The highest version in the settings that load() can read
@@ -91,8 +95,9 @@ public:
      *            (version remains readable by 2.5.1)
      * Version 3: introduction of new windows vfs mode in 2.6.0
      * Version 4: until 2.9.1 windows vfs tried to unregister folders with a different id from windows.
+     * Version 5: renamed navigationPaneClsid to uuid in the settings for FolderDefinition
      */
-    static int maxSettingsVersion() { return 4; }
+    static int maxSettingsVersion() { return 5; }
 
     /// Ensure / as separator and trailing /.
     static QString prepareLocalPath(const QString &path);
@@ -163,8 +168,24 @@ public:
      */
     QString remotePathTrailingSlash() const;
 
-    void setNavigationPaneClsid(const QUuid &clsid) { _definition.navigationPaneClsid = clsid; }
-    QUuid navigationPaneClsid() const { return _definition.navigationPaneClsid; }
+    /**
+     * UUID for the folder
+     */
+    QUuid uuid() const { return _definition.uuid; }
+
+    /**
+     * Currently only used on Windows.
+     *
+     * @return true is the folder is shown in the Windows Explorer navigation pane, false otherwise
+     */
+    bool isInNavigationPane() const { return _definition.isInNavigationPane; }
+
+    /**
+     * Currently only used on Windows.
+     *
+     * @param yesno true is the folder shold be shown in the Windows Explorer navigation pane, false otherwise
+     */
+    void setIsInNavigationPane(bool yesno) { _definition.isInNavigationPane = yesno; }
 
     /**
      * remote folder path with server url

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -44,10 +44,7 @@ namespace {
  * [Accounts]
  * 0\version=1
  */
-auto versionC()
-{
-    return QStringLiteral("version");
-}
+const QLatin1String versionC("version");
 
 /*
  * Folders with a version > maxFoldersVersion will be removed
@@ -71,7 +68,7 @@ QString makeLegacyDbName(const OCC::FolderDefinition &def, const OCC::AccountPtr
     const QString key = QStringLiteral("%1@%2:%3").arg(account->credentials()->user(), legacyUrl.toString(), def.targetPath);
     return OCC::SyncJournalDb::makeDbName(def.localPath, QString::fromUtf8(QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Md5).left(6).toHex()));
 }
-}
+} // anonymous namespace
 
 namespace OCC {
 Q_LOGGING_CATEGORY(lcFolderMan, "gui.folder.manager", QtInfoMsg)
@@ -362,7 +359,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
             Folder *f = addFolderInternal(std::move(folderDefinition), account.data(), std::move(vfs));
             if (f) {
                 // Migrate the old "usePlaceholders" setting to the root folder pin state
-                if (settings.value(versionC(), 1).toInt() == 1
+                if (settings.value(versionC, 1).toInt() == 1
                     && settings.value(QLatin1String("usePlaceholders"), false).toBool()) {
                     qCInfo(lcFolderMan) << "Migrate: From usePlaceholders to PinState::OnlineOnly";
                     f->setRootPinState(PinState::OnlineOnly);
@@ -418,12 +415,12 @@ void FolderMan::backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringLi
 
     auto processSubgroup = [&](const QString &name) {
         settings->beginGroup(name);
-        const int foldersVersion = settings->value(versionC(), 1).toInt();
+        const int foldersVersion = settings->value(versionC, 1).toInt();
         if (foldersVersion <= maxFoldersVersion) {
             const auto &childGroups = settings->childGroups();
             for (const auto &folderAlias : childGroups) {
                 settings->beginGroup(folderAlias);
-                const int folderVersion = settings->value(versionC(), 1).toInt();
+                const int folderVersion = settings->value(versionC, 1).toInt();
                 if (folderVersion > FolderDefinition::maxSettingsVersion()) {
                     ignoreKeys->append(settings->group());
                 }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -306,78 +306,79 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
         }
         settings.endGroup();
 
-        FolderDefinition folderDefinition;
         settings.beginGroup(folderAlias);
-        if (FolderDefinition::load(settings, folderAlias, &folderDefinition)) {
-            const auto defaultJournalPath = [&account, folderDefinition] {
-                // if we would have booth the 2.9.0 file name and the lagacy file
-                // with the md5 infix we prefer the 2.9.0 version
-                const QDir info(folderDefinition.localPath);
-                const QString defaultPath = SyncJournalDb::makeDbName(folderDefinition.localPath);
-                if (info.exists(defaultPath)) {
-                    return defaultPath;
-                }
-                // 2.6
-                QString legacyPath = makeLegacyDbName(folderDefinition, account->account());
-                if (info.exists(legacyPath)) {
-                    return legacyPath;
-                }
-                // pre 2.6
-                legacyPath.replace(QLatin1String(".sync_"), QLatin1String("._sync_"));
-                if (info.exists(legacyPath)) {
-                    return legacyPath;
-                }
+        FolderDefinition folderDefinition = FolderDefinition::load(settings, folderAlias);
+        const auto defaultJournalPath = [&account, folderDefinition] {
+            // if we would have both the 2.9.0 file name and the lagacy file
+            // with the md5 infix we prefer the 2.9.0 version
+            const QDir info(folderDefinition.localPath);
+            const QString defaultPath = SyncJournalDb::makeDbName(folderDefinition.localPath);
+            if (info.exists(defaultPath)) {
                 return defaultPath;
-            }();
-
-            // Migration: Old settings don't have journalPath
-            if (folderDefinition.journalPath.isEmpty()) {
-                folderDefinition.journalPath = defaultJournalPath;
             }
-
-            // Migration: ._ files sometimes can't be created.
-            // So if the configured journalPath has a dot-underscore ("._sync_*.db")
-            // but the current default doesn't have the underscore, switch to the
-            // new default if no db exists yet.
-            if (folderDefinition.journalPath.startsWith("._sync_")
-                && defaultJournalPath.startsWith(".sync_")
-                && !QFile::exists(folderDefinition.absoluteJournalPath())) {
-                folderDefinition.journalPath = defaultJournalPath;
+            // 2.6
+            QString legacyPath = makeLegacyDbName(folderDefinition, account->account());
+            if (info.exists(legacyPath)) {
+                return legacyPath;
             }
-
-            // Migration: If an old .csync_journal.db is found, move it to the new name.
-            if (backwardsCompatible) {
-                SyncJournalDb::maybeMigrateDb(folderDefinition.localPath, folderDefinition.absoluteJournalPath());
+            // pre 2.6
+            legacyPath.replace(QLatin1String(".sync_"), QLatin1String("._sync_"));
+            if (info.exists(legacyPath)) {
+                return legacyPath;
             }
+            return defaultPath;
+        }();
 
-            auto vfs = createVfsFromPlugin(folderDefinition.virtualFilesMode);
-            if (!vfs) {
-                // TODO: Must do better error handling
-                qFatal("Could not load plugin");
-            }
-
-            Folder *f = addFolderInternal(std::move(folderDefinition), account.data(), std::move(vfs));
-            if (f) {
-                // Migrate the old "usePlaceholders" setting to the root folder pin state
-                if (settings.value(versionC, 1).toInt() == 1
-                    && settings.value(QLatin1String("usePlaceholders"), false).toBool()) {
-                    qCInfo(lcFolderMan) << "Migrate: From usePlaceholders to PinState::OnlineOnly";
-                    f->setRootPinState(PinState::OnlineOnly);
-                }
-
-                // Migration: Mark folders that shall be saved in a backwards-compatible way
-                if (backwardsCompatible)
-                    f->setSaveBackwardsCompatible(true);
-                if (foldersWithPlaceholders)
-                    f->setSaveInFoldersWithPlaceholders();
-
-                // save possible changes from the migration
-                f->saveToSettings();
-
-                scheduleFolder(f);
-                emit folderSyncStateChange(f);
-            }
+        // Migration: Old settings don't have journalPath
+        if (folderDefinition.journalPath.isEmpty()) {
+            folderDefinition.journalPath = defaultJournalPath;
         }
+
+        // Migration: ._ files sometimes can't be created.
+        // So if the configured journalPath has a dot-underscore ("._sync_*.db")
+        // but the current default doesn't have the underscore, switch to the
+        // new default if no db exists yet.
+        if (folderDefinition.journalPath.startsWith("._sync_")
+            && defaultJournalPath.startsWith(".sync_")
+            && !QFile::exists(folderDefinition.absoluteJournalPath())) {
+            folderDefinition.journalPath = defaultJournalPath;
+        }
+
+        // Migration: If an old .csync_journal.db is found, move it to the new name.
+        if (backwardsCompatible) {
+            SyncJournalDb::maybeMigrateDb(folderDefinition.localPath, folderDefinition.absoluteJournalPath());
+        }
+
+        auto vfs = createVfsFromPlugin(folderDefinition.virtualFilesMode);
+        if (!vfs) {
+            // TODO: Must do better error handling
+            qFatal("Could not load plugin");
+        }
+
+        Folder *f = addFolderInternal(std::move(folderDefinition), account.data(), std::move(vfs));
+        Q_ASSERT(f);
+
+        // Migrate the old "usePlaceholders" setting to the root folder pin state
+        if (settings.value(versionC, 1).toInt() == 1
+            && settings.value(QLatin1String("usePlaceholders"), false).toBool()) {
+            qCInfo(lcFolderMan) << "Migrate: From usePlaceholders to PinState::OnlineOnly";
+            f->setRootPinState(PinState::OnlineOnly);
+        }
+
+        // Migration: Mark folders that shall be saved in a backwards-compatible way
+        if (backwardsCompatible) {
+            f->setSaveBackwardsCompatible(true);
+        }
+        if (foldersWithPlaceholders) {
+            f->setSaveInFoldersWithPlaceholders();
+        }
+
+        // save possible changes from the migration
+        f->saveToSettings();
+
+        scheduleFolder(f);
+        emit folderSyncStateChange(f);
+
         settings.endGroup();
     }
 }

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -329,7 +329,9 @@ private slots:
 private:
     /** Adds a new folder, does not add it to the account settings and
      *  does not set an account on the new folder.
-      */
+     *
+     *  \returns the newly created Folder, which can never be a nullptr.
+     */
     Folder *addFolderInternal(FolderDefinition folderDefinition,
         AccountState *accountState, std::unique_ptr<Vfs> vfs);
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -405,8 +405,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
                 folderDefinition.virtualFilesMode = bestAvailableVfsMode();
             }
 #ifdef Q_OS_WIN
-            if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
-                folderDefinition.navigationPaneClsid = QUuid::createUuid();
+            folderDefinition.isInNavigationPane = folderMan->navigationPaneHelper().showInExplorerNavigationPane();
 #endif
 
             auto f = folderMan->addFolder(account, folderDefinition);

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -57,11 +57,11 @@ void VfsSuffix::startImpl(const VfsSetupParams &params)
     Q_EMIT started();
 }
 
-void VfsSuffix::stop()
+void VfsSuffix::stopForExit()
 {
 }
 
-void VfsSuffix::unregisterFolder()
+void VfsSuffix::stopAndUnregisterFolder()
 {
 }
 

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -34,8 +34,8 @@ public:
     QString underlyingFileName(const QString &fileName) const override;
 
 
-    void stop() override;
-    void unregisterFolder() override;
+    void stopForExit() override;
+    void stopAndUnregisterFolder() override;
 
     bool socketApiPinStateActionsShown() const override { return true; }
     bool isHydrating() const override;

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -925,7 +925,7 @@ void FakeFolder::switchToVfs(QSharedPointer<OCC::Vfs> vfs)
 {
     auto opts = _syncEngine->syncOptions();
 
-    opts._vfs->stop();
+    opts._vfs->stopForExit();
     QObject::disconnect(_syncEngine.get(), nullptr, opts._vfs.data(), nullptr);
 
     opts._vfs = vfs;
@@ -940,8 +940,7 @@ void FakeFolder::switchToVfs(QSharedPointer<OCC::Vfs> vfs)
     vfsParams.providerDisplayName = QStringLiteral("OC-TEST");
     vfsParams.providerVersion = QVersionNumber(0, 1);
     QObject::connect(_syncEngine.get(), &QObject::destroyed, vfs.data(), [vfs]() {
-        vfs->stop();
-        vfs->unregisterFolder();
+        vfs->stopAndUnregisterFolder();
     });
 
     QObject::connect(vfs.get(), &OCC::Vfs::error, vfs.get(), [](const QString &error) {


### PR DESCRIPTION
In case of `stop` this makes it clear if it is a temporary state
and the connection is resumed later (e.g. when the client exits),
or if it is permanent (e.g. when the sync older is going to be
removed).