### PR TITLE
reduce time waiting for password box

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -99,8 +99,11 @@ class AccountConnectionWizard:
         syncPath = createUserSyncPath(context, clientDetails['user'])
 
         try:
+            oldwaitForObjectTimeout = squish.testSettings.waitForObjectTimeout
+            squish.testSettings.waitForObjectTimeout = 1000
             squish.clickButton(squish.waitForObject(self.ERROR_OK_BUTTON))
         except LookupError:
+            squish.testSettings.waitForObjectTimeout = oldwaitForObjectTimeout
             pass
         squish.clickButton(squish.waitForObject(self.SELECT_LOCAL_FOLDER))
         squish.mouseClick(squish.waitForObject(self.DIRECTORY_NAME_BOX))


### PR DESCRIPTION
the test code waits for the password box, which is not comming most of the time, because the password is stored in the keyring after the first test.
We can save a lot of test time by reducing that waiting
