### PR TITLE
use qt5.12 squish for UI tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -219,7 +219,7 @@ def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = [], version = "da
                  [
                      {
                          "name": "GUItests",
-                         "image": "owncloudci/squish:latest",
+                         "image": "owncloudci/squish:qt512",
                          "pull": "always",
                          "environment": {
                              "LICENSEKEY": from_secret("squish_license_server"),


### PR DESCRIPTION
there are now different versions of squish availiable with different qt versions. for the client v2.10 we need QT 5.12
