### PR TITLE
[tests-only] Added files tests from testplan

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1283,3 +1283,20 @@ def step(context):
 @Then('VFS enabled baseline image should not match the default screenshot')
 def step(context):
     test.xvp("VP_VFS_enabled")
+
+
+@Given('user "|any|" has created the following files inside the sync folder:')
+def step(context, username):
+    '''
+    Create files without any content
+    '''
+    syncPath = getUserSyncPath(context, username)
+
+    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
+    # https://github.com/owncloud/client/issues/9325
+    snooze(5)
+
+    for row in context.table[1:]:
+        filename = syncPath + row[0]
+        f = open(join(syncPath, filename), "w")
+        f.close()

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -292,3 +292,41 @@ Feature: Syncing files
         And as "Alice" folder "test%" should exist on the server
         And as "Alice" file "/PRN" should exist on the server
         And as "Alice" file "/foo%" should exist on the server
+
+
+    Scenario: various types of files can be synced from server to client
+        Given user "Alice" has set up a client with default settings
+        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has uploaded file "testavatar.png" to "simple-folder/testavatar.png" on the server
+        And user "Alice" has uploaded file "testavatar.jpg" to "simple-folder/testavatar.jpg" on the server
+        And user "Alice" has uploaded file "testavatar.jpeg" to "simple-folder/testavatar.jpeg" on the server
+        And user "Alice" has uploaded file "testimage.mp3" to "simple-folder/testimage.mp3" on the server
+        And user "Alice" has uploaded file "test_video.mp4" to "simple-folder/test_video.mp4" on the server
+        And user "Alice" has uploaded file "simple.pdf" to "simple-folder/simple.pdf" on the server
+        When the user waits for folder "simple-folder" to be synced
+        Then the folder "simple-folder" should exist on the file system
+        And the file "simple-folder/testavatar.png" should exist on the file system
+        And the file "simple-folder/testavatar.jpg" should exist on the file system
+        And the file "simple-folder/testavatar.jpeg" should exist on the file system
+        And the file "simple-folder/testimage.mp3" should exist on the file system
+        And the file "simple-folder/test_video.mp4" should exist on the file system
+        And the file "simple-folder/simple.pdf" should exist on the file system
+
+
+    Scenario: various types of files can be synced from client to server
+        Given user "Alice" has set up a client with default settings
+        And user "Alice" has created the following files inside the sync folder:
+            | files            |
+            | /testavatar.png  |
+            | /testavatar.jpg  |
+            | /testavatar.jpeg |
+            | /testaudio.mp3   |
+            | /test_video.mp4  |
+            | /simple.txt      |
+        When the user waits for the files to sync
+        Then as "Alice" file "testavatar.png" should exist on the server
+        And as "Alice" file "testavatar.jpg" should exist on the server
+        And as "Alice" file "testavatar.jpeg" should exist on the server
+        And as "Alice" file "testaudio.mp3" should exist on the server
+        And as "Alice" file "test_video.mp4" should exist on the server
+        And as "Alice" file "simple.txt" should exist on the server


### PR DESCRIPTION
### Related Issue
part of https://github.com/owncloud/client/issues/9396

### Test automated
The following test from the testplan has been automated in this PR
```
Test scenario: User adds the various types of files 
Steps to reproduce:
1. Microsoft word documents, Microsoft Excel, Microsoft Powerpoint, .JPG, .PDF, .MP3
Result: The Sync files tab show all type of files added in the Desktop Client folder from desktop, All files snyced and shown in Activities Tab under synchronization protocol
```

I have automated test for syncing files from client to server and vice-versa