### PR TITLE
Fix: `QSignalSpy: Unable to handle parameter '' of type 'SyncFileItem…

### DIFF
--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -143,7 +143,7 @@ signals:
     void rootEtag(const QByteArray &, const QDateTime &);
 
     // after the above signals. with the items that actually need propagating
-    void aboutToPropagate(SyncFileItemSet &);
+    void aboutToPropagate(const SyncFileItemSet &items);
 
     // after each item completed by a job (successful or not)
     void itemCompleted(const SyncFileItemPtr &);

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -290,6 +290,7 @@ inline bool operator<(const SyncFileItemPtr &item1, const SyncFileItemPtr &item2
 using SyncFileItemSet = std::set<SyncFileItemPtr>;
 }
 
+Q_DECLARE_METATYPE(OCC::SyncFileItemSet)
 Q_DECLARE_METATYPE(OCC::SyncFileItem)
 Q_DECLARE_METATYPE(OCC::SyncFileItemPtr)
 

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -204,7 +204,7 @@ void SyncFileStatusTracker::decSyncCountAndEmitStatusChanged(const QString &rela
     }
 }
 
-void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemSet &items)
+void SyncFileStatusTracker::slotAboutToPropagate(const SyncFileItemSet &items)
 {
     OC_ASSERT(_syncCount.isEmpty());
 

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -47,7 +47,7 @@ signals:
     void fileStatusChanged(const QString &systemFileName, SyncFileStatus fileStatus);
 
 private slots:
-    void slotAboutToPropagate(SyncFileItemSet &items);
+    void slotAboutToPropagate(const SyncFileItemSet &items);
     void slotItemCompleted(const SyncFileItemPtr &item);
     void slotSyncFinished();
     void slotSyncEngineRunningChanged();

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -267,7 +267,7 @@ private slots:
 
         // Now the next sync gets a NEW/NEW conflict and since there's no checksum
         // it just becomes a UPDATE_METADATA
-        auto checkIsUpdateMetaData = [&](SyncFileItemSet &items) {
+        auto checkIsUpdateMetaData = [&](const SyncFileItemSet &items) {
             QCOMPARE(items.size(), 2);
             auto it = items.cbegin();
             QCOMPARE(it->get()->_file, QLatin1String("A"));

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -400,7 +400,7 @@ private slots:
         fakeFolder.remoteModifier().appendByte("C/c1");
         fakeFolder.remoteModifier().setModTime("C/c1", changedMtime2);
 
-        connect(&fakeFolder.syncEngine(), &SyncEngine::aboutToPropagate, [&](SyncFileItemSet &items) {
+        connect(&fakeFolder.syncEngine(), &SyncEngine::aboutToPropagate, [&](const SyncFileItemSet &items) {
             SyncFileItemPtr a1, b1, c1;
             for (auto &item : items) {
                 if (item->_file == "A/a1")


### PR DESCRIPTION
…Set&' of method 'aboutToPropagate', use qRegisterMetaType to register it.`