### PR TITLE
Remove Availability menu from the ui

### DIFF
--- a/changelog/unreleased/9291
+++ b/changelog/unreleased/9291
@@ -1,0 +1,6 @@
+Enhancement: Remove the availability menu from the ui
+
+The availability options should be handled on a folder base and in the file browser. 
+
+
+https://github.com/owncloud/client/pull/9291

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -323,29 +323,6 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
 
     removeFolderAction(menu);
 
-    if (folder->virtualFilesEnabled()) {
-        auto availabilityMenu = menu->addMenu(tr("Availability"));
-        auto availability = folder->vfs().availability(QString());
-        if (availability) {
-            ac = availabilityMenu->addAction(Utility::vfsCurrentAvailabilityText(*availability));
-            ac->setEnabled(false);
-        }
-
-        ac = availabilityMenu->addAction(Utility::vfsPinActionText());
-        ac->setEnabled(!availability || *availability != VfsItemAvailability::AlwaysLocal);
-        connect(ac, &QAction::triggered, this, [this]() { slotSetCurrentFolderAvailability(PinState::AlwaysLocal); });
-
-        ac = availabilityMenu->addAction(Utility::vfsFreeSpaceActionText());
-        ac->setEnabled(!availability
-                || !(*availability == VfsItemAvailability::OnlineOnly
-                    || *availability == VfsItemAvailability::AllDehydrated));
-        connect(ac, &QAction::triggered, this, [this]() { slotSetCurrentFolderAvailability(PinState::OnlineOnly); });
-        if (!Theme::instance()->forceVirtualFilesOption()) {
-            ac = menu->addAction(tr("Disable virtual file support..."));
-            connect(ac, &QAction::triggered, this, &AccountSettings::slotDisableVfsCurrentFolder);
-        }
-    }
-
     if (Theme::instance()->showVirtualFilesOption()
         && !folder->virtualFilesEnabled() && FolderMan::instance()->checkVfsAvailability(folder->path())) {
         const auto mode = bestAvailableVfsMode();


### PR DESCRIPTION
@swoichha @Talank the pr removes the "Availability" entry from the context menu which causes the tests to fail.