### PR TITLE
Only check whether a file is locked before we start the upload

### DIFF
--- a/changelog/unreleased/9194
+++ b/changelog/unreleased/9194
@@ -5,3 +5,5 @@ Therefore we checked for the locked state before we start the upload.
 Due to a bug we checked that for each file chunk, now we only check when the upload starts and when it finished completely.
 
 https://github.com/owncloud/client/issues/9194
+https://github.com/owncloud/client/pull/9264
+https://github.com/owncloud/client/pull/9296

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -489,10 +489,11 @@ void PropagateUploadFileCommon::slotJobDestroyed(QObject *job)
 // This function is used whenever there is an error occuring and jobs might be in progress
 void PropagateUploadFileCommon::abortWithError(SyncFileItem::Status status, const QString &error)
 {
-    if (_aborting)
-        return;
-    abort(AbortType::Synchronous);
-    done(status, error);
+    qCWarning(lcPropagateUpload) << Q_FUNC_INFO << _item->_file << error;
+    if (!_aborting) {
+        abort(AbortType::Synchronous);
+        done(status, error);
+    }
 }
 
 QMap<QByteArray, QByteArray> PropagateUploadFileCommon::headers()

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -38,8 +38,17 @@ namespace OCC {
 
 void PropagateUploadFileV1::doStartUpload()
 {
-    if (!propagator()->account()->capabilities().bigfilechunkingEnabled())
-    {
+    const QString fileName = propagator()->fullLocalPath(_item->_file);
+    // If the file is currently locked, we want to retry the sync
+    // when it becomes available again.
+    const auto lockMode = propagator()->syncOptions().requiredLockMode();
+    if (FileSystem::isFileLocked(fileName, lockMode)) {
+        emit propagator()->seenLockedFile(fileName, lockMode);
+        abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(QDir::toNativeSeparators(fileName)));
+        return;
+    }
+
+    if (!propagator()->account()->capabilities().bigfilechunkingEnabled()) {
         _chunkCount = 1;
     } else {
         _chunkCount = int(std::ceil(_item->_size / double(chunkSize())));
@@ -129,14 +138,6 @@ void PropagateUploadFileV1::startNextChunk()
     }
 
     const QString fileName = propagator()->fullLocalPath(_item->_file);
-    // If the file is currently locked, we want to retry the sync
-    // when it becomes available again.
-    const auto lockMode = propagator()->syncOptions().requiredLockMode();
-    if (FileSystem::isFileLocked(fileName, lockMode)) {
-        emit propagator()->seenLockedFile(fileName, lockMode);
-        abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(fileName));
-        return;
-    }
     auto device = std::unique_ptr<UploadDevice>(new UploadDevice(
             fileName, chunkStart, currentChunkSize, &propagator()->_bandwidthManager));
     if (!device->open(QIODevice::ReadOnly)) {


### PR DESCRIPTION
I tried to fix this before, but in the wrong uploader.

Looking at the code I assume that legacy chunking with parallel chunking was completely  broken in 2.9