### PR TITLE
Partly Revert "Remove Availability menu from the ui"

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -323,6 +323,10 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
 
     removeFolderAction(menu);
 
+    if (folder->virtualFilesEnabled() && !Theme::instance()->forceVirtualFilesOption()) {
+        menu->addAction(tr("Disable virtual file support..."), this, &AccountSettings::slotDisableVfsCurrentFolder);
+    }
+
     if (Theme::instance()->showVirtualFilesOption()
         && !folder->virtualFilesEnabled() && FolderMan::instance()->checkVfsAvailability(folder->path())) {
         const auto mode = bestAvailableVfsMode();


### PR DESCRIPTION
This partly reverts commit 934da5b219e4774fe0f4ec422ed067437ac44e3c which removed the vfs mode selection by accident.

Fixes: #9314