### PR TITLE
Fix compilation with Qt 5.12.8

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -274,7 +274,7 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
     if (auto job = qobject_cast<AbstractNetworkJob *>(sender())) {
         if (auto reply = job->reply()) {
             _account->setHttp2Supported(
-                reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool());
+                reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool());
         }
     }
     return true;

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -209,7 +209,7 @@ void AbstractNetworkJob::slotFinished()
     const auto maxHttp2Resends = 3;
     QByteArray verb = HttpLogger::requestVerb(*reply());
     if (_reply->error() == QNetworkReply::ContentReSendError
-        && _reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool()) {
+        && _reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()) {
         if ((_requestBody && !_requestBody->isSequential()) || verb.isEmpty()) {
             qCWarning(lcNetworkJob) << "Can't resend HTTP2 request, verb or body not suitable"
                                     << _reply->request().url() << verb << _requestBody;

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -75,7 +75,7 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         // http2 seems to cause issues, as with our recommended server setup we don't support http2, disable it by default for now
         static const bool http2EnabledEnv = qEnvironmentVariableIntValue("OWNCLOUD_HTTP2_ENABLED") == 1;
 
-        newRequest.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2EnabledEnv);
+        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, http2EnabledEnv);
     }
 
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -14,8 +14,9 @@
 
 #include "capabilities.h"
 
-#include <QVariantMap>
 #include <QDebug>
+#include <QString>
+#include <QVariantMap>
 
 using namespace std::chrono;
 
@@ -244,7 +245,7 @@ TusSupport::TusSupport(const QVariantMap &tus_support)
     version = QVersionNumber::fromString(tus_support.value(QStringLiteral("version")).toString());
     resumable = QVersionNumber::fromString(tus_support.value(QStringLiteral("resumable")).toString());
 
-    extensions = tus_support.value(QStringLiteral("extension")).toString().split(QLatin1Char(','), Qt::SkipEmptyParts);
+    extensions = tus_support.value(QStringLiteral("extension")).toString().split(QLatin1Char(','), QString::SkipEmptyParts);
     max_chunk_size = tus_support.value(QStringLiteral("max_chunk_size")).value<quint64>();
     http_method_override = tus_support.value(QStringLiteral("http_method_override")).toString();
 }

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -698,7 +698,7 @@ void PropagateDownloadFile::slotGetFinished()
     // of the compressed data. See QTBUG-73364.
     const auto contentEncoding = job->reply()->rawHeader("content-encoding").toLower();
     if ((contentEncoding == "gzip" || contentEncoding == "deflate")
-        && (job->reply()->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool()
+        && (job->reply()->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()
             || job->reply()->attribute(QNetworkRequest::SpdyWasUsedAttribute).toBool())) {
         bodySize = 0;
         hasSizeHeader = false;

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -319,7 +319,7 @@ SyncFileStatus SyncFileStatusTracker::resolveSyncAndErrorStatus(const QString &r
 
 void SyncFileStatusTracker::invalidateParentPaths(const QString &path)
 {
-    QStringList splitPath = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+    QStringList splitPath = path.split(QLatin1Char('/'), QString::SkipEmptyParts);
     for (int i = 0; i < splitPath.size(); ++i) {
         QString parentPath = QStringList(splitPath.mid(0, i)).join(QLatin1Char('/'));
         emit fileStatusChanged(getSystemDestination(parentPath), fileStatus(parentPath));


### PR DESCRIPTION
Should still compile with Qt 5.15, where some of these aliases have been deprecated and replaced by the new spelling.