### PR TITLE
[Tests-Only]Fixed file creation and syncing tests

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -370,6 +370,11 @@ def createFile(context, filename, username=None):
         syncPath = getUserSyncPath(context, username)
     else:
         syncPath = context.userData['currentUserSyncPath']
+
+    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
+    # https://github.com/owncloud/client/issues/9325
+    snooze(5)
+
     f = open(join(syncPath, filename), "w")
     f.write(fileContent)
     f.close()

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -7,7 +7,7 @@ Feature: Syncing files
     Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
 
-    @smokeTest @skip @issue-9281
+    @smokeTest @issue-9281
     Scenario: Syncing a file to the server
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "lorem-for-upload.txt" with the following content inside the sync folder
@@ -215,7 +215,7 @@ Feature: Syncing files
         Then as "Alice" folder "original" should exist on the server
         And as "Alice" folder "copied" should exist on the server
 
-    @skip @issue-9281
+    @issue-9281
     Scenario: Verify that you can create a subfolder with long name
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created a folder "Folder1" inside the sync folder
@@ -276,7 +276,7 @@ Feature: Syncing files
             | foldername                                                      |
             | An empty folder which name is obviously more than 59 characters |
 
-    
+
     Scenario: Invalid system names are synced in linux
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created folder "COM" on the server


### PR DESCRIPTION
### Description
If a file fails, we mark it as ignored for 5s. If it fails again within the 25s, 525, if again 55*25...
If you want to test the "changed during upload" scenario, you should wait for the error to be resolved, or force sync.
If you don't want to test it, don't modify the src file to often and not after the sync was started.

Besides the mentioned ignore list there are other random timeouts in the client which are hard to predict.

REF: https://github.com/owncloud/client/issues/9325#issuecomment-1016179775

Hence, it looks like waiting for 5 sec in the beginning is a good solution.

### Related Issue
Fixes https://github.com/owncloud/client/issues/9325