### PR TITLE
[Tests-Only]Execute drone notification in cron pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -53,6 +53,7 @@ def main(ctx):
                 "check-starlark",
                 "changelog",
                 "clang-debug-ninja",
+                "GUI-tests",
             ],
         ),
     ]
@@ -79,6 +80,7 @@ def main(ctx):
             name = "build",
             trigger = cron_trigger,
             depends_on = [
+                "clang-debug-ninja",
                 "GUI-tests",
             ],
         ),

--- a/.drone.star
+++ b/.drone.star
@@ -79,7 +79,6 @@ def main(ctx):
             name = "build",
             trigger = cron_trigger,
             depends_on = [
-                "clang-debug-ninja",
                 "GUI-tests",
             ],
         ),

--- a/.drone.star
+++ b/.drone.star
@@ -75,6 +75,14 @@ def main(ctx):
             trigger = cron_trigger,
         ),
         gui_tests(ctx, trigger = cron_trigger),
+        notification(
+            name = "build",
+            trigger = cron_trigger,
+            depends_on = [
+                "clang-debug-ninja",
+                "GUI-tests",
+            ],
+        ),
     ]
 
     if ctx.build.event == "cron":
@@ -409,8 +417,8 @@ def notification(name, depends_on = [], trigger = {}):
                 "image": "plugins/slack",
                 "pull": "always",
                 "settings": {
-                    "webhook": from_secret("slack_webhook"),
-                    "channel": "desktop-ci",
+                    "webhook": from_secret("private_rocketchat"),
+                    "channel": "desktop-internal",
                 },
             },
         ],


### PR DESCRIPTION
Added job to send drone notification to `desktop-internal` channel in rocketchat for all the cron jobs such as nightly builds.

Part of https://github.com/owncloud/client/issues/9327