### PR TITLE
[Tests-Only]Fixed drone notification channel

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -48,6 +48,7 @@ def main(ctx):
                 "check-starlark",
                 "changelog",
                 "clang-debug-ninja",
+                "GUI-tests",
             ],
         ),
     ]
@@ -380,8 +381,8 @@ def notification(name, depends_on = [], trigger = {}):
                 "image": "plugins/slack",
                 "pull": "always",
                 "settings": {
-                    "webhook": from_secret("slack_webhook"),
-                    "channel": "desktop-ci",
+                    "webhook": from_secret("private_rocketchat"),
+                    "channel": "desktop-internal",
                 },
             },
         ],


### PR DESCRIPTION
We did not receive notification in desktop-internal channel because the notification channel was set to `desktop-ci` which does not exists AFAIK. 

part of https://github.com/owncloud/client/issues/9327