### PR TITLE
Improve oauth2 authorization

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -91,6 +91,8 @@ const QString newBigFolderSizeLimitC() { return QStringLiteral("newBigFolderSize
 const QString useNewBigFolderSizeLimitC() { return QStringLiteral("useNewBigFolderSizeLimit"); }
 const QString confirmExternalStorageC() { return QStringLiteral("confirmExternalStorage"); }
 const QString moveToTrashC() { return QStringLiteral("moveToTrash"); }
+const QString oauthPromptC() { return QStringLiteral("oauthPrompt"); }
+const QString oauthBasicAuthC() { return QStringLiteral("oauthBasicAuth"); }
 }
 
 QString ConfigFile::_confDir = QString();
@@ -751,6 +753,31 @@ void ConfigFile::setPromptDeleteFiles(bool promptDeleteFiles)
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(promptDeleteC(), promptDeleteFiles);
 }
+
+bool ConfigFile::oauthPrompt() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(oauthPromptC(), true).toBool();
+}
+
+void ConfigFile::setOauthPrompt(bool oauthPrompt)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(oauthPromptC(), oauthPrompt);
+}
+
+bool ConfigFile::oauthBasicAuth() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(oauthBasicAuthC(), true).toBool();
+}
+
+void ConfigFile::setOauthBasicAuth(bool oauthBasicAuth)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(oauthBasicAuthC(), oauthBasicAuth);
+}
+
 
 bool ConfigFile::monoIcons() const
 {

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -138,6 +138,14 @@ public:
     bool confirmExternalStorage() const;
     void setConfirmExternalStorage(bool);
 
+    //disable sending of the prompt parameter for the oauth2 authorization_endpoint
+    bool oauthPrompt() const;
+    void setOauthPrompt(bool);
+
+    //disable sending of basic auth header for the oauth2 token endpoint
+    bool oauthBasicAuth() const;
+    void setOauthBasicAuth(bool);
+
     /** If we should move the files deleted on the server in the trash  */
     bool moveToTrash() const;
     void setMoveToTrash(bool);

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -227,9 +227,6 @@ void OAuth::startAuthentication()
                     httpReplyAndClose(socket, QByteArrayLiteral("400 Bad Request"), QByteArrayLiteral("<html><head><title>400 Bad Request</title></head><body><center><h1>400 Bad Request</h1></center></body></html>"));
                     return;
                 }
-                // we only allow one response
-                qCDebug(lcOauth) << "Recieved the first valid request, stoping to listen";
-                _server.close();
 
                 auto job = postTokenRequest({
                     { QStringLiteral("grant_type"), QStringLiteral("authorization_code") },
@@ -237,6 +234,11 @@ void OAuth::startAuthentication()
                     { QStringLiteral("redirect_uri"), QStringLiteral("%1:%2").arg(_redirectUrl, QString::number(_server.serverPort())) },
                     { QStringLiteral("code_verifier"), QString::fromUtf8(_pkceCodeVerifier) },
                 });
+                
+                // we only allow one response
+                qCDebug(lcOauth) << "Recieved the first valid request, stoping to listen";
+                _server.close();
+
                 QObject::connect(job, &SimpleNetworkJob::finishedSignal, this, [this, socket](QNetworkReply *reply) {
                     const auto jsonData = reply->readAll();
                     QJsonParseError jsonParseError;


### PR DESCRIPTION
- fixed a small bug regarding the redirect_uri for the token_endpoint
- add option oauthPrompt with default value true to disable it
  the prompt parameter for the authorization_endpoint optionally, ory
  hydra doesn't support that option and the oauth2 flow would fail
- add option oauthBasicAuth with default value true to disable sending
   of the Authorization header for the token_endpoint, ory hydra only
   allows either client_secret_basic or client_secret_post not a mix of
   both