### PR TITLE
use https to clone submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/3rdparty/libcrashreporter-qt"]
 	path = src/3rdparty/libcrashreporter-qt
-	url = git://github.com/dschmidt/libcrashreporter-qt.git
+	url = https://github.com/dschmidt/libcrashreporter-qt.git


### PR DESCRIPTION
submodules step failed with 
```
fatal: clone of 'git://github.com/dschmidt/libcrashreporter-qt.git' into submodule path '/drone/src/src/3rdparty/libcrashreporter-qt' failed
Failed to clone 'src/3rdparty/libcrashreporter-qt'. Retry scheduled
```
GitHub changed stuff for security reasons and without username we have to use HTTPS see https://github.blog/2021-09-01-improving-git-protocol-security-github/