### PR TITLE
Fix public link delete test

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1192,6 +1192,10 @@ def step(context, resource):
     clickButton(waitForObject(names.linkShares_QToolButton_2))
     clickButton(waitForObject(names.oCC_ShareLinkWidget_Delete_QPushButton))
 
+    waitFor(
+        lambda: (not object.exists(names.linkShares_QToolButton_2)),
+    )
+
 
 @When(
     'the user changes the password of public link "|any|" to "|any|" using the client-UI'


### PR DESCRIPTION
After deleting the public link, wait till the delete button disappears to make sure the action is finished

fixes #9346