### PR TITLE
Make sure to use the same Qt version in our CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,10 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core)
+# global Qt version, used in all find_package calls
+set(OC_QT_VERSION 5.15)
+
+find_package(Qt5 ${OC_QT_VERSION} REQUIRED COMPONENTS Core)
 
 if(UNIT_TESTING)
     message(DEPRECATION "Setting UNIT_TESTING is deprecated please use BUILD_TESTING")

--- a/admin/osx/CMakeLists.txt
+++ b/admin/osx/CMakeLists.txt
@@ -11,7 +11,6 @@ else()
   set(MAC_INSTALLER_DO_CUSTOM_BACKGROUND "false")
 endif()
 
-find_package(Qt5 5.6 COMPONENTS Core REQUIRED)
 configure_file(create_mac.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/create_mac.sh @ONLY)
 configure_file(macosx.pkgproj.cmake ${CMAKE_CURRENT_BINARY_DIR}/macosx.pkgproj @ONLY)
 configure_file(pre_install.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/pre_install.sh @ONLY)

--- a/shell_integration/dolphin/CMakeLists.txt
+++ b/shell_integration/dolphin/CMakeLists.txt
@@ -2,10 +2,9 @@ project(dolphin-owncloud)
 
 cmake_minimum_required(VERSION 2.8.12)
 include(FeatureSummary)
-set(QT_MIN_VERSION "5.3.0")
 set(KF5_MIN_VERSION "5.16.0")
 
-find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Network)
+find_package(Qt5 ${OC_QT_VERSION} CONFIG REQUIRED COMPONENTS Core Network)
 
 find_package(ECM 1.2.0 REQUIRED CONFIG)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5 5.15 COMPONENTS Core Network Xml Concurrent REQUIRED)
+find_package(Qt5 ${OC_QT_VERSION} COMPONENTS Core Network Xml Concurrent REQUIRED)
 get_target_property (QT_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
 message(STATUS "Using Qt ${Qt5Core_VERSION} (${QT_QMAKE_EXECUTABLE})")
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -121,11 +121,11 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
 #endif
 
     // convenience OS detection methods
-    inline bool isWindows();
-    inline bool isMac();
-    inline bool isUnix();
-    inline bool isLinux(); // use with care
-    inline bool isBSD(); // use with care, does not match OS X
+    constexpr inline bool isWindows();
+    constexpr inline bool isMac();
+    constexpr inline bool isUnix();
+    constexpr inline bool isLinux(); // use with care
+    constexpr inline bool isBSD(); // use with care, does not match OS X
 
     OCSYNC_EXPORT QString platformName();
     // crash helper for --debug
@@ -301,7 +301,7 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
 }
 /** @} */ // \addtogroup
 
-inline bool Utility::isWindows()
+constexpr inline bool Utility::isWindows()
 {
 #ifdef Q_OS_WIN
     return true;
@@ -310,7 +310,7 @@ inline bool Utility::isWindows()
 #endif
 }
 
-inline bool Utility::isMac()
+constexpr inline bool Utility::isMac()
 {
 #ifdef Q_OS_MAC
     return true;
@@ -319,7 +319,7 @@ inline bool Utility::isMac()
 #endif
 }
 
-inline bool Utility::isUnix()
+constexpr inline bool Utility::isUnix()
 {
 #ifdef Q_OS_UNIX
     return true;
@@ -328,7 +328,7 @@ inline bool Utility::isUnix()
 #endif
 }
 
-inline bool Utility::isLinux()
+constexpr inline bool Utility::isLinux()
 {
 #if defined(Q_OS_LINUX)
     return true;
@@ -337,7 +337,7 @@ inline bool Utility::isLinux()
 #endif
 }
 
-inline bool Utility::isBSD()
+constexpr inline bool Utility::isBSD()
 {
 #if defined(Q_OS_FREEBSD) || defined(Q_OS_NETBSD) || defined(Q_OS_OPENBSD)
     return true;

--- a/src/crashreporter/CMakeLists.txt
+++ b/src/crashreporter/CMakeLists.txt
@@ -47,7 +47,7 @@ if(NOT BUILD_LIBRARIES_ONLY)
         MACOSX_BUNDLE FALSE
     )
 
-    find_package(Qt5 REQUIRED COMPONENTS Widgets)
+    find_package(Qt5 ${OC_QT_VERSION} REQUIRED COMPONENTS Widgets)
 
     target_include_directories(${CRASHREPORTER_EXECUTABLE} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
     target_link_libraries(${CRASHREPORTER_EXECUTABLE}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,9 +1,9 @@
 include(ECMAddAppIcon)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt5 ${OC_QT_VERSION} REQUIRED COMPONENTS Widgets)
 
 if (WIN32)
-    find_package(Qt5 REQUIRED COMPONENTS WinExtras)
+    find_package(Qt5 ${OC_QT_VERSION} REQUIRED COMPONENTS WinExtras)
 endif()
 
 add_subdirectory(updater)
@@ -152,7 +152,7 @@ target_sources(owncloudCore PRIVATE
 )
 
 IF( APPLE )
-    find_package(Qt5 COMPONENTS MacExtras)
+    find_package(Qt5 ${OC_QT_VERSION} COMPONENTS MacExtras)
     target_link_libraries(owncloudCore PUBLIC Qt5::MacExtras)
 
     target_sources(owncloudCore PRIVATE
@@ -179,7 +179,7 @@ elseif( WIN32 )
     target_link_libraries(owncloudCore PUBLIC Qt5::WinExtras)
 elseif(UNIX AND NOT APPLE )
     ## handle DBUS for Fdo notifications
-    find_package(Qt5 COMPONENTS DBus)
+    find_package(Qt5 ${OC_QT_VERSION} COMPONENTS DBus)
     if (TARGET Qt5::DBus)
         target_link_libraries(owncloudCore PUBLIC Qt5::DBus)
         target_compile_definitions(owncloudCore PUBLIC "USE_FDO_NOTIFICATIONS")

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -92,7 +92,7 @@ if ( APPLE )
 endif()
 
 if (NOT TOKEN_AUTH_ONLY)
-    find_package(Qt5 REQUIRED COMPONENTS Widgets)
+    find_package(Qt5 ${OC_QT_VERSION} REQUIRED COMPONENTS Widgets)
     target_link_libraries(libsync PUBLIC Qt5::Widgets qt5keychain)
 endif()
 

--- a/test/owncloud_add_test.cmake
+++ b/test/owncloud_add_test.cmake
@@ -1,4 +1,4 @@
-find_package(Qt5 COMPONENTS Core Test Xml Network REQUIRED)
+find_package(Qt5 ${OC_QT_VERSION} COMPONENTS Core Test Xml Network REQUIRED)
 
 include(ECMAddTests)
 


### PR DESCRIPTION
Both our own CMake code as well as third-party dependencies we use uses `find_package(Qt5 ...)` and variants to build against Qt. This PR introduces the `OC_QT_VERSION` variable in our project's root scope, and makes sure to use it in every `find_package` call.

We cannot control third-party dependency lookups this way, unfortunately. So far, this has not led to problems in our build environments, though.

The other commit implements a small change to the platform utilities which is unrelated but improves compilation speed slightly.