### PR TITLE
Ensure to performe a local discovery on force or after a paused sync

### DIFF
--- a/changelog/unreleased/9341
+++ b/changelog/unreleased/9341
@@ -1,0 +1,5 @@
+Bugfix: Run a full local discovery after we where paused or on a forced sync
+
+Previously we did a incremental search wich might have skipped some local changes.
+
+https://github.com/owncloud/client/issues/9341

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -719,6 +719,7 @@ void AccountSettings::slotEnableCurrentFolder(bool terminate)
         if (f->isSyncRunning() && terminate) {
             f->slotTerminateSync();
         }
+        f->slotNextSyncFullLocalDiscovery(); // ensure we don't forget about local errors
         f->setSyncPaused(!currentlyPaused);
 
         // keep state for the icon setting.
@@ -761,7 +762,7 @@ void AccountSettings::slotForceSyncCurrentFolder()
         }
 
         selectedFolder->slotWipeErrorBlacklist(); // issue #6757
-
+        selectedFolder->slotNextSyncFullLocalDiscovery(); // ensure we don't forget about local errors
         // Insert the selected folder at the front of the queue
         folderMan->scheduleFolderNext(selectedFolder);
     }


### PR DESCRIPTION
Fixes: #9341