### PR TITLE
[Tests-Only]Notify to rocketchat for only the nightly builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -46,16 +46,6 @@ def main(ctx):
             trigger = build_trigger,
         ),
         gui_tests(ctx, trigger = build_trigger, version = "latest"),
-        notification(
-            name = "build",
-            trigger = build_trigger,
-            depends_on = [
-                "check-starlark",
-                "changelog",
-                "clang-debug-ninja",
-                "GUI-tests",
-            ],
-        ),
     ]
     cron_pipelines = [
         # Build client


### PR DESCRIPTION
Removing the call to nofication from the normal pipeline so that it will notify only when the `cron_pipelines` is running.

Related to https://github.com/owncloud/client/issues/9327