### PR TITLE
Introduce new error category that is not handled by the ignore list

### DIFF
--- a/changelog/unreleased/9382
+++ b/changelog/unreleased/9382
@@ -1,0 +1,5 @@
+Bugfix: Immediately retry upload if file changed during sync
+
+If a file changed during discovery and the actual upload for multiple retries in a row, changes of it were ignored for a period of time.
+
+https://github.com/owncloud/client/issues/9382

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -302,14 +302,15 @@ std::function<void(void)> IssuesWidget::addStatusFilter(QMenu *menu)
     const auto initialFilter = _statusSortModel->filter();
 
     { // Add all errors under 1 action:
-        const std::array<SyncFileItem::Status, 5> ErrorStatusItems = {
+        const std::vector<SyncFileItem::Status> ErrorStatusItems = {
             SyncFileItem::Status::FatalError,
             SyncFileItem::Status::NormalError,
             SyncFileItem::Status::SoftError,
-            SyncFileItem::Status::DetailError
+            SyncFileItem::Status::DetailError,
         };
 
-        auto action = menu->addAction(SyncFileItem::statusEnumDisplayName(SyncFileItem::NormalError), [this, ErrorStatusItems](bool checked) {
+
+        auto action = menu->addAction(SyncFileItem::statusEnumDisplayName(SyncFileItem::NormalError), this, [this, ErrorStatusItems](bool checked) {
             auto currentFilter = _statusSortModel->filter();
             for (const auto &item : ErrorStatusItems) {
                 currentFilter[item] = checked;
@@ -320,23 +321,34 @@ std::function<void(void)> IssuesWidget::addStatusFilter(QMenu *menu)
         action->setChecked(initialFilter[ErrorStatusItems[0]]);
         statusFilterGroup->addAction(action);
     }
+    menu->addSeparator();
 
     // Add the other non-error items:
-    const std::array<SyncFileItem::Status, 5> OtherStatusItems = {
+    const std::vector<SyncFileItem::Status> OtherStatusItems = {
         SyncFileItem::Status::Conflict,
         SyncFileItem::Status::FileIgnored,
         SyncFileItem::Status::Restoration,
         SyncFileItem::Status::BlacklistedError,
-        SyncFileItem::Status::Excluded
+        SyncFileItem::Status::Excluded,
+        SyncFileItem::Status::Message
     };
+    // list of OtherStatusItems with the localised name
+    std::vector<std::pair<QString, SyncFileItem::Status>> otherStatusItems;
+    otherStatusItems.reserve(OtherStatusItems.size());
     for (const auto &item : OtherStatusItems) {
-        auto action = menu->addAction(SyncFileItem::statusEnumDisplayName(item), [this, item](bool checked) {
+        otherStatusItems.emplace_back(SyncFileItem::statusEnumDisplayName(item), item);
+    }
+    std::sort(otherStatusItems.begin(), otherStatusItems.end(), [](const auto &a, const auto &b) {
+        return a.first < b.first;
+    });
+    for (const auto &item : otherStatusItems) {
+        auto action = menu->addAction(item.first, this, [this, item](bool checked) {
             auto currentFilter = _statusSortModel->filter();
-            currentFilter[item] = checked;
+            currentFilter[item.second] = checked;
             _statusSortModel->setFilter(currentFilter);
         });
         action->setCheckable(true);
-        action->setChecked(initialFilter[item]);
+        action->setChecked(initialFilter[item.second]);
         statusFilterGroup->addAction(action);
     }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -258,6 +258,7 @@ void PropagateItemJob::done(SyncFileItem::Status statusArg, const QString &error
     case SyncFileItem::FatalError:
     case SyncFileItem::NormalError:
     case SyncFileItem::DetailError:
+    case SyncFileItem::Message:
         // Check the blacklist, possibly adjusting the item (including its status)
         blacklistUpdate(propagator()->_journal, *_item);
         break;

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -77,6 +77,7 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
 
 QString SyncFileItem::statusEnumDisplayName(Status s)
 {
+    // TODO: 2.11 enumDisplayName  https://github.com/owncloud/client/issues/9043
     switch (s) {
     case SyncFileItem::NoStatus:
         return QCoreApplication::translate("SyncFileItem::Status", "Undefined");
@@ -100,6 +101,8 @@ QString SyncFileItem::statusEnumDisplayName(Status s)
         return QCoreApplication::translate("SyncFileItem::Status", "Blacklisted");
     case OCC::SyncFileItem::Excluded:
         return QCoreApplication::translate("SyncFileItem::Status", "Excluded");
+    case OCC::SyncFileItem::Message:
+        return QCoreApplication::translate("SyncFileItem::Status", "Message");
     case OCC::SyncFileItem::StatusCount:
         Q_UNREACHABLE();
     }

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -93,6 +93,11 @@ public:
          */
         Excluded,
 
+        /**
+         *  Similar to SoftError but will not cause any error handling
+         */
+        Message,
+
         /** For use in an array or vector for the number of items in this enum.
          */
         StatusCount


### PR DESCRIPTION
Fixes: #9382

The filter menu will now be sorted by the localised string.
![image](https://user-images.githubusercontent.com/200626/151004234-472ea63d-df4a-49e3-aa9f-65d8e3fcd350.png)
