### PR TITLE
added test for long file name

### DIFF
--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -79,3 +79,13 @@ class Activity:
                 "type": "QModelIndex",
             }
         )
+
+    def checkAtLeastABlacklistedFile(self):
+        squish.waitForObjectExists(
+            {
+                "column": 6,
+                "container": names.oCC_IssuesWidget_tableView_QTableView,
+                "text": "Blacklisted",
+                "type": "QModelIndex",
+            }
+        )

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -328,7 +328,7 @@ def collaboratorShouldBeListed(
 @When('the user waits for the files to sync')
 def step(context):
     waitForFolderToBeSynced(context, '/')
-
+    snooze(30)
 
 def waitForResourceToSync(context, resource, resourceType):
     resource = join(context.userData['currentUserSyncPath'], resource)
@@ -399,6 +399,17 @@ def createFolder(context, foldername, username=None):
     os.makedirs(path)
 
 
+@When('user "|any|" creates a file "|any|" with size "|any|" inside the sync folder')
+def step(context, username, filename, filesize):
+    uploadFile(context, username, filename, filesize)
+
+
+def uploadFile(context, username, filename, filesize):
+    file = join(context.userData['currentUserSyncPath'], filename)
+    cmd = "truncate -s {filesize} {file}".format(filesize=filesize, file=file)
+    os.system(cmd)
+    
+    
 @When('the user copies the folder "|any|" to "|any|"')
 def step(context, sourceFolder, destinationFolder):
     source_dir = join(context.userData['currentUserSyncPath'], sourceFolder)
@@ -406,6 +417,22 @@ def step(context, sourceFolder, destinationFolder):
     shutil.copytree(source_dir, destination_dir)
 
 
+@ When('user move the file "|any|" to the root sync folder')
+def step(context, file):
+    source_dir = join(context.userData['currentUserSyncPath'], file)
+    destination_dir = join(context.userData['clientRootSyncPath'], file)
+    shutil.move(source_dir, destination_dir)
+    
+
+# @When('user "|any|" creates a folder "|any|" containing 500 files inside the sync folder')
+# def step(context, folder):
+#     
+
+
+@When('pause')
+def step(context):
+    snooze(50)
+    
 @Given(r"^(.*) on the server (.*)$", regexp=True)
 def step(context, stepPart1, stepPart2):
     executeStepThroughMiddleware(context, "Given " + stepPart1 + " " + stepPart2)

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -404,9 +404,6 @@ def step(context, username, filenumber, filesize, foldername):
     syncPath = context.userData['currentUserSyncPath']
     path = join(syncPath, foldername)
     filesize = builtins.int(filesize)
-    # Syncing all the created files at once seems to have some problem on syncing
-    # So once a file is synced the process have to wait unless the next file is created
-    # So we added Snooze of 5 sec
     snooze(5)
     for i in range(0, builtins.int(filenumber)):
         file_name = f"file{i}.txt"
@@ -428,6 +425,7 @@ def step(context, username, folder_count, folder ):
 @When('user "|any|" creates a file "|any|" with size "|any|" inside the sync folder')
 def step(context, username, filename, filesize):
     uploadFile(context, username, filename, filesize)
+
 
 def uploadFile(context, username, filename, filesize):
     file = join(context.userData['currentUserSyncPath'], filename)
@@ -1349,3 +1347,4 @@ def step(context, username):
         filename = syncPath + row[0]
         f = open(join(syncPath, filename), "w")
         f.close()
+    test.xvp("VP_VFS_enabled")

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -583,6 +583,12 @@ def step(context, filename):
     activity.checkBlackListedFileExist(filename)
 
 
+@When('the user waits until at least a file is blacklisted')
+def step(context):
+    activity = Activity()
+    activity.checkAtLeastABlacklistedFile()
+
+
 @When('the user selects "|any|" tab in the activity')
 def step(context, tabName):
     activity = Activity()

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -377,8 +377,7 @@ def createFile(context, filename, username=None):
     f = open(join(syncPath, filename), "w")
     f.write(fileContent)
     f.close()
-
-
+    
 @When('user "|any|" creates a folder "|any|" inside the sync folder')
 def step(context, username, foldername):
     createFolder(context, foldername, username)
@@ -397,6 +396,13 @@ def createFolder(context, foldername, username=None):
         syncPath = context.userData['currentUserSyncPath']
     path = join(syncPath, foldername)
     os.makedirs(path)
+
+ 
+@When('user "|any|" creates "|any|" files inside the folder "|any|"')
+def step(context, username, filenumber, foldername):
+    folder = join(context.userData['currentUserSyncPath'], foldername)
+    cmd = "cd {folder} && touch randomfile{1..{filenumber}}.txt".format(folder,filenumber)
+    os.system(cmd)
 
 
 @When('user "|any|" creates a file "|any|" with size "|any|" inside the sync folder')
@@ -417,17 +423,12 @@ def step(context, sourceFolder, destinationFolder):
     shutil.copytree(source_dir, destination_dir)
 
 
-@ When('user move the file "|any|" to the root sync folder')
-def step(context, file):
+@ When('user move the file "|any|" to folder "|any|"')
+def step(context, file, destinationFolder):
     source_dir = join(context.userData['currentUserSyncPath'], file)
-    destination_dir = join(context.userData['clientRootSyncPath'], file)
+    destination_dir = join(context.userData['currentUserSyncPath'], destinationFolder, file)
     shutil.move(source_dir, destination_dir)
     
-
-# @When('user "|any|" creates a folder "|any|" containing 500 files inside the sync folder')
-# def step(context, folder):
-#     
-
 
 @When('pause')
 def step(context):

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -378,6 +378,28 @@ Feature: Syncing files
 	    Then as "Alice" file "file1.odt" should exist on the server
 
 
+	Scenario: File of 1 GB size sync succefully
+	    Given user "Alice" has set up a client with default settings
+	    When user "Alice" creates a file "newfile.txt" with size "1GB" inside the sync folder
+	    And the user waits for file "newfile.txt" to be synced
+	    Then as "Alice" file "newfile.txt" should exist on the server
 
 
+    Scenario: File with spaces in the name can sync
+	    Given user "Alice" has set up a client with default settings
+	    When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
+		    """
+		    test contents
+		    """
+		And user move the file "file with space.txt" to the root sync folder
+		And pause
+		Then as "Alice" file "file with space.txt" should exist on the server
+
+
+	Scenario: Folders with 500 files can sync successfully
+	    Given user "Alice" has set up a client with default settings
+	    When user "Alice" creates a folder "Folder1" containing 500 files inside the sync folder
+	    And user "Alice" creates a folder "Folder2" containing 500 files inside the sync folder
+	    Then as "Alice" folder "Folder1" should exist on the server
+	    And as "Alice" folder "Folder2" should exist on the server
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -331,24 +331,31 @@ Feature: Syncing files
         And as "Alice" file "test_video.mp4" should exist on the server
         And as "Alice" file "simple.txt" should exist on the server
     Scenario: File with long name can be synced
+    Scenario Outline: File with long name can be synced
         Given user "Alice" has set up a client with default settings
         # the length of file name is 224
-        When user "Alice" creates a file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" with the following content inside the sync folder
+        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
             """
             test content
             """
-        And the user waits for file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" to be synced
-        Then as "Alice" file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" should exist on the server
+        And the user waits for file "<filename>" to be synced
+        Then as "Alice" file "<filename>" should exist on the server
+		Examples:
+		|filename|
+		|sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt|
 
 
-	Scenario: Filename with long name(>233 character) raise an error
+	Scenario Outline: Filename with long name(>233 character) raise an error
 	    Given user "Alice" has set up a client with default settings
         # the length of file name is 233
-        When user "Alice" creates a file "qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" with the following content inside the sync folder
+        When user "Alice" creates a file "<filename>" with the following content inside the sync folder
             """
             test contents
             """
         When the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
-        Then the file "qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" should be blacklisted
+        Then the file "<filename>" should be blacklisted
+        Examples:
+	        |filename|
+	        |qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt|
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -331,7 +331,8 @@ Feature: Syncing files
         And as "Alice" file "testaudio.mp3" should exist on the server
         And as "Alice" file "test_video.mp4" should exist on the server
         And as "Alice" file "simple.txt" should exist on the server
-    Scenario: File with long name can be synced
+  
+
     Scenario Outline: File with long name can be synced
         Given user "Alice" has set up a client with default settings
         # the length of file name is 224
@@ -423,6 +424,3 @@ Feature: Syncing files
         When the user waits for folder "folder2" to be synced
         Then as "Alice" folder "folder2" should exist on the server
         And as user "Alice" folder "folder2" should contain "100" items on the server
-
-
-

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -277,19 +277,19 @@ Feature: Syncing files
             | foldername                                                      |
             | An empty folder which name is obviously more than 59 characters |
 
-
+    
     Scenario: Invalid system names are synced in linux
         Given user "Alice" has set up a client with default settings
-        And user "Alice" has created folder "COM" on the server
+        And user "Alice" has created folder "CON" on the server
         And user "Alice" has created folder "test%" on the server
         And user "Alice" has uploaded file on the server with content "server content" to "/PRN"
         And user "Alice" has uploaded file on the server with content "server content" to "/foo%"
         When the user waits for the files to sync
-        Then the folder "COM" should exist on the file system
+        Then the folder "CON" should exist on the file system
         And the folder "test%" should exist on the file system
         And the file "PRN" should exist on the file system
         And the file "foo%" should exist on the file system
-        And as "Alice" folder "COM" should exist on the server
+        And as "Alice" folder "CON" should exist on the server
         And as "Alice" folder "test%" should exist on the server
         And as "Alice" file "/PRN" should exist on the server
         And as "Alice" file "/foo%" should exist on the server
@@ -396,7 +396,7 @@ Feature: Syncing files
         And the user waits for folder "testfolder" to be synced
         Then as "Alice" file "testfolder/file with space.txt" should exist on the server
 
-    @fool
+    
     Scenario: Folders with 500 files can sync successfully
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "folder1" inside the sync folder
@@ -411,7 +411,7 @@ Feature: Syncing files
         And as user "Alice" folder "folder2" should contain "500" items on the server
 
 
-    @fool1
+    
     Scenario: Folders with 15 subfolders can sync successfully
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "folder1" inside the sync folder

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -391,15 +391,18 @@ Feature: Syncing files
 		    """
 		    test contents
 		    """
-		And user move the file "file with space.txt" to the root sync folder
-		And pause
-		Then as "Alice" file "file with space.txt" should exist on the server
+		And user "Alice" creates a folder "testfolder" inside the sync folder
+		And user move the file "file with space.txt" to folder "testfolder"
+		And the user waits for folder "testfolder" to be synced
+		Then as "Alice" file "testfolder/file with space.txt" should exist on the server
 
-
+	@skip
 	Scenario: Folders with 500 files can sync successfully
 	    Given user "Alice" has set up a client with default settings
-	    When user "Alice" creates a folder "Folder1" containing 500 files inside the sync folder
-	    And user "Alice" creates a folder "Folder2" containing 500 files inside the sync folder
-	    Then as "Alice" folder "Folder1" should exist on the server
-	    And as "Alice" folder "Folder2" should exist on the server
+	    When user "Alice" creates a folder "folder1" inside the sync folder
+	    And user "Alice" creates a folder "folder2" inside the sync folder
+	    And user "Alice" creates "500" files inside the folder "folder1"
+	    And user "Alice" creates "500" files inside the folder "folder2"
+	    Then as "Alice" folder "folder1" should exist on the server
+	    And as "Alice" folder "folder2" should exist on the server
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -277,7 +277,7 @@ Feature: Syncing files
             | foldername                                                      |
             | An empty folder which name is obviously more than 59 characters |
 
-    
+
     Scenario: Invalid system names are synced in linux
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created folder "CON" on the server
@@ -401,8 +401,8 @@ Feature: Syncing files
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "folder1" inside the sync folder
         And user "Alice" creates a folder "folder2" inside the sync folder
-        And user "Alice" creates "500" files inside the folder "folder1"
-        And user "Alice" creates "500" files inside the folder "folder2"
+        And user "Alice" creates "500" files each of size "1048576" bytes inside the folder "folder1"
+        And user "Alice" creates "500" files each of size "1048576" bytes inside the folder "folder2"
         When the user waits for the files to sync
         Then as "Alice" folder "folder1" should exist on the server
         And as user "Alice" folder "folder1" should contain "500" items on the server
@@ -411,13 +411,12 @@ Feature: Syncing files
         And as user "Alice" folder "folder2" should contain "500" items on the server
 
 
-    
     Scenario: Folders with 15 subfolders can sync successfully
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "folder1" inside the sync folder
         And user "Alice" creates a folder "folder2" inside the sync folder
-        And user "Alice" creates a "100" subfolders inside the folder "folder1"
-        And user "Alice" creates a "100" subfolders inside the folder "folder2"
+        And user "Alice" creates "100" subfolders inside the folder "folder1"
+        And user "Alice" creates "100" subfolders inside the folder "folder2"
         And the user waits for folder "folder1" to be synced
         Then as "Alice" folder "folder1" should exist on the server
         And as user "Alice" folder "folder1" should contain "100" items on the server

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -361,3 +361,23 @@ Feature: Syncing files
 	        |filename|
 	        |qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt|
 
+
+	Scenario: Files with same name but different extension sync correctly
+	    Given user "Alice" has set up a client with default settings
+	    When user "Alice" creates a file "file1.txt" with the following content inside the sync folder
+	    """
+	    test contents
+	    """
+	    When user "Alice" creates a file "file1.odt" with the following content inside the sync folder
+	    """
+	    test contents
+	    """
+	    And the user waits for file "file1.txt" to be synced
+	    And the user waits for file "file1.odt" to be synced
+	    Then as "Alice" file "file1.txt" should exist on the server
+	    Then as "Alice" file "file1.odt" should exist on the server
+
+
+
+
+

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -330,3 +330,25 @@ Feature: Syncing files
         And as "Alice" file "testaudio.mp3" should exist on the server
         And as "Alice" file "test_video.mp4" should exist on the server
         And as "Alice" file "simple.txt" should exist on the server
+    Scenario: File with long name can be synced
+        Given user "Alice" has set up a client with default settings
+        # the length of file name is 224
+        When user "Alice" creates a file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" to be synced
+        Then as "Alice" file "sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" should exist on the server
+
+
+	Scenario: Filename with long name(>233 character) raise an error
+	    Given user "Alice" has set up a client with default settings
+        # the length of file name is 233
+        When user "Alice" creates a file "qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" with the following content inside the sync folder
+            """
+            test contents
+            """
+        When the user clicks on the activity tab
+        And the user selects "Not Synced" tab in the activity
+        Then the file "qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt" should be blacklisted
+

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -341,13 +341,13 @@ Feature: Syncing files
             """
         And the user waits for file "<filename>" to be synced
         Then as "Alice" file "<filename>" should exist on the server
-		Examples:
-		|filename|
-		|sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt|
+        Examples:
+            | filename                                                                                                                                                                                                                        |
+            | sdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt |
 
 
-	Scenario Outline: Filename with long name(>233 character) raise an error
-	    Given user "Alice" has set up a client with default settings
+    Scenario Outline: Filename with long name(>233 character) raise an error
+        Given user "Alice" has set up a client with default settings
         # the length of file name is 233
         When user "Alice" creates a file "<filename>" with the following content inside the sync folder
             """
@@ -358,51 +358,72 @@ Feature: Syncing files
         And the user waits until at least a file is blacklisted
         Then the file "<filename>" should be blacklisted
         Examples:
-	        |filename|
-	        |qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt|
+            | filename                                                                                                                                                                                                                                 |
+            | qqqqqqqqqsdkdfjsdfuidjfkdsjfksdjfksdjfksdjfksdjfksdjfkdsjfksdjfkdsjfkdsfjlsdkfjsdkjflksdjfklsdjfksdjfkdsjfkldsjfkldsjfkdsjfksdjfksdjfklsdjfklsdjflksdjflksdjfklsdjfklsdjfksdjfksdjfksdjfksdjfksdfjskdfjksdjfksdjfksdjfksdjfksdwwwwww.txt |
 
 
-	Scenario: Files with same name but different extension sync correctly
-	    Given user "Alice" has set up a client with default settings
-	    When user "Alice" creates a file "file1.txt" with the following content inside the sync folder
-	    """
-	    test contents
-	    """
-	    When user "Alice" creates a file "file1.odt" with the following content inside the sync folder
-	    """
-	    test contents
-	    """
-	    And the user waits for file "file1.txt" to be synced
-	    And the user waits for file "file1.odt" to be synced
-	    Then as "Alice" file "file1.txt" should exist on the server
-	    Then as "Alice" file "file1.odt" should exist on the server
+    Scenario: Files with same name but different extension sync correctly
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "file1.txt" with the following content inside the sync folder
+            """
+            test contents
+            """
+        When user "Alice" creates a file "file1.odt" with the following content inside the sync folder
+            """
+            test contents
+            """
+        And the user waits for file "file1.txt" to be synced
+        And the user waits for file "file1.odt" to be synced
+        Then as "Alice" file "file1.txt" should exist on the server
+        Then as "Alice" file "file1.odt" should exist on the server
 
 
-	Scenario: File of 1 GB size sync succefully
-	    Given user "Alice" has set up a client with default settings
-	    When user "Alice" creates a file "newfile.txt" with size "1GB" inside the sync folder
-	    And the user waits for file "newfile.txt" to be synced
-	    Then as "Alice" file "newfile.txt" should exist on the server
+    Scenario: File of 1 GB size sync succefully
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "newfile.txt" with size "1GB" inside the sync folder
+        And the user waits for file "newfile.txt" to be synced
+        Then as "Alice" file "newfile.txt" should exist on the server
 
 
     Scenario: File with spaces in the name can sync
-	    Given user "Alice" has set up a client with default settings
-	    When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
-		    """
-		    test contents
-		    """
-		And user "Alice" creates a folder "testfolder" inside the sync folder
-		And user move the file "file with space.txt" to folder "testfolder"
-		And the user waits for folder "testfolder" to be synced
-		Then as "Alice" file "testfolder/file with space.txt" should exist on the server
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a file "file with space.txt" with the following content inside the sync folder
+            """
+            test contents
+            """
+        And user "Alice" creates a folder "testfolder" inside the sync folder
+        And user move the file "file with space.txt" to folder "testfolder"
+        And the user waits for folder "testfolder" to be synced
+        Then as "Alice" file "testfolder/file with space.txt" should exist on the server
 
-	@skip
-	Scenario: Folders with 500 files can sync successfully
-	    Given user "Alice" has set up a client with default settings
-	    When user "Alice" creates a folder "folder1" inside the sync folder
-	    And user "Alice" creates a folder "folder2" inside the sync folder
-	    And user "Alice" creates "500" files inside the folder "folder1"
-	    And user "Alice" creates "500" files inside the folder "folder2"
-	    Then as "Alice" folder "folder1" should exist on the server
-	    And as "Alice" folder "folder2" should exist on the server
+    @fool
+    Scenario: Folders with 500 files can sync successfully
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "folder1" inside the sync folder
+        And user "Alice" creates a folder "folder2" inside the sync folder
+        And user "Alice" creates "500" files inside the folder "folder1"
+        And user "Alice" creates "500" files inside the folder "folder2"
+        When the user waits for the files to sync
+        Then as "Alice" folder "folder1" should exist on the server
+        And as user "Alice" folder "folder1" should contain "500" items on the server
+        When the user waits for the files to sync
+        Then as "Alice" folder "folder2" should exist on the server
+        And as user "Alice" folder "folder2" should contain "500" items on the server
+
+
+    @fool1
+    Scenario: Folders with 15 subfolders can sync successfully
+        Given user "Alice" has set up a client with default settings
+        When user "Alice" creates a folder "folder1" inside the sync folder
+        And user "Alice" creates a folder "folder2" inside the sync folder
+        And user "Alice" creates a "100" subfolders inside the folder "folder1"
+        And user "Alice" creates a "100" subfolders inside the folder "folder2"
+        And the user waits for folder "folder1" to be synced
+        Then as "Alice" folder "folder1" should exist on the server
+        And as user "Alice" folder "folder1" should contain "100" items on the server
+        When the user waits for folder "folder2" to be synced
+        Then as "Alice" folder "folder2" should exist on the server
+        And as user "Alice" folder "folder2" should contain "100" items on the server
+
+
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -244,7 +244,7 @@ Feature: Syncing files
         And as "Alice" folder "Folder1/subFolder1" should exist on the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist on the server
 
-    @skip @issue-9281
+    @issue-9281
     Scenario: Filenames that are rejected by the server are reported
         Given user "Alice" has set up a client with default settings
         And user "Alice" has created a folder "Folder1" inside the sync folder
@@ -256,6 +256,7 @@ Feature: Syncing files
         Then as "Alice" folder "Folder1" should exist on the server
         When the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
+        And the user waits until at least a file is blacklisted
         Then the file "Folder1/a\\a.txt" should be blacklisted
 
 
@@ -352,8 +353,9 @@ Feature: Syncing files
             """
             test contents
             """
-        When the user clicks on the activity tab
+        And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
+        And the user waits until at least a file is blacklisted
         Then the file "<filename>" should be blacklisted
         Examples:
 	        |filename|


### PR DESCRIPTION
### Related Issue
#9396 
### Description
The file name with length(>=233 character) is not synced and is blacklisted.

![Screenshot from 2022-01-28 15-26-33](https://user-images.githubusercontent.com/66173400/151536153-e9765e5c-26d6-4df3-998d-11bfb27aaf77.png)

This PR has been closed due to some reason, so instead of this another PR is created here->#9458.