### PR TITLE
Do not mark QA:team issues stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         debug-only: false
         exempt-all-milestones: true
-        exempt-issue-labels: "blue-ticket, p1-urgent, p2-high, p3-medium, p4-low"
+        exempt-issue-labels: "blue-ticket, p1-urgent, p2-high, p3-medium, p4-low, QA:team"
         days-before-stale: 30
         stale-issue-message: "This issue was marked stale because it has been open for 30 days with no activity. Remove the stale label or comment or this will be closed in 7 days."
         days-before-close: 7  


### PR DESCRIPTION
If we label an issue with QA:team then we don't want the stale bot to keep marking it stale.

Example: #9247 was marked stale yesterday.

This PR is to the 2.10 branch, because CI is red in `master`.

The change is really needed in `master` to change the stale bot behavior, what to do?