### PR TITLE
Use buildin timeout handling provided by Qt

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -275,7 +275,7 @@ Application::Application(int &argc, char **argv)
 
     ConfigFile cfg;
     // The timeout is initialized with an environment variable, if not, override with the value from the config
-    if (!AbstractNetworkJob::httpTimeout.count()) {
+    if (AbstractNetworkJob::httpTimeout == std::chrono::milliseconds(static_cast<int>(QNetworkRequest::DefaultTransferTimeoutConstant))) {
         AbstractNetworkJob::httpTimeout = cfg.timeout();
     }
 

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -55,7 +55,7 @@ Q_LOGGING_CATEGORY(lcNetworkJob, "sync.networkjob", QtInfoMsg)
 // If not set, it is overwritten by the Application constructor with the value from the config
 seconds AbstractNetworkJob::httpTimeout = [] {
     const auto def = qEnvironmentVariableIntValue("OWNCLOUD_TIMEOUT");
-    if (def == 0) {
+    if (def <= 0) {
         milliseconds(static_cast<int>(QNetworkRequest::DefaultTransferTimeoutConstant));
     }
     return seconds(def);

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -381,9 +381,11 @@ void AbstractNetworkJob::retry()
 void AbstractNetworkJob::abort()
 {
     if (_reply) {
+        // calling abort will trigger the execution of finished()
+        // with _reply->error() == QNetworkReply::OperationCanceledError
+        // the api user can then decide whether to discard this job or retry it.
         _reply->abort();
         _aborted = true;
-        // TODO: leak?
     } else {
         deleteLater();
     }

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -352,8 +352,6 @@ void Account::setCredentialSetting(const QString &key, const QVariant &value)
 
 void Account::slotHandleSslErrors(QPointer<QNetworkReply> reply, const QList<QSslError> &errors)
 {
-    const NetworkJobTimeoutPauser pauser(reply);
-
     // Copy info out of reply ASAP
     if (reply.isNull()) {
         return;

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -278,7 +278,6 @@ signals:
 
 private:
     bool finished() override;
-    void onTimedOut() override;
 private slots:
     virtual void metaDataChangedSlot();
     virtual void encryptedSlot();

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -332,14 +332,22 @@ void GETFileJob::slotReadyRead()
     }
 }
 
-void GETJob::onTimedOut()
+GETJob::GETJob(AccountPtr account, const QString &path, QObject *parent)
+    : AbstractNetworkJob(account, path, parent)
 {
-    qCWarning(lcGetJob) << this << "timeout";
-    if (reply()) {
-        _errorString = tr("Connection Timeout");
-        _errorStatus = SyncFileItem::FatalError;
+    connect(this, &GETJob::networkError, this, [this] {
+        if (timedOut()) {
+            qCWarning(lcGetJob) << this << "timeout";
+            _errorString = tr("Connection Timeout");
+            _errorStatus = SyncFileItem::FatalError;
+        }
+    });
+}
+GETJob::~GETJob()
+{
+    if (_bandwidthManager) {
+        _bandwidthManager->unregisterDownloadJob(this);
     }
-    AbstractNetworkJob::onTimedOut();
 }
 
 QString GETJob::errorString() const

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -35,17 +35,9 @@ protected:
     QPointer<BandwidthManager> _bandwidthManager = nullptr;
 
 public:
-    GETJob(AccountPtr account, const QString &path, QObject *parent = nullptr)
-        : AbstractNetworkJob(account, path, parent)
-    {
-    }
+    GETJob(AccountPtr account, const QString &path, QObject *parent = nullptr);
 
-    ~GETJob() override
-    {
-        if (_bandwidthManager) {
-            _bandwidthManager->unregisterDownloadJob(this);
-        }
-    }
+    ~GETJob() override;
 
     virtual qint64 currentDownloadPosition() = 0;
     virtual qint64 resumeStart() { return 0; }
@@ -61,7 +53,6 @@ public:
     void setChoked(bool c);
     void setBandwidthLimited(bool b);
     void giveBandwidthQuota(qint64 q);
-    void onTimedOut() override;
 
 signals:
     void finishedSignal();

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -918,6 +918,12 @@ QNetworkReply *FakeQNAM::createRequest(QNetworkAccessManager::Operation op, cons
             Q_UNREACHABLE();
         }
     }
+    // timeout would be handled by Qt
+    if (request.transferTimeout() != 0) {
+        QTimer::singleShot(request.transferTimeout(), reply, [reply] {
+            reply->abort();
+        });
+    }
     OCC::HttpLogger::logRequest(reply, op, outgoingData);
     return reply;
 }


### PR DESCRIPTION
One of the effects is that the time now runs on the reply, and gets reset as long as the reply is active and not on the parent job.