### PR TITLE
Only set valid icons on top-level windows

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -239,7 +239,12 @@ Application::Application(int &argc, char **argv)
     //    setOrganizationName(QLatin1String(APPLICATION_VENDOR));
     setOrganizationDomain(QLatin1String(APPLICATION_REV_DOMAIN));
     setApplicationName(_theme->appName());
-    setWindowIcon(_theme->applicationIcon());
+    QIcon appIcon = _theme->applicationIcon();
+    if (appIcon.isNull()) {
+        qCWarning(lcApplication) << "Application icon cannot be loaded!";
+    } else {
+        setWindowIcon(appIcon);
+    }
 
     // migrate old configuration files if necessary
     migrateConfigFile(this);

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -196,7 +196,11 @@ QIcon Utility::getCoreIcon(const QString &icon_name)
         return {};
     }
     const QString path = Theme::instance()->isUsingDarkTheme() ? QStringLiteral("dark") : QStringLiteral("light");
-    const QIcon icon(QStringLiteral(":/client/resources/%1/%2").arg(path, icon_name));
+    auto iconName = QStringLiteral(":/client/resources/%1/%2").arg(path, icon_name);
+    const QIcon icon(iconName);
+    if (icon.isNull()) {
+        qCWarning(lcUtility) << "Cannot find icon" << iconName;
+    }
     Q_ASSERT(!icon.isNull());
     return icon;
 }

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -165,7 +165,12 @@ public:
     void updateIcon()
     {
         if (!_iconName.isEmpty()) {
-            setIcon(Utility::getCoreIcon(_iconName));
+            QIcon icon = Utility::getCoreIcon(_iconName);
+            if (icon.isNull()) {
+                qWarning() << "Cannot load icon" << _iconName;
+            } else {
+                setIcon(icon);
+            }
         }
     }
 

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -384,7 +384,11 @@ void NSISUpdater::showNoUrlDialog(const UpdateInfo &info)
     QIcon infoIcon = msgBox->style()->standardIcon(QStyle::SP_MessageBoxInformation);
     int iconSize = msgBox->style()->pixelMetric(QStyle::PM_MessageBoxIconSize);
 
-    msgBox->setWindowIcon(infoIcon);
+    if (infoIcon.isNull()) {
+        qCWarning(lcUpdater) << "SP_MessageBoxInformation cannot be loaded!";
+    } else {
+        msgBox->setWindowIcon(infoIcon);
+    }
 
     QVBoxLayout *layout = new QVBoxLayout(msgBox);
     QHBoxLayout *hlayout = new QHBoxLayout;
@@ -435,7 +439,11 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
     QIcon infoIcon = msgBox->style()->standardIcon(QStyle::SP_MessageBoxInformation);
     int iconSize = msgBox->style()->pixelMetric(QStyle::PM_MessageBoxIconSize);
 
-    msgBox->setWindowIcon(infoIcon);
+    if (infoIcon.isNull()) {
+        qCWarning(lcUpdater) << "SP_MessageBoxInformation cannot be loaded!";
+    } else {
+        msgBox->setWindowIcon(infoIcon);
+    }
 
     QVBoxLayout *layout = new QVBoxLayout(msgBox);
     QHBoxLayout *hlayout = new QHBoxLayout;


### PR DESCRIPTION
Also warn when an icon is null.