### PR TITLE
macOS: Fix path comparison in launch-on-startup code

### DIFF
--- a/changelog/unreleased/9387
+++ b/changelog/unreleased/9387
@@ -1,0 +1,7 @@
+Bugfix: Fix toggling launch-on-login for macOS
+
+This would fail when upgrading the application, and the upgraded version
+has one or more letters in the name changed from/to upper-case.
+
+https://github.com/owncloud/client/issues/9387
+https://github.com/owncloud/client/pull/9433

--- a/src/common/utility_mac.cpp
+++ b/src/common/utility_mac.cpp
@@ -62,7 +62,13 @@ bool hasLaunchOnStartup_private(const QString &)
 
             if (LSSharedFileListItemResolve(item, 0, &itemUrlRef, NULL) == noErr && itemUrlRef) {
                 CFStringRef itemUrlString = CFURLGetString(itemUrlRef);
-                if (CFStringCompare(itemUrlString, appUrlRefString, 0) == kCFCompareEqualTo) {
+
+                // Check if we found "our" app url.
+                // IMPORTANT: this needs to be a case-insensitive compare, because (most) macOS
+                // file systems are case insensitive, so if e.g. "btr.app" is replaced by "BtR.app"
+                // in an update, they should be treated the same.
+                // See also: https://github.com/owncloud/client/issues/9387
+                if (CFStringCompare(itemUrlString, appUrlRefString, kCFCompareCaseInsensitive) == kCFCompareEqualTo) {
                     returnValue = true;
                 }
                 CFRelease(itemUrlRef);
@@ -108,7 +114,13 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
 
                 if (LSSharedFileListItemResolve(item, 0, &itemUrlRef, NULL) == noErr && itemUrlRef) {
                     CFStringRef itemUrlString = CFURLGetString(itemUrlRef);
-                    if (CFStringCompare(itemUrlString, appUrlRefString, 0) == kCFCompareEqualTo) {
+
+                    // Check if we found "our" app url.
+                    // IMPORTANT: this needs to be a case-insensitive compare, because (most) macOS
+                    // file systems are case insensitive, so if e.g. "btr.app" is replaced by "BtR.app"
+                    // in an update, they should be treated the same.
+                    // See also: https://github.com/owncloud/client/issues/9387
+                    if (CFStringCompare(itemUrlString, appUrlRefString, kCFCompareCaseInsensitive) == kCFCompareEqualTo) {
                         LSSharedFileListItemRemove(loginItems, item); // remove it!
                     }
                     CFRelease(itemUrlRef);


### PR DESCRIPTION
When checking if the client is auto-started, the list of all login-items
is retrieved, and each item is compared to the path of the .app bundle.
This comparison needs to be done ignoring the case, as most macOS file
systems are case-insensitive.

https://github.com/owncloud/client/issues/9387