### PR TITLE
[tests-only] Bumped test middleware version to v1.4.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,7 +5,7 @@
 # with a specific compiler.
 #
 
-OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.3.1"
+OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.4.0"
 
 dir = {
     "base": "/drone",


### PR DESCRIPTION
### Description
bump middleware version to v1.4.0

### Related
https://github.com/owncloud/owncloud-test-middleware/issues/104