### PR TITLE
Bugfix: mention source file in activity tab when renaming

### DIFF
--- a/changelog/unreleased/9238
+++ b/changelog/unreleased/9238
@@ -1,0 +1,4 @@
+Bugfix: mention source file in activity tab when renaming
+
+https://github.com/owncloud/client/issues/9238
+https://github.com/owncloud/client/pull/9453

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -45,7 +45,7 @@ QString Progress::asResultString(const SyncFileItem &item)
         return QCoreApplication::translate("progress", "Deleted");
     case CSYNC_INSTRUCTION_EVAL_RENAME:
     case CSYNC_INSTRUCTION_RENAME:
-        return QCoreApplication::translate("progress", "Moved to %1").arg(item._renameTarget);
+        return QCoreApplication::translate("progress", "%1 moved to %2").arg(item._file, item._renameTarget);
     case CSYNC_INSTRUCTION_IGNORE:
         return QCoreApplication::translate("progress", "Ignored");
     case CSYNC_INSTRUCTION_STAT_ERROR:


### PR DESCRIPTION
Fixed: https://github.com/owncloud/client/issues/9238