### PR TITLE
Improve poll-interval comments

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -36,6 +36,8 @@
 #include <QSet>
 #include <QNetworkProxy>
 
+using namespace std::chrono_literals;
+
 namespace {
 /*
  * [Accounts]

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -145,10 +145,12 @@ FolderMan::FolderMan(QObject *parent)
 
     _socketApi.reset(new SocketApi);
 
-    // Set the remote poll interval fixed to 1 second (1000 milliseconds)
-    // That does not mean that it polls every 1 second, but it checks every 1 second
-    // if one of the folders is due to sync.
-    _etagPollTimer.setInterval(1000);
+    // Set the remote poll interval fixed to 10 seconds.
+    // That does not mean that it polls every 10 seconds, but it checks every 10 seconds
+    // if one of the folders is due to sync. This means that if the server advertises a
+    // pollinterval that is not a multiple of 10 seconds, then that pollinterval will be
+    // rounded up to the next 10 seconds in practice. 10-second granularity is acceptable.
+    _etagPollTimer.setInterval(10s);
     QObject::connect(&_etagPollTimer, &QTimer::timeout, this, &FolderMan::slotEtagPollTimerTimeout);
     _etagPollTimer.start();
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -145,8 +145,8 @@ FolderMan::FolderMan(QObject *parent)
 
     _socketApi.reset(new SocketApi);
 
-    // Set the remote poll interval fixed to 10 seconds.
-    // That does not mean that it polls every 10 seconds, but it checks every 10 secs
+    // Set the remote poll interval fixed to 1 second (1000 milliseconds)
+    // That does not mean that it polls every 1 second, but it checks every 1 second
     // if one of the folders is due to sync.
     _etagPollTimer.setInterval(1000);
     QObject::connect(&_etagPollTimer, &QTimer::timeout, this, &FolderMan::slotEtagPollTimerTimeout);

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -93,7 +93,7 @@ const QString moveToTrashC() { return QStringLiteral("moveToTrash"); }
 }
 
 QString ConfigFile::_confDir = QString();
-const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in seconds
+const std::chrono::seconds DefaultRemotePollInterval { 30 };
 
 static chrono::milliseconds millisecondsValue(const QSettings &setting, const QString &key,
     chrono::milliseconds defaultValue)

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -93,7 +93,7 @@ const QString moveToTrashC() { return QStringLiteral("moveToTrash"); }
 }
 
 QString ConfigFile::_confDir = QString();
-const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in milliseconds
+const std::chrono::seconds DefaultRemotePollInterval { 30 }; // default remote poll time in seconds
 
 static chrono::milliseconds millisecondsValue(const QSettings &setting, const QString &key,
     chrono::milliseconds defaultValue)
@@ -418,9 +418,11 @@ chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::seconds default
 
     auto defaultPollInterval { DefaultRemotePollInterval };
 
-    // The server default-capabilities is set to 60, which is, if interpreted in milliseconds,
-    // pretty small. If the value is above 5 seconds, it was set intentionally.
+    // The server default-capabilities was set to 60 in some server releases,
+    // which, if interpreted in milliseconds, is pretty small.
+    // If the value is above 5 seconds, it was set intentionally.
     // Server admins have to set the value in Milliseconds!
+    // i.e. set to greater than 5000 milliseconds on the server to be effective.
     if (defaultVal > chrono::seconds(5)) {
         defaultPollInterval = defaultVal;
     }


### PR DESCRIPTION
PR #8777 made the client responsive to the "pollinterval" setting reporting  by the server in the capabilities.

The value of pollintervalis now interpreted as milliseconds.

This PR clarifies some comments. Hopefully I have made it clearer for future readers.