### PR TITLE
Fix timeouts in OAuth

### DIFF
--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -48,7 +48,7 @@ set(libsync_SRCS
 if(TOKEN_AUTH_ONLY)
     set (libsync_SRCS ${libsync_SRCS} creds/tokencredentials.cpp)
 else()
-    set(libsync_SRCS ${libsync_SRCS} creds/httpcredentials.cpp determineauthtypejobfactory.cpp abstractcorejob.cpp)
+    set(libsync_SRCS ${libsync_SRCS} creds/httpcredentials.cpp)
 endif()
 
 # These headers are installed for libowncloudsync to be used by 3rd party apps

--- a/src/libsync/abstractcorejob.h
+++ b/src/libsync/abstractcorejob.h
@@ -18,6 +18,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
+#include "abstractnetworkjob.h"
 #include "owncloudlib.h"
 
 namespace OCC {
@@ -121,6 +122,20 @@ protected:
      * @param networkError network error instance or NoError if the error is not caused by a network issue
      */
     static void setJobError(CoreJob *job, const QString &errorMessage, const QNetworkReply::NetworkError networkError);
+
+    /**
+     * Factory to create QNetworkRequests with properly set timeout.
+     */
+    template <typename... Params>
+    static OWNCLOUDSYNC_EXPORT QNetworkRequest makeRequest(Params... params)
+    {
+        auto request = QNetworkRequest(params...);
+
+        const auto timeoutMilliseconds = static_cast<int>(AbstractNetworkJob::httpTimeout.count());
+        request.setTransferTimeout(timeoutMilliseconds);
+
+        return request;
+    }
 
 private:
     QNetworkAccessManager *_nam;

--- a/src/libsync/creds/jobs/determineuserjobfactory.cpp
+++ b/src/libsync/creds/jobs/determineuserjobfactory.cpp
@@ -34,7 +34,7 @@ CoreJob *DetermineUserJobFactory::startJob(const QUrl &url)
 
     QUrlQuery urlQuery({ { QStringLiteral("format"), QStringLiteral("json") } });
 
-    QNetworkRequest req(Utility::concatUrlPath(url, QStringLiteral("ocs/v2.php/cloud/user"), urlQuery));
+    auto req = makeRequest(Utility::concatUrlPath(url, QStringLiteral("ocs/v2.php/cloud/user"), urlQuery));
 
     // We are not connected yet so we need to handle the authentication manually
     req.setRawHeader("Authorization", "Bearer " + _accessToken.toUtf8());

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -479,6 +479,7 @@ void OAuth::fetchWellKnown()
         QNetworkRequest req;
         req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
         req.setUrl(Utility::concatUrlPath(_serverUrl, QStringLiteral("/.well-known/openid-configuration")));
+        req.setTransferTimeout(static_cast<int>(AbstractNetworkJob::httpTimeout.count()));
         auto reply = _networkAccessManager->get(req);
         QObject::connect(reply, &QNetworkReply::finished, this, [reply, this] {
             _wellKnownFinished = true;

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -35,7 +35,8 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url)
 {
     auto job = new CoreJob;
 
-    QNetworkRequest req(Utility::concatUrlPath(url, QStringLiteral("remote.php/dav/files/")));
+    auto req = makeRequest(Utility::concatUrlPath(url, QStringLiteral("remote.php/dav/files/")));
+
     req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
     req.setAttribute(QNetworkRequest::AuthenticationReuseAttribute, QNetworkRequest::Manual);
 


### PR DESCRIPTION
Forgot to add proper handling in my previous PR, #9426. This reliably fixes the `OAuthTest` (tested with a sample size of 1000 against the previous implementation, where about 9% of the test runs failed).