### PR TITLE
Improve log message format

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -85,10 +85,6 @@ QString Logger::loggerPattern()
 {
     QString format = QStringLiteral("[%{time yyyy/MM/dd hh:mm:ss,zzz}]");
 
-    // all messages should use a category, but some may not
-    // in that case, we hide the category part
-    format += QStringLiteral("%{if-category} <%{category}>%{endif}");
-
     format += QStringLiteral(" ");
 
     // qSetMessageFormat is a bit limiting: there is no way to format the categories in upper case other than do it oneself
@@ -98,8 +94,9 @@ QString Logger::loggerPattern()
         format += QStringLiteral("%{if-") + category + QStringLiteral("}") + category.toUpper() + QStringLiteral("%{endif}");
     }
 
-    // not entirely sure why the function may be shown only for debug messages
-    format += QStringLiteral("%{if-debug} (%{function})%{endif}");
+    // all messages should use a category, but some may not
+    // in that case, we hide the category part
+    format += QStringLiteral("%{if-category} <%{category}>%{endif}");
 
     format += QStringLiteral(": %{message}");
 

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -100,10 +100,31 @@ QString Logger::loggerPattern()
 
     format += QStringLiteral(": %{message}");
 
-    // speeds up code navigation IDEs which support paths and line numbers
-    if (qEnvironmentVariableIsSet("LOG_FILE_AND_LINENO")) {
-        format += QStringLiteral(" (in %{file}:%{line})");
+#if !defined(QT_NO_DEBUG) || defined(QT_MESSAGELOGCONTEXT)
+    static const auto log_file_and_lineno = qEnvironmentVariableIsSet("LOG_FILE_AND_LINENO");
+    static const auto log_function_name = qEnvironmentVariableIsSet("LOG_FUNCTION_NAME");
+
+    if (log_file_and_lineno || log_function_name) {
+        format += QStringLiteral(" (in ");
+
+        if (log_function_name) {
+            format += QStringLiteral("%{function}");
+        }
+
+        if (log_file_and_lineno && log_function_name) {
+            format += QStringLiteral(", ");
+        }
+
+        // speeds up code navigation IDEs which support paths and line numbers
+        if (log_file_and_lineno) {
+            format += QStringLiteral("%{file}:%{line}");
+        }
+
+        format += QStringLiteral(")");
     }
+#else
+#warning "QT_MESSAGELOGCONTEXT not set and not a debug build, cannot show context of log messages"
+#endif
 
     qDebug() << format;
 


### PR DESCRIPTION
Helps making the log messages more readable, both for humans and machines.

Example log:
```
[2022/02/23 12:47:30,120] <gui.folder> INFO: Saved folder "1" to settings, status QSettings::NoError
[2022/02/23 12:47:30,120] <gui.folder.manager> INFO: Schedule folder  "1"  to sync!
[2022/02/23 12:47:30,120] <gui.folder.manager> INFO: Folder is not ready to sync, not scheduled!
[2022/02/23 12:47:30,121] <gui.application> INFO: Sync state changed for folder  "https://localhost:8443/remote.php/webdav/" :  "Not yet Started"
[2022/02/23 12:47:30,121] <sync.database.sql> DEBUG (OCC::SqlQuery::bindValue): SQL bind 1 3
[2022/02/23 12:47:30,121] <sync.database.sql> DEBUG (OCC::SqlQuery::exec): SQL exec "SELECT path FROM selectivesync WHERE type=?1"
[2022/02/23 12:47:30,121] <sync.clientproxy> INFO: Set proxy configuration to use system configuration