### PR TITLE
Enusre we close the file in time

### DIFF
--- a/changelog/unreleased/9472
+++ b/changelog/unreleased/9472
@@ -1,0 +1,6 @@
+Bugfix: Fix status of files uploaded with TUS
+
+Setting the upload status of files uploaded with TUS failed as we
+were still using the file.
+
+https://github.com/owncloud/client/pull/9472

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -734,6 +734,9 @@ void SimpleNetworkJob::addNewReplyHook(std::function<void(QNetworkReply *)> &&ho
 
 bool SimpleNetworkJob::finished()
 {
+    if (_device) {
+        _device->close();
+    }
     emit finishedSignal();
     return true;
 }


### PR DESCRIPTION
Close the body device when we finished.
This fixes:

```
02-25 14:27:42:887 [ debug sync.propagator.upload.tus ]	[ OCC::PropagateUploadFileTUS::finalize ]:	"" "a1c61d6e3a2dbc99d8c78fc9d20f0edf" "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c!c246992e-fc43-4ea1-8353-cf1740d90d3a"
02-25 14:27:42:887 [ warning sync.vfs.win ]:	"CfOpenWithOplock error C:/Users/hanna/ownCloud44/Marie Curie/CableTie1.1 - Copy.stl WindowsError: ffffffff80070020: The process cannot access the file because it is being used by another process."
```