### PR TITLE
Lock upload during finalization

### DIFF
--- a/changelog/unreleased/enterprise-5052
+++ b/changelog/unreleased/enterprise-5052
@@ -1,0 +1,6 @@
+Bugfix: Don't publish upload if we can't finish the transaction in the client
+
+When a file gets locked during an upload we aborted after the upload finished on the server.
+Resulting in a divergence of the local and remote state which could lead to conflicts.
+
+https://github.com/owncloud/enterprise/issues/5052

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -19,13 +19,15 @@
 #pragma once
 
 #include "config.h"
+#include "ocsynclib.h"
+
+#include "utility.h"
 
 #include <QString>
 #include <ctime>
 #include <QFileInfo>
 #include <QLoggingCategory>
 
-#include <ocsynclib.h>
 
 class QFile;
 
@@ -122,7 +124,17 @@ namespace FileSystem {
      * Warning: The resulting file may have an empty fileName and be unsuitable for use
      * with QFileInfo! Calling seek() on the QFile with >32bit signed values will fail!
      */
-    bool OCSYNC_EXPORT openAndSeekFileSharedRead(QFile *file, QString *error, qint64 seek);
+    bool OCSYNC_EXPORT openAndSeekFileSharedRead(QFile * file, QString * error, qint64 seek);
+
+    enum class LockMode {
+        Shared,
+        Exclusive
+    };
+    Q_ENUM_NS(LockMode);
+    /**
+     * Returns true when a file is locked. (Windows only)
+     */
+    bool OCSYNC_EXPORT isFileLocked(const QString &fileName, LockMode mode);
 
 #ifdef Q_OS_WIN
     /**
@@ -142,17 +154,12 @@ namespace FileSystem {
      *    the windows API functions work with the normal "unixoid" representation too.
      */
     QString OCSYNC_EXPORT pathtoUNC(const QString &str);
-#endif
 
-    enum class LockMode {
-        Shared,
-        Exclusive
-    };
-    Q_ENUM_NS(LockMode);
     /**
-     * Returns true when a file is locked. (Windows only)
+     * This function creates a file handle with the desired LockMode
      */
-    bool OCSYNC_EXPORT isFileLocked(const QString &fileName, LockMode mode);
+    Utility::Handle OCSYNC_EXPORT lockFile(const QString &fileName, LockMode mode);
+#endif
 
     /**
      * Returns whether the file is a shortcut file (ends with .lnk)

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -274,6 +274,59 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
         Q_DISABLE_COPY(NtfsPermissionLookupRAII);
     };
 
+
+    class OCSYNC_EXPORT Handle
+    {
+    public:
+        /**
+         * A RAAI for Windows Handles
+         */
+        Handle() = default;
+        explicit Handle(HANDLE h);
+        explicit Handle(HANDLE h, std::function<void(HANDLE)> &&close);
+
+        Handle(const Handle &) = delete;
+        Handle &operator=(const Handle &) = delete;
+
+        Handle(Handle &&other)
+        {
+            std::swap(_handle, other._handle);
+            std::swap(_close, other._close);
+        }
+
+        Handle &operator=(Handle &&other)
+        {
+            if (this != &other) {
+                std::swap(_handle, other._handle);
+                std::swap(_close, other._close);
+            }
+            return *this;
+        }
+
+        ~Handle();
+
+        HANDLE &handle()
+        {
+            return _handle;
+        }
+
+        void close();
+
+        explicit operator bool() const
+        {
+            return _handle != INVALID_HANDLE_VALUE;
+        }
+
+        operator HANDLE() const
+        {
+            return _handle;
+        }
+
+    private:
+        HANDLE _handle = INVALID_HANDLE_VALUE;
+        std::function<void(HANDLE)> _close;
+    };
+
 #endif
 
     template <class E>

--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -319,4 +319,31 @@ Utility::NtfsPermissionLookupRAII::~NtfsPermissionLookupRAII()
     qt_ntfs_permission_lookup--;
 }
 
+
+Utility::Handle::Handle(HANDLE h, std::function<void(HANDLE)> &&close)
+    : _handle(h)
+    , _close(std::move(close))
+{
+}
+
+Utility::Handle::Handle(HANDLE h)
+    : _handle(h)
+    , _close(&CloseHandle)
+{
+}
+
+Utility::Handle::~Handle()
+{
+    close();
+}
+
+void Utility::Handle::close()
+{
+    if (_handle != INVALID_HANDLE_VALUE) {
+        _close(_handle);
+        _handle = INVALID_HANDLE_VALUE;
+    }
+}
+
+
 } // namespace OCC

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -570,6 +570,10 @@ void PropagateUploadFileCommon::finalize()
     if (quotaIt != propagator()->_folderQuota.end())
         quotaIt.value() -= _item->_size;
 
+
+#ifdef Q_OS_WIN
+    m_fileLock.close();
+#endif
     // Update the database entry
     const auto result = propagator()->updateMetadata(*_item);
     if (!result) {

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -244,6 +244,10 @@ protected:
 
     /** Bases headers that need to be sent on the PUT, or in the MOVE for chunking-ng */
     QMap<QByteArray, QByteArray> headers();
+
+#ifdef Q_OS_WIN
+    Utility::Handle m_fileLock;
+#endif
 };
 
 /**

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -358,6 +358,19 @@ void PropagateUploadFileNG::doFinalMove()
 
     const QUrl source = Utility::concatUrlPath(chunkUrl(), QStringLiteral("/.file"));
 
+#ifdef Q_OS_WIN
+    // Try to accuire a lock on the file and keep it until we done.
+    // If the file is locked, abort before we perform the move on the server
+    const QString fileName = propagator()->fullLocalPath(_item->_file);
+    const auto lockMode = propagator()->syncOptions().requiredLockMode();
+    m_fileLock = FileSystem::lockFile(fileName, lockMode);
+    if (!m_fileLock) {
+        emit propagator()->seenLockedFile(fileName, lockMode);
+        abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(QDir::toNativeSeparators(fileName)));
+        return;
+    }
+#endif
+
     auto job = new MoveJob(propagator()->account(), source, destination, headers, this);
     _jobs.append(job);
     connect(job, &MoveJob::finishedSignal, this, &PropagateUploadFileNG::slotMoveJobFinished);


### PR DESCRIPTION
| Client| Server| State|
|---|---|---|
| A | A |Same version on both sides
| B | A | Versions differ, client starts upload
| B | A | During the upload, B gets locked
| B | B | B is uploaded, Local B is locked so we don't enter the state to the db
| C | B | The local db was not updated, we don't know about B on the server, local file gets updated and becomes C
| C | B | We have C locally and B on the server -> clash