### PR TITLE
Use factories to construct QSettings objects

### DIFF
--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -42,7 +42,7 @@ ProxyAuthHandler::ProxyAuthHandler()
     _dialog = new ProxyAuthDialog();
 
     _configFile.reset(new ConfigFile);
-    _settings.reset(ConfigFile::makeQSettingsPtr());
+    _settings.reset(new QSettings(ConfigFile::makeQSettings()));
     _settings->beginGroup(QLatin1String("Proxy"));
     _settings->beginGroup(QLatin1String("Credentials"));
 }

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -42,7 +42,7 @@ ProxyAuthHandler::ProxyAuthHandler()
     _dialog = new ProxyAuthDialog();
 
     _configFile.reset(new ConfigFile);
-    _settings.reset(new QSettings(ConfigFile::configFile(), QSettings::IniFormat));
+    _settings.reset(ConfigFile::makeQSettingsPtr());
     _settings->beginGroup(QLatin1String("Proxy"));
     _settings->beginGroup(QLatin1String("Credentials"));
 }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -103,7 +103,7 @@ void OCUpdater::setUpdateUrl(const QUrl &url)
 
 bool OCUpdater::performUpdate()
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     QString updateFile = settings.value(updateAvailableC).toString();
     if (!updateFile.isEmpty() && QFile(updateFile).exists()
         && !updateSucceeded() /* Someone might have run the updater manually between restarts */) {
@@ -196,7 +196,7 @@ void OCUpdater::setDownloadState(DownloadState state)
 
 void OCUpdater::slotStartInstaller()
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     QString updateFile = settings.value(updateAvailableC).toString();
     settings.setValue(autoUpdateAttemptedC, true);
     settings.sync();
@@ -244,7 +244,7 @@ void OCUpdater::slotOpenUpdateUrl()
 
 bool OCUpdater::updateSucceeded() const
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
 
     const auto targetVersionInt = QVersionNumber::fromString(settings.value(updateTargetVersionC).toString());
     return Version::versionWithBuildNumber() >= targetVersionInt;
@@ -295,7 +295,7 @@ void NSISUpdater::slotWriteFile()
 
 void NSISUpdater::wipeUpdateData()
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     QString updateFileName = settings.value(updateAvailableC).toString();
     if (!updateFileName.isEmpty())
         QFile::remove(updateFileName);
@@ -317,7 +317,7 @@ void NSISUpdater::slotDownloadFinished()
     QUrl url(reply->url());
     _file->close();
 
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
 
     // remove previously downloaded but not used installer
     QFile oldTargetFile(settings.value(updateAvailableC).toString());
@@ -335,7 +335,7 @@ void NSISUpdater::slotDownloadFinished()
 
 void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     const auto infoVersion = QVersionNumber::fromString(info.version());
     const auto seenString = settings.value(seenVersionC).toString();
     const auto seenVersion = QVersionNumber::fromString(seenString);
@@ -492,7 +492,7 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 bool NSISUpdater::handleStartup()
 {
     ConfigFile cfg;
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     QString updateFileName = settings.value(updateAvailableC).toString();
     // has the previous run downloaded an update?
     if (!updateFileName.isEmpty() && QFile(updateFileName).exists()) {
@@ -522,7 +522,7 @@ bool NSISUpdater::handleStartup()
 
 void NSISUpdater::slotSetSeenVersion()
 {
-    QSettings settings(ConfigFile::configFile(), QSettings::IniFormat);
+    auto settings = ConfigFile::makeQSettings();
     settings.setValue(seenVersionC, updateInfo().version());
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -376,11 +376,6 @@ QSettings ConfigFile::makeQSettings()
     return { configFile(), QSettings::IniFormat };
 }
 
-QSettings *ConfigFile::makeQSettingsPtr()
-{
-    return new QSettings(configFile(), QSettings::IniFormat);
-}
-
 bool ConfigFile::exists()
 {
     return QFileInfo::exists(configFile());

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -141,19 +141,19 @@ bool ConfigFile::setConfDir(const QString &value)
 
 bool ConfigFile::optionalDesktopNotifications() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(optionalDesktopNoficationsC(), true).toBool();
 }
 
 bool ConfigFile::showInExplorerNavigationPane() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(showInExplorerNavigationPaneC(), QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows10).toBool();
 }
 
 void ConfigFile::setShowInExplorerNavigationPane(bool show)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(showInExplorerNavigationPaneC(), show);
     settings.sync();
 }
@@ -167,31 +167,31 @@ std::chrono::seconds ConfigFile::timeout() const
 
 qint64 ConfigFile::chunkSize() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(chunkSizeC(), 10 * 1000 * 1000).toLongLong(); // default to 10 MB
 }
 
 qint64 ConfigFile::maxChunkSize() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(maxChunkSizeC(), 100 * 1000 * 1000).toLongLong(); // default to 100 MB
 }
 
 qint64 ConfigFile::minChunkSize() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(minChunkSizeC(), 1000 * 1000).toLongLong(); // default to 1 MB
 }
 
 chrono::milliseconds ConfigFile::targetChunkUploadDuration() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return millisecondsValue(settings, targetChunkUploadDurationC(), chrono::minutes(1));
 }
 
 void ConfigFile::setOptionalDesktopNotifications(bool show)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(optionalDesktopNoficationsC(), show);
     settings.sync();
 }
@@ -200,7 +200,7 @@ void ConfigFile::saveGeometry(QWidget *w)
 {
 #ifndef TOKEN_AUTH_ONLY
     OC_ASSERT(!w->objectName().isNull());
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(w->objectName());
     settings.setValue(geometryC(), w->saveGeometry());
     settings.sync();
@@ -221,7 +221,7 @@ void ConfigFile::saveGeometryHeader(QHeaderView *header)
         return;
     OC_ASSERT(!header->objectName().isEmpty());
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(header->objectName());
     settings.setValue(geometryC(), header->saveState());
     settings.sync();
@@ -235,7 +235,7 @@ void ConfigFile::restoreGeometryHeader(QHeaderView *header)
         return;
     OC_ASSERT(!header->objectName().isNull());
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(header->objectName());
     header->restoreState(settings.value(geometryC()).toByteArray());
 #endif
@@ -371,6 +371,16 @@ QString ConfigFile::configFile()
     return configPath() + Theme::instance()->configFileName();
 }
 
+QSettings ConfigFile::makeQSettings()
+{
+    return { configFile(), QSettings::IniFormat };
+}
+
+QSettings *ConfigFile::makeQSettingsPtr()
+{
+    return new QSettings(configFile(), QSettings::IniFormat);
+}
+
 bool ConfigFile::exists()
 {
     return QFileInfo::exists(configFile());
@@ -384,7 +394,7 @@ QString ConfigFile::defaultConnection() const
 void ConfigFile::storeData(const QString &group, const QString &key, const QVariant &value)
 {
     const QString con(group.isEmpty() ? defaultConnection() : group);
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
 
     settings.beginGroup(con);
     settings.setValue(key, value);
@@ -394,7 +404,7 @@ void ConfigFile::storeData(const QString &group, const QString &key, const QVari
 void ConfigFile::removeData(const QString &group, const QString &key)
 {
     const QString con(group.isEmpty() ? defaultConnection() : group);
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
 
     settings.beginGroup(con);
     settings.remove(key);
@@ -403,7 +413,7 @@ void ConfigFile::removeData(const QString &group, const QString &key)
 bool ConfigFile::dataExists(const QString &group, const QString &key) const
 {
     const QString con(group.isEmpty() ? defaultConnection() : group);
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
 
     settings.beginGroup(con);
     return settings.contains(key);
@@ -415,7 +425,7 @@ chrono::milliseconds ConfigFile::remotePollInterval(std::chrono::seconds default
     if (connection.isEmpty())
         con = defaultConnection();
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
 
     auto defaultPollInterval { DefaultRemotePollInterval };
@@ -446,7 +456,7 @@ void ConfigFile::setRemotePollInterval(chrono::milliseconds interval, const QStr
         qCWarning(lcConfigFile) << "Remote Poll interval of " << interval.count() << " is below five seconds.";
         return;
     }
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
     settings.setValue(remotePollIntervalC(), qlonglong(interval.count()));
     settings.sync();
@@ -459,7 +469,7 @@ chrono::milliseconds ConfigFile::forceSyncInterval(std::chrono::seconds remoteFr
     QString con(connection);
     if (connection.isEmpty())
         con = defaultConnection();
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
 
     auto defaultInterval = chrono::hours(2);
@@ -473,7 +483,7 @@ chrono::milliseconds ConfigFile::forceSyncInterval(std::chrono::seconds remoteFr
 
 chrono::milliseconds OCC::ConfigFile::fullLocalDiscoveryInterval() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(defaultConnection());
     return millisecondsValue(settings, fullLocalDiscoveryIntervalC(), chrono::hours(1));
 }
@@ -483,7 +493,7 @@ chrono::milliseconds ConfigFile::notificationRefreshInterval(const QString &conn
     QString con(connection);
     if (connection.isEmpty())
         con = defaultConnection();
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
 
     auto defaultInterval = chrono::minutes(5);
@@ -500,7 +510,7 @@ chrono::milliseconds ConfigFile::updateCheckInterval(const QString &connection) 
     QString con(connection);
     if (connection.isEmpty())
         con = defaultConnection();
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
 
     auto defaultInterval = chrono::hours(10);
@@ -533,7 +543,7 @@ void ConfigFile::setSkipUpdateCheck(bool skip, const QString &connection)
     if (connection.isEmpty())
         con = defaultConnection();
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.beginGroup(con);
 
     settings.setValue(skipUpdateCheckC(), QVariant(skip));
@@ -552,25 +562,25 @@ QString ConfigFile::updateChannel() const
         defaultUpdateChannel = QStringLiteral("beta");
     }
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(updateChannelC(), defaultUpdateChannel).toString();
 }
 
 void ConfigFile::setUpdateChannel(const QString &channel)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(updateChannelC(), channel);
 }
 
 QString ConfigFile::uiLanguage() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(uiLanguageC(), QString()).toString();
 }
 
 void ConfigFile::setUiLanguage(const QString &uiLanguage)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(uiLanguageC(), uiLanguage);
 }
 
@@ -580,7 +590,7 @@ void ConfigFile::setProxyType(int proxyType,
     const QString &user,
     const QString &pass)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
 
     settings.setValue(proxyTypeC(), proxyType);
 
@@ -620,7 +630,7 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
         systemSetting = systemSettings.value(param, defaultValue);
     }
 
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     if (!group.isEmpty())
         settings.beginGroup(group);
 
@@ -629,7 +639,7 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
 
 void ConfigFile::setValue(const QString &key, const QVariant &value)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
 
     settings.setValue(key, value);
 }
@@ -744,19 +754,19 @@ void ConfigFile::setMoveToTrash(bool isChecked)
 
 bool ConfigFile::promptDeleteFiles() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(promptDeleteC(), true).toBool();
 }
 
 void ConfigFile::setPromptDeleteFiles(bool promptDeleteFiles)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(promptDeleteC(), promptDeleteFiles);
 }
 
 bool ConfigFile::monoIcons() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     bool monoDefault = false; // On Mac we want bw by default
 #ifdef Q_OS_MAC
     // OEM themes are not obliged to ship mono icons
@@ -767,37 +777,37 @@ bool ConfigFile::monoIcons() const
 
 void ConfigFile::setMonoIcons(bool useMonoIcons)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(monoIconsC(), useMonoIcons);
 }
 
 bool ConfigFile::crashReporter() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(crashReporterC(), true).toBool();
 }
 
 void ConfigFile::setCrashReporter(bool enabled)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(crashReporterC(), enabled);
 }
 
 bool ConfigFile::automaticLogDir() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(automaticLogDirC(), false).toBool();
 }
 
 void ConfigFile::setAutomaticLogDir(bool enabled)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(automaticLogDirC(), enabled);
 }
 
 Optional<chrono::hours> ConfigFile::automaticDeleteOldLogsAge() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     auto value = settings.value(deleteOldLogsAfterHoursC());
     if (!value.isValid())
         return chrono::hours(4);
@@ -809,7 +819,7 @@ Optional<chrono::hours> ConfigFile::automaticDeleteOldLogsAge() const
 
 void ConfigFile::setAutomaticDeleteOldLogsAge(Optional<chrono::hours> expireTime)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     if (!expireTime) {
         settings.setValue(deleteOldLogsAfterHoursC(), -1);
     } else {
@@ -819,7 +829,7 @@ void ConfigFile::setAutomaticDeleteOldLogsAge(Optional<chrono::hours> expireTime
 
 void ConfigFile::setLogHttp(bool b)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(logHttpC(), b);
     const QSet<QString> rule = { QStringLiteral("sync.httplogger=true") };
     if (b) {
@@ -831,25 +841,25 @@ void ConfigFile::setLogHttp(bool b)
 
 bool ConfigFile::logHttp() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(logHttpC(), false).toBool();
 }
 
 bool ConfigFile::showExperimentalOptions() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(showExperimentalOptionsC(), false).toBool();
 }
 
 QString ConfigFile::clientVersionString() const
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     return settings.value(clientVersionC(), QString()).toString();
 }
 
 void ConfigFile::setClientVersionString(const QString &version)
 {
-    QSettings settings(configFile(), QSettings::IniFormat);
+    auto settings = makeQSettings();
     settings.setValue(clientVersionC(), version);
 }
 

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -41,6 +41,8 @@ class OWNCLOUDSYNC_EXPORT ConfigFile
 public:
     static QString configPath();
     static QString configFile();
+    static QSettings makeQSettings();
+    static QSettings *makeQSettingsPtr();
     static bool exists();
 
     ConfigFile();

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -42,7 +42,6 @@ public:
     static QString configPath();
     static QString configFile();
     static QSettings makeQSettings();
-    static QSettings *makeQSettingsPtr();
     static bool exists();
 
     ConfigFile();


### PR DESCRIPTION
Extracted from #9376, as requested by @TheOneRing.

Fun fact: I accidentally cherry-picked the commit on 2.10 first and then spent a lot of time trying to figure out why it wouldn't build. Turns out the issue was that the old branch uses `-std=gnu++14` vs. `-std=gnu++17 -fsyntax-only` on `master` (not sure about the latter, though). In C++14, return-by-value in the `makeQSettings` factory calls the copy constructor for some reason I don't know, which `QSettings` disabled, and I found no way to use move-construction instead.

The pointer factory is there for `ProxyAuthHandler`, by the way. I didn't want to rewrite that class. Perhaps we can avoid `makeQSettingsPtr` by creating a new object on the heap and then move-assigning the old one to the one on the heap?