### PR TITLE
[tests-only] Fix and unskip delete tests

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -96,7 +96,8 @@ def hook(context):
     # Detach (i.e. potentially terminate) all AUTs at the end of a scenario
     for ctx in applicationContextList():
         ctx.detach()
-        snooze(5)  # ToDo wait smarter till the app died
+        # ToDo wait smarter till the app died
+        snooze(context.userData['minSyncTimeout'])
 
     # delete local files/folders
     for filename in os.listdir(context.userData['clientRootSyncPath']):

--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -115,3 +115,4 @@ deselect_remote_folders_you_do_not_wish_to_synchronize_QHeaderView = {"container
 linkShares_QToolButton_2 = {"container": oCC_ShareLinkWidget_linkShares_QTableWidget, "occurrence": 2, "type": "QToolButton", "unnamed": 1, "visible": 1}
 oCC_ShareLinkWidget_Delete_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "text": "Delete", "type": "QPushButton", "unnamed": 1, "visible": 1}
 oCC_ShareLinkWidget_pushButton_setPassword_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_ShareLinkWidget_OCC_ShareLinkWidget, "name": "pushButton_setPassword", "type": "QPushButton", "visible": 1}
+remove_All_Files_QMessageBox = {"type": "QMessageBox", "unnamed": 1, "visible": 1, "windowTitle": "Remove All Files?"}

--- a/test/gui/shared/scripts/pageObjects/AccountStatus.py
+++ b/test/gui/shared/scripts/pageObjects/AccountStatus.py
@@ -32,6 +32,14 @@ class AccountStatus:
         "visible": 1,
     }
 
+    REMOVE_ALL_FILES = {
+        "window": names.remove_All_Files_QMessageBox,
+        "text": "Remove all files",
+        "type": "QPushButton",
+        "unnamed": 1,
+        "visible": 1,
+    }
+
     settingsdialogToolbutton = None
 
     def __init__(self, context, displayname, host=None):
@@ -66,3 +74,7 @@ class AccountStatus:
 
     def getText(self):
         return str(squish.waitForObjectExists(self.settingsdialogToolbutton).text)
+
+    @staticmethod
+    def confirmRemoveAllFiles():
+        squish.clickButton(squish.waitForObject(AccountStatus.REMOVE_ALL_FILES))

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -467,7 +467,7 @@ def createFile(context, filename, username=None):
 
     # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
     # https://github.com/owncloud/client/issues/9325
-    snooze(5)
+    snooze(context.userData['minSyncTimeout'])
 
     f = open(join(syncPath, filename), "w")
     f.write(fileContent)
@@ -934,7 +934,7 @@ def step(context, username):
 def step(context, username):
     # TODO: find some way to dynamically to check if files are synced
     # It might take some time for all files to sync and connect to ther server
-    snooze(5)
+    snooze(context.userData['minSyncTimeout'])
     isUserSignedIn(context, username)
 
 
@@ -1049,8 +1049,7 @@ def step(context, resource, content):
     # The client does not see the change although the changes have already been made thus we are having a race condition
     # So for now we add 5sec static wait
     # an issue https://github.com/owncloud/client/issues/8832 has been created for it
-
-    snooze(5)
+    snooze(context.userData['minSyncTimeout'])
 
     overwriteFile(resource, content)
 
@@ -1151,10 +1150,9 @@ def step(context, errorMsg):
 @When(r'the user deletes the (file|folder) "([^"]*)"', regexp=True)
 def step(context, itemType, resource):
     # deleting the file immediately after it has been synced from the server seems to have some problem.
-    # The client does not see the change although the changes have already been made thus we are having a race condition
-    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
+    # issue: https://github.com/owncloud/client/issues/8832
     if itemType == "file":
-        snooze(5)
+        snooze(context.userData['minSyncTimeout'])
 
     resourcePath = sanitizePath(context.userData['currentUserSyncPath'] + resource)
     if itemType == 'file':
@@ -1166,6 +1164,7 @@ def step(context, itemType, resource):
 
     isSyncFolderEmpty = True
     for item in listdir(context.userData['currentUserSyncPath']):
+        # do not count the hidden files as they are ignored by the client
         if not item.startswith("."):
             isSyncFolderEmpty = False
             break
@@ -1414,7 +1413,7 @@ def step(context, username):
 
     # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
     # https://github.com/owncloud/client/issues/9325
-    snooze(5)
+    snooze(context.userData['minSyncTimeout'])
 
     for row in context.table[1:]:
         filename = syncPath + row[0]

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -153,6 +153,7 @@ def hasSyncStatus(type, itemName, status):
     if not socketConnect.read_socket_data_with_timeout(0.1):
         return False
     for line in socketConnect.get_available_responses():
+        # print(line)
         if line.startswith(status) and line.endswith(itemName):
             return True
         elif line.endswith(itemName):
@@ -1157,6 +1158,20 @@ def step(context, itemType, resource):
         shutil.rmtree(resourcePath)
     else:
         raise Exception("No such item type for resource")
+
+    isSyncFolderEmpty = True
+    for item in listdir(context.userData['currentUserSyncPath']):
+        if not item.startswith("."):
+            isSyncFolderEmpty = False
+            break
+
+    # if the sync folder is empty after deleting file,
+    # a dialog will popup asking to confirm "Remove all files"
+    if isSyncFolderEmpty:
+        try:
+            AccountStatus.confirmRemoveAllFiles()
+        except:
+            pass
 
 
 @When(

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -153,7 +153,6 @@ def hasSyncStatus(type, itemName, status):
     if not socketConnect.read_socket_data_with_timeout(0.1):
         return False
     for line in socketConnect.get_available_responses():
-        # print(line)
         if line.startswith(status) and line.endswith(itemName):
             return True
         elif line.endswith(itemName):
@@ -1151,6 +1150,7 @@ def step(context, errorMsg):
 
 @When(r'the user deletes the (file|folder) "([^"]*)"', regexp=True)
 def step(context, itemType, resource):
+    snooze(5)
     resourcePath = sanitizePath(context.userData['currentUserSyncPath'] + resource)
     if itemType == 'file':
         os.remove(resourcePath)

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1150,7 +1150,12 @@ def step(context, errorMsg):
 
 @When(r'the user deletes the (file|folder) "([^"]*)"', regexp=True)
 def step(context, itemType, resource):
-    snooze(5)
+    # deleting the file immediately after it has been synced from the server seems to have some problem.
+    # The client does not see the change although the changes have already been made thus we are having a race condition
+    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
+    if itemType == "file":
+        snooze(5)
+
     resourcePath = sanitizePath(context.userData['currentUserSyncPath'] + resource)
     if itemType == 'file':
         os.remove(resourcePath)

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -8,24 +8,26 @@ Feature: deleting files and folders
 	Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
 
-    @skip @issue-9439
+    @issue-9439
     Scenario Outline: Delete a file
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "<fileName>" on the server
         And user "Alice" has set up a client with default settings
-        When the user waits for file "<fileName>" to be synced
+        When the user waits for the files to sync
         And the user deletes the file "<fileName>"
+        And the user waits for the files to sync
         Then as "Alice" file "<fileName>" should not exist on the server
         Examples:
             | fileName                                    |
             | textfile0.txt                               |
             | textfile0-with-name-more-than-20-characters |
 
-    @skip @issue-9439
+    @issue-9439
     Scenario Outline: Delete a folder
         Given user "Alice" has created folder "<folderName>" on the server
         And user "Alice" has set up a client with default settings
-        When the user waits for folder "<folderName>" to be synced
+        When the user waits for the files to sync
         And the user deletes the folder "<folderName>"
+        And the user waits for the files to sync
         Then as "Alice" file "<folderName>" should not exist on the server
         Examples:
             | folderName                                      |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -337,8 +337,9 @@ Feature: Sharing
         And the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
         And the user waits for the files to sync
-        Then as "Brian" file "textfile.txt" on the server should exist
-        And as "Brian" folder "Folder" on the server should exist
+        # Sharee can delete (means unshare) the file shared with read permission
+        Then as "Brian" file "textfile.txt" on the server should not exist
+        And as "Brian" folder "Folder" on the server should not exist
         And as "Alice" file "textfile.txt" on the server should exist
         And as "Alice" folder "Folder" on the server should exist
 

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -308,7 +308,7 @@ Feature: Sharing
         And as "Alice" folder "PARENT" should not exist on the server
         And as "Alice" file "lorem.txt" should not exist on the server
 
-    @skip @issue-9439
+    @issue-9439
     Scenario: sharee deletes a file and folder shared by sharer
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
         And user "Alice" has created folder "Folder" on the server
@@ -316,8 +316,7 @@ Feature: Sharing
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for file "textfile.txt" to be synced
-        And the user waits for folder "Folder" to be synced
+        When the user waits for the files to sync
         And the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
         And the user waits for the files to sync

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -322,8 +322,8 @@ Feature: Sharing
         And the user waits for the files to sync
         Then as "Brian" file "textfile.txt" on the server should not exist
         And as "Brian" folder "Folder" on the server should not exist
-        And as "Alice" file "textfile.txt" on the server should not exist
-        And as "Alice" folder "Folder" on the server should not exist
+        And as "Alice" file "textfile.txt" on the server should exist
+        And as "Alice" folder "Folder" on the server should exist
 
 
     Scenario: sharee tries to delete shared file and folder without permissions


### PR DESCRIPTION
Whenever the last file/folder is deleted from the sync directory, client will show a pop like in the issue.
This PR fixes that scenario and unskipped the tests.

Fixes https://github.com/owncloud/client/issues/9439