### PR TITLE
Leave password line edit enabled on errors

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -363,14 +363,13 @@ void ShareLinkWidget::slotShareSelectionChanged()
             _ui->lineEdit_password->setEnabled(false);
         }
     } else if (!selectionUnchanged) {
+        // we used to disable the checkbox (and thus the line edit) when setting a password failed
+        // now, we leave it enabled but clear the password in any case
+        // only if setting was successful, we want to show a placeholder afterwards to signalize success
         if (share && share->isPasswordSet()) {
             _ui->checkBox_password->setChecked(true);
             _ui->lineEdit_password->setPlaceholderText("********");
             _ui->lineEdit_password->setEnabled(true);
-        } else {
-            _ui->checkBox_password->setChecked(false);
-            _ui->lineEdit_password->setPlaceholderText(QString());
-            _ui->lineEdit_password->setEnabled(false);
         }
         _ui->lineEdit_password->setText(QString());
         _ui->pushButton_setPassword->setEnabled(false);


### PR DESCRIPTION
Contributes to #9336.

New behavior:

![screenshot_2022-03-11_10-53-21](https://user-images.githubusercontent.com/80399010/157844318-887f8b28-54f6-40a9-aa90-7dc5e2182135.png)

I think we shouldn't disable the close button, because that'll bloat the (already relatively complex) code within the dialog, and requires the user to uncheck the checkbox first (in that case, we'd actually have to disable the close button generally when information is missing to make the UX consistent). Just removing the password and asking for a new one in the line edit combined with displaying the error message gives the user sufficient feedback to continue. Keeping the password makes little sense either, we should not store secrets for longer than necessary.

Upon success, a generic placeholder will be inserted in the line edit, as before.