### PR TITLE
Fix filter menus

### DIFF
--- a/changelog/unreleased/9513
+++ b/changelog/unreleased/9513
@@ -1,0 +1,7 @@
+Bugfix: improve filter pop-up menu and button
+    
+- replaced "No filter" option text with "All", to avoid the "No filter is not enabled" situation
+- replace the "Filter" label on the button with "1 Filter"/"2 Filters" when a filter is active, so a user can immediately see that without having to open the filter pop-up
+
+https://github.com/owncloud/client/issues/9425
+https://github.com/owncloud/client/pull/9513

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -59,7 +59,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     _ui->setupUi(this);
 
     _model = new ActivityListModel(this);
-    _sortModel = new QSortFilterProxyModel(this);
+    _sortModel = new SignalledQSortFilterProxyModel(this);
     _sortModel->setSourceModel(_model);
     _ui->_activityList->setModel(_sortModel);
     _sortModel->setSortRole(Models::UnderlyingDataRole);
@@ -103,11 +103,15 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     header->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header, &QListView::customContextMenuRequested, header, [header, this] {
         auto menu = ProtocolWidget::showFilterMenu(header, _sortModel, static_cast<int>(ActivityListModel::ActivityRole::Account), tr("Account"));
+        menu->addSeparator();
         header->addResetActionToMenu(menu);
     });
 
     connect(_ui->_filterButton, &QAbstractButton::clicked, this, [this] {
         ProtocolWidget::showFilterMenu(_ui->_filterButton, _sortModel, static_cast<int>(ActivityListModel::ActivityRole::Account), tr("Account"));
+    });
+    connect(_sortModel, &SignalledQSortFilterProxyModel::filterChanged, [this]() {
+        _ui->_filterButton->setText(CommonStrings::filterButtonText(_sortModel->filterRegExp().isEmpty() ? 0 : 1));
     });
 
     connect(&_removeTimer, &QTimer::timeout, this, &ActivityWidget::slotCheckToCleanWidgets);

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -26,6 +26,8 @@
 #include "account.h"
 #include "activitydata.h"
 
+#include "models/models.h"
+
 #include "ui_activitywidget.h"
 
 class QPushButton;
@@ -113,7 +115,7 @@ private:
     int _notificationRequestsRunning;
 
     ActivityListModel *_model;
-    QSortFilterProxyModel *_sortModel;
+    SignalledQSortFilterProxyModel *_sortModel;
     QVBoxLayout *_notificationsLayout;
 };
 

--- a/src/gui/commonstrings.cpp
+++ b/src/gui/commonstrings.cpp
@@ -42,3 +42,8 @@ QString CommonStrings::copyToClipBoard()
 {
     return QCoreApplication::translate("CommonStrings", "Copy");
 }
+
+QString CommonStrings::filterButtonText(int filterCount)
+{
+    return QCoreApplication::translate("CommonStrings", "%n Filter(s)").arg(filterCount);
+}

--- a/src/gui/commonstrings.h
+++ b/src/gui/commonstrings.h
@@ -22,5 +22,6 @@ namespace CommonStrings {
     QString showInFileBrowser();
     QString showInWebBrowser();
     QString copyToClipBoard();
+    QString filterButtonText(int filterCount);
 }
 }

--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -21,6 +21,7 @@
 #include <QTimer>
 
 #include "models/expandingheaderview.h"
+#include "models/models.h"
 #include "models/protocolitemmodel.h"
 #include "owncloudgui.h"
 #include "progressdispatcher.h"
@@ -52,6 +53,7 @@ public:
 public slots:
     void slotProgressInfo(const QString &folder, const ProgressInfo &progress);
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);
+    void filterDidChange();
 
 signals:
     void issueCountUpdated(int);
@@ -65,7 +67,7 @@ private:
     std::function<void()> addStatusFilter(QMenu *menu);
 
     ProtocolItemModel *_model;
-    QSortFilterProxyModel *_sortModel;
+    SignalledQSortFilterProxyModel *_sortModel;
     SyncFileItemStatusSetSortFilterProxyModel *_statusSortModel;
 
     Ui::IssuesWidget *_ui;

--- a/src/gui/models/models.cpp
+++ b/src/gui/models/models.cpp
@@ -22,6 +22,17 @@
 
 #include <functional>
 
+OCC::SignalledQSortFilterProxyModel::SignalledQSortFilterProxyModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+}
+
+void OCC::SignalledQSortFilterProxyModel::setFilterFixedStringSignalled(const QString &pattern)
+{
+    setFilterFixedString(pattern);
+    emit filterChanged();
+}
+
 QString OCC::Models::formatSelection(const QModelIndexList &items, int dataRole)
 {
     if (items.isEmpty()) {
@@ -77,9 +88,9 @@ QString OCC::Models::formatSelection(const QModelIndexList &items, int dataRole)
     return out;
 }
 
-std::function<void()> OCC::Models::addFilterMenuItems(QMenu *menu, const QStringList &candidates, QSortFilterProxyModel *model, int column, const QString &columnName, int role)
+std::function<void()> OCC::Models::addFilterMenuItems(QMenu *menu, const QStringList &candidates, SignalledQSortFilterProxyModel *model, int column, const QString &columnName, int role)
 {
-    menu->addAction(qApp->translate("OCC::Models", "%1 Filter:").arg(columnName))->setEnabled(false);
+    menu->addAction(QApplication::translate("OCC::Models", "%1 Filter:").arg(columnName))->setEnabled(false);
 
     auto filterGroup = new QActionGroup(menu);
     filterGroup->setExclusive(true);
@@ -89,7 +100,7 @@ std::function<void()> OCC::Models::addFilterMenuItems(QMenu *menu, const QString
         auto action = menu->addAction(s, menu, [=]() {
             model->setFilterRole(role);
             model->setFilterKeyColumn(column);
-            model->setFilterFixedString(filter);
+            model->setFilterFixedStringSignalled(filter);
         });
         action->setCheckable(true);
         if (currentFilter == filter) {
@@ -100,7 +111,7 @@ std::function<void()> OCC::Models::addFilterMenuItems(QMenu *menu, const QString
     };
 
 
-    auto noFilter = addAction(QApplication::translate("OCC::Models", "No filter"), QString());
+    auto noFilter = addAction(QApplication::translate("OCC::Models", "All"), QString());
 
     for (const auto &c : candidates) {
         addAction(c, c);

--- a/src/gui/models/models.h
+++ b/src/gui/models/models.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <QModelIndexList>
+#include <QSortFilterProxyModel>
 #include <QString>
 #include <QtGlobal>
 
@@ -21,6 +22,19 @@ class QSortFilterProxyModel;
 class QMenu;
 
 namespace OCC {
+
+class SignalledQSortFilterProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    SignalledQSortFilterProxyModel(QObject *parent = nullptr);
+
+    void setFilterFixedStringSignalled(const QString &pattern);
+
+signals:
+    void filterChanged();
+};
 
 namespace Models {
     enum DataRoles {
@@ -33,7 +47,7 @@ namespace Models {
      */
     QString formatSelection(const QModelIndexList &items, int dataRole = Qt::DisplayRole);
 
-    std::function<void()> addFilterMenuItems(QMenu *menu, const QStringList &candidates, QSortFilterProxyModel *model, int column, const QString &columnName, int role);
+    std::function<void()> addFilterMenuItems(QMenu *menu, const QStringList &candidates, SignalledQSortFilterProxyModel *model, int column, const QString &columnName, int role);
 
     /**
      * Returns a vector with indices
@@ -55,5 +69,5 @@ namespace Models {
     {
         return range<T>(0, end);
     }
-};
-}
+} // OCC::Models namespace
+} // OCC namespace

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -26,6 +26,8 @@
 #include "protocolitem.h"
 #include "ui_protocolwidget.h"
 
+#include "models/models.h"
+
 class QPushButton;
 class QSortFilterProxyModel;
 
@@ -49,17 +51,18 @@ public:
     ~ProtocolWidget() override;
 
     static void showContextMenu(QWidget *parent, ProtocolItemModel *model, const QModelIndexList &items);
-    static QMenu *showFilterMenu(QWidget *parent, QSortFilterProxyModel *model, int role, const QString &columnName);
+    static QMenu *showFilterMenu(QWidget *parent, SignalledQSortFilterProxyModel *model, int role, const QString &columnName);
 
 public slots:
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);
+    void filterDidChange();
 
 private slots:
     void slotItemContextMenu();
 
 private:
     ProtocolItemModel *_model;
-    QSortFilterProxyModel *_sortModel;
+    SignalledQSortFilterProxyModel *_sortModel;
     Ui::ProtocolWidget *_ui;
 };
 }


### PR DESCRIPTION
- replaced "No filter" option text with "All", to avoid the "No filter
  is not enabled" situation
- replace the "Filter" label on the button with "1 Filter"/"2 Filters"
  when a filter is active, so a user can immediately see that without
  having to open the filter pop-up