### PR TITLE
Fix skipped update check

### DIFF
--- a/src/gui/updater/appimageupdater.cpp
+++ b/src/gui/updater/appimageupdater.cpp
@@ -142,7 +142,7 @@ void AppImageUpdater::versionInfoArrived(const UpdateInfo &info)
     }
 
     const auto seenVersion = this->seenVersion();
-    if (seenVersion <= newVersion) {
+    if (seenVersion >= newVersion) {
         qCInfo(lcUpdater) << "Update" << seenVersion << "was skipped previously by user";
         setDownloadState(UpToDate);
         return;

--- a/src/gui/updater/appimageupdater.cpp
+++ b/src/gui/updater/appimageupdater.cpp
@@ -141,9 +141,9 @@ void AppImageUpdater::versionInfoArrived(const UpdateInfo &info)
         return;
     }
 
-    const auto seenVersion = this->seenVersion();
-    if (seenVersion >= newVersion) {
-        qCInfo(lcUpdater) << "Update" << seenVersion << "was skipped previously by user";
+    const auto previouslySkippedVersion = this->previouslySkippedVersion();
+    if (previouslySkippedVersion >= newVersion) {
+        qCInfo(lcUpdater) << "Update" << previouslySkippedVersion << "was skipped previously by user";
         setDownloadState(UpToDate);
         return;
     }
@@ -165,7 +165,7 @@ void AppImageUpdater::versionInfoArrived(const UpdateInfo &info)
 
     connect(dialog, &Ui::AppImageUpdateAvailableDialog::skipUpdateButtonClicked, this, [newVersion]() {
         qCInfo(lcUpdater) << "Update" << newVersion << "skipped by user";
-        setSeenVersion(newVersion);
+        setPreviouslySkippedVersion(newVersion);
     });
 
     connect(dialog, &QDialog::accepted, this, [this, appImageUpdaterShim]() {

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -272,21 +272,21 @@ void OCUpdater::slotTimedOut()
     setDownloadState(DownloadTimedOut);
 }
 
-QVersionNumber OCUpdater::seenVersion()
+QVersionNumber OCUpdater::previouslySkippedVersion()
 {
     auto settings = ConfigFile::makeQSettings();
-    return QVersionNumber::fromString(settings.value(seenVersionC).toString());
+    return QVersionNumber::fromString(settings.value(previouslySkippedVersionC).toString());
 }
 
-void OCUpdater::setSeenVersion(const QVersionNumber &seenVersion)
+void OCUpdater::setPreviouslySkippedVersion(const QVersionNumber &previouslySkippedVersion)
 {
-    setSeenVersion(seenVersion.toString());
+    setPreviouslySkippedVersion(previouslySkippedVersion.toString());
 }
 
-void OCUpdater::setSeenVersion(const QString &seenVersionString)
+void OCUpdater::setPreviouslySkippedVersion(const QString &previouslySkippedVersionString)
 {
     auto settings = ConfigFile::makeQSettings();
-    settings.setValue(seenVersionC, seenVersionString);
+    settings.setValue(previouslySkippedVersionC, previouslySkippedVersionString);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -353,10 +353,10 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
 {
     auto settings = ConfigFile::makeQSettings();
     const auto infoVersion = QVersionNumber::fromString(info.version());
-    const auto seenVersion = this->seenVersion();
+    const auto previouslySkippedVersion = this->previouslySkippedVersion();
     qCInfo(lcUpdater) << "Version info arrived:"
                       << "Your version:" << Version::versionWithBuildNumber()
-                      << "Skipped version:" << seenVersion
+                      << "Skipped version:" << previouslySkippedVersion
                       << "Available version:" << infoVersion << info.version()
                       << "Available version string:" << info.versionString()
                       << "Web url:" << info.web()
@@ -366,7 +366,7 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
         qCInfo(lcUpdater) << "No version information available at the moment";
         setDownloadState(UpToDate);
     } else if (infoVersion <= Version::versionWithBuildNumber()
-        || infoVersion <= seenVersion) {
+        || infoVersion <= previouslySkippedVersion) {
         qCInfo(lcUpdater) << "Client is on latest version!";
         setDownloadState(UpToDate);
     } else {
@@ -435,7 +435,7 @@ void NSISUpdater::showNoUrlDialog(const UpdateInfo &info)
     connect(reject, &QAbstractButton::clicked, msgBox, &QDialog::reject);
     connect(getupdate, &QAbstractButton::clicked, msgBox, &QDialog::accept);
 
-    connect(skip, &QAbstractButton::clicked, this, &NSISUpdater::slotSetSeenVersion);
+    connect(skip, &QAbstractButton::clicked, this, &NSISUpdater::slotSetPreviouslySkippedVersion);
     connect(getupdate, &QAbstractButton::clicked, this, &NSISUpdater::slotOpenUpdateUrl);
 
     layout->addWidget(bb);
@@ -490,7 +490,7 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 
     connect(skip, &QAbstractButton::clicked, this, [this]() {
         wipeUpdateData();
-        slotSetSeenVersion();
+        slotSetPreviouslySkippedVersion();
     });
     // askagain: do nothing
     connect(retry, &QAbstractButton::clicked, this, [this]() {
@@ -537,9 +537,9 @@ bool NSISUpdater::handleStartup()
     return false;
 }
 
-void NSISUpdater::slotSetSeenVersion()
+void NSISUpdater::slotSetPreviouslySkippedVersion()
 {
-    setSeenVersion(updateInfo().version());
+    setPreviouslySkippedVersion(updateInfo().version());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -130,9 +130,9 @@ private slots:
     void slotTimedOut();
 
 protected:
-    static QVersionNumber seenVersion();
-    static void setSeenVersion(const QVersionNumber &seenVersion);
-    static void setSeenVersion(const QString &seenVersionString);
+    static QVersionNumber previouslySkippedVersion();
+    static void setPreviouslySkippedVersion(const QVersionNumber &previouslySkippedVersion);
+    static void setPreviouslySkippedVersion(const QString &previouslySkippedVersionString);
 
     virtual void versionInfoArrived(const UpdateInfo &info) = 0;
     bool updateSucceeded() const;
@@ -158,7 +158,7 @@ public:
     explicit NSISUpdater(const QUrl &url);
     bool handleStartup() override;
 private slots:
-    void slotSetSeenVersion();
+    void slotSetPreviouslySkippedVersion();
     void slotDownloadFinished();
     void slotWriteFile();
 

--- a/src/gui/updater/updater_private.h
+++ b/src/gui/updater/updater_private.h
@@ -18,6 +18,7 @@ namespace OCC {
 static const QString updateAvailableC = "Updater/updateAvailable";
 static const QString updateTargetVersionC = "Updater/updateTargetVersion";
 static const QString updateTargetVersionStringC = "Updater/updateTargetVersionString";
-static const QString seenVersionC = "Updater/seenVersion";
+// the config file key's name is preserved for legacy reasons
+static const QString previouslySkippedVersionC = "Updater/seenVersion";
 static const QString autoUpdateAttemptedC = "Updater/autoUpdateAttempted";
 }


### PR DESCRIPTION
Seems like while renaming some variables, the `if` condition was messed up.

The second commit renames a variable, making the related code easier to read and understand.