### PR TITLE
Branding parameter to prevent duplicated folder sync pair

### DIFF
--- a/changelog/unreleased/9523
+++ b/changelog/unreleased/9523
@@ -1,0 +1,6 @@
+Enhancement: Added branding parameter to disallow duplicated folder sync pairs
+
+We added a branding parameter to disallow the addition of duplicated folder sync pairs in
+the add folder wizard.
+
+https://github.com/owncloud/client/issues/9523

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -41,7 +41,7 @@ class FormatWarningsWizardPage : public QWizardPage
 {
     Q_OBJECT
 protected:
-    QString formatWarnings(const QStringList &warnings) const;
+    QString formatWarnings(const QStringList &warnings, bool isError = false) const;
 };
 
 /**

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -688,4 +688,10 @@ bool Theme::warnOnMultipleDb() const
     return isVanilla();
 }
 
+bool Theme::allowDuplicatedFolderSyncPair() const
+{
+    return true;
+}
+
+
 } // end namespace client

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -442,6 +442,12 @@ public:
     virtual bool warnOnMultipleDb() const;
 
 
+    /**
+     * Whether to or not to allow multiple sync folder pairs for the same remote folder.
+     * Default: true
+     */
+    virtual bool allowDuplicatedFolderSyncPair() const;
+
 protected:
 #ifndef TOKEN_AUTH_ONLY
     QIcon themeUniversalIcon(const QString &name, IconType iconType = IconType::BrandedIcon) const;


### PR DESCRIPTION
Default:
![image](https://user-images.githubusercontent.com/200626/159020215-162d6dff-de62-4143-a18a-39bc067477e5.png)
With branding:
![image](https://user-images.githubusercontent.com/200626/159020508-02992260-caba-4530-9abc-391f4fe8a54f.png)





Fixes: #9523