### PR TITLE
[CI] Run uploadGuiTestLogs step in nightly cron job

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -610,9 +610,6 @@ def uploadGuiTestLogs():
             "status": [
                 "failure",
             ],
-            "event": [
-                "pull_request",
-            ],
         },
     }]
 


### PR DESCRIPTION
Run uploadGuiTestLogs steps during nightly runs also so that the notification can have logs whenever there is a tests failure.