### PR TITLE
[tests-only] Stacktracing AUT crash while running gui tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,6 +6,7 @@
 #
 
 DEFAULT_PHP_VERSION = "7.4"
+STACKTRACE_FILE = "%s/stacktrace" % GUI_TEST_REPORT_DIR
 GUI_TEST_DIR = "/drone/src/test/gui"
 GUI_TEST_REPORT_DIR = "/drone/src/test/guiReportUpload"
 NOTIFICATION_TEMPLATE_DIR = "/drone/src"
@@ -251,6 +252,19 @@ def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = [], version = "da
                              "SECURE_BACKEND_HOST": "https://owncloud/",
                              "SERVER_INI": "/drone/src/test/gui/drone/server.ini",
                              "SQUISH_PARAMETERS": squish_parameters,
+                             "STACKTRACE_FILE": STACKTRACE_FILE,
+                         },
+                     },
+                     {
+                         "name": "stacktrace",
+                         "image": "owncloudci/alpine:latest",
+                         "commands": [
+                             "cat %s" % STACKTRACE_FILE,
+                         ],
+                         "when": {
+                             "status": [
+                                 "failure",
+                             ],
                          },
                      },
                  ] +
@@ -562,6 +576,7 @@ def setGuiTestReportDir():
         "image": OC_UBUNTU,
         "commands": [
             "mkdir %s/screenshots -p" % GUI_TEST_REPORT_DIR,
+            "touch %s/coredumps" % GUI_TEST_REPORT_DIR,
             "chmod 777 %s -R" % GUI_TEST_REPORT_DIR,
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -255,18 +255,6 @@ def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = [], version = "da
                              "STACKTRACE_FILE": STACKTRACE_FILE,
                          },
                      },
-                     {
-                         "name": "stacktrace",
-                         "image": "owncloudci/alpine:latest",
-                         "commands": [
-                             "cat %s" % STACKTRACE_FILE,
-                         ],
-                         "when": {
-                             "status": [
-                                 "failure",
-                             ],
-                         },
-                     },
                  ] +
                  # GUI test result has been disabled for now, as we squish can not produce the result in both html and json format.
                  # Disabled untill the feature to generate json result is implemented in squish, or some other method to reuse the log parser is implemented.
@@ -576,7 +564,6 @@ def setGuiTestReportDir():
         "image": OC_UBUNTU,
         "commands": [
             "mkdir %s/screenshots -p" % GUI_TEST_REPORT_DIR,
-            "touch %s/coredumps" % GUI_TEST_REPORT_DIR,
             "chmod 777 %s -R" % GUI_TEST_REPORT_DIR,
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -6,10 +6,10 @@
 #
 
 DEFAULT_PHP_VERSION = "7.4"
-STACKTRACE_FILE = "%s/stacktrace" % GUI_TEST_REPORT_DIR
 GUI_TEST_DIR = "/drone/src/test/gui"
 GUI_TEST_REPORT_DIR = "/drone/src/test/guiReportUpload"
 NOTIFICATION_TEMPLATE_DIR = "/drone/src"
+STACKTRACE_FILE = "%s/stacktrace.log" % GUI_TEST_REPORT_DIR
 
 CYTOPIA_BLACK = "cytopia/black"
 DOCKER_GIT = "docker:git"

--- a/test/gui/drone/comment.sh
+++ b/test/gui/drone/comment.sh
@@ -23,6 +23,12 @@ else
         echo "Server Logs: (${CACHE_ENDPOINT}/${CACHE_BUCKET}/$2/$3/guiReportUpload/serverlog.log)" >> $1/comments.file
     fi
 
+    # if there is stacktrace file then add to the comment
+    if [[ -f $1/stacktrace ]]; then
+        echo "creating comment for stacktrace"
+        echo "Stacktrace: (${CACHE_ENDPOINT}/${CACHE_BUCKET}/$2/$3/guiReportUpload/stacktrace)" >> $1/comments.file
+    fi
+
     if ! [[ $(find $1/screenshots -maxdepth 0 -empty) ]]; then
         echo "creating comment for screenshots"
         echo "Screenshots:" >> $1/comments.file 

--- a/test/gui/drone/comment.sh
+++ b/test/gui/drone/comment.sh
@@ -24,9 +24,9 @@ else
     fi
 
     # if there is stacktrace file then add to the comment
-    if [[ -f $1/stacktrace ]]; then
+    if [[ -f $1/stacktrace.log ]]; then
         echo "creating comment for stacktrace"
-        echo "Stacktrace: (${CACHE_ENDPOINT}/${CACHE_BUCKET}/$2/$3/guiReportUpload/stacktrace)" >> $1/comments.file
+        echo "Stacktrace: (${CACHE_ENDPOINT}/${CACHE_BUCKET}/$2/$3/guiReportUpload/stacktrace.log)" >> $1/comments.file
     fi
 
     if ! [[ $(find $1/screenshots -maxdepth 0 -empty) ]]; then

--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -8,11 +8,13 @@ COMMIT_SHA_SHORT=${DRONE_COMMIT:0:8}
 
 GUI_LOG="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/index.html"
 SERVER_LOG="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/serverlog.log"
+STACKTRACE="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/stacktrace"
 
 CURL="curl --write-out "%{http_code}" --silent --output /dev/null"
 
 GUI_STATUS_CODE=$($CURL "$GUI_LOG")
 SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
+STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
 
 BUILD_STATUS=":white_check_mark:Success"
 TEST_LOGS=""
@@ -24,6 +26,9 @@ if [ "${DRONE_BUILD_STATUS}" != "success" ]; then
     fi
     if [[ "$GUI_STATUS_CODE" == "200" ]]; then
         TEST_LOGS+="\n> [GUI test log]($GUI_LOG)"
+    fi
+    if [[ "$STACKTRACE_STATUS_CODE" == "200" ]]; then
+        TEST_LOGS+="\n> [Stacktrace]($STACKTRACE)"
     fi
 fi
 

--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -8,9 +8,9 @@ COMMIT_SHA_SHORT=${DRONE_COMMIT:0:8}
 
 GUI_LOG="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/index.html"
 SERVER_LOG="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/serverlog.log"
-STACKTRACE="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/stacktrace"
+STACKTRACE="${CACHE_ENDPOINT}/${CACHE_BUCKET}/${DRONE_REPO}/${DRONE_BUILD_NUMBER}/guiReportUpload/stacktrace.log"
 
-CURL="curl --write-out "%{http_code}" --silent --output /dev/null"
+CURL="curl --write-out %{http_code} --silent --output /dev/null"
 
 GUI_STATUS_CODE=$($CURL "$GUI_LOG")
 SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
@@ -32,4 +32,4 @@ if [ "${DRONE_BUILD_STATUS}" != "success" ]; then
     fi
 fi
 
-echo -e "**$BUILD_STATUS** [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" > $1/template.md
+echo -e "**$BUILD_STATUS** [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" > "$1"/template.md

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -19,7 +19,7 @@ import shutil
 import urllib.request
 import os
 import builtins
-from helpers.StacktraceHelper import getCoredump, generateStacktrace
+from helpers.StacktraceHelper import getCoredumps, generateStacktrace
 
 
 @OnScenarioStart
@@ -96,8 +96,8 @@ def hook(context):
 def hook(context):
     # search coredumps after every test scenario
     # CI pipeline might fail although all tests are passing
-    coredumps = getCoredump()
-    if len(coredumps) > 0:
+    coredumps = getCoredumps()
+    if coredumps:
         try:
             generateStacktrace(context, coredumps)
             print("Stacktrace generated.")

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -19,6 +19,7 @@ import shutil
 import urllib.request
 import os
 import builtins
+from helpers.StacktraceHelper import getCoredump, generateStacktrace
 
 
 @OnScenarioStart
@@ -64,7 +65,7 @@ def hook(context):
     for key, value in context.userData.items():
         if value == '':
             context.userData[key] = DEFAULT_CONFIG[key]
-        elif key == 'maxSyncTimeout':
+        elif key == 'maxSyncTimeout' or key == 'minSyncTimeout':
             context.userData[key] = builtins.int(value)
         elif key == 'clientRootSyncPath':
             # make sure there is always one trailing slash
@@ -93,6 +94,18 @@ def hook(context):
 
 @OnScenarioEnd
 def hook(context):
+    # search coredumps after every test scenario
+    # CI pipeline might fail although all tests are passing
+    coredumps = getCoredump()
+    if len(coredumps) > 0:
+        try:
+            generateStacktrace(context, coredumps)
+            print("Stacktrace generated.")
+        except Exception as err:
+            print(err)
+    else:
+        print("No coredump found!")
+
     # capture screenshot if there is error in the scenario execution, and if the test is being run in CI
     if test.resultCount("errors") > 0 and os.getenv('CI'):
         import gi

--- a/test/gui/shared/scripts/helpers/StacktraceHelper.py
+++ b/test/gui/shared/scripts/helpers/StacktraceHelper.py
@@ -1,0 +1,68 @@
+import os
+import builtins
+import subprocess
+import glob
+import re
+from datetime import datetime
+
+
+def getCoredump():
+    # read coredump location
+    with open("/proc/sys/kernel/core_pattern", "r") as f:
+        coredumpPath = f.read().strip("\n")
+
+    # yields something like: /tmp/core-*-*-*-*
+    coredumpFilePattern = re.sub(r'%[a-zA-Z]{1}', '*', coredumpPath)
+    return glob.glob(coredumpFilePattern)
+
+
+def generateStacktrace(context, coredumps):
+    message = ["###########################################"]
+    message.append("Scenario: " + context._data["title"])
+
+    for coredumpFile in coredumps:
+        message.append(parseStacktrace(coredumpFile))
+
+    message.append("###########################################")
+    message.append("")
+    message = "\n".join(message)
+
+    stacktrace_file = os.environ.get("STACKTRACE_FILE", "../stacktrace")
+    # save stacktrace to a file
+    open(stacktrace_file, "a").write(message)
+
+
+def parseStacktrace(coredumpFile):
+    message = []
+    if builtins.bool(coredumpFile):
+        coredumpFilename = os.path.basename(coredumpFile)
+        # example coredump file: core-1648445754-1001-11-!drone!src!build-GUI-tests!bin!owncloud
+        patterns = coredumpFilename.split('-')
+        appBinary = "-".join(patterns[4:]).replace('!', '/')
+
+        message.append("-------------------------------------------")
+        message.append("Executable: " + appBinary)
+        message.append("Timestamp: " + str(datetime.fromtimestamp(float(patterns[1]))))
+        message.append("Process ID: " + patterns[2])
+        message.append("Signal Number: " + patterns[3])
+        message.append("-------------------------------------------")
+        message.append("<<<<< STACKTRACE START >>>>>")
+        message.append(
+            subprocess.run(
+                [
+                    'gdb',
+                    appBinary,
+                    coredumpFile,
+                    '-batch',
+                    '-ex',
+                    'bt full',
+                ],
+                stdout=subprocess.PIPE,
+            ).stdout.decode('utf-8')
+        )
+        message.append("<<<<< STACKTRACE END >>>>>")
+
+        # remove coredump file
+        os.unlink(coredumpFile)
+
+    return "\n".join(message)

--- a/test/gui/shared/scripts/helpers/StacktraceHelper.py
+++ b/test/gui/shared/scripts/helpers/StacktraceHelper.py
@@ -1,12 +1,11 @@
 import os
-import builtins
 import subprocess
 import glob
 import re
 from datetime import datetime
 
 
-def getCoredump():
+def getCoredumps():
     # read coredump location
     with open("/proc/sys/kernel/core_pattern", "r") as f:
         coredumpPath = f.read().strip("\n")
@@ -27,14 +26,14 @@ def generateStacktrace(context, coredumps):
     message.append("")
     message = "\n".join(message)
 
-    stacktrace_file = os.environ.get("STACKTRACE_FILE", "../stacktrace")
+    stacktrace_file = os.environ.get("STACKTRACE_FILE", "../stacktrace.log")
     # save stacktrace to a file
     open(stacktrace_file, "a").write(message)
 
 
 def parseStacktrace(coredumpFile):
     message = []
-    if builtins.bool(coredumpFile):
+    if coredumpFile:
         coredumpFilename = os.path.basename(coredumpFile)
         # example coredump file: core-1648445754-1001-11-!drone!src!build-GUI-tests!bin!owncloud
         patterns = coredumpFilename.split('-')


### PR DESCRIPTION
 Stacktracing the AUT crash

Whenever there is a crash, coredump will be generated into `tmp/` folder with pattern `core-%t-%p-%s-%E`.
This PR reads those files and creates a readable stacktrace file, `${GUI_TEST_REPORT_DIR}/stacktrace`

Fixes https://github.com/owncloud/client/issues/9259