### PR TITLE
Advanced account configuration for new wizard

### DIFF
--- a/changelog/unreleased/9482
+++ b/changelog/unreleased/9482
@@ -6,3 +6,4 @@ been redesigned to improve the user experience.
 
 https://github.com/owncloud/client/issues/9249
 https://github.com/owncloud/client/pull/9482
+https://github.com/owncloud/client/pull/9566

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -31,6 +31,7 @@ set(client_SRCS
     accountmanager.cpp
     accountsettings.cpp
     application.cpp
+    askexperimentalvirtualfilesfeaturemessagebox.cpp
     clientproxy.cpp
     commonstrings.cpp
     connectionvalidator.cpp

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -55,7 +55,6 @@
 
 #include "account.h"
 #include "askexperimentalvirtualfilesfeaturemessagebox.h"
-#include "ocwizard_deprecated.h"
 
 namespace OCC {
 

--- a/src/gui/askexperimentalvirtualfilesfeaturemessagebox.cpp
+++ b/src/gui/askexperimentalvirtualfilesfeaturemessagebox.cpp
@@ -1,0 +1,29 @@
+#include "askexperimentalvirtualfilesfeaturemessagebox.h"
+
+namespace OCC {
+
+AskExperimentalVirtualFilesFeatureMessageBox::AskExperimentalVirtualFilesFeatureMessageBox(QWidget *parent)
+    : QMessageBox(QMessageBox::Warning,
+        tr("Enable experimental feature?"),
+        tr("When the \"virtual files\" mode is enabled no files will be downloaded initially. "
+           "Instead, a tiny file will be created for each file that exists on the server. "
+           "The contents can be downloaded by running these files or by using their context menu."
+           "\n\n"
+           "The virtual files mode is mutually exclusive with selective sync. "
+           "Currently unselected folders will be translated to online-only folders "
+           "and your selective sync settings will be reset."
+           "\n\n"
+           "Switching to this mode will abort any currently running synchronization."
+           "\n\n"
+           "This is a new, experimental mode. If you decide to use it, please report any "
+           "issues that come up."),
+        QMessageBox::NoButton,
+        parent)
+{
+    this->addButton(tr("Enable experimental placeholder mode"), QMessageBox::AcceptRole);
+    this->addButton(tr("Stay safe"), QMessageBox::RejectRole);
+
+    this->setAttribute(Qt::WA_DeleteOnClose);
+}
+
+}

--- a/src/gui/askexperimentalvirtualfilesfeaturemessagebox.h
+++ b/src/gui/askexperimentalvirtualfilesfeaturemessagebox.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QMessageBox>
+
+namespace OCC {
+
+/**
+ * A simple message box used whenever we have to ask the user whether to enable VFS, which is an experimental feature.
+ * The dialog will clean itself up after it has been closed.
+ */
+class AskExperimentalVirtualFilesFeatureMessageBox : public QMessageBox
+{
+public:
+    explicit AskExperimentalVirtualFilesFeatureMessageBox(QWidget *parent = nullptr);
+};
+
+}

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -25,6 +25,8 @@
 #include "navigationpanehelper.h"
 #include "syncfileitem.h"
 
+#include "newwizard/syncmode.h"
+
 class TestFolderMigration;
 
 namespace OCC {
@@ -116,7 +118,7 @@ public:
     /**
      * Adds a folder for an account. Used to be part of the wizard code base. Constructs the folder definition from the parameters.
      */
-    Folder *addFolder(AccountStatePtr accountStatePtr, const QString &localFolder, const QString &remotePath, const QUrl &webDavUrl);
+    void addFolderFromWizard(AccountStatePtr accountStatePtr, const QString &localFolder, const QString &remotePath, const QUrl &webDavUrl, Wizard::SyncMode syncMode);
 
     /** Removes a folder */
     void removeFolder(Folder *);

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -27,7 +27,6 @@
 
 #include "gui/accountstate.h"
 #include "gui/folderman.h"
-#include "gui/ocwizard_deprecated.h"
 #include "gui/selectivesyncdialog.h"
 
 #include <QCheckBox>

--- a/src/gui/newwizard/CMakeLists.txt
+++ b/src/gui/newwizard/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(newwizard OBJECT
 
     jobs/resolveurljobfactory.cpp
     jobs/resolveurljobfactory.h
+
+    syncmode.cpp
 )
 target_link_libraries(newwizard PUBLIC Qt5::Widgets libsync)
 set_target_properties(newwizard PROPERTIES AUTOUIC ON AUTORCC ON)

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -1,20 +1,160 @@
 #include "accountconfiguredwizardpage.h"
-#include <QMessageBox>
 
-#include "gui/selectivesyncdialog.h"
 #include "theme.h"
 #include "ui_accountconfiguredwizardpage.h"
 
+#include <QDir>
+#include <QFileDialog>
+#include <QMessageBox>
+
 namespace OCC::Wizard {
 
-AccountConfiguredWizardPage::AccountConfiguredWizardPage()
+AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultSyncTargetDir, bool vfsIsAvailable, bool enableVfsByDefault, bool vfsModeIsExperimental)
     : _ui(new ::Ui::AccountConfiguredWizardPage)
 {
     _ui->setupUi(this);
+
+    // by default, sync everything to an automatically chosen directory, VFS use depends on the OS
+    // the defaults are provided by the controller
+    _ui->localDirectoryLineEdit->setText(QDir::toNativeSeparators(defaultSyncTargetDir));
+    _ui->syncEverythingRadioButton->setChecked(true);
+
+    // could also make it invisible, but then the UX is different for different installations
+    // this may be overwritten by a branding option (see below)
+    _ui->useVfsRadioButton->setEnabled(vfsIsAvailable);
+
+    _ui->useVfsRadioButton->setText(tr("Use &virtual files instead of downloading content immediately"));
+    if (vfsModeIsExperimental) {
+        _ui->useVfsRadioButton->setIcon(QIcon(QStringLiteral(":/client/resources/light/warning.svg")));
+    }
+
+    // just adjusting the visibility should be sufficient for these branding options
+    if (Theme::instance()->wizardSkipAdvancedPage()) {
+        _ui->advancedConfigSeparatorLine->setVisible(false);
+        _ui->advancedConfigGroupBox->setVisible(false);
+    }
+
+    if (!Theme::instance()->showVirtualFilesOption()) {
+        _ui->useVfsRadioButton->setVisible(false);
+        vfsIsAvailable = false;
+    }
+
+    if (!vfsIsAvailable) {
+        enableVfsByDefault = false;
+    }
+
+    if (enableVfsByDefault) {
+        _ui->useVfsRadioButton->setChecked(true);
+
+        // move up top
+        _ui->syncModeGroupBoxLayout->removeWidget(_ui->useVfsRadioButton);
+        _ui->syncModeGroupBoxLayout->insertWidget(0, _ui->useVfsRadioButton);
+    }
+
+    if (!vfsIsAvailable) {
+        // fallback: it's set as default option in Qt Designer, but we should make sure the option is selected if VFS is not available
+        _ui->syncEverythingRadioButton->setChecked(true);
+
+        _ui->useVfsRadioButton->setToolTip(tr("The virtual filesystem feature is not available for this installation."));
+    } else if (vfsModeIsExperimental) {
+        _ui->useVfsRadioButton->setToolTip(tr("The virtual filesystem feature is not stable yet. Use with caution."));
+    }
+
+    connect(_ui->chooseLocalDirectoryButton, &QToolButton::clicked, this, [=]() {
+        auto dialog = new QFileDialog(this, tr("Choose"), defaultSyncTargetDir);
+        dialog->setFileMode(QFileDialog::Directory);
+        dialog->setOption(QFileDialog::ShowDirsOnly);
+
+        connect(dialog, &QFileDialog::fileSelected, this, [this](const QString &directory) {
+            // the directory chooser should guarantee that the directory exists
+            Q_ASSERT(QDir(directory).exists());
+
+            _ui->localDirectoryLineEdit->setText(QDir::toNativeSeparators(directory));
+        });
+
+        dialog->show();
+    });
+
+    // this should be handled on application startup, too
+    OC_ENFORCE(!Theme::instance()->forceVirtualFilesOption() || vfsIsAvailable);
+
+    if (Theme::instance()->forceVirtualFilesOption()) {
+        // this has no visual effect, but is needed for syncMode()
+        _ui->useVfsRadioButton->setChecked(true);
+
+        // we want to hide the entire sync mode selection from the user, not just disable it
+        _ui->syncModeGroupBox->setVisible(false);
+    }
+
+    connect(_ui->advancedConfigGroupBox, &QGroupBox::toggled, this, [this](bool enabled) {
+        // layouts cannot be hidden, therefore we use a plain widget within the group box to "house" the contained widgets
+        _ui->advancedConfigGroupBoxContentWidget->setVisible(enabled);
+
+        // could not find a better way to hide the frame on demand, which is needed to hide the widget completely
+        _ui->advancedConfigGroupBox->setStyleSheet(enabled ? QString() : QStringLiteral("QGroupBox#advancedConfigGroupBox{border: 0}"));
+    });
+
+    if (vfsModeIsExperimental) {
+        connect(_ui->useVfsRadioButton, &QRadioButton::clicked, this, [this]() {
+            auto messageBox = new QMessageBox(
+                QMessageBox::Warning,
+                tr("Enable experimental feature?"),
+                tr("When the \"virtual files\" mode is enabled no files will be downloaded initially. "
+                   "Instead, a tiny file will be created for each file that exists on the server. "
+                   "The contents can be downloaded by running these files or by using their context menu."
+                   "\n\n"
+                   "The virtual files mode is mutually exclusive with selective sync. "
+                   "Currently unselected folders will be translated to online-only folders "
+                   "and your selective sync settings will be reset."
+                   "\n\n"
+                   "Switching to this mode will abort any currently running synchronization."
+                   "\n\n"
+                   "This is a new, experimental mode. If you decide to use it, please report any "
+                   "issues that come up."),
+                QMessageBox::NoButton,
+                this);
+
+            messageBox->addButton(tr("Enable experimental placeholder mode"), QMessageBox::AcceptRole);
+            messageBox->addButton(tr("Stay safe"), QMessageBox::RejectRole);
+
+            messageBox->setAttribute(Qt::WA_DeleteOnClose);
+
+            connect(messageBox, &QMessageBox::rejected, this, [this]() {
+                // bring back to "safety"
+                _ui->syncEverythingRadioButton->setChecked(true);
+            });
+
+            messageBox->show();
+        });
+    }
+
+    // toggle once to have the according handlers set up the initial UI state
+    _ui->advancedConfigGroupBox->setChecked(true);
+    _ui->advancedConfigGroupBox->setChecked(false);
 }
 
 AccountConfiguredWizardPage::~AccountConfiguredWizardPage() noexcept
 {
     delete _ui;
+}
+
+QString AccountConfiguredWizardPage::syncTargetDir() const
+{
+    return QDir::toNativeSeparators(_ui->localDirectoryLineEdit->text());
+}
+
+SyncMode AccountConfiguredWizardPage::syncMode() const
+{
+    if (_ui->syncEverythingRadioButton->isChecked()) {
+        return SyncMode::SyncEverything;
+    }
+    if (_ui->selectiveSyncRadioButton->isChecked()) {
+        return SyncMode::SelectiveSync;
+    }
+    if (_ui->useVfsRadioButton->isChecked()) {
+        return SyncMode::UseVfs;
+    }
+
+    Q_UNREACHABLE();
 }
 }

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.h
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <QSharedPointer>
+
 #include "abstractsetupwizardpage.h"
+#include "setupwizardcontroller.h"
 
 namespace Ui {
 class AccountConfiguredWizardPage;
@@ -13,8 +16,12 @@ class AccountConfiguredWizardPage : public AbstractSetupWizardPage
     Q_OBJECT
 
 public:
-    AccountConfiguredWizardPage();
+    explicit AccountConfiguredWizardPage(const QString &defaultSyncTargetDir, bool vfsIsAvailable, bool enableVfsByDefault, bool vfsModeIsExperimental);
     ~AccountConfiguredWizardPage() noexcept override;
+
+    QString syncTargetDir() const;
+
+    SyncMode syncMode() const;
 
 private:
     ::Ui::AccountConfiguredWizardPage *_ui;

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.ui
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>732</width>
-    <height>434</height>
+    <width>689</width>
+    <height>513</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -50,8 +50,198 @@
      </property>
     </spacer>
    </item>
+   <item>
+    <widget class="Line" name="advancedConfigSeparatorLine">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="advancedConfigGroupBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Advanced configuration</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>60</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="advancedConfigGroupBoxContentWidget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>50</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QGroupBox" name="syncModeGroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QGroupBox {border:0;}</string>
+           </property>
+           <property name="title">
+            <string notr="true"/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <layout class="QVBoxLayout" name="syncModeGroupBoxLayout">
+            <property name="spacing">
+             <number>3</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="syncEverythingRadioButton">
+              <property name="text">
+               <string>Download everything</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="selectiveSyncRadioButton">
+              <property name="toolTip">
+               <string>You can configure which directories to download from the server in a dialog once the wizard has finished.</string>
+              </property>
+              <property name="text">
+               <string>Choose what to download</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="useVfsRadioButton">
+              <property name="text">
+               <string notr="true">Enable virtual filesystem (placeholder)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QGroupBox {border:0;}</string>
+           </property>
+           <property name="title">
+            <string notr="true"/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Choose local download directory:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <item>
+               <widget class="QLineEdit" name="localDirectoryLineEdit"/>
+              </item>
+              <item>
+               <widget class="QToolButton" name="chooseLocalDirectoryButton">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>1</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../../client.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/gui/newwizard/setupwizardcontroller.h
+++ b/src/gui/newwizard/setupwizardcontroller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pages/abstractsetupwizardpage.h"
+#include "syncmode.h"
 #include <QDialog>
 #include <account.h>
 #include <optional>
@@ -31,7 +32,7 @@ Q_SIGNALS:
     /**
      * Emitted when the wizard has finished. It passes the built account object.
      */
-    void finished(AccountPtr newAccount);
+    void finished(AccountPtr newAccount, const QString &localFolder, SyncMode syncMode);
 
 private:
     void nextStep(std::optional<PageIndex> currentPage, std::optional<PageIndex> desiredPage);

--- a/src/gui/newwizard/syncmode.cpp
+++ b/src/gui/newwizard/syncmode.cpp
@@ -1,0 +1,2 @@
+// just a stub so the MOC file can be included somewhere
+#include "moc_syncmode.cpp"

--- a/src/gui/newwizard/syncmode.h
+++ b/src/gui/newwizard/syncmode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QObject>
+
+namespace OCC::Wizard {
+Q_NAMESPACE
+
+enum class SyncMode {
+    Invalid = 0,
+    SyncEverything,
+    SelectiveSync,
+    UseVfs,
+};
+Q_ENUM_NS(SyncMode)
+}

--- a/src/gui/ocwizard_deprecated.h
+++ b/src/gui/ocwizard_deprecated.h
@@ -6,11 +6,6 @@
 
 namespace OCC::OwncloudWizard {
 
-[[deprecated]] static inline void askExperimentalVirtualFilesFeature(QObject *, std::function<void(bool)>)
-{
-    qWarning() << "Currently unsupported function askExperimentalVirtualFilesFeature called";
-}
-
 [[deprecated]] static inline bool useVirtualFileSync()
 {
     qWarning() << "Currently unsupported function useVirtualFileSync called";

--- a/src/gui/ocwizard_deprecated.h
+++ b/src/gui/ocwizard_deprecated.h
@@ -6,18 +6,6 @@
 
 namespace OCC::OwncloudWizard {
 
-[[deprecated]] static inline bool useVirtualFileSync()
-{
-    qWarning() << "Currently unsupported function useVirtualFileSync called";
-    return false;
-}
-
-[[deprecated]] static inline QList<QString> selectiveSyncBlacklist()
-{
-    qWarning() << "Currently unsupported function selectiveSyncBlacklist called";
-    return {};
-}
-
 [[deprecated]] static inline bool isConfirmBigFolderChecked()
 {
     qWarning() << "Currently unsupported function isConfirmBigFolderChecked called";

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -429,13 +429,12 @@ SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, Folder *folder, QWi
     connect(_folder, &QObject::destroyed, this, &QObject::deleteLater);
 }
 
-SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, const QString &folder,
-    const QStringList &blacklist, QWidget *parent, Qt::WindowFlags f)
+SelectiveSyncDialog::SelectiveSyncDialog(AccountPtr account, const QString &folder, QWidget *parent, Qt::WindowFlags f)
     : QDialog(parent, f)
     , _folder(nullptr)
 {
     init(account);
-    _selectiveSync->setFolderInfo(folder, folder, blacklist);
+    _selectiveSync->setFolderInfo(folder, folder);
 }
 
 void SelectiveSyncDialog::init(const AccountPtr &account)

--- a/src/gui/selectivesyncdialog.h
+++ b/src/gui/selectivesyncdialog.h
@@ -92,7 +92,7 @@ public:
     explicit SelectiveSyncDialog(AccountPtr account, Folder *folder, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
     // Dialog for the whole account (Used from the wizard)
-    explicit SelectiveSyncDialog(AccountPtr account, const QString &folder, const QStringList &blacklist, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
+    explicit SelectiveSyncDialog(AccountPtr account, const QString &folder, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
 
     void accept() override;
 


### PR DESCRIPTION
Contributes to #9249.

This PR implements the remaining configuration options missing in the new wizard. It adds an hidden-by-default advanced options group box to the final wizard page.

I think we can just squash this PR entirely before merging it.