### PR TITLE
Fix wizard navigation

### DIFF
--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -26,8 +26,6 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
     connect(reply, &QNetworkReply::finished, job, [oldUrl = url, reply, job] {
         reply->deleteLater();
 
-        const auto status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-
         if (reply->error() != QNetworkReply::NoError) {
             setJobError(job, tr("Failed to resolve the url %1, error: %2").arg(oldUrl.toDisplayString(), reply->errorString()), reply->error());
             qCWarning(lcResolveUrl) << job->errorMessage();

--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -61,6 +61,9 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
 
                     dialog->show();
                 }
+            } else {
+                qCInfo(lcResolveUrl) << "No need to alter URL" << newUrl;
+                setJobResult(job, newUrl);
             }
         }
     });

--- a/src/gui/newwizard/setupwizardwindow.cpp
+++ b/src/gui/newwizard/setupwizardwindow.cpp
@@ -39,6 +39,7 @@ SetupWizardWindow::SetupWizardWindow(QWidget *parent)
 
 void SetupWizardWindow::displayPage(AbstractSetupWizardPage *page, PageIndex index)
 {
+    _transitioning = false;
     _ui->backButton->setEnabled(true);
     _ui->nextButton->setEnabled(true);
 
@@ -110,7 +111,7 @@ void SetupWizardWindow::setPaginationEntries(const QStringList &paginationEntrie
 
 bool SetupWizardWindow::eventFilter(QObject *obj, QEvent *event)
 {
-    if (obj == _currentPage.data() || obj == this) {
+    if (!_transitioning && (obj == _currentPage.data() || obj == this)) {
         if (event->type() == QEvent::KeyPress) {
             auto keyEvent = dynamic_cast<QKeyEvent *>(event);
 

--- a/src/gui/newwizard/setupwizardwindow.h
+++ b/src/gui/newwizard/setupwizardwindow.h
@@ -74,5 +74,7 @@ private:
 
     // need to keep track of the current page for event filtering
     QPointer<AbstractSetupWizardPage> _currentPage;
+    // during a transition, the event filter must be disabled
+    bool _transitioning;
 };
 }


### PR DESCRIPTION
Depends on #9566.

This pull request

- fixes the back button/pagination behavior by fixing the root cause within `ResolveUrlJobFactory`
- removes some dead code
- fixes segfaults when users hit `Enter` while a transition is active (also fixes potential emission of duplicate signals)