### PR TITLE
Stracktrace done after application gets closed

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -448,7 +448,7 @@ def notification(name, depends_on = [], trigger = {}):
                 "image": PLUGINS_SLACK,
                 "settings": {
                     "webhook": from_secret("private_rocketchat"),
-                    "channel": "desktop-client-builds",
+                    "channel": "desktop-internal",
                     "template": "file:%s/template.md" % NOTIFICATION_TEMPLATE_DIR,
                 },
                 "depends_on": ["create-template"],

--- a/.drone.star
+++ b/.drone.star
@@ -448,7 +448,7 @@ def notification(name, depends_on = [], trigger = {}):
                 "image": PLUGINS_SLACK,
                 "settings": {
                     "webhook": from_secret("private_rocketchat"),
-                    "channel": "desktop-internal",
+                    "channel": "desktop-client-builds",
                     "template": "file:%s/template.md" % NOTIFICATION_TEMPLATE_DIR,
                 },
                 "depends_on": ["create-template"],

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -63,7 +63,7 @@ def hook(context):
             if value == '':
                 context.userData[key] = cfg.get('DEFAULT', CONFIG_ENV_MAP[key])
     except Exception as err:
-        print(err)
+        test.log(str(err))
 
     # Set the default values if empty
     for key, value in context.userData.items():
@@ -101,18 +101,6 @@ def hook(context):
 
 @OnScenarioEnd
 def hook(context):
-    # search coredumps after every test scenario
-    # CI pipeline might fail although all tests are passing
-    coredumps = getCoredumps()
-    if coredumps:
-        try:
-            generateStacktrace(context, coredumps)
-            print("Stacktrace generated.")
-        except Exception as err:
-            print(err)
-    else:
-        print("No coredump found!")
-
     # capture screenshot if there is error in the scenario execution, and if the test is being run in CI
     if test.resultCount("errors") > 0 and os.getenv('CI'):
         import gi
@@ -147,7 +135,19 @@ def hook(context):
             elif os.path.isdir(file_path):
                 shutil.rmtree(file_path)
         except Exception as e:
-            print('Failed to delete %s. Reason: %s' % (file_path, e))
+            test.log('Failed to delete' + file_path + ". Reason: " + e + '.')
+
+    # search coredumps after every test scenario
+    # CI pipeline might fail although all tests are passing
+    coredumps = getCoredumps()
+    if coredumps:
+        try:
+            generateStacktrace(context, coredumps)
+            test.log("Stacktrace generated!")
+        except Exception as err:
+            test.log("Exception occured:" + err)
+    else:
+        test.log("No coredump found!")
 
     # cleanup test server
     req = urllib.request.Request(


### PR DESCRIPTION
Closes https://github.com/owncloud/client/issues/9609
Previously, the stack trace used to be generated before the application gets closed so there was some issue with the generated stack trace. That issue is fixed in this PR and now the stack trace is done only after the application gets closed. 