### PR TITLE
[Tests-Only]Removed GUI test retry option as it is errorsome in Squish

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -211,7 +211,7 @@ def build_and_test_client(ctx, c_compiler, cxx_compiler, build_type, generator, 
 def gui_tests(ctx, trigger = {}, depends_on = [], filterTags = [], version = "daily-master-qa"):
     pipeline_name = "GUI-tests"
     build_dir = "build-" + pipeline_name
-    squish_parameters = "--retry 1 --reportgen html,%s --envvar QT_LOGGING_RULES=sync.httplogger=true;gui.socketapi=false --tags ~@skip" % GUI_TEST_REPORT_DIR
+    squish_parameters = "--reportgen html,%s --envvar QT_LOGGING_RULES=sync.httplogger=true;gui.socketapi=false --tags ~@skip" % GUI_TEST_REPORT_DIR
 
     if (len(filterTags) > 0):
         for tags in filterTags:


### PR DESCRIPTION
Overall test result shows the test has failed even if there is any pass in retry situation. Hence, the `retry` function is not working as expected, and there is no point on using it because it raises more confusions. So, I removed that option here.