### PR TITLE
Handle custom trusted CA certificates in our access manager

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -321,7 +321,7 @@ void AccountState::checkConnectivity(bool blockJobs)
         // and #2973.
         // As an attempted workaround, reset the QNAM regularly if the account is
         // disconnected.
-        account()->resetNetworkAccessManager();
+        account()->resetAccessManager();
 
         // If we don't reset the ssl config a second CheckServerJob can produce a
         // ssl config that does not have a sensible certificate chain.

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -72,7 +72,7 @@ void ConnectionValidator::checkServerAndUpdate()
             this, SLOT(systemProxyLookupDone(QNetworkProxy)));
     } else {
         // We want to reset the QNAM proxy so that the global proxy settings are used (via ClientProxy settings)
-        _account->networkAccessManager()->setProxy(QNetworkProxy(QNetworkProxy::DefaultProxy));
+        _account->accessManager()->setProxy(QNetworkProxy(QNetworkProxy::DefaultProxy));
         // use a queued invocation so we're as asynchronous as with the other code path
         QMetaObject::invokeMethod(this, "slotCheckServerAndAuth", Qt::QueuedConnection);
     }
@@ -90,7 +90,7 @@ void ConnectionValidator::systemProxyLookupDone(const QNetworkProxy &proxy)
     } else {
         qCInfo(lcConnectionValidator) << "No system proxy set by OS";
     }
-    _account->networkAccessManager()->setProxy(proxy);
+    _account->accessManager()->setProxy(proxy);
 
     slotCheckServerAndAuth();
 }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1153,9 +1153,9 @@ void FolderMan::setDirtyProxy()
     for (auto *f : qAsConst(_folders)) {
         if (f) {
             if (f->accountState() && f->accountState()->account()
-                && f->accountState()->account()->networkAccessManager()) {
+                && f->accountState()->account()->accessManager()) {
                 // Need to do this so we do not use the old determined system proxy
-                f->accountState()->account()->networkAccessManager()->setProxy(
+                f->accountState()->account()->accessManager()->setProxy(
                     QNetworkProxy(QNetworkProxy::DefaultProxy));
             }
         }

--- a/src/gui/newwizard/setupwizardcontroller.h
+++ b/src/gui/newwizard/setupwizardcontroller.h
@@ -60,6 +60,6 @@ private:
 
     SetupWizardAccountBuilder _accountBuilder;
 
-    QNetworkAccessManager *_networkAccessManager;
+    AccessManager *_accessManager;
 };
 }

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -88,7 +88,7 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
         // Since we go into an event loop, it's possible for the account's qnam
         // to be destroyed before we get back. We can use this to check for its
         // liveness.
-        sending_qnam = account->sharedNetworkAccessManager().data();
+        sending_qnam = account->sharedAccessManager().data();
     }
     if (!sending_qnam) {
         qCWarning(lcProxy) << "Could not get the sending QNAM for" << sender();

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -78,9 +78,13 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         newRequest.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2EnabledEnv);
     }
 
-    auto sslConfiguration = newRequest.sslConfiguration();
-    sslConfiguration.addCaCertificates({ _customTrustedCaCertificates.begin(), _customTrustedCaCertificates.end() });
-    newRequest.setSslConfiguration(sslConfiguration);
+    // for some reason, passing an empty list causes the default chain to be removed
+    // this behavior does not match the documentation
+    if (!_customTrustedCaCertificates.isEmpty()) {
+        auto sslConfiguration = newRequest.sslConfiguration();
+        sslConfiguration.addCaCertificates({ _customTrustedCaCertificates.begin(), _customTrustedCaCertificates.end() });
+        newRequest.setSslConfiguration(sslConfiguration);
+    }
 
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);
     HttpLogger::logRequest(reply, op, outgoingData);

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -78,9 +78,33 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         newRequest.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2EnabledEnv);
     }
 
+    auto sslConfiguration = newRequest.sslConfiguration();
+    sslConfiguration.addCaCertificates({ _customTrustedCaCertificates.begin(), _customTrustedCaCertificates.end() });
+    newRequest.setSslConfiguration(sslConfiguration);
+
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);
     HttpLogger::logRequest(reply, op, outgoingData);
     return reply;
+}
+
+QSet<QSslCertificate> AccessManager::customTrustedCaCertificates()
+{
+    return _customTrustedCaCertificates;
+}
+
+void AccessManager::setCustomTrustedCaCertificates(const QSet<QSslCertificate> &certificates)
+{
+    _customTrustedCaCertificates = certificates;
+}
+
+void AccessManager::addCustomTrustedCaCertificates(const QList<QSslCertificate> &certificates)
+{
+    _customTrustedCaCertificates.unite({ certificates.begin(), certificates.end() });
+}
+
+void AccessManager::addCustomTrustedCaCertificate(const QSslCertificate &certificate)
+{
+    _customTrustedCaCertificates.insert(certificate);
 }
 
 } // namespace OCC

--- a/src/libsync/accessmanager.h
+++ b/src/libsync/accessmanager.h
@@ -36,8 +36,16 @@ public:
 
     AccessManager(QObject *parent = nullptr);
 
+    QSet<QSslCertificate> customTrustedCaCertificates();
+    void setCustomTrustedCaCertificates(const QSet<QSslCertificate> &certificates);
+    void addCustomTrustedCaCertificates(const QList<QSslCertificate> &certificates);
+    void addCustomTrustedCaCertificate(const QSslCertificate &certificate);
+
 protected:
     QNetworkReply *createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr) override;
+
+private:
+    QSet<QSslCertificate> _customTrustedCaCertificates;
 };
 
 } // namespace OCC

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -164,7 +164,7 @@ void Account::setCredentials(AbstractCredentials *cred)
     // Note: This way the QNAM can outlive the Account and Credentials.
     // This is necessary to avoid issues with the QNAM being deleted while
     // processing slotHandleSslErrors().
-    _am.reset(_credentials->createQNAM(), &QObject::deleteLater);
+    _am.reset(_credentials->createAM(), &QObject::deleteLater);
 
     if (jar) {
         _am->setCookieJar(jar);
@@ -218,7 +218,7 @@ QString Account::cookieJarPath()
     return QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + QStringLiteral("/cookies") + id() + QStringLiteral(".db");
 }
 
-void Account::resetNetworkAccessManager()
+void Account::resetAccessManager()
 {
     if (!_credentials || !_am) {
         return;
@@ -227,9 +227,9 @@ void Account::resetNetworkAccessManager()
     qCDebug(lcAccount) << "Resetting QNAM";
     QNetworkCookieJar *jar = _am->cookieJar();
 
-    // Use a QSharedPointer to allow locking the life of the QNAM on the stack.
-    // Make it call deleteLater to make sure that we can return to any QNAM stack frames safely.
-    _am = QSharedPointer<QNetworkAccessManager>(_credentials->createQNAM(), &QObject::deleteLater);
+    // Use a QSharedPointer to allow locking the life of the AM on the stack.
+    // Make it call deleteLater to make sure that we can return to any AM stack frames safely.
+    _am = QSharedPointer<AccessManager>(_credentials->createAM(), &QObject::deleteLater);
 
     _am->setCookieJar(jar); // takes ownership of the old cookie jar
     connect(_am.data(), &QNetworkAccessManager::sslErrors, this,
@@ -238,12 +238,12 @@ void Account::resetNetworkAccessManager()
         this, &Account::proxyAuthenticationRequired);
 }
 
-QNetworkAccessManager *Account::networkAccessManager()
+AccessManager *Account::accessManager()
 {
     return _am.data();
 }
 
-QSharedPointer<QNetworkAccessManager> Account::sharedNetworkAccessManager()
+QSharedPointer<AccessManager> Account::sharedAccessManager()
 {
     return _am;
 }
@@ -454,7 +454,7 @@ JobQueue *Account::jobQueue()
     return &_jobQueue;
 }
 
-void Account::clearQNAMCache()
+void Account::clearAMCache()
 {
     _am->clearAccessCache();
 }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -17,16 +17,17 @@
 #define SERVERCONNECTION_H
 
 #include <QByteArray>
-#include <QUrl>
-#include <QUuid>
+#include <QNetworkAccessManager>
 #include <QNetworkCookie>
 #include <QNetworkRequest>
-#include <QSslSocket>
-#include <QSslCertificate>
-#include <QSslConfiguration>
-#include <QSslCipher>
-#include <QSslError>
 #include <QSharedPointer>
+#include <QSslCertificate>
+#include <QSslCipher>
+#include <QSslConfiguration>
+#include <QSslError>
+#include <QSslSocket>
+#include <QUrl>
+#include <QUuid>
 
 #ifndef TOKEN_AUTH_ONLY
 #include <QPixmap>
@@ -40,7 +41,7 @@
 class QSettings;
 class QNetworkReply;
 class QUrl;
-class QNetworkAccessManager;
+class AccessManager;
 
 namespace OCC {
 
@@ -226,9 +227,9 @@ public:
     void lendCookieJarTo(QNetworkAccessManager *guest);
     QString cookieJarPath();
 
-    void resetNetworkAccessManager();
-    QNetworkAccessManager *networkAccessManager();
-    QSharedPointer<QNetworkAccessManager> sharedNetworkAccessManager();
+    void resetAccessManager();
+    AccessManager *accessManager();
+    QSharedPointer<AccessManager> sharedAccessManager();
 
     JobQueue *jobQueue();
 
@@ -238,7 +239,7 @@ public:
 
 public slots:
     /// Used when forgetting credentials
-    void clearQNAMCache();
+    void clearAMCache();
     void slotHandleSslErrors(QPointer<QNetworkReply>, const QList<QSslError> &);
 
 signals:
@@ -292,7 +293,7 @@ private:
     QString _serverVersion;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
     QuotaInfo *_quotaInfo;
-    QSharedPointer<QNetworkAccessManager> _am;
+    QSharedPointer<AccessManager> _am;
     QScopedPointer<AbstractCredentials> _credentials;
     bool _http2Supported = false;
 

--- a/src/libsync/creds/abstractcredentials.h
+++ b/src/libsync/creds/abstractcredentials.h
@@ -17,9 +17,10 @@
 
 #include <QObject>
 
-#include <csync.h>
-#include "owncloudlib.h"
+#include "accessmanager.h"
 #include "accountfwd.h"
+#include "owncloudlib.h"
+#include <csync.h>
 
 class QNetworkAccessManager;
 class QNetworkReply;
@@ -45,7 +46,7 @@ public:
 
     virtual QString authType() const = 0;
     virtual QString user() const = 0;
-    virtual QNetworkAccessManager *createQNAM() const = 0;
+    virtual AccessManager *createAM() const = 0;
 
     /** Whether there are credentials that can be used for a connection attempt. */
     virtual bool ready() const = 0;

--- a/src/libsync/creds/dummycredentials.cpp
+++ b/src/libsync/creds/dummycredentials.cpp
@@ -27,7 +27,7 @@ QString DummyCredentials::user() const
     return _user;
 }
 
-QNetworkAccessManager *DummyCredentials::createQNAM() const
+AccessManager *DummyCredentials::createAM() const
 {
     return new AccessManager;
 }

--- a/src/libsync/creds/dummycredentials.h
+++ b/src/libsync/creds/dummycredentials.h
@@ -28,7 +28,7 @@ public:
     QString _password;
     QString authType() const override;
     QString user() const override;
-    QNetworkAccessManager *createQNAM() const override;
+    AccessManager *createAM() const override;
     bool ready() const override;
     bool stillValid(QNetworkReply *reply) override;
     void fetchFromKeychain() override;

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -143,14 +143,14 @@ void HttpCredentials::setAccount(Account *account)
     }
 }
 
-QNetworkAccessManager *HttpCredentials::createQNAM() const
+AccessManager *HttpCredentials::createAM() const
 {
-    AccessManager *qnam = new HttpCredentialsAccessManager(this);
+    AccessManager *am = new HttpCredentialsAccessManager(this);
 
-    connect(qnam, &QNetworkAccessManager::authenticationRequired,
+    connect(am, &QNetworkAccessManager::authenticationRequired,
         this, &HttpCredentials::slotAuthentication);
 
-    return qnam;
+    return am;
 }
 
 bool HttpCredentials::ready() const
@@ -345,7 +345,7 @@ void HttpCredentials::invalidateToken()
     // indirectly) from QNetworkAccessManagerPrivate::authenticationRequired, which itself
     // is a called from a BlockingQueuedConnection from the Qt HTTP thread. And clearing the
     // cache needs to synchronize again with the HTTP thread.
-    QTimer::singleShot(0, _account, &Account::clearQNAMCache);
+    QTimer::singleShot(0, _account, &Account::clearAMCache);
 }
 
 void HttpCredentials::forgetSensitiveData()

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -59,7 +59,7 @@ public:
     explicit HttpCredentials(DetermineAuthTypeJob::AuthType authType, const QString &user, const QString &password);
 
     QString authType() const override;
-    QNetworkAccessManager *createQNAM() const override;
+    AccessManager *createAM() const override;
     bool ready() const override;
     void fetchFromKeychain() override;
     bool stillValid(QNetworkReply *reply) override;

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -568,7 +568,7 @@ void OAuth::dynamicRegistrationDataReceived(const QVariantMap &dynamicRegistrati
 
 
 AccountBasedOAuth::AccountBasedOAuth(AccountPtr account, QObject *parent)
-    : OAuth(account->url(), account->davUser(), account->networkAccessManager(), {}, parent)
+    : OAuth(account->url(), account->davUser(), account->accessManager(), {}, parent)
     , _account(account)
 {
 }

--- a/src/libsync/creds/tokencredentials.cpp
+++ b/src/libsync/creds/tokencredentials.cpp
@@ -102,14 +102,14 @@ QString TokenCredentials::password() const
     return _password;
 }
 
-QNetworkAccessManager *TokenCredentials::createQNAM() const
+AccessManager *TokenCredentials::createAM() const
 {
-    AccessManager *qnam = new TokenCredentialsAccessManager(this);
+    AccessManager *am = new TokenCredentialsAccessManager(this);
 
-    connect(qnam, &AccessManager::authenticationRequired,
+    connect(am, &AccessManager::authenticationRequired,
         this, &TokenCredentials::slotAuthentication);
 
-    return qnam;
+    return am;
 }
 
 bool TokenCredentials::ready() const

--- a/src/libsync/creds/tokencredentials.h
+++ b/src/libsync/creds/tokencredentials.h
@@ -40,7 +40,7 @@ public:
     TokenCredentials(const QString &user, const QString &password, const QString &token);
 
     QString authType() const override;
-    QNetworkAccessManager *createQNAM() const override;
+    AccessManager *createAM() const override;
     bool ready() const override;
     void askFromUser() override;
     void fetchFromKeychain() override;

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -871,13 +871,13 @@ void FakeHangingReply::abort()
     emit finished();
 }
 
-FakeQNAM::FakeQNAM(FileInfo initialRoot)
+FakeAM::FakeAM(FileInfo initialRoot)
     : _remoteRootFileInfo { std::move(initialRoot) }
 {
     setCookieJar(new OCC::CookieJar);
 }
 
-QNetworkReply *FakeQNAM::createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData)
+QNetworkReply *FakeAM::createRequest(QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *outgoingData)
 {
     QNetworkReply *reply = nullptr;
     auto newRequest = request;
@@ -940,10 +940,10 @@ FakeFolder::FakeFolder(const FileInfo &fileTemplate, OCC::Vfs::Mode vfsMode)
     qDebug() << "FakeFolder operating on" << rootDir;
     toDisk(rootDir, fileTemplate);
 
-    _fakeQnam = new FakeQNAM(fileTemplate);
+    _fakeAm = new FakeAM(fileTemplate);
     _account = OCC::Account::create();
     _account->setUrl(QUrl(QStringLiteral("http://admin:admin@localhost/owncloud")));
-    _account->setCredentials(new FakeCredentials { _fakeQnam });
+    _account->setCredentials(new FakeCredentials { _fakeAm });
     _account->setDavDisplayName(QStringLiteral("fakename"));
     _account->setServerVersion(QStringLiteral("10.0.0"));
     _account->setCapabilities(OCC::TestUtils::testCapabilities());


### PR DESCRIPTION
Preparation for an upcoming PR that implements a TLS error dialog in the wizard.

This PR extends the existing `AccessManager` subclass of `QNetworkAccessManager` with TLS certificates management. Unfortunately, the default Qt class does not support this.

This PR replaces all the hacks that altered the global state in order to make requests to servers using (previously untrusted) certificates work.