### PR TITLE
TLS error dialog for new setup wizard

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -21,6 +21,7 @@ set(client_UI_SRCS
     shareusergroupwidget.ui
     shareuserline.ui
     sslerrordialog.ui
+    tlserrordialog.ui
     proxyauthdialog.ui
     notificationwidget.ui
     logbrowser.ui
@@ -62,6 +63,7 @@ set(client_SRCS
     sharee.cpp
     sslbutton.cpp
     sslerrordialog.cpp
+    tlserrordialog.cpp
     syncrunfilelog.cpp
     systray.cpp
     thumbnailjob.cpp

--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -1,3 +1,17 @@
+/*
+* Copyright (C) Fabian Müller <fmueller@owncloud.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+* for more details.
+*/
+
 #include "resolveurljobfactory.h"
 
 #include "accessmanager.h"

--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -77,6 +77,8 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
 
                     dialog->show();
                 }
+            } else {
+                setJobResult(job, newUrl);
             }
         };
     };

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -99,6 +99,8 @@ AccountPtr SetupWizardAccountBuilder::build()
     newAccountPtr->setDavUser(_authenticationStrategy->davUser());
     newAccountPtr->setCredentials(_authenticationStrategy->makeCreds());
 
+    newAccountPtr->addApprovedCerts({ _customTrustedCaCertificates.begin(), _customTrustedCaCertificates.end() });
+
     return newAccountPtr;
 }
 
@@ -121,5 +123,10 @@ QString SetupWizardAccountBuilder::displayName() const
 void SetupWizardAccountBuilder::setAuthenticationStrategy(AbstractAuthenticationStrategy *strategy)
 {
     _authenticationStrategy.reset(strategy);
+}
+
+void SetupWizardAccountBuilder::addCustomTrustedCaCertificate(const QSslCertificate &customTrustedCaCertificate)
+{
+    _customTrustedCaCertificates.insert(customTrustedCaCertificate);
 }
 }

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -129,4 +129,9 @@ void SetupWizardAccountBuilder::addCustomTrustedCaCertificate(const QSslCertific
 {
     _customTrustedCaCertificates.insert(customTrustedCaCertificate);
 }
+
+void SetupWizardAccountBuilder::clearCustomTrustedCaCertificates()
+{
+    _customTrustedCaCertificates.clear();
+}
 }

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -120,6 +120,11 @@ public:
     void addCustomTrustedCaCertificate(const QSslCertificate &customTrustedCaCertificate);
 
     /**
+     * Remove all stored custom trusted CA certificates.
+     */
+    void clearCustomTrustedCaCertificates();
+
+    /**
      * Attempt to build an account from the previously entered information.
      * @return built account or null if information is still missing
      */

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -114,6 +114,12 @@ public:
     QString displayName() const;
 
     /**
+     * Store custom CA certificate for the newly built account.
+     * @param customTrustedCaCertificate certificate to store
+     */
+    void addCustomTrustedCaCertificate(const QSslCertificate &customTrustedCaCertificate);
+
+    /**
      * Attempt to build an account from the previously entered information.
      * @return built account or null if information is still missing
      */
@@ -125,5 +131,7 @@ private:
     DetermineAuthTypeJob::AuthType _authType = DetermineAuthTypeJob::AuthType::Unknown;
 
     std::unique_ptr<AbstractAuthenticationStrategy> _authenticationStrategy;
+
+    QSet<QSslCertificate> _customTrustedCaCertificates;
 };
 }

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -209,6 +209,12 @@ void SetupWizardController::nextStep(std::optional<PageIndex> currentPage, std::
                 connect(authTypeJob, &CoreJob::finished, authTypeJob, [this, authTypeJob, resolvedUrl]() {
                     authTypeJob->deleteLater();
 
+                    if (authTypeJob->result().isNull()) {
+                        _wizardWindow->showErrorMessage(authTypeJob->errorMessage());
+                        nextStep(0, 0);
+                        return;
+                    }
+
                     _accountBuilder.setServerUrl(resolvedUrl, qvariant_cast<DetermineAuthTypeJob::AuthType>(authTypeJob->result()));
 
                     switch (_accountBuilder.authType()) {

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -291,6 +291,9 @@ void SetupWizardController::nextStep(std::optional<PageIndex> currentPage, std::
                     // future requests made through this access manager should accept the certificate
                     _accessManager->addCustomTrustedCaCertificate(caCertificate);
 
+                    // we have to terminate the existing (cached) connection to make the access manager re-evaluate the certificate sent by the server
+                    _accessManager->clearConnectionCache();
+
                     // the account maintains a list, too, which is also saved in the config file
                     _accountBuilder.addCustomTrustedCaCertificate(caCertificate);
                 },

--- a/src/gui/tlserrordialog.cpp
+++ b/src/gui/tlserrordialog.cpp
@@ -1,0 +1,117 @@
+/*
+* Copyright (C) Fabian Müller <fmueller@owncloud.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+* for more details.
+*/
+
+#include "tlserrordialog.h"
+#include "common/utility.h"
+#include "ui_tlserrordialog.h"
+
+#include <QAbstractButton>
+#include <QPushButton>
+
+namespace OCC {
+TlsErrorDialog::TlsErrorDialog(const QList<QSslError> &sslErrors, const QString &host, QWidget *parent)
+    : QDialog(parent)
+    , _ui(new Ui::TlsErrorDialog)
+{
+    _ui->setupUi(this);
+
+    _ui->hostnameLabel->setText(tr("Cannot connect securely to %1").arg(host));
+
+    QStringList errorStrings;
+
+    for (const auto &error : sslErrors) {
+        errorStrings << error.errorString() << describeCertificateHtml(error.certificate());
+    }
+
+    _ui->textBrowser->setHtml(errorStrings.join("\n"));
+
+    // FIXME: add checkbox for second confirmation
+
+    connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, [this]() {
+        accept();
+    });
+    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
+        reject();
+    });
+
+    // of course, we require an answer from the user, they may not proceed with anything else
+    setModal(true);
+}
+
+TlsErrorDialog::~TlsErrorDialog()
+{
+    delete _ui;
+}
+
+QString TlsErrorDialog::describeCertificateHtml(const QSslCertificate &certificate)
+{
+    auto formatFingerprint = [certificate](QCryptographicHash::Algorithm algorithm) {
+        return Utility::escape(certificate.digest(algorithm).toHex());
+    };
+
+    auto formatInfo = [](const QStringList &stringList) {
+        return Utility::escape(stringList.join(", "));
+    };
+
+    auto escapeValueOrNotSpecified = [&](const QStringList &stringList) {
+        if (stringList.isEmpty()) {
+            return tr("&lt;not specified&gt;");
+        } else {
+            return formatInfo(stringList);
+        }
+    };
+
+    QString msg = tr(
+        "<div id=\"cert\">"
+        "<h3>with Certificate %1</h3>"
+        "<div id=\"ccert\">"
+        "<p>"
+        "Organization: %2<br/>"
+        "Unit: %3<br/>"
+        "Country: %4"
+        "</p>"
+        "<p>"
+        "Fingerprint (MD5): <tt>%5</tt><br/>"
+        "Fingerprint (SHA1): <tt>%6</tt><br/>"
+        "<br/>"
+        "Effective Date: %7"
+        "Expiration Date: %8"
+        "</div>"
+        "<h3>Issuer: %9</h3>"
+        "<div id=\"issuer\">"
+        "<p>"
+        "Organization: %10<br/>"
+        "Unit: %11<br/>"
+        "Country: %12"
+        "</p>"
+        "</div>"
+        "</div>")
+                      .arg(
+                          formatInfo(certificate.subjectInfo(QSslCertificate::CommonName)),
+                          escapeValueOrNotSpecified(certificate.subjectInfo(QSslCertificate::Organization)),
+                          escapeValueOrNotSpecified(certificate.subjectInfo(QSslCertificate::OrganizationalUnitName)),
+                          escapeValueOrNotSpecified(certificate.subjectInfo(QSslCertificate::CountryName)),
+                          formatFingerprint(QCryptographicHash::Md5),
+                          formatFingerprint(QCryptographicHash::Sha1),
+                          certificate.effectiveDate().toString(),
+                          certificate.expiryDate().toString(),
+                          formatInfo(certificate.issuerInfo(QSslCertificate::CommonName)),
+                          escapeValueOrNotSpecified(certificate.issuerInfo(QSslCertificate::Organization)),
+                          escapeValueOrNotSpecified(certificate.issuerInfo(QSslCertificate::OrganizationalUnitName)),
+                          escapeValueOrNotSpecified(certificate.issuerInfo(QSslCertificate::CountryName)));
+
+    return msg;
+}
+
+} // OCC

--- a/src/gui/tlserrordialog.h
+++ b/src/gui/tlserrordialog.h
@@ -1,0 +1,40 @@
+/*
+* Copyright (C) Fabian Müller <fmueller@owncloud.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+* for more details.
+*/
+
+#pragma once
+
+#include <QDialog>
+#include <QNetworkReply>
+
+namespace OCC {
+
+namespace Ui {
+    class TlsErrorDialog;
+}
+
+class TlsErrorDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TlsErrorDialog(const QList<QSslError> &sslErrors, const QString &host, QWidget *parent = nullptr);
+    ~TlsErrorDialog() override;
+
+private:
+    static QString describeCertificateHtml(const QSslCertificate &certificate);
+
+    Ui::TlsErrorDialog *_ui;
+};
+
+}

--- a/src/gui/tlserrordialog.ui
+++ b/src/gui/tlserrordialog.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OCC::TlsErrorDialog</class>
+ <widget class="QDialog" name="OCC::TlsErrorDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>534</width>
+    <height>493</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>TLS Certificate Error</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="hostnameLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true">Cannot connect securely to host hostname (placeholder)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="textBrowser"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Do you want to trust this certificate anyway?</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/libsync/abstractcorejob.h
+++ b/src/libsync/abstractcorejob.h
@@ -68,6 +68,13 @@ Q_SIGNALS:
      */
     void finished();
 
+    /**
+     * Emitted whenever the user accepts a CA certificate which is not trusted yet using the TlsErrorDialog.
+     * Handlers should store the certificate in the access manager passed to the corresponding job.
+     * @param caCertificate accepted CA certificate
+     */
+    void caCertificateAccepted(const QSslCertificate &caCertificate);
+
 private:
     // job result/error should be set only once, because that emits the "finished" signal
     void assertNotFinished();

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -49,7 +49,7 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url)
         case QNetworkReply::AuthenticationRequiredError:
             break;
         case QNetworkReply::NoError:
-            setJobError(job, tr("Server did not ask for authorization"));
+            setJobError(job, tr("Server did not ask for authorization"), reply->error());
             return;
         default:
             setJobError(job, tr("Failed to determine auth type: %1").arg(reply->errorString()), reply->error());

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -45,6 +45,17 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url)
     connect(reply, &QNetworkReply::finished, job, [reply, job] {
         reply->deleteLater();
 
+        switch (reply->error()) {
+        case QNetworkReply::AuthenticationRequiredError:
+            break;
+        case QNetworkReply::NoError:
+            setJobError(job, tr("Server did not ask for authorization"));
+            return;
+        default:
+            setJobError(job, tr("Failed to determine auth type: %1").arg(reply->errorString()), reply->error());
+            return;
+        }
+
         const auto authChallenge = reply->rawHeader(QByteArrayLiteral("WWW-Authenticate")).toLower();
 
         // we fall back to basic in any case


### PR DESCRIPTION
Depends on #9642.

This PR implements a new TLS error dialog similar to the old SSL error dialog (which had a dependency on an account object and didn't implement separation of concerns) 

There are some TODOs/FIXMEs left, please leave your opinion there.

Contributes to https://github.com/owncloud/client/issues/9249.