### PR TITLE
Make reply available for core jobs

### DIFF
--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -53,7 +53,7 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
                     return;
                 }
 
-                setJobError(job, tr("Failed to resolve the url %1, error: %2").arg(oldUrl.toDisplayString(), reply->errorString()), reply->error());
+                setJobError(job, tr("Failed to resolve the url %1, error: %2").arg(oldUrl.toDisplayString(), reply->errorString()), reply);
                 qCWarning(lcResolveUrl) << job->errorMessage();
                 return;
             }
@@ -86,7 +86,7 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
                     });
 
                     connect(dialog, &UpdateUrlDialog::rejected, job, [=]() {
-                        setJobError(job, tr("User rejected redirect from %1 to %2").arg(oldUrl.toDisplayString(), newUrl.toDisplayString()), QNetworkReply::InsecureRedirectError);
+                        setJobError(job, tr("User rejected redirect from %1 to %2").arg(oldUrl.toDisplayString(), newUrl.toDisplayString()), nullptr);
                     });
 
                     dialog->show();
@@ -114,7 +114,7 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
         });
 
         connect(tlsErrorDialog, &TlsErrorDialog::rejected, job, [job]() {
-            setJobError(job, tr("User rejected invalid SSL certificate"), QNetworkReply::SslHandshakeFailedError);
+            setJobError(job, tr("User rejected invalid SSL certificate"), nullptr);
         });
 
         tlsErrorDialog->show();

--- a/src/libsync/abstractcorejob.cpp
+++ b/src/libsync/abstractcorejob.cpp
@@ -37,9 +37,9 @@ void AbstractCoreJobFactory::setJobResult(CoreJob *job, const QVariant &result)
     job->setResult(result);
 }
 
-void AbstractCoreJobFactory::setJobError(CoreJob *job, const QString &errorMessage, const QNetworkReply::NetworkError networkError)
+void AbstractCoreJobFactory::setJobError(CoreJob *job, const QString &errorMessage, QNetworkReply *reply)
 {
-    job->setError(errorMessage, networkError);
+    job->setError(errorMessage, reply);
 }
 
 const QVariant &CoreJob::result() const
@@ -52,9 +52,9 @@ const QString &CoreJob::errorMessage() const
     return _errorMessage;
 }
 
-QNetworkReply::NetworkError CoreJob::networkError() const
+QNetworkReply *CoreJob::reply() const
 {
-    return _networkError;
+    return _reply;
 }
 
 bool CoreJob::success() const
@@ -72,12 +72,12 @@ void CoreJob::setResult(const QVariant &result)
     Q_EMIT finished();
 }
 
-void CoreJob::setError(const QString &errorMessage, QNetworkReply::NetworkError networkError)
+void CoreJob::setError(const QString &errorMessage, QNetworkReply *reply)
 {
     assertNotFinished();
 
     _errorMessage = errorMessage;
-    _networkError = networkError;
+    _reply = reply;
 
     Q_EMIT finished();
 }

--- a/src/libsync/abstractcorejob.h
+++ b/src/libsync/abstractcorejob.h
@@ -42,7 +42,8 @@ public:
     [[nodiscard]] const QVariant &result() const;
 
     [[nodiscard]] const QString &errorMessage() const;
-    [[nodiscard]] QNetworkReply::NetworkError networkError() const;
+
+    [[nodiscard]] QNetworkReply *reply() const;
 
     [[nodiscard]] bool success() const;
 
@@ -58,9 +59,9 @@ protected:
      * Set job error details. This emits the finished() signal, and marks the job as failed.
      * The job result or error can be set only once.
      * @param errorMessage network error or other suitable error message
-     * @param networkError network error instance or NoError if the error is not caused by a network issue
+     * @param reply reply received from server
      */
-    void setError(const QString &errorMessage, QNetworkReply::NetworkError networkError);
+    void setError(const QString &errorMessage, QNetworkReply *reply = nullptr);
 
 Q_SIGNALS:
     /**
@@ -84,7 +85,7 @@ private:
     QVariant _result;
 
     QString _errorMessage;
-    QNetworkReply::NetworkError _networkError = QNetworkReply::NoError;
+    QNetworkReply *_reply = nullptr;
 };
 
 
@@ -128,7 +129,7 @@ protected:
      * @param errorMessage network error or other suitable error message
      * @param networkError network error instance or NoError if the error is not caused by a network issue
      */
-    static void setJobError(CoreJob *job, const QString &errorMessage, const QNetworkReply::NetworkError networkError);
+    static void setJobError(CoreJob *job, const QString &errorMessage, QNetworkReply *reply);
 
     /**
      * Factory to create QNetworkRequests with properly set timeout.

--- a/src/libsync/creds/jobs/determineuserjobfactory.cpp
+++ b/src/libsync/creds/jobs/determineuserjobfactory.cpp
@@ -55,7 +55,7 @@ CoreJob *DetermineUserJobFactory::startJob(const QUrl &url)
         qCDebug(lcDetermineUserJob) << "data:" << data;
 
         if (reply->error() != QNetworkReply::NoError || statusCode != 200) {
-            setJobError(job, tr("Failed to retrieve user info"), reply->error());
+            setJobError(job, tr("Failed to retrieve user info"), reply);
         } else {
             qCWarning(lcDetermineUserJob) << data;
 
@@ -66,7 +66,7 @@ CoreJob *DetermineUserJobFactory::startJob(const QUrl &url)
                 const QString user = json.object().value(QStringLiteral("ocs")).toObject().value(QStringLiteral("data")).toObject().value(QStringLiteral("id")).toString();
                 setJobResult(job, user);
             } else {
-                setJobError(job, error.errorString(), reply->error());
+                setJobError(job, error.errorString(), reply);
             }
         }
     });

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -49,10 +49,10 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url)
         case QNetworkReply::AuthenticationRequiredError:
             break;
         case QNetworkReply::NoError:
-            setJobError(job, tr("Server did not ask for authorization"), reply->error());
+            setJobError(job, tr("Server did not ask for authorization"), reply);
             return;
         default:
-            setJobError(job, tr("Failed to determine auth type: %1").arg(reply->errorString()), reply->error());
+            setJobError(job, tr("Failed to determine auth type: %1").arg(reply->errorString()), reply);
             return;
         }
 


### PR DESCRIPTION
Needed for an upcoming refactoring of the `CheckServerJob`.

Note that by default the corresponding nam is set as parent. I presume this will work for us. Moving ownership to the `CoreJob` causes a segfault in the destructor.