### PR TITLE
Check basic auth credentials in wizard

### DIFF
--- a/src/gui/newwizard/CMakeLists.txt
+++ b/src/gui/newwizard/CMakeLists.txt
@@ -34,6 +34,9 @@ add_library(newwizard OBJECT
     jobs/resolveurljobfactory.cpp
     jobs/resolveurljobfactory.h
 
+    jobs/checkbasicauthjobfactory.cpp
+    jobs/checkbasicauthjobfactory.h
+
     syncmode.cpp
 )
 target_link_libraries(newwizard PUBLIC Qt5::Widgets libsync)

--- a/src/gui/newwizard/jobs/checkbasicauthjobfactory.cpp
+++ b/src/gui/newwizard/jobs/checkbasicauthjobfactory.cpp
@@ -1,0 +1,70 @@
+/*
+* Copyright (C) Fabian Müller <fmueller@owncloud.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+* for more details.
+*/
+
+#include "checkbasicauthjobfactory.h"
+
+#include "accessmanager.h"
+#include "common/utility.h"
+#include "creds/httpcredentials.h"
+#include "gui/tlserrordialog.h"
+#include "gui/updateurldialog.h"
+#include "theme.h"
+
+#include <QNetworkReply>
+
+namespace OCC::Wizard::Jobs {
+
+CoreJob *CheckBasicAuthJobFactory::startJob(const QUrl &url)
+{
+    auto *job = new CoreJob;
+
+    QNetworkRequest req(Utility::concatUrlPath(url, Theme::instance()->webDavPath()));
+
+    req.setAttribute(QNetworkRequest::AuthenticationReuseAttribute, QNetworkRequest::Manual);
+
+    QString authorizationHeader = QStringLiteral("Basic %1").arg(QString::fromLocal8Bit(QStringLiteral("%1:%2").arg(_username, _password).toLocal8Bit().toBase64()));
+    req.setRawHeader("Authorization", authorizationHeader.toLocal8Bit());
+
+    auto *reply = nam()->sendCustomRequest(req, "PROPFIND");
+
+    connect(reply, &QNetworkReply::finished, job, [reply, job]() {
+        switch (reply->error()) {
+        case QNetworkReply::NoError:
+            setJobResult(job, true);
+            return;
+        case QNetworkReply::AuthenticationRequiredError:
+            if (OC_ENSURE(reply->rawHeader(QByteArrayLiteral("WWW-Authenticate")).toLower().contains("basic "))) {
+                setJobResult(job, false);
+                return;
+            }
+            Q_FALLTHROUGH();
+        default:
+            setJobError(job, tr("Invalid reply received from server"), reply);
+            return;
+        }
+    });
+
+    makeRequest();
+
+    return job;
+}
+
+CheckBasicAuthJobFactory::CheckBasicAuthJobFactory(QNetworkAccessManager *nam, const QString &username, const QString &password, QObject *parent)
+    : AbstractCoreJobFactory(nam, parent)
+    , _username(username)
+    , _password(password)
+{
+}
+
+}

--- a/src/gui/newwizard/jobs/checkbasicauthjobfactory.h
+++ b/src/gui/newwizard/jobs/checkbasicauthjobfactory.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Fabian Müller <fmueller@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include "abstractcorejob.h"
+
+namespace OCC::Wizard::Jobs {
+
+class CheckBasicAuthJobFactory : public AbstractCoreJobFactory
+{
+    Q_OBJECT
+
+public:
+    CheckBasicAuthJobFactory(QNetworkAccessManager *nam, const QString &username, const QString &password, QObject *parent = nullptr);
+
+    CoreJob *startJob(const QUrl &url) override;
+
+private:
+    QString _username;
+    QString _password;
+};
+
+}

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -42,6 +42,16 @@ QString HttpBasicAuthenticationStrategy::davUser()
     return _username;
 }
 
+QString HttpBasicAuthenticationStrategy::username() const
+{
+    return _username;
+}
+
+QString HttpBasicAuthenticationStrategy::password() const
+{
+    return _password;
+}
+
 OAuth2AuthenticationStrategy::OAuth2AuthenticationStrategy(const QString &davUser, const QString &token, const QString &refreshToken)
     : _davUser(davUser)
     , _token(token)
@@ -133,5 +143,10 @@ void SetupWizardAccountBuilder::addCustomTrustedCaCertificate(const QSslCertific
 void SetupWizardAccountBuilder::clearCustomTrustedCaCertificates()
 {
     _customTrustedCaCertificates.clear();
+}
+
+AbstractAuthenticationStrategy *SetupWizardAccountBuilder::authenticationStrategy() const
+{
+    return _authenticationStrategy.get();
 }
 }

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -61,6 +61,10 @@ public:
 
     QString davUser() override;
 
+    // access is needed to be able to check these credentials against the server
+    QString username() const;
+    QString password() const;
+
 private:
     QString _username;
     QString _password;
@@ -103,6 +107,7 @@ public:
     DetermineAuthTypeJob::AuthType authType();
 
     void setAuthenticationStrategy(AbstractAuthenticationStrategy *strategy);
+    AbstractAuthenticationStrategy *authenticationStrategy() const;
 
     /**
      * Check whether credentials passed to the builder so far can be used to create a new account object.

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -89,9 +89,6 @@ void SetupWizardController::nextStep(std::optional<PageIndex> currentPage, std::
             // therefore we clear the certificates storage before resolving the URL
             _accountBuilder = {};
 
-            _accessManager->deleteLater();
-            _accessManager = new AccessManager(this);
-
             const auto *pagePtr = qobject_cast<ServerUrlSetupWizardPage *>(_currentPage);
 
             const auto serverUrl = [pagePtr]() {
@@ -190,6 +187,11 @@ void SetupWizardController::nextStep(std::optional<PageIndex> currentPage, std::
         });
 
         connect(messageBox, &QMessageBox::accepted, this, [this, showFirstPage]() {
+            // when moving back to this page (or retrying a failed credentials check), we need to make sure existing cookies
+            // and certificates are deleted from the access manager
+            _accessManager->deleteLater();
+            _accessManager = new AccessManager(this);
+
             // first, we must resolve the actual server URL
             auto resolveJob = Jobs::ResolveUrlJobFactory(_accessManager).startJob(_accountBuilder.serverUrl());
 

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -17,6 +17,7 @@
 
 #include "common/utility.h"
 #include "creds/httpcredentials.h"
+#include "theme.h"
 
 #include <QLoggingCategory>
 
@@ -35,7 +36,8 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url)
 {
     auto job = new CoreJob;
 
-    auto req = makeRequest(Utility::concatUrlPath(url, QStringLiteral("remote.php/dav/files/")));
+    // we explicitly use a legacy dav path here
+    auto req = makeRequest(Utility::concatUrlPath(url, Theme::instance()->webDavPath()));
 
     req.setAttribute(HttpCredentials::DontAddCredentialsAttribute, true);
     req.setAttribute(QNetworkRequest::AuthenticationReuseAttribute, QNetworkRequest::Manual);


### PR DESCRIPTION
This way, users don't unexpectedly have to re-login after the wizard completes if they entered the wrong credentials.

Fixes #9623.

Please note that there is one issue which I haven't been able to fully resolve. When moving back from the last page to the second one, the wizard re-checks the auth type (which should not be necessary but also shouldn't hurt). For some reason, this time, the lookup fails. You can move forward from the first page just fine, though, and the lookup works again.