### PR TITLE
Fix object path passed to DBus by libcloudproviders

### DIFF
--- a/src/gui/libcloudproviders/libcloudproviders.cpp
+++ b/src/gui/libcloudproviders/libcloudproviders.cpp
@@ -126,7 +126,15 @@ void LibCloudProvidersPrivate::exportFolder(Folder *folder)
         g_error_free(error);
     }
 
-    auto exporter = cloud_providers_account_exporter_new(_exporter, folder->id().constData());
+    // DBus object paths must not contain characters other than [A-Z][a-z][0-9]_, see g_variant_is_object_path
+    const QByteArray dBusCompatibleFolderId = [folder]() {
+        // replace works inplace
+        auto rv = folder->id();
+        rv.replace("-", "");
+        return rv;
+    }();
+
+    auto exporter = cloud_providers_account_exporter_new(_exporter, dBusCompatibleFolderId.constData());
     cloud_providers_account_exporter_set_path(exporter, folder->path().toUtf8().constData());
     cloud_providers_account_exporter_set_icon(exporter, icon);
     cloud_providers_account_exporter_set_status(exporter, CLOUD_PROVIDERS_ACCOUNT_STATUS_IDLE);


### PR DESCRIPTION
Fixes #9683.

I don't think we need a changelog item, since we just enabled cloudproviders integration with the upcoming 3.0 release.