### PR TITLE
Use static libraries again

### DIFF
--- a/src/gui/folderwizard/CMakeLists.txt
+++ b/src/gui/folderwizard/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(folderwizard OBJECT
+add_library(folderwizard STATIC
     folderwizard.cpp
     folderwizardsourcepage.ui
     folderwizardtargetpage.ui

--- a/src/gui/newwizard/CMakeLists.txt
+++ b/src/gui/newwizard/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(newwizard OBJECT
+add_library(newwizard STATIC
     pages/abstractsetupwizardpage.h
     pages/abstractsetupwizardpage.cpp
 

--- a/src/gui/spaces/CMakeLists.txt
+++ b/src/gui/spaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(spaces OBJECT
+add_library(spaces STATIC
 	spacesmodel.cpp spacesbrowser.cpp spacesbrowser.ui)
 target_link_libraries(spaces PUBLIC Qt5::Widgets libsync)
 set_target_properties(spaces PROPERTIES AUTOUIC ON AUTORCC ON)


### PR DESCRIPTION
In recent CMake versions (> 3.19.2 at least), using OBJECT libraries with Qt fails because CMake does not link AUTOMOC targets properly into users of the OBJECT libraries. This should have been fixed in 3.20, but apparently in our case this still is not working. Suggested workarounds like linking Qt5::Core into the OBJECT libraries also did not yield success.