### PR TITLE
Make sure AppImage update dialog uses application icon

### DIFF
--- a/src/gui/updater/appimageupdateavailabledialog.cpp
+++ b/src/gui/updater/appimageupdateavailabledialog.cpp
@@ -27,8 +27,6 @@ AppImageUpdateAvailableDialog::AppImageUpdateAvailableDialog(const QVersionNumbe
 {
     _ui->setupUi(this);
 
-    setWindowIcon(style()->standardIcon(QStyle::SP_MessageBoxInformation));
-
     // we want an immediate response from the user
     setModal(true);
 


### PR DESCRIPTION
Dialogs inherit the icon from their parent, so we do not have to set it manually.

Closes #9704.