### PR TITLE
Document how native file dialog must be initialized

### DIFF
--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -71,6 +71,8 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
         auto dialog = new QFileDialog(this, tr("Select the local folder"), defaultSyncTargetDir);
         dialog->setFileMode(QFileDialog::Directory);
         dialog->setOption(QFileDialog::ShowDirsOnly);
+
+        // this makes Qt use the native file dialog on Windows
         dialog->setModal(true);
 
         connect(dialog, &QFileDialog::fileSelected, this, [this](const QString &directory) {


### PR DESCRIPTION
I just re-reviewed #9688, and noticed a comment would be very useful, since this behavior is not clearly documented by Qt.