### PR TITLE
Change the way the continous log files are created

### DIFF
--- a/changelog/unreleased/9731
+++ b/changelog/unreleased/9731
@@ -1,0 +1,9 @@
+Enhancement: Create continuus log files
+
+Previously, when logging was enabled, we started a new log file for every sync.
+This worked quite well if you sync a single account and a single folder.
+With spaces however we have a multitude of sync folders, which resulted in hundreds of tiny log files.
+
+Now, as soon as a log file's size exceeds 100 MiB, a new log file is started, and the old one is moved and compressed.
+
+https://github.com/owncloud/client/issues/9731

--- a/changelog/unreleased/9731
+++ b/changelog/unreleased/9731
@@ -1,9 +1,10 @@
-Enhancement: Create continuus log files
+Enhancement: Create continuous log files
 
 Previously, when logging was enabled, we started a new log file for every sync.
 This worked quite well if you sync a single account and a single folder.
 With spaces however we have a multitude of sync folders, which resulted in hundreds of tiny log files.
 
 Now, as soon as a log file's size exceeds 100 MiB, a new log file is started, and the old one is moved and compressed.
+The option to delete log files older than 4h was replaced by an option to keep a number of log files.
 
 https://github.com/owncloud/client/issues/9731

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -224,7 +224,6 @@ Application::Application(int &argc, char **argv)
     : SharedTools::QtSingleApplication(Theme::instance()->appName(), argc, argv)
     , _gui(nullptr)
     , _theme(Theme::instance())
-    , _logExpire(0)
     , _logFlush(false)
     , _logDebug(false)
     , _userTriggeredConnect(false)
@@ -525,7 +524,6 @@ void Application::setupLogging()
     auto logger = Logger::instance();
     logger->setLogFile(_logFile);
     logger->setLogDir(_logDir);
-    logger->setLogExpire(_logExpire);
     logger->setLogFlush(_logFlush);
     logger->setLogDebug(_logDebug);
 
@@ -604,7 +602,6 @@ void Application::parseOptions(const QStringList &arguments)
     auto quitInstanceOption = addOption({ { "q", "quit" }, tr("Quit the running instance.") });
     auto logFileOption = addOption({ "logfile", tr("Write log to file (use - to write to stdout)."), "filename" });
     auto logDirOption = addOption({ "logdir", tr("Write each sync log output in a new file in folder."), "name" });
-    auto logExpireOption = addOption({ "logexpire", tr("Remove logs older than <hours> hours (to be used with --logdir)."), "hours" });
     auto logFlushOption = addOption({ "logflush", tr("Flush the log file after every write.") });
     auto logDebugOption = addOption({ "logdebug", tr("Output debug-level messages in the log.") });
     auto languageOption = addOption({ "language", tr("Override UI language."), "language" });
@@ -629,9 +626,6 @@ void Application::parseOptions(const QStringList &arguments)
     }
     if (parser.isSet(logDirOption)) {
         _logDir = parser.value(logDirOption);
-    }
-    if (parser.isSet(logExpireOption)) {
-        _logExpire = std::chrono::hours(parser.value(logExpireOption).toInt());
     }
     if (parser.isSet(logFlushOption)) {
         _logFlush = true;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -528,7 +528,6 @@ void Application::setupLogging()
     logger->setLogExpire(_logExpire);
     logger->setLogFlush(_logFlush);
     logger->setLogDebug(_logDebug);
-    logger->enterNextLogFile();
 
     // Possibly configure logging from config file
     LogBrowser::setupLoggingFromConfig();

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -117,7 +117,6 @@ private:
     bool _quitInstance = false;
     QString _logFile;
     QString _logDir;
-    std::chrono::hours _logExpire;
     bool _logFlush;
     bool _logDebug;
     bool _userTriggeredConnect;

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -38,8 +38,6 @@ namespace OCC {
 
 // ==============================================================================
 
-const std::chrono::hours defaultExpireDuration(4);
-
 LogBrowser::LogBrowser(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::LogBrowser)
@@ -58,9 +56,11 @@ LogBrowser::LogBrowser(QWidget *parent)
         ConfigFile().setLogHttp(b);
     });
 
-    ui->deleteLogsButton->setText(tr("Delete logs older than %1 hours").arg(QString::number(defaultExpireDuration.count())));
-    ui->deleteLogsButton->setChecked(bool(ConfigFile().automaticDeleteOldLogsAge()));
-    connect(ui->deleteLogsButton, &QCheckBox::toggled, this, &LogBrowser::toggleLogDeletion);
+    ui->spinBox_numberOflogsToKeep->setValue(ConfigFile().automaticDeleteOldLogs());
+    connect(ui->spinBox_numberOflogsToKeep, qOverload<int>(&QSpinBox::valueChanged), this, [](int i) {
+        ConfigFile().setAutomaticDeleteOldLogs(i);
+        Logger::instance()->setMaxLogFiles(i);
+    });
 
 
     connect(ui->openFolderButton, &QPushButton::clicked, this, []() {
@@ -89,11 +89,7 @@ void LogBrowser::setupLoggingFromConfig()
             return;
 
         logger->setupTemporaryFolderLogDir();
-        if (auto deleteOldLogsHours = config.automaticDeleteOldLogsAge()) {
-            logger->setLogExpire(*deleteOldLogsHours);
-        } else {
-            logger->setLogExpire(std::chrono::hours(0));
-        }
+        Logger::instance()->setMaxLogFiles(config.automaticDeleteOldLogs());
     } else {
         logger->disableTemporaryFolderLogDir();
     }
@@ -104,20 +100,6 @@ void LogBrowser::togglePermanentLogging(bool enabled)
     ConfigFile config;
     config.setAutomaticLogDir(enabled);
     setupLoggingFromConfig();
-}
-
-void LogBrowser::toggleLogDeletion(bool enabled)
-{
-    ConfigFile config;
-    auto logger = Logger::instance();
-
-    if (enabled) {
-        config.setAutomaticDeleteOldLogsAge(defaultExpireDuration);
-        logger->setLogExpire(defaultExpireDuration);
-    } else {
-        config.setAutomaticDeleteOldLogsAge({});
-        logger->setLogExpire(std::chrono::hours(0));
-    }
 }
 
 } // namespace

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -94,7 +94,6 @@ void LogBrowser::setupLoggingFromConfig()
         } else {
             logger->setLogExpire(std::chrono::hours(0));
         }
-        logger->enterNextLogFile();
     } else {
         logger->disableTemporaryFolderLogDir();
     }

--- a/src/gui/logbrowser.h
+++ b/src/gui/logbrowser.h
@@ -53,7 +53,6 @@ public:
 
 protected slots:
     void togglePermanentLogging(bool enabled);
-    void toggleLogDeletion(bool enabled);
 
 private:
     QScopedPointer<Ui::LogBrowser> ui;

--- a/src/gui/logbrowser.ui
+++ b/src/gui/logbrowser.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>300</height>
+    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -125,11 +125,35 @@ Since log files can get large, the client will start a new one for each sync run
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="deleteLogsButton">
-     <property name="text">
-      <string notr="true">Delete logs older than %1 hours</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Log files to keep:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBox_numberOflogsToKeep">
+       <property name="minimum">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QLabel" name="label_3">

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -203,13 +203,6 @@ void ownCloudGui::slotSyncStateChange(Folder *folder)
 
     qCInfo(lcApplication) << "Sync state changed for folder " << folder->remoteUrl().toString() << ": " << result.statusString();
 
-    if (result.status() == SyncResult::Success
-        || result.status() == SyncResult::Problem
-        || result.status() == SyncResult::SyncAbortRequested
-        || result.status() == SyncResult::Error) {
-        Logger::instance()->enterNextLogFile();
-    }
-
     if (result.status() == SyncResult::NotYetStarted) {
         _settingsDialog->slotRefreshActivity(folder->accountState());
     }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -71,7 +71,7 @@ const QString minChunkSizeC() { return QStringLiteral("minChunkSize"); }
 const QString maxChunkSizeC() { return QStringLiteral("maxChunkSize"); }
 const QString targetChunkUploadDurationC() { return QStringLiteral("targetChunkUploadDuration"); }
 const QString automaticLogDirC() { return QStringLiteral("logToTemporaryLogDir"); }
-const QString deleteOldLogsAfterHoursC() { return QStringLiteral("temporaryLogDirDeleteOldLogsAfterHours"); }
+const QString numberOfLogsToKeepC() { return QStringLiteral("numberOfLogsToKeep"); }
 const QString showExperimentalOptionsC() { return QStringLiteral("showExperimentalOptions"); }
 const QString clientVersionC() { return QStringLiteral("clientVersion"); }
 
@@ -800,26 +800,16 @@ void ConfigFile::setAutomaticLogDir(bool enabled)
     settings.setValue(automaticLogDirC(), enabled);
 }
 
-Optional<chrono::hours> ConfigFile::automaticDeleteOldLogsAge() const
+int ConfigFile::automaticDeleteOldLogs() const
 {
     auto settings = makeQSettings();
-    auto value = settings.value(deleteOldLogsAfterHoursC());
-    if (!value.isValid())
-        return chrono::hours(4);
-    auto hours = value.toInt();
-    if (hours <= 0)
-        return {};
-    return chrono::hours(hours);
+    return settings.value(numberOfLogsToKeepC()).toInt();
 }
 
-void ConfigFile::setAutomaticDeleteOldLogsAge(Optional<chrono::hours> expireTime)
+void ConfigFile::setAutomaticDeleteOldLogs(int number)
 {
     auto settings = makeQSettings();
-    if (!expireTime) {
-        settings.setValue(deleteOldLogsAfterHoursC(), -1);
-    } else {
-        settings.setValue(deleteOldLogsAfterHoursC(), QVariant::fromValue(expireTime->count()));
-    }
+    settings.setValue(numberOfLogsToKeepC(), number);
 }
 
 void ConfigFile::setLogHttp(bool b)

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -98,9 +98,9 @@ public:
     bool automaticLogDir() const;
     void setAutomaticLogDir(bool enabled);
 
-    /** Wheter the automaticLogDir should expire logs, and after how many hours */
-    Optional<std::chrono::hours> automaticDeleteOldLogsAge() const;
-    void setAutomaticDeleteOldLogsAge(Optional<std::chrono::hours> expireTime);
+    /** Number of log files to keep */
+    int automaticDeleteOldLogs() const;
+    void setAutomaticDeleteOldLogs(int number);
 
     /** Whether to log http traffic */
     void setLogHttp(bool b);

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -13,14 +13,14 @@
  */
 
 #include "logger.h"
-
 #include "config.h"
+#include "theme.h"
 
 #include <QCoreApplication>
 #include <QDir>
 #include <QStringList>
+#include <QtConcurrent>
 #include <QtGlobal>
-#include <qmetaobject.h>
 
 #include <iostream>
 
@@ -33,7 +33,8 @@
 #endif
 
 namespace {
-constexpr int CrashLogSize = 20;
+constexpr int crashLogSizeC = 20;
+constexpr int maxLogSizeC = 1024 * 1024 * 100; // 100 MiB
 
 #ifdef Q_OS_WIN
 bool isDebuggerPresent()
@@ -66,7 +67,7 @@ Logger::Logger(QObject *parent)
     : QObject(parent)
 {
     qSetMessagePattern(loggerPattern());
-    _crashLog.resize(CrashLogSize);
+    _crashLog.resize(crashLogSizeC);
 #ifndef NO_MSG_HANDLER
     qInstallMessageHandler([](QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
             Logger::instance()->doLog(type, ctx, message);
@@ -97,7 +98,7 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
     const QString msg = qFormatLogMessage(type, ctx, message) + QLatin1Char('\n');
     {
         QMutexLocker lock(&_mutex);
-        _crashLogIndex = (_crashLogIndex + 1) % CrashLogSize;
+        _crashLogIndex = (_crashLogIndex + 1) % crashLogSizeC;
         _crashLog[_crashLogIndex] = msg;
         if (_logstream) {
             (*_logstream) << msg;
@@ -117,7 +118,33 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
             Utility::crash();
 #endif
         }
+        if (!_logDirectory.isEmpty()) {
+            if (_logFile.size() > maxLogSizeC) {
+                rotateLog();
+            }
+        }
     }
+}
+
+void Logger::open(const QString &name)
+{
+    bool openSucceeded = false;
+    if (name == QLatin1Char('-')) {
+        attacheToConsole();
+        setLogFlush(true);
+        openSucceeded = _logFile.open(stdout, QIODevice::WriteOnly);
+    } else {
+        _logFile.setFileName(name);
+        openSucceeded = _logFile.open(QIODevice::WriteOnly);
+    }
+
+    if (!openSucceeded) {
+        std::cerr << "Failed to open the log file" << std::endl;
+        return;
+    }
+    _logstream.reset(new QTextStream(&_logFile));
+    _logstream->setCodec("UTF-8");
+    (*_logstream) << Theme::instance()->aboutVersions(Theme::VersionFormat::OneLiner) << Qt::endl;
 }
 
 void Logger::close()
@@ -142,33 +169,19 @@ void Logger::setLogFile(const QString &name)
         return;
     }
 
-    bool openSucceeded = false;
-    if (name == QLatin1Char('-')) {
-        attacheToConsole();
-        setLogFlush(true);
-        openSucceeded = _logFile.open(stdout, QIODevice::WriteOnly);
-    } else {
-        _logFile.setFileName(name); 
-        openSucceeded = _logFile.open(QIODevice::WriteOnly);
-    }
-
-    if (!openSucceeded) {
-        std::cerr << "Failed to open the log file" << std::endl;
-        return;
-    }
-
-    _logstream.reset(new QTextStream(&_logFile));
-    _logstream->setCodec("UTF-8");
+    open(name);
 }
 
 void Logger::setLogExpire(std::chrono::hours expire)
 {
     _logExpire = expire;
+    rotateLog();
 }
 
 void Logger::setLogDir(const QString &dir)
 {
     _logDirectory = dir;
+    rotateLog();
 }
 
 void Logger::setLogFlush(bool flush)
@@ -206,8 +219,6 @@ void Logger::disableTemporaryFolderLogDir()
 {
     if (!_temporaryFolderLogDir)
         return;
-
-    enterNextLogFile();
     setLogDir(QString());
     setLogDebug(false);
     setLogFile(QString());
@@ -234,8 +245,8 @@ void Logger::dumpCrashLog()
     if (logFile.open(QFile::WriteOnly)) {
         QTextStream out(&logFile);
         out.setCodec("UTF-8");
-        for (int i = 1; i <= CrashLogSize; ++i) {
-            out << _crashLog[(_crashLogIndex + i) % CrashLogSize];
+        for (int i = 1; i <= crashLogSizeC; ++i) {
+            out << _crashLog[(_crashLogIndex + i) % crashLogSizeC];
         }
     }
 }
@@ -262,7 +273,7 @@ static bool compressLog(const QString &originalName, const QString &targetName)
     return true;
 }
 
-void Logger::enterNextLogFile()
+void Logger::rotateLog()
 {
     if (!_logDirectory.isEmpty()) {
 
@@ -272,44 +283,49 @@ void Logger::enterNextLogFile()
         }
 
         // Tentative new log name, will be adjusted if one like this already exists
-        QDateTime now = QDateTime::currentDateTime();
-        QString newLogName = now.toString(QStringLiteral("yyyyMMdd_HHmm")) + QStringLiteral("_owncloud.log");
+        const QString logName = dir.filePath(QStringLiteral(APPLICATION_SHORTNAME ".log"));
+        QString previousLog;
 
-        // Expire old log files and deal with conflicts
-        const auto &files = dir.entryList(QStringList(QStringLiteral("*owncloud.log.*")),
-            QDir::Files, QDir::Name);
-        QRegExp rx(QStringLiteral(R"(.*owncloud\.log\.(\d+).*)"));
-        int maxNumber = -1;
-        for (const auto &s : files) {
-            if (_logExpire.count() > 0) {
-                std::chrono::seconds expireSeconds(_logExpire);
-                QFileInfo fileInfo(dir.absoluteFilePath(s));
-                if (fileInfo.lastModified().addSecs(expireSeconds.count()) < now) {
-                    dir.remove(s);
+        if (_logFile.isOpen()) {
+            _logFile.close();
+        }
+        // rename previous log file if size != 0
+        const auto info = QFileInfo(logName);
+        if (info.exists(logName) && !info.size() == 0) {
+            previousLog = dir.filePath(QStringLiteral(APPLICATION_SHORTNAME "-%1.log").arg(info.created().toString(QStringLiteral("MMdd_hh.mm.ss.zzz"))));
+            if (!QFile(logName).rename(previousLog)) {
+                std::cerr << "Failed to rename: " << qPrintable(logName) << " to " << qPrintable(previousLog) << std::endl;
+            }
+        }
+
+        const auto now = QDateTime::currentDateTime();
+        open(logName);
+        // set the creation time to now
+        _logFile.setFileTime(now, QFileDevice::FileTime::FileBirthTime);
+
+        QtConcurrent::run([now, previousLog, dir, logExpire = _logExpire] {
+            // Expire old log files and deal with conflicts
+            const auto &files = dir.entryList(QStringList(QStringLiteral("*" APPLICATION_SHORTNAME "-*.log.gz")),
+                QDir::Files, QDir::Name);
+            for (const auto &s : files) {
+                if (logExpire.count() > 0) {
+                    std::chrono::seconds expireSeconds(logExpire);
+                    QFileInfo fileInfo(dir.absoluteFilePath(s));
+                    if (fileInfo.lastModified().addSecs(expireSeconds.count()) < now) {
+                        QFile::remove(fileInfo.absoluteFilePath());
+                    }
                 }
             }
-            if (s.startsWith(newLogName) && rx.exactMatch(s)) {
-                maxNumber = qMax(maxNumber, rx.cap(1).toInt());
+            // Compress the previous log file.
+            if (!previousLog.isEmpty() && QFileInfo::exists(previousLog)) {
+                QString compressedName = QStringLiteral("%1.gz").arg(previousLog);
+                if (compressLog(previousLog, compressedName)) {
+                    QFile::remove(previousLog);
+                } else {
+                    QFile::remove(compressedName);
+                }
             }
-        }
-        newLogName.append(QLatin1Char('.') + QString::number(maxNumber + 1));
-
-        auto previousLog = _logFile.fileName();
-        setLogFile(dir.filePath(newLogName));
-
-        // Compress the previous log file. On a restart this can be the most recent
-        // log file.
-        auto logToCompress = previousLog;
-        if (logToCompress.isEmpty() && files.size() > 0 && !files.last().endsWith(QLatin1String(".gz")))
-            logToCompress = dir.absoluteFilePath(files.last());
-        if (!logToCompress.isEmpty()) {
-            QString compressedName = logToCompress + QStringLiteral(".gz");
-            if (compressLog(logToCompress, compressedName)) {
-                QFile::remove(logToCompress);
-            } else {
-                QFile::remove(compressedName);
-            }
-        }
+        });
     }
 }
 

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -47,9 +47,14 @@ public:
     static Logger *instance();
 
     void setLogFile(const QString &name);
-    void setLogExpire(std::chrono::hours expire);
     void setLogDir(const QString &dir);
     void setLogFlush(bool flush);
+
+    /**
+     * Set the maximum number of logs files to keep.
+     * Setting values below 5 will have no effect.
+     */
+    void setMaxLogFiles(int i);
 
     bool logDebug() const { return _logDebug; }
     void setLogDebug(bool debug);
@@ -90,7 +95,6 @@ private:
 
     QFile _logFile;
     bool _doFileFlush = false;
-    std::chrono::hours _logExpire;
     bool _logDebug = false;
     QScopedPointer<QTextStream> _logstream;
     mutable QMutex _mutex;
@@ -100,6 +104,8 @@ private:
     QVector<QString> _crashLog;
     int _crashLogIndex = 0;
     bool _consoleIsAttached = false;
+
+    int _maxLogFiles;
 };
 
 } // namespace OCC

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -78,13 +78,13 @@ public:
     }
     void setLogRules(const QSet<QString> &rules);
 
-public slots:
-    void enterNextLogFile();
-
 private:
     Logger(QObject *parent = nullptr);
     ~Logger() override;
 
+    void rotateLog();
+
+    void open(const QString &name);
     void close();
     void dumpCrashLog();
 


### PR DESCRIPTION
We now only rotate the logs when the client is started or the log gets bigger than 100mb

An inititial sync with cloud.owncloud.com creates archives of 4-7mb .
Keeping only 5 log files is however not enough for servers like that.