### PR TITLE
Remove now broken nextcloud detection

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -310,9 +310,6 @@ bool Account::serverVersionUnsupported() const
     if (capabilities().status().legacyVersion < QVersionNumber(10)) {
         return true;
     }
-    if (capabilities().status().productname.endsWith(QLatin1String("Nextcloud"))) {
-        return true;
-    }
     return false;
 }
 


### PR DESCRIPTION
While we have our version info in `data`->`capabilities`->`core`->`status`  theirs is in `data`->`version`.
As putting effort in better detection support for an unsupported server feels wrong, just remove the check.
Users will now only see the 
![image](https://user-images.githubusercontent.com/200626/170266344-e0cdfe11-f546-45f3-b0ad-675324aa4342.png)

banner.

```
    "data": {
      "version": {
        "major": 23,
        "minor": 0,
        "micro": 2,
        "string": "23.0.2",
        "edition": "",
        "extendedSupport": false
      }
```