### PR TITLE
Fix bookmark creation in GNOME, XFCE etc.

### DIFF
--- a/changelog/unreleased/9752
+++ b/changelog/unreleased/9752
@@ -1,0 +1,7 @@
+Bugfix: Fix adding bookmarks on Gtk+ 3 based desktops
+
+We used to add those bookmarks in a Gtk+ 2 compatible way only.
+Now, bookmarks are added to the file belonging to Gtk+ 3, dropping support for end-of-life Gtk+ 2.
+The bookmarks are now shown again for all Gtk+ 3 compatible file browsers, including Thunar, Nautilus, Nemo, Caja, etc.
+
+https://github.com/owncloud/client/pull/9752

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -31,7 +31,7 @@ namespace OCC {
 void Utility::setupFavLink(const QString &folder)
 {
     // Nautilus: add to ~/.gtk-bookmarks
-    QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.gtk-bookmarks"));
+    QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.config/gtk-3.0/bookmarks"));
     QByteArray folderUrl = "file://" + folder.toUtf8();
     if (gtkBookmarks.open(QFile::ReadWrite)) {
         QByteArray places = gtkBookmarks.readAll();


### PR DESCRIPTION
Gtk+ 3 based desktops store bookmarks information in another location. The old path was valid for Gtk+ 2 only.

Tested on xUbuntu 20.04, 22.04, Fedora 36, openSUSE Leap 15.3.