### PR TITLE
Allow to use our logger code in external libraries

### DIFF
--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -69,30 +69,14 @@ endif()
 
 # These headers are installed for libowncloudsync to be used by 3rd party apps
 set(owncloudsync_HEADERS
-    account.h
-    syncengine.h
-    configfile.h
-    networkjobs.h
-    progressdispatcher.h
-    syncfileitem.h
-    syncresult.h
+    ${CMAKE_CURRENT_BINARY_DIR}/owncloudlib.h
+    logger.h
 )
 
-set(creds_HEADERS
-    creds/abstractcredentials.h
-    creds/httpcredentials.h
+INSTALL(
+    FILES ${owncloudsync_HEADERS}
+    DESTINATION ${INCLUDE_INSTALL_DIR}/${synclib_NAME}
 )
-
-IF (NOT APPLE)
-    INSTALL(
-        FILES ${owncloudsync_HEADERS}
-        DESTINATION ${INCLUDE_INSTALL_DIR}/${synclib_NAME}/mirall
-    )
-    INSTALL(
-        FILES ${creds_HEADERS}
-        DESTINATION ${INCLUDE_INSTALL_DIR}/${synclib_NAME}/creds
-    )
-ENDIF(NOT APPLE)
 
 add_library(libsync SHARED ${libsync_SRCS})
 

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -145,7 +145,7 @@ void Logger::open(const QString &name)
     }
     _logstream.reset(new QTextStream(&_logFile));
     _logstream->setCodec("UTF-8");
-    (*_logstream) << Theme::instance()->aboutVersions(Theme::VersionFormat::OneLiner) << qApp->applicationName() << Qt::endl;
+    (*_logstream) << Theme::instance()->aboutVersions(Theme::VersionFormat::OneLiner) << " " << qApp->applicationName() << Qt::endl;
 }
 
 void Logger::close()

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -15,15 +15,14 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include <QObject>
-#include <QList>
 #include <QDateTime>
 #include <QFile>
+#include <QList>
+#include <QMutex>
+#include <QObject>
+#include <QSet>
 #include <QTextStream>
-#include <qmutex.h>
-#include <chrono>
 
-#include "common/utility.h"
 #include "owncloudlib.h"
 
 namespace OCC {


### PR DESCRIPTION
I removed the install target for probably not working headers and added the logger.h file instead.
Ideally we would also provide a cmake export target but at the moment I would not recommend anybody to use the logger besides for testing purposes.