### PR TITLE
[Tests-Only] Converted stacktrace error into str while logging

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -145,7 +145,7 @@ def hook(context):
             generateStacktrace(context, coredumps)
             test.log("Stacktrace generated!")
         except Exception as err:
-            test.log("Exception occured:" + err)
+            test.log("Exception occured:" + str(err))
     else:
         test.log("No coredump found!")
 


### PR DESCRIPTION
Since the last 2 days, an error occurred in the after scenario in the nightly builds saying `can only concatenate str (not "FileNotFoundError") to str`

Test Result: https://cache.owncloud.com/public//owncloud/client/11991/guiReportUpload/index.html

Solution Ref: https://stackoverflow.com/questions/63223226/python-try-except-include-the-custom-message-in-the-error-variable 

### Explanation of the solution
In the test log, we can see that there is no error until the users are deleted. And only place where error might occur is while generating the stacktrace. So, this solution should work.