### PR TITLE
Make use of new issue forms feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: "Bug report"
+description: "Report a bug to help us improve the ownCloud desktop client"
+labels: ["bug"]
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      We appreciate you taking the time to make the ownCloud desktop client better by reporting a bug. In order for us to quickly grasp the problem, please do not hesitate to provide as many details as possible. There is no need to be afraid of overloading the issue.
+
+      In case you have little experience in reporting bugs, we kindly ask you to read https://www.chiark.greenend.org.uk/~sgtatham/bugs.html, which provides a great introduction to the matter.
+
+      **Please note: this is an issue tracker.** Questions are best asked in our [**community forum**](https://central.owncloud.org) or our [**community chat**](https://talk.owncloud.org)!
+
+- type: checkboxes
+  id: presubmission-checks
+  attributes:
+    label: Pre-submission Checks
+    description: |
+      Before submitting your bug report, please make sure you fulfill the following criteria. Otherwise, your issue will most likely be dismissed.
+    options:
+      - label: I [checked for similar issues](https://github.com/owncloud/client/issues?q=), but could not find any. I also checked the closed issues. I could not contribute additional information to any existing issue.
+        required: true
+      - label: I will take the time to fill in all the required fields. I know that the bug report may be dismissed otherwise due to lack of information.
+        required: true
+
+- type: textarea
+  id: description
+  attributes:
+    label: Describe the bug
+    description: Please provide a detailed, precise description of the bug. Please do not hesitate to add as many details as possible, every information is relevant.
+    placeholder: While clicking on button [...], the application unexpectedly [...]
+  validations:
+    required: true
+
+- type: textarea
+  id: expected-behavior
+  attributes:
+    label: Expected behavior
+    description: Please explain which behavior you expected from the application. We need to know what you think should have happened.
+    placeholder: "I expected to see [...]"
+  validations:
+    required: true
+
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Steps to reproduce the issue
+    description: |
+      Ideally, we can reproduce the issue using steps you describe to us. This allows us to perform our own tests and thus better understand the issue.
+      Please don't hesitate to add as many details as possible.
+    placeholder: |
+      1. Enter [...] into [...]
+      2. Click on [...]
+      3. Scroll down to [...]
+      4. See the error message
+
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Screenshots
+    description: Please add screenshots if possible that visualize your problem and/or show how to reproduce the bug.
+    placeholder: Add your screenshots here!
+
+- type: textarea
+  id: logs
+  attributes:
+    label: Logs
+    description: |
+      Please add (complete) log contents or files to this section. Logs contain very valuable information. **Make sure to redact personal/private information!**
+      If your logs are longer than 10 lines, you should paste them on a pastebin service (e.g., [Gist](https://gist.github.com)) and insert links here.
+    placeholder: Add your logs here!
+
+- type: textarea
+  id: client-version
+  attributes:
+    label: Client version number
+    description: Please provide the **ownCloud desktop client and Qt version number** (see the *Version* tab in the *About* dialog, which can be found in the client settings).
+    placeholder: |
+      Example:
+      ownCloud 2.10.1 (build 7188) 82eefd Apr 5 2022 11:25:27
+      Libraries Qt 5.12.11, OpenSSL 1.1.1k 25 Mar 2021
+      Using virtual files plugin: suffix
+      ubuntu-5.4.0-109-generic
+  validations:
+    required: true
+
+- type: input
+  id: os-version
+  attributes:
+    label: Desktop environment (Linux only)
+    description: Please provide a precise description of the desktop environment version used on your Linux-based operating system.
+    placeholder: "Example: Fedora 36 with GNOME 3 version 42.0, ..."
+
+- type: input
+  id: linux-client-packaging
+  attributes:
+    label: Client package version and origin (Linux only)
+    description: In case you use a Linux-based operating system, please describe how you installed the ownCloud desktop client, and where you installed it from (e.g., from your distribution, from the ownCloud-provided mirrors, etc.).
+    placeholder: "Example: Installed from https://download.owncloud.com/desktop/ownCloud/stable/latest/"
+
+- type: input
+  id: windows-install-path
+  attributes:
+    label: Installation path (Windows only)
+    description: In case you use Windows, we'd like to know which path you installed the client into.
+    placeholder: "Example: C:\\Program Files\\ownCloud"
+
+- type: textarea
+  id: server-info
+  attributes:
+    label: Server information
+    description: |
+      Please include all relevant information (e.g., server operating system version, web server, database and PHP version (applicable to ownCloud 10 only), storage backend (in case external storage is used).
+    placeholder: |
+      ownCloud 10.9.1 (stable) on Ubuntu 20.04 using PHP 7.3
+
+      PHP 7.4.3 (cli) (built: Mar  2 2022 15:36:52) ( NTS )
+      Copyright (c) The PHP Group
+      Zend Engine v3.4.0, Copyright (c) Zend Technologies
+          with Zend OPcache v7.4.3, Copyright (c), by Zend Technologies
+
+- type: textarea
+  id: additional-context
+  attributes:
+    label: Additional context
+    description: Any other information you'd like to include.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: 📚 Official ownCloud Documentation
+    url: https://doc.owncloud.com/docs/next/client_releases.html
+    about: You can find a detailed user guide in our official documentation. Please refer to this document first before asking a question!
+  - name: 💡 Discussion Forum
+    url: https://central.owncloud.org/
+    about: Interact with our community. Feel free to ask questions there!
+  - name: 💬 ownCloud Talk
+    url: https://talk.owncloud.com
+    about: Chat with other users and the developers!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: "Feature request"
+description: "Propose a new feature for the ownCloud desktop client"
+labels: ["enhancement"]
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for your interest in making the ownCloud desktop client better! Your feature proposals are highly welcome.
+
+      Please try to describe your feature as precisely as possible. If we fully understand a feature request, we can discuss it with you a lot better. Please don't hesitate to add screenshots or mockups, which greatly aide 
+
+      **Please note: this is an issue tracker.** Questions are best asked in our [**community forum**](https://central.owncloud.org) or our [**community chat**](https://talk.owncloud.org)!
+
+- type: checkboxes
+  id: presubmission-checks
+  attributes:
+    label: Pre-submission Checks
+    description: |
+      Before submitting your feature proposal, please make sure you fulfill the following criteria. Otherwise, your issue will most likely be dismissed.
+    options:
+      - label: I [checked for similar issues](https://github.com/owncloud/client/issues?q=), but could not find any. I also checked the closed issues. I could not contribute additional information to any existing issue.
+        required: true
+      - label: I will take the time to fill in all the required fields. I know that the bug report may be dismissed otherwise due to lack of information.
+        required: true
+
+- type: textarea
+  id: description
+  attributes:
+    label: Feature description
+    description: |
+      Please describe your suggestion, including as many details as possible.
+      Is your feature request related to an existing issue? In this case, please describe the problem or provide a link to the issue.
+    placeholder: I would like to have another button that [...]
+  validations:
+    required: true
+
+- type: textarea
+  id: proposed-solution
+  attributes:
+    label: Proposed solution
+    description: Please explain the solution you have in mind.
+    placeholder: Instead of using a text field, I would like a dropdown containing a list of choices [...]
+  validations:
+    required: true
+
+- type: textarea
+  id: alternatives
+  attributes:
+    label: Alternative solutions you considered
+    description: |
+      Please list alternative solutions or features you considered to cover your use case. Feel free to discuss their pros and cons.
+
+- type: textarea
+  id: additional-context
+  attributes:
+    label: Additional context
+    description: Any other information you'd like to include, for instance, screnshots, mockups, etc.
+


### PR DESCRIPTION
This pull request changes the way users report new issues. It makes use of the [issue forms beta feature](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms). This should increase the quality of new issues significantly, since the new forms guide reporters much better. They also no longer have to manually remove/replace Markdown text (in fact, reporting without knowing any Markdown is possible).

Since the issue forms need to be committed before they can be tested, I set up a demo/development project. You can see these templates in action here: https://github.com/fmoc/issue-forms-demo/issues/new/choose. Please do not hesitate to open issues for testing!

Feedback is highly appreciated!