### PR TITLE
Fix FakeGetReply for non-existing files

### DIFF
--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -25,9 +25,12 @@ public:
 
     qint64 bytesAvailable() const override
     {
-        if (aborted)
-            return 0;
-        return std::min(size, fakeSize) + QIODevice::bytesAvailable();
+        switch (state) {
+        case State::Ok:
+            return std::min(size, fakeSize) + QIODevice::bytesAvailable();
+        default:
+            return FakeGetReply::bytesAvailable();
+        }
     }
 
     qint64 readData(char *data, qint64 maxlen) override

--- a/test/testutils/syncenginetestutils.h
+++ b/test/testutils/syncenginetestutils.h
@@ -342,10 +342,16 @@ class FakeGetReply : public FakeReply
 {
     Q_OBJECT
 public:
+    enum class State {
+        Ok,
+        Aborted,
+        FileNotFound,
+    };
+
     const FileInfo *fileInfo;
     char payload;
     int size;
-    bool aborted = false;
+    State state = State::Ok;
 
     FakeGetReply(FileInfo &remoteRootFileInfo, QNetworkAccessManager::Operation op, const QNetworkRequest &request, QObject *parent);
 


### PR DESCRIPTION
The old code didn't take into account the case where a file was removed
on the server. It just Q_ASSERT-ed that it should always exist. However,
the CI does release builds, so the assert never triggered.

The problem is that in TestSyncVirtualFiles::testVirtualFileDownload the
file "A/a3" *is* removed from the server while a download is scheduled.

The fix is to handle this case separately as a valid response.