### PR TITLE
removed `@skip` tag from a scenario `Syncing a file from the server and creating a conflict` to check if it fails

### DIFF
--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -32,7 +32,7 @@ Feature: Syncing files
         And the folder "simple-folder" should exist on the file system
         And the folder "large-folder" should exist on the file system
 
-    @skip @issue-9733
+    @issue-9733
     Scenario: Syncing a file from the server and creating a conflict
         Given user "Alice" has uploaded file on the server with content "server content" to "/conflict.txt"
         And user "Alice" has set up a client with default settings


### PR DESCRIPTION
Closes #9680
`@skip` tag is removed from the scenario `Syncing a file from the server and creating a conflict` to check if it fails or not in master, new client version 3.0