### PR TITLE
Improve oauth error handling

### DIFF
--- a/changelog/unreleased/9772
+++ b/changelog/unreleased/9772
@@ -1,0 +1,7 @@
+Enhancement: Display a correct error when the wrong user was authenticated
+
+When the wrong user was authenticated using oauth we used to display a misleading message.
+We now also style the html response the client provides to the file browser.
+
+https://github.com/owncloud/client/issues/9772
+https://github.com/owncloud/client/pull/9813

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -614,7 +614,13 @@ QString Utility::renderTemplate(QString templ, const QMap<QString, QString> &val
         while (it.hasNext()) {
             const auto match = it.next();
             Q_ASSERT(match.lastCapturedIndex() == 1);
-            Q_ASSERT(values.contains(match.captured(1)));
+            Q_ASSERT([&] {
+                if (!values.contains(match.captured(1))) {
+                    qCCritical(lcUtility) << "Unknown key:" << match.captured(1);
+                    return false;
+                }
+                return true;
+            }());
             templ.replace(match.captured(0), values.value(match.captured(1)));
         }
     };

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -391,12 +391,10 @@ void OAuth::finalize(const QPointer<QTcpSocket> &socket, const QString &accessTo
         qCWarning(lcOauth) << "We expected the user" << _davUser << "but the server answered with user" << userName;
         const QString message = tr("<h1>Wrong user</h1>"
                                    "<p>You logged-in with user <em>%1</em>, but must login with user <em>%2</em>.<br>"
-                                   "Please log out of %3 in another tab, then <a href='%4'>click here</a> "
-                                   "and log in as user %2</p>")
-                                    .arg(userName, _davUser, Theme::instance()->appNameGUI(),
-                                        authorisationLink().toString(QUrl::FullyEncoded));
+                                   "Please return to the %3 client and restart the authentication.</p>")
+                                    .arg(userName, _davUser, Theme::instance()->appNameGUI());
         httpReplyAndClose(socket, QByteArrayLiteral("403 Forbidden"), message.toUtf8());
-        // We are still listening on the socket so we will get the new connection
+        emit result(Error);
         return;
     }
     const auto loginSuccessfullHtml = QByteArrayLiteral("<h1>Login Successful</h1><p>You can close this window.</p>");

--- a/src/resources/client.qrc
+++ b/src/resources/client.qrc
@@ -16,7 +16,6 @@
         <file alias="resources/light/check.svg">font-awesome/dark/check-solid.svg</file>
         <file alias="resources/light/step-forward.svg">font-awesome/dark/step-forward-solid.svg</file>
         <file alias="resources/light/clipboard.svg">font-awesome/dark/clipboard-solid.svg</file>
-
         <file alias="resources/dark/folder-sync.svg">font-awesome/dark/folder-solid.svg</file>
         <file alias="resources/dark/settings.svg">font-awesome/dark/cog-solid.svg</file>
         <file alias="resources/dark/activity.svg">font-awesome/dark/bolt-solid.svg</file>
@@ -33,7 +32,7 @@
         <file alias="resources/dark/check.svg">font-awesome/dark/check-solid.svg</file>
         <file alias="resources/dark/step-forward.svg">font-awesome/dark/step-forward-solid.svg</file>
         <file alias="resources/dark/clipboard.svg">font-awesome/dark/clipboard-solid.svg</file>
-
         <file alias="resources/wizard/style.qss">wizard/style.qss</file>
+        <file alias="resources/oauth/oauth.html.in">oauth/oauth.html.in</file>
     </qresource>
 </RCC>

--- a/src/resources/oauth/oauth.html.in
+++ b/src/resources/oauth/oauth.html.in
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+<title>@{TITLE}</title>
+<style>
+html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+}
+
+body {
+    background-color: @{BACKGROUND_COLOR};
+    color: @{FONT_COLOR};
+    font-family: "Noto Sans", OpenSans, Verdana, Helvetica, Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 100%;
+}
+
+.content {
+    text-align: center;
+}
+</style>
+</head>
+
+<body>
+<div class="row">
+    <div class="content">
+        <img src="data:image/png;base64,@{ICON}" />
+        @{CONTENT}
+    </div>
+</div>
+</body>

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -464,5 +464,5 @@ private slots:
 };
 
 
-QTEST_GUILESS_MAIN(TestOAuth)
+QTEST_MAIN(TestOAuth)
 #include "testoauth.moc"


### PR DESCRIPTION
Depends on: https://github.com/owncloud/client/pull/9815
With the ownCloud 10 app we used to be redirected to a theme "you can now close the browser window" page.
With oidc we will display our own page which looks kind of unprofessional.
This change starts theming the web page we display.

Old:
![image](https://user-images.githubusercontent.com/200626/175058554-d8761849-f2c4-469d-8de2-1cb578dee512.png)

New:
![image](https://user-images.githubusercontent.com/200626/175058807-364f5a49-0af9-43b1-8300-14a42fd6a56e.png)

@fmoc thx for the css :D
