### PR TITLE
fixed test for `Sync only one folder from the server`

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/AccountConnectionWizard.py
@@ -71,19 +71,22 @@ class AccountConnectionWizard:
     ADD_FOLDER_SYNC_CONNECTION_WIZARD = (
         names.add_Folder_Sync_Connection_FolderWizardSourcePage_OCC_FolderWizardLocalPath
     )
-    SYNC_DIALOG_FOLDER_TREE = names.choose_What_To_Synchronize_QTreeWidget
+    ADD_SYNC_CONNECTION_BUTTON = {
+        "name": "qt_wizard_finish",
+        "type": "QPushButton",
+        "visible": 1,
+        "window": names.add_Folder_Sync_Connection_OCC_FolderWizard,
+    }
+    SYNC_DIALOG_FOLDER_TREE = {
+        "column": 0,
+        "container": names.deselect_remote_folders_you_do_not_wish_to_synchronize_ownCloud_QModelIndex,
+        "type": "QModelIndex",
+    }
     SYNC_DIALOG_ROOT_FOLDER = {
         "column": 0,
         "container": names.add_Folder_Sync_Connection_Deselect_remote_folders_you_do_not_wish_to_synchronize_QTreeWidget,
         "text": "ownCloud",
         "type": "QModelIndex",
-    }
-    SYNC_DIALOG_OK_BUTTON = {
-        "text": "OK",
-        "type": "QPushButton",
-        "unnamed": 1,
-        "visible": 1,
-        "window": SELECTIVE_SYNC_DIALOG,
     }
     ADVANCED_CONFIGURATION_CHECKBOX = {
         "container": names.setupWizardWindow_contentWidget_QStackedWidget,
@@ -178,8 +181,6 @@ class AccountConnectionWizard:
         squish.clickButton(squish.waitForObject(self.MANUAL_SYNC_FOLDER_OPTION))
 
     def selectFoldersToSync(self, context):
-        self.openSyncDialog()
-
         # first deselect all
         squish.mouseClick(
             squish.waitForObject(self.SYNC_DIALOG_ROOT_FOLDER),
@@ -189,14 +190,16 @@ class AccountConnectionWizard:
             squish.Qt.LeftButton,
         )
         for row in context.table[1:]:
+            self.SYNC_DIALOG_FOLDER_TREE['text'] = row[
+                0
+            ]  # added a new key 'text' to dictionary SYNC_DIALOG_FOLDER_TREE
             squish.mouseClick(
-                squish.waitForObjectItem(self.SYNC_DIALOG_FOLDER_TREE, "/." + row[0]),
+                squish.waitForObject(self.SYNC_DIALOG_FOLDER_TREE),
                 11,
                 11,
                 squish.Qt.NoModifier,
                 squish.Qt.LeftButton,
             )
-        squish.clickButton(squish.waitForObject(self.SYNC_DIALOG_OK_BUTTON))
 
     def sortBy(self, headerText):
         squish.mouseClick(

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1265,6 +1265,7 @@ def step(context):
 def step(context):
     newAccount = AccountConnectionWizard()
     newAccount.selectFoldersToSync(context)
+    clickButton(waitForObject(newAccount.ADD_SYNC_CONNECTION_BUTTON))
 
 
 @When('the user selects manual sync folder option')

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -70,7 +70,7 @@ Feature: Syncing files
         And the user selects "ownCloud" as a remote destination folder
         Then the sync all checkbox should be checked
 
-    @skip @issue-9733
+
     Scenario: Sync only one folder from the server
         Given user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created folder "large-folder" on the server
@@ -79,10 +79,12 @@ Feature: Syncing files
             | server   | %local_server% |
             | user     | Alice          |
             | password | 1234           |
-        When the user selects the following folders to sync:
+        When the user selects configure_synchronization_manually option in advanced section
+        And the user "Alice" clicks on the next button in sync connection wizard
+        And the user selects "ownCloud" as a remote destination folder
+        And the user selects the following folders to sync:
             | folder        |
             | simple-folder |
-        And the user connects the account
         Then the folder "simple-folder" should exist on the file system
         But the folder "large-folder" should not exist on the file system
 


### PR DESCRIPTION
This PR refactors the test related to the `account connection wizard`. The wizard of client version 3.0 is somewhat different than version 2.10. In version 3.0, the `choose_what_to_sync` button appears only when we select the `Configure synchronization manually` option in the advanced section. Also, the folders to be synced don't appear in a single tree selector. So here we're fixing the test for `Scenario: Sync only one folder from the server` in the `tst_syncing` suite to match the selectors in the new client version.

Related issue:
#9762