### PR TITLE
Oauth: case insensitive username compare

### DIFF
--- a/changelog/unreleased/5174
+++ b/changelog/unreleased/5174
@@ -1,0 +1,5 @@
+Bugfix: Compare usernames case insensitive
+
+We fixed a bug where the user name was compared with the name provided by the server in a case sensitive way.
+
+https://github.com/owncloud/enterprise/issues/5174

--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -381,7 +381,8 @@ void OAuth::refreshAuthentication(const QString &refreshToken)
 void OAuth::finalize(const QPointer<QTcpSocket> &socket, const QString &accessToken,
     const QString &refreshToken, const QString &user, const QUrl &messageUrl)
 {
-    if (!_account->davUser().isNull() && user != _account->davUser()) {
+    // dav user names are case insensetive, we might compare a user input with the string provided by the server
+    if (!_account->davUser().isEmpty() && user.compare(_account->davUser(), Qt::CaseInsensitive) != 0) {
         // Connected with the wrong user
         qCWarning(lcOauth) << "We expected the user" << _account->davUser() << "but the server answered with user" << user;
         const QString message = tr("<h1>Wrong user</h1>"


### PR DESCRIPTION
The issue occurred as we compare the user input (webfinger) with the string returned by the server.
This only happens during the initial authentication as we later use the string returned by the server.

I don't think this would still be needed in 3.0 but it most probably also won't hurt.
@DeepDiver1975 any thoughts?