### PR TITLE
[Tests-only] Run `append scenario title to serverlog` code  only in CI

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -53,15 +53,16 @@ def hook(context):
     }
 
     # log tests scenario title on serverlog file
-    guiTestReportDir = os.environ.get("GUI_TEST_REPORT_DIR")
-    f = open(guiTestReportDir + "/serverlog.log", "a")
-    f.write(
-        str((datetime.now()).strftime("%H:%M:%S:%f"))
-        + "\tBDD Scenario: "
-        + context._data["title"]
-        + "\n"
-    )
-    f.close()
+    if os.getenv('CI'):
+        guiTestReportDir = os.environ.get("GUI_TEST_REPORT_DIR")
+        f = open(guiTestReportDir + "/serverlog.log", "a")
+        f.write(
+            str((datetime.now()).strftime("%H:%M:%S:%f"))
+            + "\tBDD Scenario: "
+            + context._data["title"]
+            + "\n"
+        )
+        f.close()
 
     # read configs from environment variables
     context.userData = {}


### PR DESCRIPTION
### Description
This PR 
- refactor appending scenario title to serverlog.log  so that it runs only in CI 


### Related Issue:
- https://github.com/owncloud/client/issues/9826