### PR TITLE
Fix installation of new resources library

### DIFF
--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -14,6 +14,8 @@ set_target_properties(owncloudResources PROPERTIES
     OUTPUT_NAME "${APPLICATION_EXECUTABLE}Resources"
     AUTOUIC ON
     AUTORCC ON
+    VERSION ${MIRALL_VERSION}
+    SOVERSION ${MIRALL_SOVERSION}
 )
 
 generate_export_header(owncloudResources


### PR DESCRIPTION
Makes sure the new installed library file has a version suffix like all the other libraries. Most important for Linux distro packaging.

Fixes a minor issue introduced in #9815. We can't provide working Linux packages before this has been merged.