### PR TITLE
Fix another group box label truncation

### DIFF
--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -53,7 +53,7 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
 
         // move up top
         _ui->syncModeGroupBoxLayout->removeWidget(_ui->useVfsRadioButton);
-        _ui->syncModeGroupBoxLayout->insertWidget(0, _ui->useVfsRadioButton);
+        _ui->syncModeGroupBoxLayout->insertWidget(1, _ui->useVfsRadioButton);
     } else {
         setRecommendedOption(_ui->syncEverythingRadioButton);
     }

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.ui
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.ui
@@ -116,24 +116,34 @@
          <item>
           <widget class="QGroupBox" name="syncModeGroupBox">
            <property name="title">
-            <string>Configure files download</string>
+            <string/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
            </property>
            <layout class="QVBoxLayout" name="syncModeGroupBoxLayout">
             <property name="spacing">
              <number>3</number>
             </property>
             <property name="leftMargin">
-             <number>3</number>
+             <number>0</number>
             </property>
             <property name="topMargin">
-             <number>3</number>
+             <number>0</number>
             </property>
             <property name="rightMargin">
-             <number>3</number>
+             <number>0</number>
             </property>
             <property name="bottomMargin">
-             <number>3</number>
+             <number>0</number>
             </property>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Configure files download:</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QRadioButton" name="syncEverythingRadioButton">
               <property name="text">
@@ -226,8 +236,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../../client.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Same as #9862, but this time in the advanced section of the account
wizard page.

Fixes #9718