### PR TITLE
Prevent loading of 3.0 profiles with older clients

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -70,8 +70,8 @@ auto displayNameC()
 {
     return QLatin1String("displayString");
 }
-constexpr int WinVfsSettingsVersion = 4;
-constexpr int SettingsVersion = 2;
+
+constexpr int SettingsVersionC = 5;
 }
 
 namespace OCC {
@@ -1369,10 +1369,8 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
 
     settings.setValue(QStringLiteral("virtualFilesMode"), Vfs::modeToString(folder.virtualFilesMode));
 
-    // Ensure new vfs modes won't be attempted by older clients
-    const int version = folder.virtualFilesMode == Vfs::WindowsCfApi ? WinVfsSettingsVersion : SettingsVersion;
-    Q_ASSERT(version <= maxSettingsVersion());
-    settings.setValue(versionC(), version);
+    // Prevent loading of profiles in old clients
+    settings.setValue(versionC(), maxSettingsVersion());
 
     // Happens only on Windows when the explorer integration is enabled.
     if (!folder.navigationPaneClsid.isNull())
@@ -1406,6 +1404,11 @@ FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &i
         }
     }
     return folder;
+}
+
+int FolderDefinition::maxSettingsVersion()
+{
+    return SettingsVersionC;
 }
 
 void FolderDefinition::setLocalPath(const QString &path)

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -84,8 +84,9 @@ public:
      *            (version remains readable by 2.5.1)
      * Version 3: introduction of new windows vfs mode in 2.6.0
      * Version 4: until 2.9.1 windows vfs tried to unregister folders with a different id from windows.
+     * Version 5: 3.0.0 Introduced spaces, the profiles are not downwards compatible
      */
-    static int maxSettingsVersion() { return 4; }
+    static int maxSettingsVersion();
 
     /// Ensure / as separator and trailing /.
     void setLocalPath(const QString &path);


### PR DESCRIPTION
As older clients don't know spaces yet, loading a spaces profiles
would result in all spaces being synced to the legacy dav point.