### PR TITLE
added implicit wait for resource to sync

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -723,6 +723,11 @@ def step(context, tabName):
 
 def openSharingDialog(context, resource, itemType='file'):
     resource = getResourcePath(context, resource)
+    resourceExist = waitFor(
+        lambda: os.path.exists(resource), context.userData['maxSyncTimeout'] * 1000
+    )
+    if not resourceExist:
+        raise Exception("{} doesn't exists".format(resource))
     waitFor(lambda: shareResource(resource), context.userData['maxSyncTimeout'] * 1000)
 
 


### PR DESCRIPTION
Closes: #9872
Related issue: #9811

This PR aims to fix an issue reported on https://github.com/owncloud/client/issues/9811. The scenario `reshare a file/folder` was failing on CI and by observing the PR https://github.com/owncloud/client/pull/9872, we concluded that the failure was due to a lack of the desired wait time for files to sync. So, to sync a resource from server to client an implicit wait has been added in this PR. 

In [debugging PR](https://github.com/owncloud/client/pull/9872), we ran 50 copies of the same scenario. Before adding the wait, 42 scenarios of them were failing. But none of the scenarios are failing after adding the wait for files to sync.

Previous build: https://drone.owncloud.com/owncloud/client/12368/6/1
After build: https://drone.owncloud.com/owncloud/client/12397