### PR TITLE
Deprecate Theme::forceConfigAuthType

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -296,15 +296,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 
     auto acc = createAccount();
 
-    QString overrideUrl = Theme::instance()->overrideServerUrlV2();
-    QString forceAuth = Theme::instance()->forceConfigAuthType();
-    if (!forceAuth.isEmpty() && !overrideUrl.isEmpty()) {
-        // If forceAuth is set, this might also mean the overrideURL has changed.
-        // See enterprise issues #1126
-        acc->setUrl(overrideUrl);
-    } else {
-        acc->setUrl(urlConfig.toUrl());
-    }
+    acc->setUrl(urlConfig.toUrl());
 
     acc->_davUser = settings.value(davUserC()).toString();
     acc->_displayName = settings.value(davUserDisplyNameC()).toString();

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -178,7 +178,7 @@ public:
      * with a different auth type in that case You should then specify "http" or "shibboleth".
      * Normaly this should be left empty.
      */
-    virtual QString forceConfigAuthType() const;
+    [[deprecated]] virtual QString forceConfigAuthType() const;
 
     /**
      * The default folder name without path on the server at setup time.


### PR DESCRIPTION
This option seems to have been useful in the past, but is no longer in use. 