### PR TITLE
Don't check for db exists

### DIFF
--- a/changelog/unreleased/9918
+++ b/changelog/unreleased/9918
@@ -1,0 +1,9 @@
+Enhancement: We improved the performance of db access
+
+We removed a check for the existence of the db that was executed before every access to the db.
+
+The check was introduced in #6049 to prevent crashes if the db does not exist or is removed during runtime.
+We nowadays gracefully handle missing dbs on startup, removing the db at runtime is too much of a corner case
+to sacrifice that much performance however.
+
+https://github.com/owncloud/client/pull/9918

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -262,13 +262,6 @@ bool SyncJournalDb::checkConnect()
     }
 
     if (_db.isOpen()) {
-        // Unfortunately the sqlite isOpen check can return true even when the underlying storage
-        // has become unavailable - and then some operations may cause crashes. See #6049
-        if (!QFile::exists(_dbFile)) {
-            qCWarning(lcDb) << "Database open, but file" << _dbFile << "does not exist";
-            close();
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
In context of #6049 a check for the existance of the db file was introduced.
That check is performed before every db access... so serveral 100 times per second.