### PR TITLE
Ensure we remove a child job from before we trigger the next

### DIFF
--- a/changelog/unreleased/9725
+++ b/changelog/unreleased/9725
@@ -1,0 +1,6 @@
+Bugfix: Fix never ending sync
+
+Under certain conditions an upload could enter a state were it would never finish.
+The client would wait for that upload so only a restart of the client or a manual abort of the sync could resolve the issue.
+
+https://github.com/owncloud/client/issues/9725

--- a/src/gui/thumbnailjob.cpp
+++ b/src/gui/thumbnailjob.cpp
@@ -31,7 +31,7 @@ void ThumbnailJob::start()
     AbstractNetworkJob::start();
 }
 
-bool ThumbnailJob::finished()
+void ThumbnailJob::finished()
 {
     const auto result = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     QPixmap p;
@@ -42,6 +42,5 @@ bool ThumbnailJob::finished()
         }
     }
     emit jobFinished(result, p);
-    return true;
 }
 }

--- a/src/gui/thumbnailjob.h
+++ b/src/gui/thumbnailjob.h
@@ -44,7 +44,7 @@ signals:
      */
     void jobFinished(int statusCode, QPixmap reply);
 private slots:
-    bool finished() override;
+    void finished() override;
 };
 }
 

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -221,6 +221,7 @@ void AbstractNetworkJob::slotFinished()
 
     bool discard = finished();
     if (discard) {
+        Q_EMIT abstractJobFinished();
         qCDebug(lcNetworkJob) << "Network job finished" << this;
         deleteLater();
     }

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -218,13 +218,11 @@ void AbstractNetworkJob::slotFinished()
             qCWarning(lcNetworkJob) << "Don't retry:" << _reply->url();
         }
     }
-
-    bool discard = finished();
-    if (discard) {
-        Q_EMIT abstractJobFinished();
-        qCDebug(lcNetworkJob) << "Network job finished" << this;
-        deleteLater();
-    }
+    Q_EMIT aboutToFinishSignal(AbstractNetworkJob::QPrivateSignal());
+    finished();
+    Q_EMIT finishedSignal(AbstractNetworkJob::QPrivateSignal());
+    qCDebug(lcNetworkJob) << "Network job finished" << this;
+    deleteLater();
 }
 
 QByteArray AbstractNetworkJob::responseTimestamp()

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -134,9 +134,10 @@ signals:
     void networkError(QNetworkReply *reply);
 
     /**
-     * Use complex name to prevent clash with other implementations of a finish signal...
+     * The job is done
      */
-    void abstractJobFinished();
+    void aboutToFinishSignal(QPrivateSignal);
+    void finishedSignal(QPrivateSignal);
 
 protected:
     /** Initiate a network request, returning a QNetworkReply.
@@ -158,10 +159,8 @@ protected:
     virtual void newReplyHook(QNetworkReply *) {}
 
     /** Called at the end of QNetworkReply::finished processing.
-     *
-     * Returning true triggers a deleteLater() of this job.
      */
-    virtual bool finished() = 0;
+    virtual void finished() = 0;
 
     QByteArray _responseTimestamp;
 

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -133,6 +133,11 @@ signals:
      */
     void networkError(QNetworkReply *reply);
 
+    /**
+     * Use complex name to prevent clash with other implementations of a finish signal...
+     */
+    void abstractJobFinished();
+
 protected:
     /** Initiate a network request, returning a QNetworkReply.
      *

--- a/src/libsync/bandwidthmanager.h
+++ b/src/libsync/bandwidthmanager.h
@@ -24,7 +24,7 @@
 namespace OCC {
 
 class UploadDevice;
-class GETJob;
+class GETFileJob;
 class OwncloudPropagator;
 
 /**
@@ -48,8 +48,8 @@ public slots:
     void registerUploadDevice(UploadDevice *);
     void unregisterUploadDevice(QObject *);
 
-    void registerDownloadJob(GETJob *);
-    void unregisterDownloadJob(QObject *);
+    void registerDownloadJob(GETFileJob *);
+    void unregisterDownloadJob(GETFileJob *);
 
     void absoluteLimitTimerExpired();
     void switchingTimerExpired();
@@ -87,14 +87,14 @@ private:
     qint64 _relativeUploadLimitProgressAtMeasuringRestart;
     qint64 _currentUploadLimit;
 
-    std::list<GETJob *> _downloadJobList;
+    std::list<GETFileJob *> _downloadJobList;
     QTimer _relativeDownloadMeasuringTimer;
 
     // for relative bw limiting, we need to wait this amount before measuring again
     QTimer _relativeDownloadDelayTimer;
 
     // the device measured
-    GETJob *_relativeLimitCurrentMeasuredJob;
+    GETFileJob *_relativeLimitCurrentMeasuredJob;
 
     // for measuring how much progress we made at start
     qint64 _relativeDownloadLimitProgressAtMeasuringRestart;

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -95,7 +95,7 @@ void RequestEtagJob::start()
     AbstractNetworkJob::start();
 }
 
-bool RequestEtagJob::finished()
+void RequestEtagJob::finished()
 {
     qCInfo(lcEtagJob) << "Request Etag of" << reply()->request().url() << "FINISHED WITH STATUS"
                       <<  replyStatusString();
@@ -126,7 +126,6 @@ bool RequestEtagJob::finished()
     } else {
         emit finishedWithResult(HttpError{ httpCode, errorString() });
     }
-    return true;
 }
 
 /*********************************************************************************************/
@@ -152,7 +151,7 @@ void MkColJob::start()
     AbstractNetworkJob::start();
 }
 
-bool MkColJob::finished()
+void MkColJob::finished()
 {
     qCInfo(lcMkColJob) << "MKCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
                        << replyStatusString();
@@ -162,7 +161,6 @@ bool MkColJob::finished()
     } else {
         Q_EMIT finishedWithoutError();
     }
-    return true;
 }
 
 /*********************************************************************************************/
@@ -326,7 +324,7 @@ void LsColJob::start()
 // TODO: Instead of doing all in this slot, we should iteratively parse in readyRead(). This
 // would allow us to be more asynchronous in processing while data is coming from the network,
 // not all in one big blob at the end.
-bool LsColJob::finished()
+void LsColJob::finished()
 {
     qCInfo(lcLsColJob) << "LSCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
                        << replyStatusString();
@@ -356,8 +354,6 @@ bool LsColJob::finished()
         // wrong HTTP code or any other network error
         emit finishedWithError(reply());
     }
-
-    return true;
 }
 
 void LsColJob::startImpl(const QNetworkRequest &req)
@@ -449,7 +445,7 @@ QPixmap AvatarJob::makeCircularAvatar(const QPixmap &baseAvatar)
     return avatar;
 }
 
-bool AvatarJob::finished()
+void AvatarJob::finished()
 {
     int http_result_code = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
@@ -464,7 +460,6 @@ bool AvatarJob::finished()
         }
     }
     emit avatarPixmap(avImage);
-    return true;
 }
 #endif
 
@@ -481,10 +476,9 @@ void EntityExistsJob::start()
     AbstractNetworkJob::start();
 }
 
-bool EntityExistsJob::finished()
+void EntityExistsJob::finished()
 {
     emit exists(reply());
-    return true;
 }
 
 /*********************************************************************************************/
@@ -510,7 +504,7 @@ void DetermineAuthTypeJob::start()
     AbstractNetworkJob::start();
 }
 
-bool DetermineAuthTypeJob::finished()
+void DetermineAuthTypeJob::finished()
 {
     auto authChallenge = reply()->rawHeader("WWW-Authenticate").toLower();
     auto result = AuthType::Basic;
@@ -521,7 +515,6 @@ bool DetermineAuthTypeJob::finished()
     }
     qCInfo(lcDetermineAuthTypeJob) << "Auth type for" << _account->davUrl() << "is" << result;
     emit this->authType(result);
-    return true;
 }
 
 SimpleNetworkJob::SimpleNetworkJob(AccountPtr account, const QUrl &rootUrl, const QString &path, const QByteArray &verb, const QNetworkRequest &req, QObject *parent)
@@ -588,13 +581,11 @@ void SimpleNetworkJob::addNewReplyHook(std::function<void(QNetworkReply *)> &&ho
     _replyHooks.push_back(hook);
 }
 
-bool SimpleNetworkJob::finished()
+void SimpleNetworkJob::finished()
 {
     if (_device) {
         _device->close();
     }
-    emit finishedSignal();
-    return true;
 }
 
 void SimpleNetworkJob::newReplyHook(QNetworkReply *reply)

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -53,7 +53,7 @@ signals:
     void exists(QNetworkReply *);
 
 private slots:
-    bool finished() override;
+    void finished() override;
 };
 
 /**
@@ -102,7 +102,7 @@ signals:
     void finishedWithoutError();
 
 private slots:
-    bool finished() override;
+    void finished() override;
 
 protected:
     void startImpl(const QNetworkRequest &req);
@@ -167,7 +167,7 @@ signals:
     void avatarPixmap(const QPixmap &);
 
 private slots:
-    bool finished() override;
+    void finished() override;
 };
 #endif
 
@@ -190,7 +190,7 @@ signals:
     void finishedWithoutError();
 
 private:
-    bool finished() override;
+    void finished() override;
 };
 
 /**
@@ -208,7 +208,7 @@ signals:
     void finishedWithResult(const HttpResult<QByteArray> &etag);
 
 private slots:
-    bool finished() override;
+    void finished() override;
 };
 
 /**
@@ -232,7 +232,7 @@ signals:
     void authType(AuthType);
 
 protected Q_SLOTS:
-    bool finished() override;
+    void finished() override;
 };
 
 /**
@@ -259,11 +259,8 @@ public:
 
     void addNewReplyHook(std::function<void(QNetworkReply *)> &&hook);
 
-signals:
-    void finishedSignal();
-
 protected:
-    bool finished() override;
+    void finished() override;
     void newReplyHook(QNetworkReply *) override;
 
     QNetworkRequest _request;

--- a/src/libsync/networkjobs/jsonjob.cpp
+++ b/src/libsync/networkjobs/jsonjob.cpp
@@ -28,7 +28,7 @@ JsonJob::~JsonJob()
 {
 }
 
-bool JsonJob::finished()
+void JsonJob::finished()
 {
     qCInfo(lcJsonApiJob) << "JsonJob of" << reply()->request().url() << "FINISHED WITH STATUS"
                          << replyStatusString();
@@ -38,7 +38,7 @@ bool JsonJob::finished()
     } else {
         parse(reply()->readAll());
     }
-    return SimpleNetworkJob::finished();
+    SimpleNetworkJob::finished();
 }
 
 void JsonJob::parse(const QByteArray &data)

--- a/src/libsync/networkjobs/jsonjob.h
+++ b/src/libsync/networkjobs/jsonjob.h
@@ -33,7 +33,7 @@ public:
     const QJsonParseError &parseError() const;
 
 protected:
-    bool finished() override;
+    void finished() override;
 
     virtual void parse(const QByteArray &data);
 

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -35,13 +35,10 @@ void DeleteJob::start()
     AbstractNetworkJob::start();
 }
 
-bool DeleteJob::finished()
+void DeleteJob::finished()
 {
     qCInfo(lcDeleteJob) << "DELETE of" << reply()->request().url() << "FINISHED WITH STATUS"
                        << replyStatusString();
-
-    emit finishedSignal();
-    return true;
 }
 
 void PropagateRemoteDelete::start()

--- a/src/libsync/propagateremotedelete.h
+++ b/src/libsync/propagateremotedelete.h
@@ -29,10 +29,7 @@ public:
     explicit DeleteJob(AccountPtr account, const QUrl &url, const QString &path, QObject *parent = nullptr);
 
     void start() override;
-    bool finished() override;
-
-signals:
-    void finishedSignal();
+    void finished() override;
 };
 
 /**

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -48,13 +48,10 @@ void MoveJob::start()
 }
 
 
-bool MoveJob::finished()
+void MoveJob::finished()
 {
     qCInfo(lcMoveJob) << "MOVE of" << reply()->request().url() << "FINISHED WITH STATUS"
                       << replyStatusString();
-
-    emit finishedSignal();
-    return true;
 }
 
 void PropagateRemoteMove::start()

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -33,10 +33,7 @@ public:
         HeaderMap _extraHeaders, QObject *parent = nullptr);
 
     void start() override;
-    bool finished() override;
-
-signals:
-    void finishedSignal();
+    void finished() override;
 };
 
 /**

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -106,7 +106,7 @@ public:
 
     void start() override;
 
-    bool finished() override;
+    void finished() override;
 
     QIODevice *device()
     {
@@ -127,7 +127,6 @@ protected:
     void newReplyHook(QNetworkReply *reply) override;
 
 signals:
-    void finishedSignal();
     void uploadProgress(qint64, qint64);
 
 };

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -27,13 +27,12 @@
 #include "propagateremotedelete.h"
 #include "common/asserts.h"
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
 #include <QNetworkAccessManager>
 #include <QRandomGenerator>
 
-#include <cmath>
-#include <cstring>
 #include <memory>
 
 namespace OCC {
@@ -221,6 +220,7 @@ void PropagateUploadFileNG::slotPropfindFinished()
         for (auto it = _serverChunks.begin(); it != _serverChunks.end(); ++it) {
             auto job = new DeleteJob(propagator()->account(), propagator()->account()->url(), chunkPath() + QLatin1Char('/') + it->originalName, this);
             addChildJob(job);
+            connect(job, &DeleteJob::finishedSignal, this, &PropagateUploadFileNG::slotDeleteJobFinished);
             job->start();
         }
         _serverChunks.clear();
@@ -336,8 +336,7 @@ void PropagateUploadFileNG::doFinalMove()
     // Still not finished all ranges.
     if (!_rangesToUpload.isEmpty())
         return;
-
-    Q_ASSERT(childJobs().empty(), "MOVE for upload even though jobs are still running");
+    Q_ASSERT_X(childJobs().empty(), Q_FUNC_INFO, "MOVE for upload even though jobs are still running");
 
     _finished = true;
 

--- a/test/testjobqueue.cpp
+++ b/test/testjobqueue.cpp
@@ -45,9 +45,8 @@ public:
     }
 
 protected:
-    bool finished() override
+    void finished() override
     {
-        return true;
     }
 };
 

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -1011,7 +1011,7 @@ QString FakeFolder::localPath() const
 void FakeFolder::scheduleSync()
 {
     // Have to be done async, else, an error before exec() does not terminate the event loop.
-    QMetaObject::invokeMethod(_syncEngine.get(), "startSync", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(_syncEngine.get(), &OCC::SyncEngine::startSync, Qt::QueuedConnection);
 }
 
 void FakeFolder::execUntilBeforePropagation()


### PR DESCRIPTION
A delete job that triggered slotComputeContentChecksum could reach slotComputeTransmissionChecksum before the delete job was removed from _jobs.
The upload job would then not start the first chunk upload and be stalled for ever.

Fixes: #9725