### PR TITLE
Use pattern for QTemporaryDir in unit tests

### DIFF
--- a/test/modeltests/testprotocolmodel.cpp
+++ b/test/modeltests/testprotocolmodel.cpp
@@ -30,7 +30,7 @@ private Q_SLOTS:
 
         new QAbstractItemModelTester(model, this);
 
-        QTemporaryDir dir;
+        auto dir = TestUtils::createTempDir();
 
         auto account = TestUtils::createDummyAccount();
 

--- a/test/testchecksumvalidator.cpp
+++ b/test/testchecksumvalidator.cpp
@@ -23,7 +23,7 @@ using namespace OCC::Utility;
     {
         Q_OBJECT
     private:
-        QTemporaryDir _root;
+        const QTemporaryDir _root = TestUtils::createTempDir();
         QString _testfile;
         QString _expectedError;
         QByteArray     _expected;

--- a/test/testexcludedfiles.cpp
+++ b/test/testexcludedfiles.cpp
@@ -9,6 +9,7 @@
 #include <QTemporaryDir>
 
 #include "csync_exclude.h"
+#include "testutils.h"
 
 using namespace OCC;
 
@@ -70,7 +71,7 @@ private slots:
         bool keepHidden = false;
 
         auto check_isExcluded = [&](const QString &a, bool keepHidden, bool create = true) {
-            QTemporaryDir tmp;
+            auto tmp = OCC::TestUtils::createTempDir();
             Q_ASSERT(tmp.isValid());
 
             auto createTree = [&](const QString &path) {

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -29,7 +29,7 @@ private slots:
 #ifdef Q_OS_WIN
         Utility::NtfsPermissionLookupRAII ntfs_perm;
 #endif
-        QTemporaryDir dir;
+        auto dir = TestUtils::createTempDir();
         QVERIFY(dir.isValid());
         QDir dir2(dir.path());
         QVERIFY(dir2.mkpath("sub/ownCloud1/folder/f"));
@@ -156,7 +156,7 @@ private slots:
     {
         // SETUP
 
-        QTemporaryDir dir;
+        auto dir = TestUtils::createTempDir();
         QVERIFY(dir.isValid());
         QDir dir2(dir.path());
         QVERIFY(dir2.mkpath("sub/ownCloud1/folder/f"));

--- a/test/testfoldermigration.cpp
+++ b/test/testfoldermigration.cpp
@@ -11,6 +11,7 @@
 #include "common/utility.h"
 #include "configfile.h"
 #include "folderman.h"
+#include "testutils/testutils.h"
 
 using namespace OCC;
 
@@ -72,7 +73,7 @@ private slots:
     {
         QFETCH(QStringList, journalPaths);
         QFETCH(QString, url);
-        QTemporaryDir tmp;
+        auto tmp = OCC::TestUtils::createTempDir();
         const auto settings = writeSettings(tmp, Settings_2_4());
         settings->setValue("0/url", url);
         settings->remove("0/Folders/1/journalPath");

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -75,7 +75,7 @@ class TestFolderWatcher : public QObject
 {
     Q_OBJECT
 
-    QTemporaryDir _root;
+    const QTemporaryDir _root = TestUtils::createTempDir();
     QString _rootPath;
     QScopedPointer<FolderWatcher> _watcher;
     QScopedPointer<QSignalSpy> _pathChangedSpy;

--- a/test/testlockedfiles.cpp
+++ b/test/testlockedfiles.cpp
@@ -5,11 +5,13 @@
  *
  */
 
-#include <QtTest>
-#include "testutils/syncenginetestutils.h"
+#include "localdiscoverytracker.h"
 #include "lockwatcher.h"
-#include <syncengine.h>
-#include <localdiscoverytracker.h>
+#include "syncengine.h"
+#include "testutils.h"
+#include "testutils/syncenginetestutils.h"
+
+#include <QtTest>
 
 using namespace std::chrono_literals;
 using namespace OCC;
@@ -41,7 +43,7 @@ class TestLockedFiles : public QObject
 private slots:
     void testBasicLockFileWatcher()
     {
-        QTemporaryDir tmp;
+        auto tmp = TestUtils::createTempDir();
         int count = 0;
         QString file;
 

--- a/test/testlongpath.cpp
+++ b/test/testlongpath.cpp
@@ -20,6 +20,7 @@
 #include "common/filesystembase.h"
 #include "csync/csync.h"
 #include "csync/vio/csync_vio_local.h"
+#include "testutils/testutils.h"
 
 #include <QTemporaryFile>
 #include <QTest>
@@ -116,7 +117,7 @@ private Q_SLOTS:
 
     void testLongPathStat()
     {
-        QTemporaryDir tmp;
+        auto tmp = OCC::TestUtils::createTempDir();
         QFETCH(QString, name);
         const QFileInfo longPath(tmp.path() + name);
 

--- a/test/testownsql.cpp
+++ b/test/testownsql.cpp
@@ -4,18 +4,19 @@
  *          any purpose.
  *          */
 
+#include "common/ownsql.h"
+#include "testutils.h"
+
 #include <QtTest>
 
 #include <sqlite3.h>
-
-#include "common/ownsql.h"
 
 using namespace OCC;
 
 class TestOwnSql : public QObject
 {
     Q_OBJECT
-    QTemporaryDir _tempDir;
+    const QTemporaryDir _tempDir = TestUtils::createTempDir();
 
 private slots:
     void testOpenDb() {

--- a/test/testutils/syncenginetestutils.h
+++ b/test/testutils/syncenginetestutils.h
@@ -17,6 +17,7 @@
 #include "folder.h"
 #include "logger.h"
 #include "syncengine.h"
+#include "testutils.h"
 #include <cstring>
 
 #include <QDir>
@@ -528,7 +529,7 @@ private:
 
 class FakeFolder
 {
-    QTemporaryDir _tempDir;
+    const QTemporaryDir _tempDir = OCC::TestUtils::createTempDir();
     DiskFileModifier _localModifier;
     // FIXME: Clarify ownership, double delete
     FakeAM *_fakeAm;

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -46,6 +46,11 @@ namespace TestUtils {
         return d;
     }
 
+    QTemporaryDir createTempDir()
+    {
+        return QTemporaryDir { QStringLiteral("%1/ownCloud-unit-test-%2-XXXXXX").arg(QDir::tempPath(), qApp->applicationName()) };
+    }
+
     FolderMan *folderMan()
     {
         static QPointer<FolderMan> man;

--- a/test/testutils/testutils.h
+++ b/test/testutils/testutils.h
@@ -6,6 +6,7 @@
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QTemporaryDir>
 
 namespace OCC {
 
@@ -15,6 +16,12 @@ namespace TestUtils {
     AccountPtr createDummyAccount();
     bool writeRandomFile(const QString &fname, int size = -1);
 
+    /***
+     * Create a QTemporaryDir with a test specific name pattern
+     * ownCloud-unit-test-{TestName}-XXXXXX
+     * This allow to clean up after failed tests
+     */
+    QTemporaryDir createTempDir();
 
     const QVariantMap testCapabilities();
 }

--- a/test/testutils/testutilsloader.cpp
+++ b/test/testutils/testutilsloader.cpp
@@ -1,6 +1,7 @@
 #include "configfile.h"
 #include "logger.h"
 #include "resources/loadresources.h"
+#include "testutils.h"
 
 #include <QCoreApplication>
 #include <QTemporaryDir>
@@ -11,7 +12,7 @@ void setupLogger()
     // load the resources
     static const OCC::ResourcesLoader resources;
 
-    static QTemporaryDir dir;
+    static auto dir = OCC::TestUtils::createTempDir();
     OCC::ConfigFile::setConfDir(dir.path()); // we don't want to pollute the user's config file
 
     OCC::Logger::instance()->setLogFile(QStringLiteral("-"));


### PR DESCRIPTION
Startig all QTemporaryDirs in unit tests with ownCloud-unit-test-...
simplifies the cleanup after a unit test crashed