### PR TITLE
Use more generic message when asking the user to authenticate

### DIFF
--- a/src/gui/askforoauthlogindialog.cpp
+++ b/src/gui/askforoauthlogindialog.cpp
@@ -28,7 +28,7 @@ AskForOAuthLoginDialog::AskForOAuthLoginDialog(AccountPtr accountPtr, QWidget *p
 {
     _ui->setupUi(this);
 
-    _ui->label->setText(tr("The account %1 has been logged out by the server.\n\nPlease use your browser to log in to %2.").arg(accountPtr->displayName(), Theme::instance()->appNameGUI()));
+    _ui->label->setText(tr("The account %1 is currently logged out.\n\nPlease authenticate using your browser.").arg(accountPtr->displayName()));
     _ui->iconLabel->setPixmap(Theme::instance()->applicationIcon().pixmap(64, 64));
 
     setModal(true);

--- a/src/gui/askforoauthlogindialog.ui
+++ b/src/gui/askforoauthlogindialog.ui
@@ -47,7 +47,7 @@
         <string notr="true">The account has been logged out [...] &lt;placeholder&gt;</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        <set>Qt::AlignHCenter|Qt::AlignTop</set>
        </property>
        <property name="wordWrap">
         <bool>true</bool>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/200626/179961696-c4c68339-3efb-4658-b74a-380257433c16.png)

Fixes: #9896