### PR TITLE
[tests-only] Add wait until sync in `editfile` suite

### DIFF
--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -12,6 +12,7 @@ Feature: edit files
     Scenario: Modify orignal content of a file with special character
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "S@mpleFile!With,$pecial?Characters.txt" on the server
         And user "Alice" has set up a client with default settings
+        And the user has waited for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
         When the user overwrites the file "S@mpleFile!With,$pecial?Characters.txt" with content "overwrite ownCloud test text file"
         And the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
         Then as "Alice" the file "S@mpleFile!With,$pecial?Characters.txt" on the server should have the content "overwrite ownCloud test text file"


### PR DESCRIPTION
### Description
This PR adds the wait until sync step in the tst_editfile suite to solve the intermittent failure 

In the investigation, it was found that the file was not synced in the server from the desktop properly. 

### Related issue
[[QA] Scenario Modify original content of a file with special character failed at execution through middleware in CI](https://github.com/owncloud/client/issues/9890)