### PR TITLE
wait for files to sync after adding user to the client

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -427,9 +427,9 @@ def step(context, type, resource):
     waitForFileOrFolderToSync(context, resource, type)
 
 
-@Given(r'user has waited for (file|folder) to be synced', regexp=True)
-def step(context, type, resource):
-    waitForFileOrFolderToSync(context, resource, type)
+@Given('the user has waited for files to be synced')
+def step(context):
+    waitForRootFolderToSync(context)
 
 
 @When(r'the user waits for (file|folder) "([^"]*)" to have sync error', regexp=True)

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -198,9 +198,11 @@ Feature: Sharing
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
+        And the user has waited for files to be synced
         When the user overwrites the file "textfile.txt" with content "overwrite file in the root"
+        And the user waits for file "textfile.txt" to be synced
         And the user overwrites the file "simple-folder/textfile.txt" with content "overwrite file inside a folder"
-        And the user waits for the files to sync
+        And the user waits for file "simple-folder/textfile.txt" to be synced
         Then as "Brian" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"
         And as "Brian" the file "textfile.txt" on the server should have the content "overwrite file in the root"
         And as "Alice" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"


### PR DESCRIPTION
closes:https://github.com/owncloud/client/issues/9850
Debugging has shown that the scenario `sharee edits content of files shared by sharer` from `test/gui/tst_sharing` suite was failing because the files may not be synced to the server just after their modification. So, our test may not find the files with the modified content on the server. Thus for that reason, here I've added a step to wait for files to sync after each overwrites.

Also, it is reasonable to add wait for files to sync after a user has been added to the client, as mentioned in [issue](https://github.com/owncloud/client/issues/9939)