### PR TITLE
[GUI-tests] Open only one socket connection per test scenario

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -151,6 +151,12 @@ def scenarioFailed():
 
 @OnScenarioEnd
 def hook(context):
+    # close socket connection
+    global socketConnect
+    if socketConnect:
+        socketConnect.connected = False
+        socketConnect._sock.close()
+
     # Currently, this workaround is needed because we cannot find out a way to determine the pass/fail status of currently running test scenario.
     # And, resultCount("errors")  and resultCount("fails") return the total number of error/failed test scenarios of a test suite.
     global previousFailResultCount

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -27,7 +27,7 @@ from pageObjects.AccountStatus import AccountStatus
 # to switch from the built-in interpreter see https://kb.froglogic.com/squish/howto/using-external-python-interpreter-squish-6-6/
 # if the IDE fails to reference the script, add the folder in Edit->Preferences->PyDev->Interpreters->Libraries
 sys.path.append(os.path.realpath('../../../shell_integration/nautilus/'))
-import syncstate
+from syncstate import SocketConnect
 import functools
 
 
@@ -138,11 +138,18 @@ def step(context):
     newAccount.addAccountCredential(context)
 
 
+def getSocketConnection():
+    global socketConnect
+    if not socketConnect or not socketConnect.connected:
+        socketConnect = SocketConnect()
+    return socketConnect
+
+
 # Using socket API to check file sync status
 def hasSyncStatus(type, itemName, status):
     if type != 'FILE' and type != 'FOLDER':
         raise Exception("type must be 'FILE' or 'FOLDER'")
-    socketConnect = syncstate.SocketConnect()
+    socketConnect = getSocketConnection()
     socketConnect.sendCommand("RETRIEVE_" + type + "_STATUS:" + itemName + "\n")
 
     if not socketConnect.read_socket_data_with_timeout(0.1):
@@ -278,7 +285,7 @@ def sanitizePath(path):
 
 
 def shareResource(resource):
-    socketConnect = syncstate.SocketConnect()
+    socketConnect = getSocketConnection()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
     if not socketConnect.read_socket_data_with_timeout(0.1):
         return False
@@ -372,7 +379,7 @@ def collaboratorShouldBeListed(
     context, receiver, resource, permissions, receiverCount=0
 ):
     resource = getResourcePath(context, resource)
-    socketConnect = syncstate.SocketConnect()
+    socketConnect = getSocketConnection()
     socketConnect.sendCommand("SHARE:" + resource + "\n")
     permissionsList = permissions.split(',')
 


### PR DESCRIPTION
In the GUI tests, the function `hasSyncStatus` opens a new socket connection every time it is called. The main issue is with `waitForFileOrFolderToHaveSyncStatus` function which calls `hasSyncStatus` function rapidly until the condition is met. So, there will be many socket connection requests in a single test scenario (which may or may not be an issue for the Unix socket server).

IMO, I think we must open only a single socket connection per test scenario. So, in this PR,  I have refactored the test code to only create a new socket connection if there is none and reuse the existing connection until a test scenario finishes and close the connection afterward. This way, we will open only one socket connection per scenario.

I tried to reuse a single connection for a whole test suite but that was not possible. I think the connection will be different every time we add a user to the client (I have no idea).