### PR TITLE
[tests-only]Add tests for filter in activity tab

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -137,3 +137,7 @@ deselect_remote_folders_you_do_not_wish_to_synchronize_ownCloud_QModelIndex = {"
 syncModeGroupBox_useVfsRadioButton_QRadioButton = {"container": advancedConfigGroupBox_syncModeGroupBox_QGroupBox, "name": "useVfsRadioButton", "type": "QRadioButton", "visible": 1}
 contentWidget_Enable_experimental_placeholder_mode_QPushButton = {"container": setupWizardWindow_contentWidget_QStackedWidget, "text": "Enable experimental placeholder mode", "type": "QPushButton", "unnamed": 1, "visible": 1}
 contentWidget_Stay_safe_QPushButton = {"container": setupWizardWindow_contentWidget_QStackedWidget, "text": "Stay safe", "type": "QPushButton", "unnamed": 1, "visible": 1}
+oCC_ProtocolWidget_filterButton_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_ProtocolWidget_OCC_ProtocolWidget, "name": "_filterButton", "type": "QPushButton", "visible": 1}
+oCC_ProtocolWidget_tableView_QTableView = {"container": qt_tabwidget_stackedwidget_OCC_ProtocolWidget_OCC_ProtocolWidget, "name": "_tableView", "type": "QTableView", "visible": 1}
+stack_QTabWidget = {"container": settings_stack_QStackedWidget, "type": "QTabWidget", "unnamed": 1, "visible": 1}
+oCC_IssuesWidget_filterButton_QPushButton = {"container": qt_tabwidget_stackedwidget_OCC_IssuesWidget_OCC_IssuesWidget, "name": "_filterButton", "type": "QPushButton", "visible": 1}

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -43,7 +43,7 @@ class Activity:
         if not tabFound:
             raise Exception("Tab not found: " + tabName)
 
-    def checkFileExist(self, filename):
+    def checkConflictFileExist(self, filename):
         squish.waitForObject(names.settings_OCC_SettingsDialog)
         squish.waitForObjectExists(
             {
@@ -90,3 +90,55 @@ class Activity:
             return True
         except:
             return False
+
+    def isResourceExcluded(self, context, filename):
+        try:
+            fileRow = squish.waitForObject(
+                {
+                    "column": 1,
+                    "container": names.oCC_IssuesWidget_tableView_QTableView,
+                    "text": filename,
+                    "type": "QModelIndex",
+                },
+                context.userData['lowestSyncTimeout'] * 1000,
+            )["row"]
+            squish.waitForObjectExists(
+                {
+                    "column": 6,
+                    "row": fileRow,
+                    "container": names.oCC_IssuesWidget_tableView_QTableView,
+                    "text": "Excluded",
+                    "type": "QModelIndex",
+                },
+                context.userData['lowestSyncTimeout'] * 1000,
+            )
+
+            return True
+        except:
+            return False
+
+    def checkResourceNotExist(self, context, filename):
+        squish.waitForObject(names.settings_OCC_SettingsDialog)
+
+        result = squish.waitFor(
+            lambda: self.isResourceNotVisible(context, filename),
+            context.userData['maxSyncTimeout'] * 1000,
+        )
+
+        return result
+
+    def isResourceNotVisible(self, context, filename):
+        try:
+            squish.waitForObjectExists(
+                {
+                    "column": 1,
+                    "container": names.oCC_IssuesWidget_tableView_QTableView,
+                    "text": filename,
+                    "type": "QModelIndex",
+                },
+            context.userData['lowestSyncTimeout'] * 1000,
+            )
+
+            return False
+        except:
+            return True

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -54,17 +54,27 @@ class Activity:
             }
         )
 
-    def checkBlackListedResourceExist(self, context, filename):
+    def checkNotSyncedResourceExist(self, context, filename, status):
         squish.waitForObject(names.settings_OCC_SettingsDialog)
 
         result = squish.waitFor(
-            lambda: self.isResourceBlackListed(context, filename),
+            lambda: self.isNotSyncedResourceExist(context, filename, status),
             context.userData['maxSyncTimeout'] * 1000,
         )
 
         return result
 
-    def isResourceBlackListed(self, context, filename):
+    def waitForResourceNotExist(self, context, filename, status="Excluded"):
+        squish.waitForObject(names.settings_OCC_SettingsDialog)
+
+        result = squish.waitFor(
+            lambda: not self.isNotSyncedResourceExist(context, filename, status),
+            context.userData['maxSyncTimeout'] * 1000,
+        )
+
+        return result
+    
+    def isNotSyncedResourceExist(self, context, filename, status):
         try:
             # The blacklisted file does not have text like (conflicted copy) appended to it in the not synced table.
             fileRow = squish.waitForObject(
@@ -81,33 +91,53 @@ class Activity:
                     "column": 6,
                     "row": fileRow,
                     "container": names.oCC_IssuesWidget_tableView_QTableView,
-                    "text": "Blacklisted",
+                    "text": status,
                     "type": "QModelIndex",
                 },
                 context.userData['lowestSyncTimeout'] * 1000,
             )
-
+            
             return True
         except:
             return False
 
-    def isResourceExcluded(self, context, filename):
+    def checkTableContent(self, context, action, resource, account):
+        squish.waitForObject(names.settings_OCC_SettingsDialog)
+
+        result = squish.waitFor(
+            lambda: self.isTableContentMatch(context, action, resource, account),
+            context.userData['maxSyncTimeout'] * 1000,
+        )
+
+        return result
+
+    def isTableContentMatch(self, context, action, resource, account):
         try:
             fileRow = squish.waitForObject(
                 {
                     "column": 1,
-                    "container": names.oCC_IssuesWidget_tableView_QTableView,
-                    "text": filename,
+                    "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                    "text": resource,
                     "type": "QModelIndex",
                 },
                 context.userData['lowestSyncTimeout'] * 1000,
             )["row"]
             squish.waitForObjectExists(
                 {
-                    "column": 6,
+                    "column": 0,
                     "row": fileRow,
-                    "container": names.oCC_IssuesWidget_tableView_QTableView,
-                    "text": "Excluded",
+                    "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                    "text": action,
+                    "type": "QModelIndex",
+                },
+                context.userData['lowestSyncTimeout'] * 1000,
+            )
+            squish.waitForObjectExists(
+                {
+                    "column": 4,
+                    "row": fileRow,
+                    "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                    "text": account,
                     "type": "QModelIndex",
                 },
                 context.userData['lowestSyncTimeout'] * 1000,
@@ -116,29 +146,3 @@ class Activity:
             return True
         except:
             return False
-
-    def checkResourceNotExist(self, context, filename):
-        squish.waitForObject(names.settings_OCC_SettingsDialog)
-
-        result = squish.waitFor(
-            lambda: self.isResourceNotVisible(context, filename),
-            context.userData['maxSyncTimeout'] * 1000,
-        )
-
-        return result
-
-    def isResourceNotVisible(self, context, filename):
-        try:
-            squish.waitForObjectExists(
-                {
-                    "column": 1,
-                    "container": names.oCC_IssuesWidget_tableView_QTableView,
-                    "text": filename,
-                    "type": "QModelIndex",
-                },
-            context.userData['lowestSyncTimeout'] * 1000,
-            )
-
-            return False
-        except:
-            return True

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -73,7 +73,7 @@ class Activity:
         )
 
         return result
-    
+
     def isNotSyncedResourceExist(self, context, filename, status):
         try:
             # The blacklisted file does not have text like (conflicted copy) appended to it in the not synced table.
@@ -96,7 +96,7 @@ class Activity:
                 },
                 context.userData['lowestSyncTimeout'] * 1000,
             )
-            
+
             return True
         except:
             return False

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1526,3 +1526,81 @@ def step(context):
     newAccount = AccountConnectionWizard()
     clickButton(waitForObject(newAccount.STAY_SAFE_BUTTON))
     clickButton(waitForObject(newAccount.NEXT_BUTTON))
+
+
+@When('the user selects "|any|" option on filter dropdown button')
+def step(context, account):
+    clickButton(waitForObject(names.oCC_ProtocolWidget_filterButton_QPushButton))
+    activateItem(waitForObjectItem(names.settings_QMenu, account))
+
+@Then(r'^the following information should be displayed on the sync table$', regexp=True)
+def step(context):
+    rowIndex = 0
+    for row in context.table[1:]:
+        action = row[0]
+        resource = row[1]
+        account = row[2]
+        test.compare(
+            str(
+                waitForObjectExists(
+                    {
+                        "column": 0,
+                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                        "row": rowIndex,
+                        "type": "QModelIndex",
+                    }
+                ).text
+            ),
+            action,
+        )
+        test.compare(
+            str(
+                waitForObjectExists(
+                    {
+                        "column": 1,
+                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                        "row": rowIndex,
+                        "type": "QModelIndex",
+                    }
+                ).text
+            ),
+            resource,
+        )
+        test.compare(
+            str(
+                waitForObjectExists(
+                    {
+                        "column": 4,
+                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
+                        "row": rowIndex,
+                        "type": "QModelIndex",
+                    }
+                ).text
+            ),
+            account,
+        )
+        rowIndex += 1
+
+@Then('the file "|any|" should be excluded')
+def step(context, filename):
+    activity = Activity()
+    test.compare(
+        True,
+        activity.isResourceExcluded(context, filename),
+        "File is excluded",
+    )
+
+
+@When('the user uncheck "|any|" filter on not synced tab')
+def step(context, filename):
+    clickButton(waitForObject(names.oCC_IssuesWidget_filterButton_QPushButton))
+    activateItem(waitForObjectItem(names.settings_QMenu, filename))
+
+
+@Then('the file "|any|" should not be visible')
+def step(context, filename):
+    activity = Activity()
+    test.compare(
+        activity.checkResourceNotExist(context, filename),
+        True,
+        "File not visible")

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -705,13 +705,13 @@ def step(context, filename):
     activity.checkFileExist(filename)
 
 
-@Then('the file "|any|" should be blacklisted')
-def step(context, filename):
+@Then(r'the file "([^"]*)" should be "([^"]*)"', regexp=True)
+def step(context, filename, status):
     activity = Activity()
     test.compare(
         True,
-        activity.checkBlackListedResourceExist(context, filename),
-        "File is blacklisted",
+        activity.checkNotSyncedResourceExist(context, filename, status),
+        filename + " file status should be " + status
     )
 
 
@@ -1533,65 +1533,18 @@ def step(context, account):
     clickButton(waitForObject(names.oCC_ProtocolWidget_filterButton_QPushButton))
     activateItem(waitForObjectItem(names.settings_QMenu, account))
 
+
 @Then(r'^the following information should be displayed on the sync table$', regexp=True)
 def step(context):
-    rowIndex = 0
+    activity = Activity()
     for row in context.table[1:]:
         action = row[0]
         resource = row[1]
         account = row[2]
-        test.compare(
-            str(
-                waitForObjectExists(
-                    {
-                        "column": 0,
-                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
-                        "row": rowIndex,
-                        "type": "QModelIndex",
-                    }
-                ).text
-            ),
-            action,
-        )
-        test.compare(
-            str(
-                waitForObjectExists(
-                    {
-                        "column": 1,
-                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
-                        "row": rowIndex,
-                        "type": "QModelIndex",
-                    }
-                ).text
-            ),
-            resource,
-        )
-        test.compare(
-            str(
-                waitForObjectExists(
-                    {
-                        "column": 4,
-                        "container": names.oCC_ProtocolWidget_tableView_QTableView,
-                        "row": rowIndex,
-                        "type": "QModelIndex",
-                    }
-                ).text
-            ),
-            account,
-        )
-        rowIndex += 1
-
-@Then('the file "|any|" should be excluded')
-def step(context, filename):
-    activity = Activity()
-    test.compare(
-        True,
-        activity.isResourceExcluded(context, filename),
-        "File is excluded",
-    )
+        test.compare(activity.checkTableContent(context, action, resource, account), True, "Matching sync tab table content")
 
 
-@When('the user uncheck "|any|" filter on not synced tab')
+@When('the user uncheck "|any|" filter on the not_synced tab')
 def step(context, filename):
     clickButton(waitForObject(names.oCC_IssuesWidget_filterButton_QPushButton))
     activateItem(waitForObjectItem(names.settings_QMenu, filename))
@@ -1601,6 +1554,5 @@ def step(context, filename):
 def step(context, filename):
     activity = Activity()
     test.compare(
-        activity.checkResourceNotExist(context, filename),
-        True,
-        "File not visible")
+        activity.waitForResourceNotExist(context, filename), True, filename + " file should not exist in not_synced tab"
+    )

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -711,7 +711,7 @@ def step(context, filename, status):
     test.compare(
         True,
         activity.checkNotSyncedResourceExist(context, filename, status),
-        filename + " file status should be " + status
+        filename + " file status should be " + status,
     )
 
 
@@ -1541,7 +1541,11 @@ def step(context):
         action = row[0]
         resource = row[1]
         account = row[2]
-        test.compare(activity.checkTableContent(context, action, resource, account), True, "Matching sync tab table content")
+        test.compare(
+            activity.checkTableContent(context, action, resource, account),
+            True,
+            "Matching sync tab table content",
+        )
 
 
 @When('the user uncheck "|any|" filter on the not_synced tab')
@@ -1554,5 +1558,7 @@ def step(context, filename):
 def step(context, filename):
     activity = Activity()
     test.compare(
-        activity.waitForResourceNotExist(context, filename), True, filename + " file should not exist in not_synced tab"
+        activity.waitForResourceNotExist(context, filename),
+        True,
+        filename + " file should not exist in not_synced tab",
     )

--- a/test/gui/tst_activity/test.feature
+++ b/test/gui/tst_activity/test.feature
@@ -1,0 +1,40 @@
+Feature: filter accounts
+
+    As a user
+    I want to filter the accounts
+    So that I can view the data of the filtered accounts
+
+    Scenario: synced files can be filter based on user account
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has set up a client with default settings
+        And the user has waited for folder "simple-folder" to be synced
+        And the user has added another account with
+            | server   | %local_server% |
+            | user     | Brian          |
+            | password | AaBb2Cc3Dd4    |
+        When the user clicks on the activity tab
+        And the user selects "Alice Hansen@localhost" option on filter dropdown button
+        Then the following information should be displayed on the sync table
+            |action    |resource		   |account                 |
+            |Downloaded|simple-folder      |Alice Hansen@localhost  |
+
+	Scenario: Filter not synced file
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has set up a client with default settings
+        And user "Alice" has created a folder "Folder1" inside the sync folder
+        And the user has waited for folder "Folder1" to be synced
+        And user "Alice" has created the following files inside the sync folder:
+            | files             |
+            | /.htaccess        |
+            | /Folder1/a\\a.txt |
+        When the user clicks on the activity tab
+        And the user selects "Not Synced" tab in the activity
+        Then the file "Folder1/a\\a.txt" should be blacklisted
+        And the file ".htaccess" should be excluded
+        When the user uncheck "Excluded" filter on not synced tab
+        Then the file ".htaccess" should not be visible
+
+
+

--- a/test/gui/tst_activity/test.feature
+++ b/test/gui/tst_activity/test.feature
@@ -1,10 +1,10 @@
 Feature: filter accounts
 
     As a user
-    I want to filter the accounts
-    So that I can view the data of the filtered accounts
+    I want to filter the resource
+    So that I can view the specific resources only
 
-    Scenario: synced files can be filter based on user account
+    Scenario: synced files can be filtered based on user account
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "simple-folder" on the server
@@ -15,10 +15,10 @@ Feature: filter accounts
             | user     | Brian          |
             | password | AaBb2Cc3Dd4    |
         When the user clicks on the activity tab
-        And the user selects "Alice Hansen@localhost" option on filter dropdown button
+        And the user selects "Alice Hansen@owncloud" option on filter dropdown button
         Then the following information should be displayed on the sync table
-            |action    |resource		   |account                 |
-            |Downloaded|simple-folder      |Alice Hansen@localhost  |
+            | action     | resource      | account               |
+            | Downloaded | simple-folder | Alice Hansen@owncloud |
 
 	Scenario: Filter not synced file
         Given user "Alice" has been created on the server with default attributes and without skeleton files
@@ -31,10 +31,7 @@ Feature: filter accounts
             | /Folder1/a\\a.txt |
         When the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
-        Then the file "Folder1/a\\a.txt" should be blacklisted
-        And the file ".htaccess" should be excluded
-        When the user uncheck "Excluded" filter on not synced tab
+        Then the file "Folder1/a\\a.txt" should be "Blacklisted"
+        And the file ".htaccess" should be "Excluded"
+        When the user uncheck "Excluded" filter on the not_synced tab
         Then the file ".htaccess" should not be visible
-
-
-

--- a/test/gui/tst_activity/test.py
+++ b/test/gui/tst_activity/test.py
@@ -1,0 +1,9 @@
+source(findFile('scripts', 'python/bdd.py'))
+
+setupHooks('../shared/scripts/bdd_hooks.py')
+collectStepDefinitions('./steps', '../shared/steps')
+
+
+def main():
+    testSettings.throwOnFailure = True
+    runFeatureFile('test.feature')

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -241,7 +241,7 @@ Feature: Syncing files
         Then as "Alice" folder "Folder1" should exist on the server
         When the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
-        Then the file "Folder1/a\\a.txt" should be blacklisted
+        Then the file "Folder1/a\\a.txt" should be "Blacklisted"
 
 
     Scenario Outline: Verify one empty folder with a length longer than the allowed limit will not be synced
@@ -338,7 +338,7 @@ Feature: Syncing files
             """
         And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
-        Then the file "<filename>" should be blacklisted
+        Then the file "<filename>" should be "Blacklisted"
         Examples:
             | filename                                                                                                                                                                                                                                  |
             | aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFoxJumpsOverAVeryLazyDog-aQuickBrownFo.txt |


### PR DESCRIPTION
### Description
This PR adds tests related to filter status

### Test coverage:
Scenario: synced files can be filter based on user account
Scenario: Filter not synced file

### Related Issue:
- [Add automated GUI test for activity -> filter ](https://github.com/owncloud/client/issues/9788)