### PR TITLE
Don't abort sync to dehydrate files

### DIFF
--- a/changelog/unreleased/9956
+++ b/changelog/unreleased/9956
@@ -1,0 +1,8 @@
+Enhancement: Don't abort sync if a user requests a file
+
+Previously we aborted any running sync if a user requested a file that was not yet available locally.
+This was done to ensure the user does not need to wait for the current sync to finish.
+However in todays code both actions the download and the sync can run in parallel.
+
+https://github.com/owncloud/client/pull/9956
+https://github.com/owncloud/client/issues/9832

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -155,12 +155,6 @@ public:
      */
     virtual bool socketApiPinStateActionsShown() const = 0;
 
-    /** Return true when download of a file's data is currently ongoing.
-     *
-     * See also the beginHydrating() and doneHydrating() signals.
-     */
-    virtual bool isHydrating() const = 0;
-
     /// Create a new dehydrated placeholder. Called from PropagateDownload.
     OC_REQUIRED_RESULT virtual Result<void, QString> createPlaceholder(const SyncFileItem &item) = 0;
 
@@ -224,10 +218,6 @@ public slots:
     virtual void fileStatusChanged(const QString &systemFileName, SyncFileStatus fileStatus) = 0;
 
 signals:
-    /// Emitted when a user-initiated hydration starts
-    void beginHydrating();
-    /// Emitted when the hydration ends
-    void doneHydrating();
     /// start complete
     void started();
 
@@ -281,7 +271,6 @@ public:
     void unregisterFolder() override {}
 
     bool socketApiPinStateActionsShown() const override { return false; }
-    bool isHydrating() const override { return false; }
 
     Result<void, QString> createPlaceholder(const SyncFileItem &) override { return {}; }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -283,7 +283,7 @@ QString Folder::cleanPath() const
 
 bool Folder::isSyncRunning() const
 {
-    return !hasSetupError() && (_engine->isSyncRunning() || _vfs->isHydrating());
+    return !hasSetupError() && _engine->isSyncRunning();
 }
 
 QString Folder::remotePath() const
@@ -547,9 +547,6 @@ void Folder::startVfs()
     vfsParams.providerName = Theme::instance()->appName();
     vfsParams.providerVersion = Theme::instance()->version();
     vfsParams.multipleAccountsRegistered = AccountManager::instance()->accounts().size() > 1;
-
-    connect(_vfs.data(), &Vfs::beginHydrating, this, &Folder::slotHydrationStarts);
-    connect(_vfs.data(), &Vfs::doneHydrating, this, &Folder::slotHydrationDone);
 
     connect(&_engine->syncFileStatusTracker(), &SyncFileStatusTracker::fileStatusChanged,
         _vfs.data(), &Vfs::fileStatusChanged);
@@ -1246,30 +1243,6 @@ void Folder::slotWatcherUnreliable(const QString &message)
            "\n"
            "%1").arg(message);
     ocApp()->gui()->slotShowGuiMessage(Theme::instance()->appNameGUI(), fullMessage);
-}
-
-void Folder::slotHydrationStarts()
-{
-    // Abort any running full sync run and reschedule
-    if (_engine->isSyncRunning()) {
-        slotTerminateSync();
-        scheduleThisFolderSoon();
-        // TODO: This sets the sync state to AbortRequested on done, we don't want that
-    }
-
-    // Let everyone know we're syncing
-    _syncResult.reset();
-    _syncResult.setStatus(SyncResult::SyncRunning);
-    emit syncStarted();
-    emit syncStateChange();
-}
-
-void Folder::slotHydrationDone()
-{
-    // emit signal to update ui and reschedule normal syncs if necessary
-    _syncResult.setStatus(SyncResult::Success);
-    emit syncFinished(_syncResult);
-    emit syncStateChange();
 }
 
 void Folder::scheduleThisFolderSoon()

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -441,17 +441,6 @@ private slots:
 
     /** Warn users about an unreliable folder watcher */
     void slotWatcherUnreliable(const QString &message);
-
-    /** Aborts any running sync and blocks it until hydration is finished.
-     *
-     * Hydration circumvents the regular SyncEngine and both mustn't be running
-     * at the same time.
-     */
-    void slotHydrationStarts();
-
-    /** Unblocks normal sync operation */
-    void slotHydrationDone();
-
 private:
     void connectSyncRoot();
 

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -65,11 +65,6 @@ void VfsSuffix::unregisterFolder()
 {
 }
 
-bool VfsSuffix::isHydrating() const
-{
-    return false;
-}
-
 Result<Vfs::ConvertToPlaceholderResult, QString> VfsSuffix::updateMetadata(const SyncFileItem &item, const QString &filePath, const QString &)
 {
     if (item._type == ItemTypeVirtualFileDehydration) {

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -38,7 +38,6 @@ public:
     void unregisterFolder() override;
 
     bool socketApiPinStateActionsShown() const override { return true; }
-    bool isHydrating() const override;
 
 
     Result<void, QString> createPlaceholder(const SyncFileItem &item) override;


### PR DESCRIPTION
Notes for testing:
- Lots of files online
- Initial sync
- While the sync is running, double click on a placeholder already created
  - The file should be downloaded in reasonable time
  - The sync progress bar should behave sensible
  -  No warnings are expected
  - The initial sync continues