### PR TITLE
Don't set the pin state of the root folder but assume unspecified

### DIFF
--- a/changelog/unreleased/9966
+++ b/changelog/unreleased/9966
@@ -1,0 +1,5 @@
+Bugfix: Windows VFS: Files in an existing folder are dehydrated
+
+We fixed a bug, when a user selects an existing folder as sync root we previously dehydrated all existing files.
+
+https://github.com/owncloud/client/pull/9966

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -2110,9 +2110,10 @@ Optional<PinState> SyncJournalDb::PinStateInterface::effectiveForPath(const QByt
     auto next = query->next();
     if (!next.ok)
         return {};
-    // If the root path has no setting, assume AlwaysLocal
-    if (!next.hasData)
-        return PinState::AlwaysLocal;
+    // If the root path has no setting, assume Unspecified
+    if (!next.hasData) {
+        return PinState::Unspecified;
+    }
 
     return static_cast<PinState>(query->intValue(0));
 }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -478,9 +478,6 @@ void AccountSettings::slotFolderWizardAccepted()
 
     Folder *f = folderMan->addFolder(_accountState, definition);
     if (f) {
-        if (definition.virtualFilesMode != Vfs::Off && folderWizard->property("useVirtualFiles").toBool())
-            f->setRootPinState(PinState::OnlineOnly);
-
         f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, selectiveSyncBlackList);
 
         // The user already accepted the selective sync dialog. everything is in the white list
@@ -567,9 +564,6 @@ void AccountSettings::slotEnableVfsCurrentFolder()
             folder->setVirtualFilesEnabled(true);
             folder->setVfsOnOffSwitchPending(false);
 
-            // Setting to Unspecified retains existing data.
-            // Selective sync excluded folders become OnlineOnly.
-            folder->setRootPinState(PinState::Unspecified);
             for (const auto &entry : oldBlacklist) {
                 folder->journalDb()->schedulePathForRemoteDiscovery(entry);
                 folder->vfs().setPinState(entry, PinState::OnlineOnly);
@@ -634,9 +628,6 @@ void AccountSettings::slotDisableVfsCurrentFolder()
             // Also wipes virtual files, schedules remote discovery
             folder->setVirtualFilesEnabled(false);
             folder->setVfsOnOffSwitchPending(false);
-
-            // Wipe pin states and selective sync db
-            folder->setRootPinState(PinState::AlwaysLocal);
             folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, {});
 
             // Prevent issues with missing local files
@@ -657,21 +648,6 @@ void AccountSettings::slotDisableVfsCurrentFolder()
         }
     });
     msgBox->open();
-}
-
-void AccountSettings::slotSetCurrentFolderAvailability(PinState state)
-{
-    OC_ASSERT(state == PinState::OnlineOnly || state == PinState::AlwaysLocal);
-
-    FolderMan *folderMan = FolderMan::instance();
-    QPointer<Folder> folder = folderMan->folder(selectedFolderAlias());
-    QModelIndex selected = ui->_folderList->selectionModel()->currentIndex();
-    if (!selected.isValid() || !folder)
-        return;
-
-    // similar to socket api: sets pin state recursively and sync
-    folder->setRootPinState(state);
-    folder->scheduleThisFolderSoon();
 }
 
 void AccountSettings::showConnectionLabel(const QString &message, QStringList errors)

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -76,7 +76,6 @@ protected slots:
     void slotRemoveCurrentFolder();
     void slotEnableVfsCurrentFolder();
     void slotDisableVfsCurrentFolder();
-    void slotSetCurrentFolderAvailability(PinState state);
     void slotFolderWizardAccepted();
     void slotFolderWizardRejected();
     void slotDeleteAccount();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -743,15 +743,6 @@ void Folder::setVirtualFilesEnabled(bool enabled)
     }
 }
 
-void Folder::setRootPinState(PinState state)
-{
-    _vfs->setPinState(QString(), state);
-
-    // We don't actually need discovery, but it's important to recurse
-    // into all folders, so the changes can be applied.
-    slotNextSyncFullLocalDiscovery();
-}
-
 bool Folder::supportsSelectiveSync() const
 {
     return !virtualFilesEnabled() && !isVfsOnOffSwitchPending();

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -312,8 +312,6 @@ public:
     bool virtualFilesEnabled() const;
     void setVirtualFilesEnabled(bool enabled);
 
-    void setRootPinState(PinState state);
-
     /** Whether user desires a switch that couldn't be executed yet, see member */
     bool isVfsOnOffSwitchPending() const { return _vfsOnOffPending; }
     void setVfsOnOffSwitchPending(bool pending) { _vfsOnOffPending = pending; }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -364,13 +364,6 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
 
             Folder *f = addFolderInternal(std::move(folderDefinition), account.data(), std::move(vfs));
             if (f) {
-                // Migrate the old "usePlaceholders" setting to the root folder pin state
-                if (settings.value(versionC(), 1).toInt() == 1
-                    && settings.value(QLatin1String("usePlaceholders"), false).toBool()) {
-                    qCInfo(lcFolderMan) << "Migrate: From usePlaceholders to PinState::OnlineOnly";
-                    f->setRootPinState(PinState::OnlineOnly);
-                }
-
                 // Migration: Mark folders that shall be saved in a backwards-compatible way
                 if (backwardsCompatible)
                     f->setSaveBackwardsCompatible(true);

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -409,9 +409,6 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
 
             auto f = folderMan->addFolder(account, folderDefinition);
             if (f) {
-                if (folderDefinition.virtualFilesMode != Vfs::Off && _ocWizard->useVirtualFileSync())
-                    f->setRootPinState(PinState::OnlineOnly);
-
                 f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList,
                     _ocWizard->selectiveSyncBlacklist());
                 if (!_ocWizard->isConfirmBigFolderChecked()) {


### PR DESCRIPTION
For suffix vfs the code returned always local by default and thus needed the setRootPinState.
Obviously that wrong with anything but he suffix plugin.

For testing:
- Nothing for Windows VFS
- Suffix VFS: test how pinning behaves for child items of pinned directories.
- What happens on enable disable VFS.
- Adding a folder with files

The expected behavior is:
- Remote new remote files are online only by default.
- Existing local files stay available
- Pin states persist.