### PR TITLE
[CI] Fix build notification: apply bold to text only

### DIFF
--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -16,11 +16,11 @@ GUI_STATUS_CODE=$($CURL "$GUI_LOG")
 SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
 STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
 
-BUILD_STATUS=":white_check_mark:Success"
+BUILD_STATUS=":white_check_mark:**Success**"
 TEST_LOGS=""
 
 if [ "${DRONE_BUILD_STATUS}" != "success" ]; then
-    BUILD_STATUS=":x:Failure"
+    BUILD_STATUS=":x:**Failure**"
     if [[ "$SERVER_STATUS_CODE" == "200" ]]; then
         TEST_LOGS="\n> [Server log]($SERVER_LOG)  " # 2 spaces at the end act as line-break
     fi
@@ -32,4 +32,4 @@ if [ "${DRONE_BUILD_STATUS}" != "success" ]; then
     fi
 fi
 
-echo -e "**$BUILD_STATUS** [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" > "$1"/template.md
+echo -e "$BUILD_STATUS [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" > "$1"/template.md


### PR DESCRIPTION
With Rocket.chat version 5, `**:x: Failure**` doesn't yield expected :x: **Failure**
![dc-ss](https://user-images.githubusercontent.com/52366632/181679792-0e96b601-778f-4e6f-a16e-5c7f6c13cdb4.png)

This PR has fix for such an issue.