### PR TITLE
Raise dialogs and message boxes

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -491,7 +491,7 @@ void AccountSettings::slotEnableVfsCurrentFolder()
     if (!selected.isValid() || !folder)
         return;
 
-    auto messageBox = new AskExperimentalVirtualFilesFeatureMessageBox(this);
+    auto messageBox = new AskExperimentalVirtualFilesFeatureMessageBox(ocApp()->gui()->settingsDialog());
 
     connect(messageBox, &AskExperimentalVirtualFilesFeatureMessageBox::accepted, this, [this, folder]() {
         if (!folder) {
@@ -548,6 +548,7 @@ void AccountSettings::slotEnableVfsCurrentFolder()
         Q_EMIT messageBox->accepted();
     } else {
         messageBox->show();
+        ocApp()->gui()->raiseDialog(messageBox);
     }
 }
 
@@ -797,9 +798,9 @@ void AccountSettings::slotAccountStateChanged()
 
                 qCDebug(lcAccountSettings) << "showing modal dialog asking user to log in again via OAuth2";
 
-                _askForOAuthLoginDialog = new AskForOAuthLoginDialog(_accountState->account(), this);
+                _askForOAuthLoginDialog = new AskForOAuthLoginDialog(_accountState->account(), ocApp()->gui()->settingsDialog());
 
-                // make sure to clean up the memory and to null the QPointer once finished
+                // make sure it's cleaned up since it's not owned by the account settings (also prevents memory leaks)
                 _askForOAuthLoginDialog->setAttribute(Qt::WA_DeleteOnClose);
 
                 connect(
@@ -815,6 +816,7 @@ void AccountSettings::slotAccountStateChanged()
                 showConnectionLabel(tr("Reauthorization required."));
 
                 _askForOAuthLoginDialog->show();
+                ocApp()->gui()->raiseDialog(_askForOAuthLoginDialog);
             } else {
                 showConnectionLabel(tr("Connecting to %1...").arg(serverWithUser));
             }

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -59,7 +59,7 @@ UpdateUrlDialog *AccountState::updateUrlDialog(const QUrl &newUrl)
         return nullptr;
     }
 
-    _updateUrlDialog = UpdateUrlDialog::fromAccount(_account, newUrl, ocApp()->activeWindow());
+    _updateUrlDialog = UpdateUrlDialog::fromAccount(_account, newUrl, ocApp()->gui()->settingsDialog());
 
     connect(_updateUrlDialog, &UpdateUrlDialog::accepted, this, [=]() {
         _account->setUrl(newUrl);
@@ -68,6 +68,7 @@ UpdateUrlDialog *AccountState::updateUrlDialog(const QUrl &newUrl)
     });
 
     _updateUrlDialog->show();
+    ocApp()->gui()->raiseDialog(_updateUrlDialog);
 
     return _updateUrlDialog;
 }

--- a/src/gui/askexperimentalvirtualfilesfeaturemessagebox.h
+++ b/src/gui/askexperimentalvirtualfilesfeaturemessagebox.h
@@ -11,7 +11,7 @@ namespace OCC {
 class AskExperimentalVirtualFilesFeatureMessageBox : public QMessageBox
 {
 public:
-    explicit AskExperimentalVirtualFilesFeatureMessageBox(QWidget *parent = nullptr);
+    AskExperimentalVirtualFilesFeatureMessageBox(QWidget *parent = nullptr);
 };
 
 }

--- a/src/gui/folderwizard/folderwizardselectivesync.cpp
+++ b/src/gui/folderwizard/folderwizardselectivesync.cpp
@@ -21,12 +21,14 @@
 #include "folderwizard.h"
 #include "folderwizard_p.h"
 
+#include "gui/application.h"
 #include "gui/askexperimentalvirtualfilesfeaturemessagebox.h"
 #include "gui/selectivesyncdialog.h"
 
 #include "libsync/theme.h"
 
 #include "common/vfs.h"
+#include "gui/settingsdialog.h"
 
 #include <QCheckBox>
 #include <QVBoxLayout>
@@ -88,7 +90,9 @@ void FolderWizardSelectiveSync::virtualFilesCheckboxClicked()
     // The click has already had an effect on the box, so if it's
     // checked it was newly activated.
     if (_virtualFilesCheckBox->isChecked()) {
-        auto *messageBox = new AskExperimentalVirtualFilesFeatureMessageBox(this);
+        auto *messageBox = new AskExperimentalVirtualFilesFeatureMessageBox(ocApp()->gui()->settingsDialog());
+
+        messageBox->setAttribute(Qt::WA_DeleteOnClose);
 
         connect(messageBox, &AskExperimentalVirtualFilesFeatureMessageBox::rejected, this, [this]() {
             _virtualFilesCheckBox->setChecked(false);
@@ -100,6 +104,7 @@ void FolderWizardSelectiveSync::virtualFilesCheckboxClicked()
             Q_EMIT messageBox->accepted();
         } else {
             messageBox->show();
+            ocApp()->gui()->raiseDialog(messageBox);
         }
     }
 }


### PR DESCRIPTION
This PR should ensure all dialogs and message boxes opened within the client are raised to front to improve the UX, especially on macOS.