### PR TITLE
Use existing helper to display directory in file browser

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -57,6 +57,7 @@
 #include "account.h"
 #include "askexperimentalvirtualfilesfeaturemessagebox.h"
 #include "askforoauthlogindialog.h"
+#include "openfilemanager.h"
 
 namespace OCC {
 
@@ -281,9 +282,9 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     if (!folderUrl.isEmpty()) {
         QAction *ac = menu->addAction(CommonStrings::showInFileBrowser(), [folderUrl]() {
             qCInfo(lcAccountSettings) << "Opening local folder" << folderUrl;
-            if (!QDesktopServices::openUrl(folderUrl)) {
-                qCWarning(lcAccountSettings) << "QDesktopServices::openUrl failed for" << folderUrl;
-            }
+
+            // it does not make too much sense to convert it back, but it's easier than maintaining another variable
+            showInFileManager(folderUrl.toLocalFile());
         });
 
         if (!QFile::exists(folderUrl.toLocalFile())) {


### PR DESCRIPTION
Should fix #9750 (which I have not been able to reproduce so far).

This change should reduce the cases in which we fall back to `QDesktopServices` to open a directory in the user's file manager on Linux. The helper in use should usually detach (orphan) the process from the parent process and therefore the AppImage runtime can exit just fine when the client is terminated.

Not sure if we need a changelog item, this possibly fixes an issue present in 2.10. However, we considered the AppImage support experimental there.