### PR TITLE
[GUI-tests] Skip selective sync tests until the issue #9971 is fixed

### DIFF
--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -56,7 +56,7 @@ Feature: Syncing files
             client content
             """
 
-
+    @skip @issue-9971
     Scenario: Sync all is selected by default
         Given user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created folder "large-folder" on the server
@@ -70,7 +70,7 @@ Feature: Syncing files
         And the user selects "ownCloud" as a remote destination folder
         Then the sync all checkbox should be checked
 
-
+    @skip @issue-9971
     Scenario: Sync only one folder from the server
         Given user "Alice" has created folder "simple-folder" on the server
         And user "Alice" has created folder "large-folder" on the server


### PR DESCRIPTION
Looks like there has been a regression in desktop client (master branch). These tests are hard failures and I am skipping them in this PR until the issue is fixed.
See https://github.com/owncloud/client/issues/9971