### PR TITLE
Support overrideServerUrlV2 branding in wizard

### DIFF
--- a/src/gui/newwizard/enums.cpp
+++ b/src/gui/newwizard/enums.cpp
@@ -14,6 +14,7 @@
 
 // just a stub so the MOC file can be included somewhere
 #include "moc_enums.cpp"
+#include "theme.h"
 
 #include <QApplication>
 
@@ -28,7 +29,11 @@ QString OCC::Utility::enumToDisplayName(SetupWizardState state)
 {
     switch (state) {
     case SetupWizardState::ServerUrlState:
-        return QApplication::translate(contextC, "Server URL");
+        if (Theme::instance()->overrideServerUrlV2().isEmpty()) {
+            return QApplication::translate(contextC, "Server URL");
+        } else {
+            return QApplication::translate(contextC, "Welcome");
+        }
     case SetupWizardState::WebFingerState:
         return QApplication::translate(contextC, "WebFinger");
     case SetupWizardState::CredentialsState:

--- a/src/gui/newwizard/navigation.cpp
+++ b/src/gui/newwizard/navigation.cpp
@@ -70,7 +70,7 @@ void Navigation::setActiveState(SetupWizardState newState)
     _activeState = newState;
 
     for (const auto key : _entries.keys()) {
-        auto button = _entries.value(newState);
+        auto button = _entries.value(key);
         button->setChecked(key == _activeState);
     }
 

--- a/src/gui/newwizard/pages/serverurlsetupwizardpage.cpp
+++ b/src/gui/newwizard/pages/serverurlsetupwizardpage.cpp
@@ -15,11 +15,20 @@ ServerUrlSetupWizardPage::ServerUrlSetupWizardPage(const QUrl &serverUrl)
 
     _ui->welcomeTextLabel->setText(tr("Welcome to %1").arg(Theme::instance()->appNameGUI()));
 
-    _ui->urlLineEdit->setText(serverUrl.toString());
+    // not the best style, but we hacked such branding into the pages elsewhere, too
+    if (!Theme::instance()->overrideServerUrlV2().isEmpty()) {
+        // note that the text should be set before the page is displayed, this way validateInput() will enable the next button
+        _ui->urlLineEdit->setText(Theme::instance()->overrideServerUrlV2());
 
-    connect(this, &AbstractSetupWizardPage::pageDisplayed, this, [this]() {
-        _ui->urlLineEdit->setFocus();
-    });
+        _ui->urlLineEdit->hide();
+        _ui->serverUrlLabel->hide();
+    } else {
+        _ui->urlLineEdit->setText(serverUrl.toString());
+
+        connect(this, &AbstractSetupWizardPage::pageDisplayed, this, [this]() {
+            _ui->urlLineEdit->setFocus();
+        });
+    }
 
     _ui->logoLabel->setText(QString());
     _ui->logoLabel->setPixmap(Theme::instance()->wizardHeaderLogo().pixmap(200, 200));

--- a/src/gui/newwizard/setupwizardwindow.cpp
+++ b/src/gui/newwizard/setupwizardwindow.cpp
@@ -53,7 +53,7 @@ SetupWizardWindow::SetupWizardWindow(QWidget *parent)
 
     connect(_ui->navigation, &Navigation::paginationEntryClicked, this, [this](SetupWizardState clickedState) {
         slotStartTransition();
-        Q_EMIT paginationEntryClicked(clickedState);
+        Q_EMIT navigationEntryClicked(clickedState);
     });
 
     resize(ocApp()->gui()->settingsDialog()->sizeHintForChild());

--- a/src/gui/newwizard/setupwizardwindow.h
+++ b/src/gui/newwizard/setupwizardwindow.h
@@ -65,7 +65,7 @@ protected:
     bool eventFilter(QObject *obj, QEvent *event) override;
 
 Q_SIGNALS:
-    void paginationEntryClicked(SetupWizardState clickedState);
+    void navigationEntryClicked(SetupWizardState clickedState);
     void nextButtonClicked();
     void backButtonClicked();
 


### PR DESCRIPTION
One of the last remaining branding options to be implemented in the new wizard.

I wasn't sure where to put `getNavigationEntries`, feedback appreciated. Opening as a draft to make sure we discuss this first.