### PR TITLE
Make URL resolving error more user friendly

### DIFF
--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -56,7 +56,9 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url)
                     return;
                 }
 
-                setJobError(job, tr("Failed to resolve the url %1, error: %2").arg(oldUrl.toDisplayString(), reply->errorString()), reply);
+                qCCritical(lcResolveUrl) << QStringLiteral("Failed to resolve URL %1, error: %2").arg(oldUrl.toDisplayString(), reply->errorString());
+
+                setJobError(job, tr("Could not detect compatible server at %1").arg(oldUrl.toDisplayString()), reply);
                 qCWarning(lcResolveUrl) << job->errorMessage();
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/owncloud/client/issues/9540.

![screenshot_2022-08-09_19-29-59](https://user-images.githubusercontent.com/80399010/183720088-9bbc6886-58c8-4dc4-af70-56184030a9df.png)

This also removes the app name from the string since we do not know (and do not care) what branding the server uses.