### PR TITLE
Use correctly themed icons

### DIFF
--- a/src/gui/askforoauthlogindialog.cpp
+++ b/src/gui/askforoauthlogindialog.cpp
@@ -56,6 +56,9 @@ AskForOAuthLoginDialog::AskForOAuthLoginDialog(AccountPtr accountPtr, QWidget *p
         ocApp()->clipboard()->setText(link);
     });
     connect(_ui->logoutButton, &QPushButton::clicked, this, &QDialog::reject);
+
+    // depending on the theme we have to use a light or dark icon
+    _ui->copyUrlToClipboardButton->setIcon(Utility::getCoreIcon(QStringLiteral("clipboard")));
 }
 
 AskForOAuthLoginDialog::~AskForOAuthLoginDialog()

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -1,6 +1,7 @@
 #include "accountconfiguredwizardpage.h"
 #include "ui_accountconfiguredwizardpage.h"
 
+#include "gui/guiutility.h"
 #include "theme.h"
 
 #include <QDir>
@@ -26,7 +27,7 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
 
     _ui->useVfsRadioButton->setText(tr("Use &virtual files instead of downloading content immediately"));
     if (vfsModeIsExperimental) {
-        _ui->useVfsRadioButton->setIcon(QIcon(QStringLiteral(":/client/resources/light/warning.svg")));
+        _ui->useVfsRadioButton->setIcon(Utility::getCoreIcon(QStringLiteral("warning")));
     }
 
     // just adjusting the visibility should be sufficient for these branding options

--- a/src/gui/newwizard/pages/oauthcredentialssetupwizardpage.cpp
+++ b/src/gui/newwizard/pages/oauthcredentialssetupwizardpage.cpp
@@ -15,6 +15,7 @@
 #include "oauthcredentialssetupwizardpage.h"
 #include "ui_oauthcredentialssetupwizardpage.h"
 
+#include "gui/guiutility.h"
 #include "theme.h"
 
 namespace OCC::Wizard {
@@ -44,6 +45,9 @@ OAuthCredentialsSetupWizardPage::OAuthCredentialsSetupWizardPage(const QUrl &ser
     });
 
     _ui->pleaseLogIntoLabel->setText(tr("Please use your browser to log in to %1").arg(Theme::instance()->appNameGUI()));
+
+    // depending on the theme we have to use a light or dark icon
+    _ui->copyUrlToClipboardButton->setIcon(Utility::getCoreIcon(QStringLiteral("clipboard")));
 }
 
 OAuthCredentialsSetupWizardPage::~OAuthCredentialsSetupWizardPage()


### PR DESCRIPTION
I kept the icons within the Qt Designer files because it helps visualize changes.