### PR TITLE
Ci: Don't package debug symbols

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -43,6 +43,7 @@ Packager/CacheDir = ${Variables:WORKSPACE}/cache
 Packager/UseCache = ${Variables:UseCache}
 Packager/CreateCache = ${Variables:CreateCache}
 Packager/CacheVersion = ${Variables:ownCloudVersion}/Qt_${Variables:QtVersion}_${Variables:CachePatchLvl}
+Packager/PackageDebugSymbols = False
 ; Packager/RepositoryUrl = https://files.kde.org/craft/
 Packager/RepositoryUrl =  https://download.owncloud.com/desktop/craft/cache/
 Compile/BuildType = RelWithDebInfo


### PR DESCRIPTION
Packaging and uploading the symbols takes ages.
Our nightlies have an integrated crash reporter and local full debug builds are rather easy with craft.