### PR TITLE
Don't display error if server is unavailable

### DIFF
--- a/changelog/unreleased/9790
+++ b/changelog/unreleased/9790
@@ -1,0 +1,5 @@
+Change: Don't display error state when server is unreachable
+
+We no longer display a network error if the server is currently unavailable.
+
+https://github.com/owncloud/client/issues/9790

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -831,9 +831,9 @@ void AccountSettings::slotAccountStateChanged()
             break;
         }
         case AccountState::NetworkError:
+            // don't display the error to the user, https://github.com/owncloud/client/issues/9790
             showConnectionLabel(tr("No connection to %1.")
-                                    .arg(server),
-                _accountState->connectionErrors());
+                                    .arg(server));
             break;
         case AccountState::ConfigurationError:
             showConnectionLabel(tr("Server configuration error: %1.")


### PR DESCRIPTION
Are there errors we really should display?

Fixes: #9790