### PR TITLE
Pretty print sqlite log

### DIFF
--- a/src/common/ownsql.cpp
+++ b/src/common/ownsql.cpp
@@ -263,6 +263,7 @@ int SqlQuery::prepare(const QByteArray &sql, bool allow_failure)
     if (_stmt) {
         finish();
     }
+    _boundQuery = QString::fromUtf8(_sql);
     if (!_sql.isEmpty()) {
         int rc = {};
         for (int n = 0; n < SQLITE_REPEAT_COUNT; ++n) {
@@ -316,12 +317,11 @@ bool SqlQuery::exec()
         qCWarning(lcSql) << "Can't exec query, statement unprepared.";
         return false;
     }
-
     // Don't do anything for selects, that is how we use the lib :-|
     if (!isSelect() && !isPragma()) {
         int rc = 0;
         for (int n = 0; n < SQLITE_REPEAT_COUNT; ++n) {
-            qCDebug(lcSql) << "SQL exec" << _sql << "Try:" << n;
+            qCDebug(lcSql) << "SQL exec" << _boundQuery << "Try:" << n;
             rc = sqlite3_step(_stmt);
             if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
                 qCWarning(lcSql) << "SQL exec failed" << _sql << QString::fromUtf8(sqlite3_errmsg(_db));
@@ -503,6 +503,7 @@ void SqlQuery::reset_and_clear_bindings()
     if (_stmt) {
         SQLITE_DO(sqlite3_reset(_stmt));
         SQLITE_DO(sqlite3_clear_bindings(_stmt));
+        _boundQuery = QString::fromUtf8(_sql);
     }
 }
 


### PR DESCRIPTION
New:
```
08-18 12:09:09:012 [ debug sync.database.sql ]	[ OCC::SqlQuery::exec ]:	SQL exec "INSERT OR REPLACE INTO metadata (phash, pathlen, path, inode, uid, gid, mode, modtime, type, md5, fileid, remotePerm, filesize, ignoredChildrenRemote, contentChecksum, contentChecksumTypeId) VALUES ('-7718185600186795398' , '53', 'New folder/ownCloud-3.0.0-daily20220525.7687.AppImage' , '169157' , '0' , '0' , '0',  '1653476593' , 'CSyncEnums::ItemTypeVirtualFile' , '-7718185600186795398'0, '-7718185600186795398'1, '-7718185600186795398'2, '-7718185600186795398'3, '-7718185600186795398'4, '-7718185600186795398'5, '-7718185600186795398'6);" Try: 0
````

Old:
```
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 1 -8239167585704120375
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 2 43
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 3 "Share-Test-Personal/Shared-File-Personal.md"
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 4 7400114
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 5 0
08-18 11:17:21:279 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 6 0
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 7 0
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 8 1660814051
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 9 CSyncEnums::ItemTypeFile
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 10 "85be50cfd9278744e4303c97446aa186"
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 11 "1284d238-aa92-42ce-bdc4-0b0000009157$6b6253d5-cea6-4533-bd59-a34d160ffd24!ab8e840e-26b7-4bbb-9ddc-11bc79d32738"
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 12 "WDNVR"
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 13 0
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 14 0
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 15 "da39a3ee5e6b4b0d3255bfef95601890afd80709"
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::bindValue ]:	SQL bind 16 1
08-18 11:17:21:280 [ debug sync.database.sql ]	[ OCC::SqlQuery::exec ]:	SQL exec "INSERT OR REPLACE INTO metadata (phash, pathlen, path, inode, uid, gid, mode, modtime, type, md5, fileid, remotePerm, filesize, ignoredChildrenRemote, contentChecksum, contentChecksumTypeId) VALUES (?1 , ?2, ?3 , ?4 , ?5 , ?6 , ?7,  ?8 , ?9 , ?10, ?11, ?12, ?13, ?14, ?15, ?16);" Try: 0
```

It could make sense to also log the raw data passed to sqlite instead of the pretty printed version.
