### PR TITLE
Remove build time from about

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -427,14 +427,13 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
         }
     }
     return QCoreApplication::translate("ownCloudTheme::aboutVersions()",
-        "%1 %2 %3%8"
-        "%9"
-        "Libraries Qt %4, %5%8"
-        "Using virtual files plugin: %6%8"
-        "%7")
+        "%1 %2%7"
+        "%8"
+        "Libraries Qt %3, %4%7"
+        "Using virtual files plugin: %5%7"
+        "%6")
         .arg(appName(),
             _version,
-            QStringLiteral(__DATE__ " " __TIME__),
             qtVersionString,
             QSslSocket::sslLibraryVersionString(),
             Vfs::modeToString(bestAvailableVfsMode()),


### PR DESCRIPTION
We have the date in the build number, no need for the unpopular __DATE__ macro.