### PR TITLE
Fix crash in selective sync configuration

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -259,7 +259,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     }
 
     // Only allow removal if the item isn't in "ready" state.
-    if (classification == FolderStatusModel::RootFolder && _model->folder(index)->isReady() && !_model->folder(index)->isDeployed()) {
+    if (classification == FolderStatusModel::RootFolder && !_model->data(index, FolderStatusDelegate::IsReady).toBool() && !_model->folder(index)->isDeployed()) {
         QMenu *menu = new QMenu(tv);
         menu->setAttribute(Qt::WA_DeleteOnClose);
         removeFolderAction(menu);

--- a/src/gui/folderstatusdelegate.h
+++ b/src/gui/folderstatusdelegate.h
@@ -48,6 +48,8 @@ public:
 
         AddButton, // 1 = enabled; 2 = disabled
         FolderSyncText,
+
+        IsReady // boolean
     };
     void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const override;
     QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const override;

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -185,6 +185,10 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
                 return QVariant();
             return QVariant(f->path() + x._path);
         }
+        case FolderStatusDelegate::IsReady: {
+            auto f = x._folder;
+            return f->isReady();
+        }
         }
     }
         return QVariant();
@@ -281,6 +285,8 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
         return progress._overallSyncString;
     case FolderStatusDelegate::FolderSyncText:
         return tr("Local folder: %1").arg(f->shortGuiLocalPath());
+    case FolderStatusDelegate::IsReady:
+        return f->isReady();
     }
     return QVariant();
 }
@@ -568,8 +574,14 @@ bool FolderStatusModel::canFetchMore(const QModelIndex &parent) const
 
 void FolderStatusModel::fetchMore(const QModelIndex &parent)
 {
-    if (!folder(parent)->isReady()) {
-        return;
+    {
+        const auto isReady = data(parent, FolderStatusDelegate::IsReady);
+
+        Q_ASSERT(isReady.isValid());
+
+        if (!isReady.toBool()) {
+            return;
+        }
     }
 
     auto info = infoForIndex(parent);


### PR DESCRIPTION
This commit restores the use of FolderStatusDelegate::data(...) to check whether a folder is ready. The two additions fix two different ways in which the client could crash.

Using data(...) makes sure we use the right data structure to look up the ready state for the subfolders. Using folder(...) rightfully causes an index out of range error.

This commit partially reverts #10058 and restores a previous version of said PR.