### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
       - '[0-9]+.*'
   pull_request:
   
-permissions: {} # none
+permissions: {}
 
 defaults:
   run:
@@ -17,7 +17,8 @@ jobs:
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build:
     permissions:
-      contents: read # actions/upload-artifact doesn't need contents: write
+      # actions/upload-artifact doesn't need contents: write
+      contents: read
     strategy:
         matrix:
             include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
       - master
       - '[0-9]+.*'
   pull_request:
+  
+permissions: {} # none
 
 defaults:
   run:
@@ -14,6 +16,8 @@ defaults:
 jobs:
 # ------------------------------------------------------------------------------------------------------------------------------------------
   build:
+    permissions:
+      contents: read # actions/upload-artifact doesn't need contents: write
     strategy:
         matrix:
             include:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,13 +3,13 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
-permissions: {} # none
+permissions: {}
 
 jobs:
   stale:
     permissions:
+      # for closing and commenting on stale issues
       issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,13 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions: {} # none
+
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v5

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 3 * * *"
     
-permissions: {} # none
+permissions: {}
 
 defaults:
   run:
@@ -14,7 +14,8 @@ defaults:
 jobs:
   update-translations:
     permissions:
-      contents: write # for git push
+      # for git push
+      contents: write
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *"
+    
+permissions: {} # none
 
 defaults:
   run:
@@ -11,6 +13,8 @@ defaults:
 
 jobs:
   update-translations:
+    permissions:
+      contents: write # for git push
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.