### PR TITLE
[gui-tests-only] Unskip vfs tests

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -438,6 +438,11 @@ def step(context, type, resource):
     waitForFileOrFolderToBeSyncIgnored(context, resource, type)
 
 
+@Given('the user has waited for the files to be synced')
+def step(context):
+    waitForRootFolderToSync(context)
+
+
 @Given(r'the user has waited for (file|folder) "([^"]*)" to be synced', regexp=True)
 def step(context, type, resource):
     waitForFileOrFolderToSync(context, resource, type)

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -423,11 +423,6 @@ def step(context, type, resource):
     waitForFileOrFolderToSync(context, resource, type)
 
 
-@Given(r'user has waited for (file|folder) to be synced', regexp=True)
-def step(context, type, resource):
-    waitForFileOrFolderToSync(context, resource, type)
-
-
 @When(r'the user waits for (file|folder) "([^"]*)" to have sync error', regexp=True)
 def step(context, type, resource):
     waitForFileOrFolderToHaveSyncError(context, resource, type)
@@ -438,7 +433,7 @@ def step(context, type, resource):
     waitForFileOrFolderToBeSyncIgnored(context, resource, type)
 
 
-@Given('the user has waited for the files to be synced')
+@Given('user has waited for the files to be synced')
 def step(context):
     waitForRootFolderToSync(context)
 

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -1,4 +1,3 @@
-@skip
 Feature: Enable/disable virtual file support
 
     As a user
@@ -9,6 +8,7 @@ Feature: Enable/disable virtual file support
     Scenario: Enable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
+        And the user has waited for the files to be synced
         When the user enables virtual file support
         Then the "Disable virtual file support..." button should be available
         And VFS enabled baseline image should match the default screenshot
@@ -17,12 +17,14 @@ Feature: Enable/disable virtual file support
     Scenario: VFS is disabled by default
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
+        And the user has waited for the files to be synced
         Then VFS enabled baseline image should not match the default screenshot
 
 
     Scenario: Disable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
+        And the user has waited for the files to be synced
         And the user has enabled virtual file support
         When the user disables virtual file support
         Then the "Enable virtual file support (experimental)..." button should be available

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -8,7 +8,7 @@ Feature: Enable/disable virtual file support
     Scenario: Enable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And the user has waited for the files to be synced
+        And user has waited for the files to be synced
         When the user enables virtual file support
         Then the "Disable virtual file support..." button should be available
         And VFS enabled baseline image should match the default screenshot
@@ -17,14 +17,14 @@ Feature: Enable/disable virtual file support
     Scenario: VFS is disabled by default
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And the user has waited for the files to be synced
+        And user has waited for the files to be synced
         Then VFS enabled baseline image should not match the default screenshot
 
 
     Scenario: Disable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And the user has waited for the files to be synced
+        And user has waited for the files to be synced
         And the user has enabled virtual file support
         When the user disables virtual file support
         Then the "Enable virtual file support (experimental)..." button should be available


### PR DESCRIPTION
Previously, the vfs tests failed because of trying to enable vfs feature before the user account was set up. In this PR, I have added wait for files to sync step so that the enabling vfs action will be successful.

This PR unskips the vfs tests.

### Related issues:
part of https://github.com/owncloud/client/issues/10072