### PR TITLE
Compatibility with older python3-nautilus

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -200,9 +200,13 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
                 break
         return (topLevelFolder, internalFile)
 
-    def get_file_items(self, window, files):
+    # args in Nautilus 4.0: [files: List[Nautilus.FileInfo]]
+    # args in Nautilus 3.0: [window: Gtk.Widget, files: List[Nautilus.FileInfo]]
+    # args[-1] is then compatible with both APIs
+    def get_file_items(self, *args):
         # Show the menu extension to share a file or folder
 
+        files = args[-1]
         # Get usable file paths from the uris
         all_internal_files = True
         for i, file_uri in enumerate(files):


### PR DESCRIPTION
Quoting from [devhelp](https://tracker.debian.org/pkg/devhelp) (sorry, couldn't find a web document to link to), migrating Nautilus section:

>    The get_file_items, get_file_items_full, get_background_items a get_background_items_full methods of Nautilus.MenuProvider no longer take the window argument. Remove it from your implementations.
    If you need to keep supporting older versions of Nautilus, you can use variadic arguments:
```
  def get_file_items(self, *args):
      # `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
      # and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
      files = args[-1]
```