### PR TITLE
[gui-tests] Update/Add users in the global user store

### DIFF
--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -35,7 +35,6 @@ confdir = '/tmp/bdd-tests-owncloud-client/'
 confFilePath = confdir + 'owncloud.cfg'
 socketConnect = None
 
-stateDataFromMiddleware = None
 
 # File syncing in client has the following status
 SYNC_STATUS = {
@@ -48,16 +47,14 @@ SYNC_STATUS = {
 
 
 def getTestStateFromMiddleware(context):
-    global stateDataFromMiddleware
-    if stateDataFromMiddleware is None:
+    try:
         res = requests.get(
             os.path.join(context.userData['middlewareUrl'], 'state'),
             headers={"Content-Type": "application/json"},
         )
-        try:
-            stateDataFromMiddleware = res.json()
-        except ValueError:
-            raise Exception("Could not get created users information from middleware")
+        stateDataFromMiddleware = res.json()
+    except ValueError:
+        raise Exception("Could not get created users information from middleware")
 
     return stateDataFromMiddleware
 

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -35,6 +35,7 @@ confdir = '/tmp/bdd-tests-owncloud-client/'
 confFilePath = confdir + 'owncloud.cfg'
 socketConnect = None
 
+stateDataFromMiddleware = {}
 
 # File syncing in client has the following status
 SYNC_STATUS = {
@@ -47,6 +48,7 @@ SYNC_STATUS = {
 
 
 def getTestStateFromMiddleware(context):
+    stateDataFromMiddleware = {}
     try:
         res = requests.get(
             os.path.join(context.userData['middlewareUrl'], 'state'),
@@ -99,14 +101,21 @@ def step(context, displayname, host):
     )
 
 
+def getUserInfo(context, username, attribute):
+    global stateDataFromMiddleware
+    if stateDataFromMiddleware and username in stateDataFromMiddleware['created_users']:
+        return stateDataFromMiddleware['created_users'][username][attribute]
+    else:
+        stateDataFromMiddleware = {**stateDataFromMiddleware, **getTestStateFromMiddleware(context)}
+        return stateDataFromMiddleware['created_users'][username][attribute]
+
+
 def getDisplaynameForUser(context, username):
-    usersDataFromMiddleware = getTestStateFromMiddleware(context)
-    return usersDataFromMiddleware['created_users'][username]['displayname']
+    return getUserInfo(context, username, 'displayname')
 
 
 def getPasswordForUser(context, username):
-    usersDataFromMiddleware = getTestStateFromMiddleware(context)
-    return usersDataFromMiddleware['created_users'][username]['password']
+    return getUserInfo(context, username, 'password')
 
 
 @Given('user "|any|" has set up a client with default settings')

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -107,13 +107,10 @@ def getUserInfo(context, username, attribute):
     # so that we don't have to request for user information in every scenario
     # but instead get user information from the global dict
     global createdUsers
-    if createdUsers and username in createdUsers:
+    if username in createdUsers:
         return createdUsers[username][attribute]
     else:
-        createdUsers = {
-            **createdUsers,
-            **getCreatedUsersFromMiddleware(context)
-        }
+        createdUsers = {**createdUsers, **getCreatedUsersFromMiddleware(context)}
         return createdUsers[username][attribute]
 
 


### PR DESCRIPTION
We want to have the current scenario's state of the server not the state stored in global by the previous scenario. Storing state in global causes this issue #9866 if the scenarios are to be shuffled. Because if the first scenario only creates user Alice then in the second scenario where Alice and Brian are created, `KeyError` will be thrown if we want to add user Brain to desktop client.

UPDATE: user information is stored in a global variable and information of new user is added to the list

### Related issues
Fixes https://github.com/owncloud/client/issues/9866