### PR TITLE
Make wizard store dynamic registration data

### DIFF
--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -183,4 +183,14 @@ QUrl SetupWizardAccountBuilder::webFingerServerUrl() const
 {
     return _webFingerServerUrl;
 }
+
+void SetupWizardAccountBuilder::setDynamicRegistrationData(const QVariantMap &dynamicRegistrationData)
+{
+    _dynamicRegistrationData = dynamicRegistrationData;
+}
+
+QVariantMap SetupWizardAccountBuilder::dynamicRegistrationData() const
+{
+    return _dynamicRegistrationData;
+}
 }

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -150,6 +150,12 @@ public:
     void clearCustomTrustedCaCertificates();
 
     /**
+     * Set dynamic registration data. Used by OIDC servers to identify dynamically registered clients.
+     */
+    void setDynamicRegistrationData(const QVariantMap &dynamicRegistrationData);
+    QVariantMap dynamicRegistrationData() const;
+
+    /**
      * Attempt to build an account from the previously entered information.
      * @return built account or null if information is still missing
      */
@@ -164,6 +170,8 @@ private:
     DetermineAuthTypeJob::AuthType _authType = DetermineAuthTypeJob::AuthType::Unknown;
 
     std::unique_ptr<AbstractAuthenticationStrategy> _authenticationStrategy;
+
+    QVariantMap _dynamicRegistrationData;
 
     QString _displayName;
 

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -66,7 +66,7 @@ SetupWizardController::SetupWizardController(SettingsDialog *parent)
     // allow settings dialog to clean up the wizard controller and all the objects it created
     connect(_context->window(), &SetupWizardWindow::rejected, this, [this]() {
         qCDebug(lcSetupWizardController) << "wizard window closed";
-        Q_EMIT finished(nullptr, SyncMode::Invalid);
+        Q_EMIT finished(nullptr, SyncMode::Invalid, {});
     });
 
     connect(_context->window(), &SetupWizardWindow::navigationEntryClicked, this, [this](SetupWizardState clickedState) {
@@ -177,7 +177,7 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState)
 
             auto account = _context->accountBuilder().build();
             Q_ASSERT(account != nullptr);
-            Q_EMIT finished(account, pagePtr->syncMode());
+            Q_EMIT finished(account, pagePtr->syncMode(), _context->accountBuilder().dynamicRegistrationData());
             return;
         }
         default:

--- a/src/gui/newwizard/setupwizardcontroller.h
+++ b/src/gui/newwizard/setupwizardcontroller.h
@@ -50,7 +50,7 @@ Q_SIGNALS:
     /**
      * Emitted when the wizard has finished. It passes the built account object.
      */
-    void finished(AccountPtr newAccount, SyncMode syncMode);
+    void finished(AccountPtr newAccount, SyncMode syncMode, const QVariantMap &dynamicRegistrationData);
 
 private:
     void changeStateTo(SetupWizardState nextState);

--- a/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
+++ b/src/gui/newwizard/states/oauthcredentialssetupwizardstate.cpp
@@ -67,6 +67,10 @@ OAuthCredentialsSetupWizardState::OAuthCredentialsSetupWizardState(SetupWizardCo
         oAuthCredentialsPage->setButtonsEnabled(true);
     });
 
+    connect(oAuth, &OAuth::dynamicRegistrationDataReceived, this, [this](const QVariantMap &dynamicRegistrationData) {
+        _context->accountBuilder().setDynamicRegistrationData(dynamicRegistrationData);
+    });
+
     connect(oAuthCredentialsPage, &OAuthCredentialsSetupWizardPage::copyUrlToClipboardButtonPushed, this, [oAuth]() {
         const auto link = oAuth->authorisationLink();
         Q_ASSERT(!link.isEmpty());

--- a/src/libsync/creds/credentialmanager.cpp
+++ b/src/libsync/creds/credentialmanager.cpp
@@ -211,7 +211,7 @@ void CredentialJob::start()
             _data = obj.toVariant();
             OC_ASSERT(_data.isValid());
         } else {
-            qCWarning(lcCredentaislManager) << "Failed to read client id" << _job->errorString();
+            qCWarning(lcCredentaislManager) << "Failed to get password" << scopedKey(_parent, _key) << _job->errorString();
             _error = _job->error();
             _errorString = _job->errorString();
         }

--- a/src/libsync/creds/oauth.h
+++ b/src/libsync/creds/oauth.h
@@ -67,6 +67,8 @@ public:
     void openBrowser();
     QUrl authorisationLink() const;
 
+    static void saveDynamicRegistrationDataForAccount(const AccountPtr &accountPtr, const QVariantMap &dynamicRegistrationData);
+
 Q_SIGNALS:
     /**
      * The state has changed.


### PR DESCRIPTION
So far, dynamic registration data (i.e., data the IdP uses to identify dynamically registered clients, the method of choice when, e.g., using Keycloak with oCIS) has not been stored by the setup wizard, causing users to be logged out and requiring them to log in again after the client restarts.