### PR TITLE
Tests: Clean up FileModifier API

### DIFF
--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -67,9 +67,10 @@ private slots:
             });
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
-        const auto &children = fakeFolder.currentRemoteState().children;
-        for (auto it = children.cbegin(); it != children.cend(); ++it)
+        const auto children = fakeFolder.currentRemoteState().children; // make sure to take a copy, otherwise it's a use-after-free
+        for (auto it = children.cbegin(); it != children.cend(); ++it) {
             modifier.remove(it.key());
+        }
 
         QVERIFY(!fakeFolder.syncOnce()); // Should fail because we cancel the sync
         QCOMPARE(aboutToRemoveAllFilesCalled, 1);
@@ -108,9 +109,10 @@ private slots:
             });
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
-        const auto &children = fakeFolder.currentRemoteState().children;
-        for (auto it = children.cbegin(); it != children.cend(); ++it)
+        const auto children = fakeFolder.currentRemoteState().children; // make sure to take a copy, otherwise it's a use-after-free
+        for (auto it = children.cbegin(); it != children.cend(); ++it) {
             modifier.remove(it.key());
+        }
 
         QVERIFY(fakeFolder.syncOnce()); // Should succeed, and all files must then be deleted
 
@@ -187,18 +189,18 @@ private slots:
 
     }
 
-    void testDataFingetPrint_data()
+    void testDataFingerPrint_data()
     {
         QTest::addColumn<bool>("hasInitialFingerPrint");
         QTest::newRow("initial finger print") << true;
         QTest::newRow("no initial finger print") << false;
     }
 
-    void testDataFingetPrint()
+    void testDataFingerPrint()
     {
         QFETCH(bool, hasInitialFingerPrint);
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
-        fakeFolder.remoteModifier().setContents(QStringLiteral("C/c1"), 'N');
+        fakeFolder.remoteModifier().setContents(QStringLiteral("C/c1"), FileModifier::DefaultFileSize, 'N');
         fakeFolder.remoteModifier().setModTime(QStringLiteral("C/c1"), QDateTime::currentDateTimeUtc().addDays(-2));
         fakeFolder.remoteModifier().remove(QStringLiteral("C/c2"));
         if (hasInitialFingerPrint) {
@@ -234,12 +236,12 @@ private slots:
         /* Simulate a backup restoration */
 
         // A/a1 is an old file
-        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), 'O');
+        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'O');
         fakeFolder.remoteModifier().setModTime(QStringLiteral("A/a1"), QDateTime::currentDateTimeUtc().addDays(-2));
         // B/b1 did not exist at the time of the backup
         fakeFolder.remoteModifier().remove(QStringLiteral("B/b1"));
         // B/b2 was uploaded by another user in the mean time.
-        fakeFolder.remoteModifier().setContents(QStringLiteral("B/b2"), 'N');
+        fakeFolder.remoteModifier().setContents(QStringLiteral("B/b2"), FileModifier::DefaultFileSize, 'N');
         fakeFolder.remoteModifier().setModTime(QStringLiteral("B/b2"), QDateTime::currentDateTimeUtc().addDays(2));
 
         // C/c3 was removed since we made the backup

--- a/test/testblacklist.cpp
+++ b/test/testblacklist.cpp
@@ -79,8 +79,9 @@ private slots:
             QVERIFY(entry._ignoreDuration > 0);
             QCOMPARE(entry._requestId, reqId);
 
-            if (remote)
+            if (remote) {
                 QCOMPARE(journalRecord(fakeFolder, "A")._etag, initialEtag);
+            }
         }
         cleanup();
 
@@ -131,6 +132,10 @@ private slots:
                 QCOMPARE(journalRecord(fakeFolder, "A")._etag, initialEtag);
         }
         cleanup();
+
+        // Try to make sure that the modifications below do are not within the same second as the
+        // previous sync attempt was done, otherwise the changes go undetected.
+        QThread::sleep(1);
 
         // When the file changes a retry happens immediately
         modifier.appendByte(testFileName);

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -174,8 +174,9 @@ private slots:
 
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
         fakeFolder.syncEngine().setIgnoreHiddenFiles(true);
-        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), 'A');
-        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), 'B');
+        fakeFolder.account()->setCapabilities(TestUtils::testCapabilities(CheckSums::Algorithm::ADLER32));
+        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'A');
+        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'B');
 
         bool propConnected = false;
         QString conflictFile;

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -313,7 +313,7 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
 
         editReadOnly(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"));
-        fakeFolder.localModifier().setContents(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"), 's');
+        fakeFolder.localModifier().setContents(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"), FileModifier::DefaultFileSize, 's');
         //do the sync
         applyPermissionsFromName(fakeFolder.remoteModifier());
         QVERIFY(fakeFolder.syncOnce());
@@ -321,7 +321,7 @@ private slots:
 
         QThread::sleep(1); // make sure changes have different mtime
         editReadOnly(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"));
-        fakeFolder.localModifier().setContents(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"), 'd');
+        fakeFolder.localModifier().setContents(QStringLiteral("readonlyDirectory_PERM_M_/cannotBeModified_PERM_DVN_.data"), FileModifier::DefaultFileSize, 'd');
 
         //do the sync
         applyPermissionsFromName(fakeFolder.remoteModifier());

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -86,8 +86,8 @@ private slots:
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
 
-        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), 'L');
-        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), 'R');
+        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'L');
+        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'R');
         fakeFolder.localModifier().appendByte(QStringLiteral("A/a2"));
         fakeFolder.remoteModifier().appendByte(QStringLiteral("A/a2"));
         fakeFolder.remoteModifier().appendByte(QStringLiteral("A/a2"));
@@ -129,8 +129,8 @@ private slots:
             return nullptr;
         });
 
-        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), 'L');
-        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), 'R');
+        fakeFolder.localModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'L');
+        fakeFolder.remoteModifier().setContents(QStringLiteral("A/a1"), FileModifier::DefaultFileSize, 'R');
         fakeFolder.localModifier().appendByte(QStringLiteral("A/a2"));
         fakeFolder.remoteModifier().appendByte(QStringLiteral("A/a2"));
         fakeFolder.remoteModifier().appendByte(QStringLiteral("A/a2"));
@@ -200,7 +200,7 @@ private slots:
 
         // Now the user can locally alter the conflict file and it will be uploaded
         // as usual.
-        fakeFolder.localModifier().setContents(conflictName, 'P');
+        fakeFolder.localModifier().setContents(conflictName, FileModifier::DefaultFileSize + 1, 'P'); // make sure the file sizes are different
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(conflictMap.size(), 1);
         QCOMPARE(conflictMap[a1FileId], conflictName);
@@ -208,7 +208,7 @@ private slots:
         conflictMap.clear();
 
         // Similarly, remote modifications of conflict files get propagated downwards
-        fakeFolder.remoteModifier().setContents(conflictName, 'Q');
+        fakeFolder.remoteModifier().setContents(conflictName, FileModifier::DefaultFileSize + 1, 'Q'); // make sure the file sizes are different
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         QVERIFY(conflictMap.isEmpty());
@@ -222,8 +222,8 @@ private slots:
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         QCOMPARE(conflictMap.size(), 1);
         QVERIFY(conflictMap.contains(a1ConflictFileId));
-        QCOMPARE(fakeFolder.currentRemoteState().find(conflictName)->contentSize, 66);
-        QCOMPARE(fakeFolder.currentRemoteState().find(conflictMap[a1ConflictFileId])->contentSize, 65);
+        QCOMPARE(fakeFolder.currentRemoteState().find(conflictName)->contentSize, FileModifier::DefaultFileSize + 3);
+        QCOMPARE(fakeFolder.currentRemoteState().find(conflictMap[a1ConflictFileId])->contentSize, FileModifier::DefaultFileSize + 2);
         conflictMap.clear();
     }
 


### PR DESCRIPTION
- make the default values into static constexpr member fields
- remove unused method `modifyByte`
- don't rely on on-disk info like file sizes (so it can be used in dehydrated VFS modes)