### PR TITLE
Add a prefer minimal header to PROPFINDs.

### DIFF
--- a/changelog/unreleased/10104
+++ b/changelog/unreleased/10104
@@ -1,0 +1,6 @@
+Enhancement: Add a prefer: minimal header to PROPFINDs.
+
+This will not return missing attribs in the reply in a 404 not found status propset. 
+That reduces the amount of transfered data significantely.
+
+https://github.com/owncloud/client/pull/10104

--- a/changelog/unreleased/10104
+++ b/changelog/unreleased/10104
@@ -1,4 +1,4 @@
-Enhancement: Add a prefer: minimal header to PROPFINDs.
+Enhancement: Add a prefer: minimal header to PROPFINDs
 
 This will not return missing attribs in the reply in a 404 not found status propset. 
 That reduces the amount of transfered data significantely.

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -79,7 +79,8 @@ RequestEtagJob::RequestEtagJob(AccountPtr account, const QUrl &rootUrl, const QS
 void RequestEtagJob::start()
 {
     QNetworkRequest req;
-    req.setRawHeader("Depth", "0");
+    req.setRawHeader(QByteArrayLiteral("Depth"), QByteArrayLiteral("0"));
+    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("Prefer: return=minimal"));
 
     const QByteArray xml = QByteArrayLiteral("<?xml version=\"1.0\" ?>\n"
                                              "<d:propfind xmlns:d=\"DAV:\">\n"
@@ -318,6 +319,8 @@ void LsColJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader(QByteArrayLiteral("Depth"), QByteArrayLiteral("1"));
+    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("Prefer: return=minimal"));
+
     startImpl(req);
 }
 

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -80,7 +80,7 @@ void RequestEtagJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader(QByteArrayLiteral("Depth"), QByteArrayLiteral("0"));
-    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("Prefer: return=minimal"));
+    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("return=minimal"));
 
     const QByteArray xml = QByteArrayLiteral("<?xml version=\"1.0\" ?>\n"
                                              "<d:propfind xmlns:d=\"DAV:\">\n"
@@ -319,7 +319,7 @@ void LsColJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader(QByteArrayLiteral("Depth"), QByteArrayLiteral("1"));
-    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("Prefer: return=minimal"));
+    req.setRawHeader(QByteArrayLiteral("Prefer"), QByteArrayLiteral("return=minimal"));
 
     startImpl(req);
 }


### PR DESCRIPTION
Implements RFC 8144, which reduces the amount of transferred data by leaving out the 404 not found attributes of items.

see https://github.com/cs3org/reva/pull/3222