### PR TITLE
Mac: do not restart after crash

### DIFF
--- a/src/common/utility_mac.mm
+++ b/src/common/utility_mac.mm
@@ -126,7 +126,7 @@ static Result<void, QString> writeNewPlistFile(NSString *plistFile, NSString *fu
     NSDictionary *plistTemplate = @{
         @"Label" : QCoreApplication::organizationDomain().toNSString(),
         @"KeepAlive" : @ {
-            @"Crashed" : @YES,
+            @"Crashed" : @NO,
             @"SuccessfulExit" : @NO
         },
         @"Program" : fullPath,


### PR DESCRIPTION
When the crash is due to a library load failure while starting, having this turned on would result in an endless loop of crash-restarts.

Fixes: #9800