### PR TITLE
Improve network job logging

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -345,7 +345,7 @@ void AbstractNetworkJob::retry()
 {
     OC_ENFORCE(!_verb.isEmpty());
     _retryCount++;
-    qCInfo(lcNetworkJob) << "Restarting" << _verb << _request.url() << "for the" << _retryCount << "time";
+    qCInfo(lcNetworkJob) << "Restarting" << this << "for the" << _retryCount << "time";
     if (_requestBody) {
         if (_requestBody->isSequential()) {
             Q_ASSERT(_requestBody->isOpen());
@@ -389,18 +389,18 @@ QDebug operator<<(QDebug debug, const OCC::AbstractNetworkJob *job)
 {
     QDebugStateSaver saver(debug);
     debug.setAutoInsertSpaces(false);
-    debug << job->metaObject()->className() << "(" << job->url().toDisplayString()
-          << "," << job->_verb;
+    debug << job->metaObject()->className() << "(Account: " << job->account()->uuid().toString(QUuid::WithoutBraces) << ", " << job->url().toDisplayString()
+          << ", " << job->_verb;
     if (auto reply = job->_reply) {
-        debug << ", " << reply->request().rawHeader("Original-Request-ID")
-              << ", " << reply->request().rawHeader("X-Request-ID");
+        debug << ", Original-Request-ID: " << reply->request().rawHeader("Original-Request-ID")
+              << ", X-Request-ID: " << reply->request().rawHeader("X-Request-ID");
 
         const auto errorString = reply->rawHeader(QByteArrayLiteral("OC-ErrorString"));
         if (!errorString.isEmpty()) {
-            debug << ", " << errorString;
+            debug << ", Error:" << errorString;
         }
         if (reply->error() != QNetworkReply::NoError) {
-            debug << ", " << reply->errorString();
+            debug << ", NetworkError: " << reply->errorString();
         }
     }
     if (job->_timedout) {

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -389,7 +389,7 @@ QDebug operator<<(QDebug debug, const OCC::AbstractNetworkJob *job)
 {
     QDebugStateSaver saver(debug);
     debug.setAutoInsertSpaces(false);
-    debug << job->metaObject()->className() << "(Account: " << job->account()->uuid().toString(QUuid::WithoutBraces) << ", " << job->url().toDisplayString()
+    debug << job->metaObject()->className() << "(" << job->account().data() << ", " << job->url().toDisplayString()
           << ", " << job->_verb;
     if (auto reply = job->_reply) {
         debug << ", Original-Request-ID: " << reply->request().rawHeader("Original-Request-ID")

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -345,3 +345,12 @@ const AppProvider &Account::appProvider() const
 }
 
 } // namespace OCC
+
+
+QDebug operator<<(QDebug debug, const OCC::Account *acc)
+{
+    QDebugStateSaver saver(debug);
+    debug.setAutoInsertSpaces(false);
+    debug << "OCC::Account(" << acc->displayName() << ")";
+    return debug.maybeSpace();
+}

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -263,4 +263,7 @@ private:
 
 Q_DECLARE_METATYPE(OCC::AccountPtr)
 
+
+QDebug operator<<(QDebug debug, const OCC::Account *job);
+
 #endif //SERVERCONNECTION_H


### PR DESCRIPTION
````
09-14 13:06:06:958 [ info sync.networkjob ]:	Created OCC::PropfindJob(OCC::Account("Einstein@foo.de"), "https://foo.de/remote.php/webdav/", "PROPFIND", Original-Request-ID: "550809ee-8b92-4dd0-bd69-67c89956ffbd", X-Request-ID: "550809ee-8b92-4dd0-bd69-67c89956ffbd") 