### PR TITLE
Only use bandwidth manager if needed

### DIFF
--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -18,11 +18,6 @@
 #include "propagatorjobs.h"
 #include "common/utility.h"
 
-#ifdef Q_OS_WIN
-#include <windef.h>
-#include <winbase.h>
-#endif
-
 #include <QLoggingCategory>
 #include <QTimer>
 #include <QObject>

--- a/src/libsync/bandwidthmanager.h
+++ b/src/libsync/bandwidthmanager.h
@@ -44,6 +44,12 @@ public:
     bool usingRelativeDownloadLimit() { return _currentDownloadLimit < 0; }
 
 
+    qint64 currentDownloadLimit() const;
+    void setCurrentDownloadLimit(qint64 newCurrentDownloadLimit);
+
+    qint64 currentUploadLimit() const;
+    void setCurrentUploadLimit(qint64 newCurrentUploadLimit);
+
 public slots:
     void registerUploadDevice(UploadDevice *);
     void unregisterUploadDevice(QObject *);
@@ -52,7 +58,6 @@ public slots:
     void unregisterDownloadJob(GETFileJob *);
 
     void absoluteLimitTimerExpired();
-    void switchingTimerExpired();
 
     void relativeUploadMeasuringTimerExpired();
     void relativeUploadDelayTimerExpired();
@@ -61,9 +66,6 @@ public slots:
     void relativeDownloadDelayTimerExpired();
 
 private:
-    // for switching between absolute and relative bw limiting
-    QTimer _switchingTimer;
-
     // FIXME this timer and this variable should be replaced
     // by the propagator emitting the changed limit values to us as signal
     OwncloudPropagator *_propagator;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -84,9 +84,7 @@ OwncloudPropagator::~OwncloudPropagator()
 
 int OwncloudPropagator::maximumActiveTransferJob()
 {
-    if (_downloadLimit != 0
-        || _uploadLimit != 0
-        || !_syncOptions._parallelNetworkJobs) {
+    if (_bandwidthManager || !_syncOptions._parallelNetworkJobs) {
         // disable parallelism when there is a network limit.
         return 1;
     }

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -375,7 +375,6 @@ public:
         const QString &remoteFolder, SyncJournalDb *progressDb)
         : _journal(progressDb)
         , _finishedEmited(false)
-        , _bandwidthManager(this)
         , _anotherSyncNeeded(false)
         , _chunkSize(options._initialChunkSize)
         , _account(account)
@@ -393,9 +392,7 @@ public:
 
     const SyncOptions &syncOptions() const;
 
-    int _downloadLimit = 0;
-    int _uploadLimit = 0;
-    BandwidthManager _bandwidthManager;
+    QPointer<BandwidthManager> _bandwidthManager;
 
     bool _abortRequested = false;
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -560,7 +560,7 @@ void PropagateDownloadFile::startFullDownload()
             {},
             &_tmpFile, headers, _expectedEtagForResume, _resumeStart, this);
     }
-    _job->setBandwidthManager(&propagator()->_bandwidthManager);
+    _job->setBandwidthManager(propagator()->_bandwidthManager);
     connect(_job.data(), &GETFileJob::finishedSignal, this, &PropagateDownloadFile::slotGetFinished);
     connect(qobject_cast<GETFileJob *>(_job.data()), &GETFileJob::downloadProgress,
         this, &PropagateDownloadFile::slotDownloadProgress);

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -240,14 +240,18 @@ void GETFileJob::setBandwidthManager(BandwidthManager *bwm)
 
 void GETFileJob::setChoked(bool c)
 {
-    _bandwidthChoked = c;
-    QMetaObject::invokeMethod(this, &GETFileJob::slotReadyRead, Qt::QueuedConnection);
+    if (c != _bandwidthChoked) {
+        _bandwidthChoked = c;
+        QMetaObject::invokeMethod(this, &GETFileJob::slotReadyRead, Qt::QueuedConnection);
+    }
 }
 
 void GETFileJob::setBandwidthLimited(bool b)
 {
-    _bandwidthLimited = b;
-    QMetaObject::invokeMethod(this, &GETFileJob::slotReadyRead, Qt::QueuedConnection);
+    if (_bandwidthLimited != b) {
+        _bandwidthLimited = b;
+        QMetaObject::invokeMethod(this, &GETFileJob::slotReadyRead, Qt::QueuedConnection);
+    }
 }
 
 void GETFileJob::giveBandwidthQuota(qint64 q)

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -261,7 +261,9 @@ UploadDevice::UploadDevice(const QString &fileName, qint64 start, qint64 size, B
     , _bandwidthLimited(false)
     , _choked(false)
 {
-    _bandwidthManager->registerUploadDevice(this);
+    if (_bandwidthManager) {
+        _bandwidthManager->registerUploadDevice(this);
+    }
 }
 
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -391,8 +391,10 @@ void UploadDevice::giveBandwidthQuota(qint64 bwq)
 
 void UploadDevice::setBandwidthLimited(bool b)
 {
-    _bandwidthLimited = b;
-    QMetaObject::invokeMethod(this, "readyRead", Qt::QueuedConnection);
+    if (_bandwidthLimited != b) {
+        _bandwidthLimited = b;
+        QMetaObject::invokeMethod(this, "readyRead", Qt::QueuedConnection);
+    }
 }
 
 void UploadDevice::setChoked(bool b)

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -397,7 +397,7 @@ void PropagateUploadFileNG::startNextChunk()
 
     const QString fileName = propagator()->fullLocalPath(_item->_file);
     auto device = std::make_unique<UploadDevice>(fileName, _currentChunkOffset, _currentChunkSize,
-        &propagator()->_bandwidthManager);
+        propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadNG) << "Could not prepare upload device: " << device->errorString();
         // Soft error because this is likely caused by the user modifying his files while syncing

--- a/src/libsync/propagateuploadtus.cpp
+++ b/src/libsync/propagateuploadtus.cpp
@@ -65,7 +65,7 @@ UploadDevice *PropagateUploadFileTUS::prepareDevice(const quint64 &chunkSize)
         abortWithError(SyncFileItem::SoftError, tr("%1 the file is currently in use").arg(localFileName));
         return nullptr;
     }
-    auto device = std::make_unique<UploadDevice>(localFileName, _currentOffset, chunkSize, &propagator()->_bandwidthManager);
+    auto device = std::make_unique<UploadDevice>(localFileName, _currentOffset, chunkSize, propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadTUS) << "Could not prepare upload device: " << device->errorString();
 

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -141,7 +141,7 @@ void PropagateUploadFileV1::startNextChunk()
 
     const QString fileName = propagator()->fullLocalPath(_item->_file);
     auto device = std::make_unique<UploadDevice>(fileName, chunkStart, currentChunkSize,
-        &propagator()->_bandwidthManager);
+        propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadV1) << "Could not prepare upload device: " << device->errorString();
         // Soft error because this is likely caused by the user modifying his files while syncing

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -716,14 +716,18 @@ void SyncEngine::setNetworkLimits(int upload, int download)
     _uploadLimit = upload;
     _downloadLimit = download;
 
-    if (!_propagator)
-        return;
-
-    _propagator->_uploadLimit = upload;
-    _propagator->_downloadLimit = download;
-
-    if (upload != 0 || download != 0) {
-        qCInfo(lcEngine) << "Network Limits (down/up) " << upload << download;
+    if (_propagator) {
+        if (upload != 0 || download != 0) {
+            qCInfo(lcEngine) << "Network Limits (down/up) " << upload << download;
+            if (!_propagator->_bandwidthManager) {
+                _propagator->_bandwidthManager = new BandwidthManager(_propagator.data());
+            }
+        }
+        // this might set the limit to 0 but only the next sync will have no bandwithd manager set
+        if (_propagator->_bandwidthManager) {
+            _propagator->_bandwidthManager->setCurrentDownloadLimit(download);
+            _propagator->_bandwidthManager->setCurrentUploadLimit(upload);
+        }
     }
 }
 


### PR DESCRIPTION
This might not fix the referenced issue, however there is no point in calling all those functions and run all those timers for no reason at all.

Downside:
If we have a huge download running, it will not be affected by changes to the limit.

Issue: #10031