### PR TITLE
Don't trigger ignore list when files are locked on the server

### DIFF
--- a/changelog/unreleased/5382
+++ b/changelog/unreleased/5382
@@ -1,0 +1,3 @@
+Bugfix: Don't trigger ignore list when files are locked on the server
+
+https://github.com/owncloud/enterprise/issues/5382

--- a/src/libsync/owncloudpropagator_p.h
+++ b/src/libsync/owncloudpropagator_p.h
@@ -55,7 +55,10 @@ inline SyncFileItem::Status classifyError(QNetworkReply::NetworkError nerror,
     case 423:
         // "Locked"
         // Should be temporary.
-        Q_FALLTHROUGH();
+        if (anotherSyncNeeded != nullptr) {
+            *anotherSyncNeeded = true;
+        }
+        return SyncFileItem::Message;
     case 502:
         // "Bad Gateway"
         // Should be temporary.


### PR DESCRIPTION
This should fix the issue where huge file uploads failed because the uploaded file could not be moved as it was still locked by the AV.

@dragotin What do you think?
