### PR TITLE
Ci: Switch translations branch to master

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-          ref: "2.11"
+          ref: "master"
 
       - name: l10n-remove-old
         run: bash .github/workflows/run-in-docker.sh rabits/qt:5.12-desktop "cd translations && make l10n-remove-old"


### PR DESCRIPTION
This will give the translators some time to prepare for the huge amount of string changes.