### PR TITLE
Remove OC-Chunk-Offset header

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -405,12 +405,9 @@ void PropagateUploadFileNG::startNextChunk()
         return;
     }
 
-    QMap<QByteArray, QByteArray> headers;
-    headers["OC-Chunk-Offset"] = QByteArray::number(_currentChunkOffset);
-
     // job takes ownership of device via a QScopedPointer. Job deletes itself when finishing
     auto devicePtr = device.get(); // for connections later
-    PUTFileJob *job = new PUTFileJob(propagator()->account(), propagator()->account()->url(), chunkPath(_currentChunkOffset), std::move(device), headers, 0, this);
+    PUTFileJob *job = new PUTFileJob(propagator()->account(), propagator()->account()->url(), chunkPath(_currentChunkOffset), std::move(device), {}, 0, this);
     addChildJob(job);
     connect(job, &PUTFileJob::finishedSignal, this, &PropagateUploadFileNG::slotPutFinished);
     connect(job, &PUTFileJob::uploadProgress,

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -95,10 +95,7 @@ private slots:
         fakeFolder.uploadState().children.first().insert(QStringLiteral("10000"), size);
 
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
-            if (op == QNetworkAccessManager::PutOperation) {
-                // Test that we properly resuming and are not sending past data again.
-                Q_ASSERT(request.rawHeader("OC-Chunk-Offset").toLongLong() >= uploadedSize);
-            } else if (op == QNetworkAccessManager::DeleteOperation) {
+            if (op == QNetworkAccessManager::DeleteOperation) {
                 Q_ASSERT(request.url().path().endsWith("/10000"));
             }
             return nullptr;
@@ -138,10 +135,7 @@ private slots:
 
         QStringList deletedPaths;
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) -> QNetworkReply * {
-            if (op == QNetworkAccessManager::PutOperation) {
-                // Test that we properly resuming, not resending the first chunk
-                Q_ASSERT(request.rawHeader("OC-Chunk-Offset").toLongLong() >= firstChunk.contentSize);
-            } else if (op == QNetworkAccessManager::DeleteOperation) {
+            if (op == QNetworkAccessManager::DeleteOperation) {
                 deletedPaths.append(request.url().path());
             }
             return nullptr;


### PR DESCRIPTION
The header was a leftover from delta sync and is not used by the server

https://github.com/owncloud/client/commit/12aeb890c9a6ad329e3612ebb96d843d70e413c9