### PR TITLE
[tests-only] Make sync wait more reliable using sync status pattern matching

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -27,6 +27,8 @@ from datetime import datetime
 previousFailResultCount = 0
 previousErrorResultCount = 0
 
+# socket messages
+socket_messages = []
 
 @OnScenarioStart
 def hook(context):
@@ -151,8 +153,9 @@ def scenarioFailed():
 
 @OnScenarioEnd
 def hook(context):
-    # close socket connection
-    global socketConnect
+    # close socket connection and clear messages
+    global socketConnect, socket_messages
+    socket_messages.clear()
     if socketConnect:
         socketConnect.connected = False
         socketConnect._sock.close()

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -30,6 +30,7 @@ previousErrorResultCount = 0
 # socket messages
 socket_messages = []
 
+
 @OnScenarioStart
 def hook(context):
     from configparser import ConfigParser

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -3,11 +3,11 @@ import re
 
 # File syncing in client has the following status
 SYNC_STATUS = {
-    'SYNC': 'STATUS:SYNC',  # sync in process
+    'SYNC': 'STATUS:SYNC',  # sync in progress
     'OK': 'STATUS:OK',  # sync completed
-    'ERROR': 'STATUS:ERROR',  # file sync has error
-    'IGNORE': 'STATUS:IGNORE',  # file is igored
-    'NOP': 'STATUS:NOP',  # file yet to be synced
+    'ERROR': 'STATUS:ERROR',  # sync error
+    'IGNORE': 'STATUS:IGNORE',  # sync ignored
+    'NOP': 'STATUS:NOP',  # not in sync yet
     'REGISTER': 'REGISTER_PATH',
     'UNREGISTER': 'UNREGISTER_PATH',
     'UPDATE': 'UPDATE_VIEW',

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -15,43 +15,21 @@ SYNC_STATUS = {
 
 # default sync patterns for the initial sync (after adding account)
 SYNC_PATTERNS = {
-    'root_sync': [
-        {
-            'length': 2,
-            'pattern': {
-                SYNC_STATUS['UPDATE']: [0],
-                SYNC_STATUS['OK']: [1],
-            },
-        },
-        {
-            'length': 2,
-            'pattern': {
-                SYNC_STATUS['SYNC']: [0],
-                SYNC_STATUS['OK']: [1],
-            },
-        },
+    'initial': [
+        [SYNC_STATUS['UPDATE'], SYNC_STATUS['OK']],
+        [SYNC_STATUS['SYNC'], SYNC_STATUS['OK']],
     ],
+    'synced': [SYNC_STATUS['SYNC'], SYNC_STATUS['OK']],
+    'error': [SYNC_STATUS['ERROR']],
 }
 
 
-# generate sync pattern from pattern meta data
-#
-# returns List
-# e.g: ['UPDATE_VIEW', 'STATUS:OK']
-def generateSyncPattern(pattern_meta):
-    pattern = [None] * pattern_meta['length']
-    for status in pattern_meta['pattern']:
-        for idx in pattern_meta['pattern'][status]:
-            pattern[idx] = status
-    return pattern
+def getInitialSyncPatterns():
+    return SYNC_PATTERNS['initial']
 
 
-def getRootSyncPatterns():
-    patterns = []
-    for pattern_meta in SYNC_PATTERNS['root_sync']:
-        patterns.append(generateSyncPattern(pattern_meta))
-
-    return patterns
+def getSyncedPattern():
+    return SYNC_PATTERNS['synced']
 
 
 # generate sync pattern from the socket messages
@@ -81,6 +59,14 @@ def filterSyncMessages(messages):
     if 'GET_STRINGS:END' in messages:
         start_idx = messages.index('GET_STRINGS:END') + 1
     return messages[start_idx:]
+
+
+def filterMessageForItem(messages, item):
+    filteredMsg = []
+    for msg in messages:
+        if msg.rstrip('/').endswith(item.rstrip('/')):
+            filteredMsg.append(msg)
+    return filteredMsg
 
 
 def matchPatterns(p1, p2):

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -1,0 +1,89 @@
+import re
+
+
+# File syncing in client has the following status
+SYNC_STATUS = {
+    'SYNC': 'STATUS:SYNC',  # sync in process
+    'OK': 'STATUS:OK',  # sync completed
+    'ERROR': 'STATUS:ERROR',  # file sync has error
+    'IGNORE': 'STATUS:IGNORE',  # file is igored
+    'NOP': 'STATUS:NOP',  # file yet to be synced
+    'REGISTER': 'REGISTER_PATH',
+    'UNREGISTER': 'UNREGISTER_PATH',
+    'UPDATE': 'UPDATE_VIEW',
+}
+
+# default sync patterns for the initial sync (after adding account)
+SYNC_PATTERNS = {
+    'root_sync': [
+        {
+            'length': 2,
+            'pattern': {
+                SYNC_STATUS['UPDATE']: [0],
+                SYNC_STATUS['OK']: [1],
+            },
+        },
+        {
+            'length': 2,
+            'pattern': {
+                SYNC_STATUS['SYNC']: [0],
+                SYNC_STATUS['OK']: [1],
+            },
+        },
+    ],
+}
+
+
+# generate sync pattern from pattern meta data
+#
+# returns List
+# e.g: ['UPDATE_VIEW', 'STATUS:OK']
+def generateSyncPattern(pattern_meta):
+    pattern = [None] * pattern_meta['length']
+    for status in pattern_meta['pattern']:
+        for idx in pattern_meta['pattern'][status]:
+            pattern[idx] = status
+    return pattern
+
+
+def getRootSyncPatterns():
+    patterns = []
+    for pattern_meta in SYNC_PATTERNS['root_sync']:
+        patterns.append(generateSyncPattern(pattern_meta))
+
+    return patterns
+
+
+# generate sync pattern from the socket messages
+#
+# returns List
+# e.g: ['UPDATE_VIEW', 'STATUS:OK']
+def generateSyncPatternFromMessages(messages):
+    pattern = []
+    if not messages:
+        return pattern
+
+    sync_messages = filterSyncMessages(messages)
+    for message in sync_messages:
+        # E.g; from "STATUS:OK:/tmp/client-bdd/Alice/"
+        # excludes ":/tmp/client-bdd/Alice/"
+        # adds only "STATUS:OK" to the pattern list
+        match = re.search(":/.*", message)
+        if match:
+            (end, _) = match.span()
+            pattern.append(message[:end])
+    return pattern
+
+
+# strip out the messages that are not related to sync
+def filterSyncMessages(messages):
+    start_idx = 0
+    if 'GET_STRINGS:END' in messages:
+        start_idx = messages.index('GET_STRINGS:END') + 1
+    return messages[start_idx:]
+
+
+def matchPatterns(p1, p2):
+    if p1 == p2:
+        return True
+    return False

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -13,10 +13,13 @@ SYNC_STATUS = {
     'UPDATE': 'UPDATE_VIEW',
 }
 
-# default sync patterns for the initial sync (after adding account)
 SYNC_PATTERNS = {
+    # default sync patterns for the initial sync (after adding account)
+    # the pattern can be of TWO types depending on the available resources (files/folders)
     'initial': [
+        # when syncing empty account (hidden files are ignored)
         [SYNC_STATUS['UPDATE'], SYNC_STATUS['OK']],
+        # when syncing an account that has some files/folders
         [SYNC_STATUS['SYNC'], SYNC_STATUS['OK']],
     ],
     'synced': [SYNC_STATUS['SYNC'], SYNC_STATUS['OK']],
@@ -61,7 +64,7 @@ def filterSyncMessages(messages):
     return messages[start_idx:]
 
 
-def filterMessageForItem(messages, item):
+def filterMessagesForItem(messages, item):
     filteredMsg = []
     for msg in messages:
         if msg.rstrip('/').endswith(item.rstrip('/')):

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -52,7 +52,9 @@ def generateSyncPatternFromMessages(messages):
         match = re.search(":/.*", message)
         if match:
             (end, _) = match.span()
-            pattern.append(message[:end])
+            # shared resources will have status like "STATUS:OK+SWM"
+            status = message[:end].replace('+SWM', '')
+            pattern.append(status)
     return pattern
 
 
@@ -72,7 +74,7 @@ def filterMessagesForItem(messages, item):
     return filteredMsg
 
 
-def matchPatterns(p1, p2):
+def isEqual(p1, p2):
     if p1 == p2:
         return True
     return False

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -42,15 +42,14 @@ socketConnect = None
 createdUsers = {}
 
 
-def waitForRootSyncToComplete(context, timeout=None, pool_interval=500):
+def waitForRootSyncToComplete(context):
     # listen for root folder status before syncing
     listenSyncStatusForItem(context.userData['currentUserSyncPath'])
 
-    if not timeout:
-        timeout = context.userData['maxSyncTimeout'] * 1000
+    timeout = context.userData['maxSyncTimeout'] * 1000
 
     synced = waitFor(
-        lambda: checkRootSyncPattern(pool_interval),
+        lambda: checkRootSyncPattern(),
         timeout,
     )
     if not synced:
@@ -61,7 +60,7 @@ def waitForRootSyncToComplete(context, timeout=None, pool_interval=500):
         )
 
 
-def checkRootSyncPattern(pool_interval):
+def checkRootSyncPattern():
     patterns = getRootSyncPatterns()
     new_messages = getSocketMessagesDry()
     messages = updateSocketMessages(new_messages)
@@ -72,9 +71,8 @@ def checkRootSyncPattern(pool_interval):
             for pattern in patterns:
                 if matchPatterns(pattern, actual_pattern):
                     return True
-    # snooze takes time in seconds
-    # convert to milliseconds
-    snooze(pool_interval / 1000)
+    # 100 milliseconds polling interval
+    snooze(0.1)
     return False
 
 

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -85,7 +85,9 @@ def listenSyncStatusForItem(item, type='FOLDER'):
     socketConnect.sendCommand("RETRIEVE_" + type + "_STATUS:" + item + "\n")
 
 
-def waitForSyncToComplete(context, resource='', resourceType='FOLDER', patterns=None):
+def waitForFileOrFolderToSync(
+    context, resource='', resourceType='FOLDER', patterns=None
+):
     resource = join(context.userData['currentUserSyncPath'], resource)
     listenSyncStatusForItem(resource, resourceType)
 
@@ -108,7 +110,7 @@ def waitForSyncToComplete(context, resource='', resourceType='FOLDER', patterns=
 
 
 def waitForInitialSyncToComplete(context):
-    waitForSyncToComplete(
+    waitForFileOrFolderToSync(
         context,
         context.userData['currentUserSyncPath'],
         'FOLDER',
@@ -275,14 +277,6 @@ def hasSyncStatus(itemName, status):
     return False
 
 
-def folderHasSyncStatus(folderName, status):
-    return hasSyncStatus('FOLDER', folderName, status)
-
-
-def fileHasSyncStatus(fileName, status):
-    return hasSyncStatus('FILE', fileName, status)
-
-
 # useful for checking sync status such as 'error', 'ignore'
 # but not quite so reliable for checking 'ok' sync status
 def waitForFileOrFolderToHaveSyncStatus(
@@ -316,53 +310,6 @@ def waitForFileOrFolderToHaveSyncStatus(
             + expected
             + ", but not."
         )
-
-
-def waitForSyncToStart(context, resource, resourceType):
-    resource = join(context.userData['currentUserSyncPath'], resource)
-
-    hasStatusNOP = hasSyncStatus(resourceType.upper(), resource, SYNC_STATUS['NOP'])
-    hasStatusSYNC = hasSyncStatus(resourceType.upper(), resource, SYNC_STATUS['SYNC'])
-
-    if hasStatusSYNC:
-        return
-
-    try:
-        if hasStatusNOP:
-            waitForFileOrFolderToHaveSyncStatus(
-                context, resource, resourceType, SYNC_STATUS['SYNC']
-            )
-        else:
-            waitForFileOrFolderToHaveSyncStatus(
-                context,
-                resource,
-                resourceType,
-                SYNC_STATUS['SYNC'],
-                context.userData['minSyncTimeout'] * 1000,
-            )
-    except:
-        hasStatusNOP = hasSyncStatus(resourceType.upper(), resource, SYNC_STATUS['NOP'])
-        if hasStatusNOP:
-            raise Exception(
-                "Expected "
-                + resourceType
-                + " '"
-                + resource
-                + "' to have sync started but not."
-            )
-
-
-def waitForFileOrFolderToSync(context, resource, resourceType):
-    waitForSyncToStart(context, resource, resourceType)
-    waitForFileOrFolderToHaveSyncStatus(
-        context, resource, resourceType, SYNC_STATUS['OK']
-    )
-
-
-def waitForRootFolderToSync(context):
-    waitForFileOrFolderToSync(
-        context, context.userData['currentUserSyncPath'], 'folder'
-    )
 
 
 def waitForFileOrFolderToHaveSyncError(context, resource, resourceType):
@@ -533,12 +480,12 @@ def collaboratorShouldBeListed(
 
 @When('the user waits for the files to sync')
 def step(context):
-    waitForSyncToComplete(context)
+    waitForFileOrFolderToSync(context)
 
 
 @When(r'the user waits for (file|folder) "([^"]*)" to be synced', regexp=True)
 def step(context, type, resource):
-    waitForSyncToComplete(context, resource, type)
+    waitForFileOrFolderToSync(context, resource, type)
 
 
 @When(r'the user waits for (file|folder) "([^"]*)" to have sync error', regexp=True)
@@ -561,12 +508,12 @@ def step(context, type, resource):
 
 @Given('user has waited for the files to be synced')
 def step(context):
-    waitForSyncToComplete(context)
+    waitForFileOrFolderToSync(context)
 
 
 @Given(r'the user has waited for (file|folder) "([^"]*)" to be synced', regexp=True)
 def step(context, type, resource):
-    waitForSyncToComplete(context, resource, type)
+    waitForFileOrFolderToSync(context, resource, type)
 
 
 @Given(

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1532,6 +1532,20 @@ def step(context, username):
         f.close()
 
 
+@When('user "|any|" creates the following files inside the sync folder:')
+def step(context, username):
+    syncPath = getUserSyncPath(context, username)
+
+    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
+    # https://github.com/owncloud/client/issues/9325
+    snooze(context.userData['minSyncTimeout'])
+
+    for row in context.table[1:]:
+        filename = syncPath + row[0]
+        f = open(join(syncPath, filename), "w")
+        f.close()
+
+
 @Given(
     'the user has created a folder "|any|" with "|any|" files each of size "|any|" bytes in temp folder'
 )

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -55,9 +55,9 @@ def waitForRootSyncToComplete(context, timeout=None, pool_interval=500):
     )
     if not synced:
         raise Exception(
-            "[Timeout Error] "
+            "Timeout while waiting for sync to complete for "
             + timeout
-            + "ms timeout while waiting for sync to complete"
+            + " milliseconds"
         )
 
 

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -269,7 +269,6 @@ def getSocketConnection():
 def hasSyncStatus(itemName, status):
     sync_messages = readAndUpdateSocketMessages()
     sync_messages = filterMessagesForItem(sync_messages, itemName)
-    print(sync_messages)
     for line in sync_messages:
         if line.startswith(status) and line.rstrip('/').endswith(itemName.rstrip('/')):
             return True
@@ -1209,12 +1208,22 @@ def step(context, resource, content):
 @When('the user tries to overwrite the file "|any|" with content "|any|"')
 def step(context, resource, content):
     resource = context.userData['currentUserSyncPath'] + resource
+    # overwriting the file immediately after it has been synced from the server seems to have some problem.
+    # The client does not see the change although the changes have already been made thus we are having a race condition
+    # So for now we add 5sec static wait
+    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
+    snooze(context.userData['minSyncTimeout'])
     tryToOverwriteFile(context, resource, content)
 
 
 @When('user "|any|" tries to overwrite the file "|any|" with content "|any|"')
 def step(context, user, resource, content):
     resource = getResourcePath(context, resource, user)
+    # overwriting the file immediately after it has been synced from the server seems to have some problem.
+    # The client does not see the change although the changes have already been made thus we are having a race condition
+    # So for now we add 5sec static wait
+    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
+    snooze(context.userData['minSyncTimeout'])
     tryToOverwriteFile(context, resource, content)
 
 

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -1264,8 +1264,7 @@ def step(context, errorMsg):
 def step(context, itemType, resource):
     # deleting the file immediately after it has been synced from the server seems to have some problem.
     # issue: https://github.com/owncloud/client/issues/8832
-    if itemType == "file":
-        snooze(context.userData['minSyncTimeout'])
+    snooze(context.userData['minSyncTimeout'])
 
     resourcePath = sanitizePath(context.userData['currentUserSyncPath'] + resource)
     if itemType == 'file':

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -8,6 +8,7 @@ Feature: adding accounts
     Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
 
+
     Scenario: Adding normal Account
         Given the user has started the client
         When the user adds the first account with

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -12,8 +12,7 @@ Feature: deleting files and folders
     Scenario Outline: Delete a file
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "<fileName>" on the server
         And user "Alice" has set up a client with default settings
-        When the user waits for the files to sync
-        And the user deletes the file "<fileName>"
+        When the user deletes the file "<fileName>"
         And the user waits for the files to sync
         Then as "Alice" file "<fileName>" should not exist on the server
         Examples:
@@ -25,8 +24,7 @@ Feature: deleting files and folders
     Scenario Outline: Delete a folder
         Given user "Alice" has created folder "<folderName>" on the server
         And user "Alice" has set up a client with default settings
-        When the user waits for the files to sync
-        And the user deletes the folder "<folderName>"
+        When the user deletes the folder "<folderName>"
         And the user waits for the files to sync
         Then as "Alice" file "<folderName>" should not exist on the server
         Examples:

--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -13,5 +13,5 @@ Feature: edit files
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "S@mpleFile!With,$pecial?Characters.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user overwrites the file "S@mpleFile!With,$pecial?Characters.txt" with content "overwrite ownCloud test text file"
-        And the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
+        When the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
         Then as "Alice" the file "S@mpleFile!With,$pecial?Characters.txt" on the server should have the content "overwrite ownCloud test text file"

--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -13,5 +13,5 @@ Feature: edit files
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "S@mpleFile!With,$pecial?Characters.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user overwrites the file "S@mpleFile!With,$pecial?Characters.txt" with content "overwrite ownCloud test text file"
-        When the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
+        And the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
         Then as "Alice" the file "S@mpleFile!With,$pecial?Characters.txt" on the server should have the content "overwrite ownCloud test text file"

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -447,21 +447,21 @@ Feature: Sharing
 
     Scenario: sharing of a file by public link and deleting the link
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has set up a client with default settings
         And user "Alice" has created a public link on the server with following settings
             | path     | textfile0.txt |
             | name     | Public-link   |
+        And user "Alice" has set up a client with default settings
         When the user deletes the public link for file "textfile0.txt"
         Then as user "Alice" the file "/textfile0.txt" should not have any public link on the server
 
 
     Scenario: sharing of a file by public link with password and changing the password
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
         And user "Alice" has created a public link on the server with following settings
             | path     | textfile0.txt |
             | name     | Public-link   |
             | password | 1234          |
+        And user "Alice" has set up a client with default settings
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user changes the password of public link "Public-link" to "password1234" using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link on the server
@@ -469,8 +469,8 @@ Feature: Sharing
 
 
     Scenario: simple sharing of a file by public link with default expiration date
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | expireDate | %default%    |
@@ -480,9 +480,9 @@ Feature: Sharing
 
     @issue-9321
     Scenario: simple sharing of file and folder by public link with expiration date
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has created folder "FOLDER" on the server
+        Given user "Alice" has created folder "FOLDER" on the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | expireDate | 2031-10-14   |
@@ -499,8 +499,8 @@ Feature: Sharing
 
     @issue-9321
     Scenario: simple sharing of a file by public link with password and expiration date
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | password   | pass123      |
@@ -513,11 +513,11 @@ Feature: Sharing
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has set up a client with default settings
         And user "Alice" has created a public link on the server with following settings
             | path       | textfile0.txt |
             | name       | Public link   |
             | expireDate | 2031-10-14    |
+        And user "Alice" has set up a client with default settings
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user edits the public link named "Public link" of file "textfile0.txt" changing following
             | expireDate | 2038-07-21 |
@@ -527,12 +527,12 @@ Feature: Sharing
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for folder using client-UI
         Given user "Alice" has created folder "simple-folder" on the server
-        And user "Alice" has set up a client with default settings
         And user "Alice" has created a public link on the server with following settings
             | path        | simple-folder                |
             | name        | Public link                  |
             | expireDate  | 2031-10-14                   |
             | permissions | read, update, create, delete |
+        And user "Alice" has set up a client with default settings
         When the user opens the public links dialog of "simple-folder" using the client-UI
         And the user edits the public link named "Public link" of file "simple-folder" changing following
             | expireDate | 2038-07-21 |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -217,7 +217,7 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user tries to overwrite the file "Parent/textfile.txt" with content "overwrite file inside a folder"
         And the user tries to overwrite the file "textfile.txt" with content "overwrite file in the root"
-        And the user waits for the files to sync
+        And the user waits for file "textfile.txt" to have sync error
         Then as "Brian" the file "Parent/textfile.txt" on the server should have the content "file inside a folder"
         And as "Brian" the file "textfile.txt" on the server should have the content "file in the root"
         And as "Alice" the file "Parent/textfile.txt" on the server should have the content "file inside a folder"

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -199,8 +199,9 @@ Feature: Sharing
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user overwrites the file "textfile.txt" with content "overwrite file in the root"
+        And the user waits for file "textfile.txt" to be synced
         And the user overwrites the file "simple-folder/textfile.txt" with content "overwrite file inside a folder"
-        And the user waits for the files to sync
+        And the user waits for file "simple-folder/textfile.txt" to be synced
         Then as "Brian" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"
         And as "Brian" the file "textfile.txt" on the server should have the content "overwrite file in the root"
         And as "Alice" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"
@@ -241,7 +242,7 @@ Feature: Sharing
         And the user removes permissions "edit" for user "Brian Murphy" of resource "FOLDER" using the client-UI
         And user "Brian" tries to overwrite the file "textfile.txt" with content "overwrite ownCloud test text file"
         And user "Brian" tries to overwrite the file "FOLDER/simple.txt" with content "overwrite some content"
-        And the user waits for the files to sync
+        And user "Brian" waits for file "textfile.txt" to have sync error
         Then as "Brian" the file "textfile.txt" on the server should have the content "ownCloud test text file"
         And as "Brian" the file "FOLDER/simple.txt" on the server should have the content "some content"
         And as "Alice" the file "textfile.txt" on the server should have the content "ownCloud test text file"

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -253,8 +253,7 @@ Feature: Sharing
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for the files to sync
-        And user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
+        When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
             """
             test content
             """
@@ -272,8 +271,7 @@ Feature: Sharing
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for the files to sync
-        And user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
+        When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
             """
             test content
             """
@@ -293,8 +291,7 @@ Feature: Sharing
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for the files to sync
-        And the user renames a file "textfile.txt" to "lorem.txt"
+        When the user renames a file "textfile.txt" to "lorem.txt"
         And the user renames a folder "FOLDER" to "PARENT"
         And the user waits for folder "PARENT" to be synced
         And the user waits for file "lorem.txt" to be synced
@@ -316,8 +313,7 @@ Feature: Sharing
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for the files to sync
-        And the user deletes the file "textfile.txt"
+        When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
         And the user waits for the files to sync
         Then as "Brian" file "textfile.txt" on the server should not exist
@@ -333,8 +329,7 @@ Feature: Sharing
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
-        When the user waits for the files to sync
-        And the user deletes the file "textfile.txt"
+        When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
         And the user waits for the files to sync
         # Sharee can delete (means unshare) the file shared with read permission

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -23,7 +23,6 @@ Feature: Syncing files
         And user "Alice" has created folder "large-folder" on the server
         And user "Alice" has uploaded file on the server with content "test content" to "uploaded-lorem.txt"
         And user "Alice" has set up a client with default settings
-        When the user waits for the files to sync
         Then the file "uploaded-lorem.txt" should exist on the file system
         And the file "uploaded-lorem.txt" should exist on the file system with the following content
             """
@@ -224,7 +223,6 @@ Feature: Syncing files
         And user "Alice" has created a folder "Folder1/subFolder1" inside the sync folder
         And user "Alice" has created a folder "Folder1/subFolder1/subFolder2" inside the sync folder
         And user "Alice" has set up a client with default settings
-        When the user waits for folder "Folder1" to be synced
         Then as "Alice" folder "Folder1" should exist on the server
         And as "Alice" folder "Folder1/subFolder1" should exist on the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist on the server
@@ -268,7 +266,6 @@ Feature: Syncing files
         And user "Alice" has uploaded file on the server with content "server content" to "/PRN"
         And user "Alice" has uploaded file on the server with content "server content" to "/foo%"
         And user "Alice" has set up a client with default settings
-        When the user waits for the files to sync
         Then the folder "CON" should exist on the file system
         And the folder "test%" should exist on the file system
         And the file "PRN" should exist on the file system
@@ -288,7 +285,6 @@ Feature: Syncing files
         And user "Alice" has uploaded file "test_video.mp4" to "simple-folder/test_video.mp4" on the server
         And user "Alice" has uploaded file "simple.pdf" to "simple-folder/simple.pdf" on the server
         And user "Alice" has set up a client with default settings
-        When the user waits for the files to sync
         Then the folder "simple-folder" should exist on the file system
         And the file "simple-folder/testavatar.png" should exist on the file system
         And the file "simple-folder/testavatar.jpg" should exist on the file system

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -200,20 +200,9 @@ Feature: Syncing files
         Given user "Alice" has created folder "Folder1" on the server
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" inside the sync folder
-        And user "Alice" creates a file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" with the following content inside the sync folder
-            """
-            test content
-            """
-        And the user clicks on the activity tab
-        And the user selects "Not Synced" tab in the activity
-        And the user waits for file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" to be synced
-        Then as "Alice" folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the server
-        And the file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" should exist on the file system with the following content
-            """
-            test content
-            """
-        And as "Alice" the file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" on the server should have the content "test content"
-
+        And the user waits for folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" to be synced
+        Then the folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the file system
+        And as "Alice" folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the server
 
     Scenario: Verify pre existing folders in local (Desktop client) are copied over to the server
         Given user "Alice" has created a folder "Folder1" inside the sync folder

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -189,28 +189,23 @@ Feature: Syncing files
 
     Scenario: Both original and copied folders can be synced
         Given user "Alice" has set up a client with default settings
-        And user "Alice" has created a folder "original" inside the sync folder
-        And user "Alice" has created a file "original/test.txt" with the following content inside the sync folder
-            """
-            test content
-            """
-        When the user copies the folder "original" to "copied"
+        When user "Alice" creates a folder "original" inside the sync folder
+        And the user copies the folder "original" to "copied"
         And the user waits for folder "copied" to be synced
         Then as "Alice" folder "original" should exist on the server
         And as "Alice" folder "copied" should exist on the server
 
     @issue-9281
     Scenario: Verify that you can create a subfolder with long name
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has created a folder "Folder1" inside the sync folder
+        Given user "Alice" has created folder "Folder1" on the server
+        And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" inside the sync folder
         And user "Alice" creates a file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" with the following content inside the sync folder
             """
             test content
             """
         And the user waits for the files to sync
-        Then as "Alice" folder "Folder1" should exist on the server
-        And as "Alice" folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the server
+        Then as "Alice" folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the server
         And the file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" should exist on the file system with the following content
             """
             test content
@@ -229,29 +224,27 @@ Feature: Syncing files
 
 
     Scenario: Filenames that are rejected by the server are reported
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has created a folder "Folder1" inside the sync folder
-        And the user has waited for folder "Folder1" to be synced
+        Given user "Alice" has created folder "Folder1" on the server
+        And user "Alice" has set up a client with default settings
         When user "Alice" creates a file "Folder1/a\\a.txt" with the following content inside the sync folder
             """
             test content
             """
-        Then as "Alice" folder "Folder1" should exist on the server
-        When the user clicks on the activity tab
+        And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
-        Then the file "Folder1/a\\a.txt" should be blacklisted
+        Then the file "Folder1/a\\a.txt" should exist on the file system
+        And the file "Folder1/a\\a.txt" should be blacklisted
 
 
     Scenario Outline: Verify one empty folder with a length longer than the allowed limit will not be synced
-        Given user "Alice" has set up a client with default settings
-        And user "Alice" has created a folder "<foldername>" inside the sync folder
+        Given user "Alice" has created folder "<foldername>" on the server
+        And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "<foldername>/<foldername>" inside the sync folder
         And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>" inside the sync folder
         And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
         And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" inside the sync folder
         And the user waits for folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" to be synced
-        Then as "Alice" folder "<foldername>" should exist on the server
-        And as "Alice" folder "<foldername>/<foldername>" should exist on the server
+        Then as "Alice" folder "<foldername>/<foldername>" should exist on the server
         And as "Alice" folder "<foldername>/<foldername>/<foldername>" should exist on the server
         And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>" should exist on the server
         And as "Alice" folder "<foldername>/<foldername>/<foldername>/<foldername>/<foldername>" should exist on the server
@@ -296,7 +289,7 @@ Feature: Syncing files
 
     Scenario: various types of files can be synced from client to server
         Given user "Alice" has set up a client with default settings
-        And user "Alice" has created the following files inside the sync folder:
+        When user "Alice" creates the following files inside the sync folder:
             | files            |
             | /testavatar.png  |
             | /testavatar.jpg  |
@@ -304,7 +297,7 @@ Feature: Syncing files
             | /testaudio.mp3   |
             | /test_video.mp4  |
             | /simple.txt      |
-        When the user waits for the files to sync
+        And the user waits for the files to sync
         Then as "Alice" file "testavatar.png" should exist on the server
         And as "Alice" file "testavatar.jpg" should exist on the server
         And as "Alice" file "testavatar.jpeg" should exist on the server
@@ -358,9 +351,9 @@ Feature: Syncing files
 
 
     Scenario: Syncing folders each having 500 files
-        Given user "Alice" has set up a client with default settings
-        And the user has created a folder "folder1" with "500" files each of size "1048576" bytes in temp folder
+        Given the user has created a folder "folder1" with "500" files each of size "1048576" bytes in temp folder
         And the user has created a folder "folder2" with "500" files each of size "1048576" bytes in temp folder
+        And user "Alice" has set up a client with default settings
         When user "Alice" moves folder "folder1" from the temp folder into the sync folder
         And user "Alice" moves folder "folder2" from the temp folder into the sync folder
         And the user waits for folder "folder1" to be synced

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -204,7 +204,9 @@ Feature: Syncing files
             """
             test content
             """
-        And the user waits for the files to sync
+        And the user clicks on the activity tab
+        And the user selects "Not Synced" tab in the activity
+        And the user waits for file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" to be synced
         Then as "Alice" folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" should exist on the server
         And the file "Folder1/really long folder name with some spaces and special char such as $%ñ&/test.txt" should exist on the file system with the following content
             """

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -8,7 +8,6 @@ Feature: Enable/disable virtual file support
     Scenario: Enable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And user has waited for the files to be synced
         When the user enables virtual file support
         Then the "Disable virtual file support..." button should be available
         And VFS enabled baseline image should match the default screenshot
@@ -17,14 +16,12 @@ Feature: Enable/disable virtual file support
     Scenario: VFS is disabled by default
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And user has waited for the files to be synced
         Then VFS enabled baseline image should not match the default screenshot
 
 
     Scenario: Disable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
         And user "Alice" has set up a client with default settings
-        And user has waited for the files to be synced
         And the user has enabled virtual file support
         When the user disables virtual file support
         Then the "Enable virtual file support (experimental)..." button should be available


### PR DESCRIPTION
Making sync wait more reliable using pattern matching. Meaning, certain patterns can be found in the socket messages while the desktop-client is syncing files/folder. This PR utilizes those patterns in order to determine the different sync statuses of the file/folder.
For example; while a file/folder undergoes sync and sync is completed, we can see the following pattern (in order):
```
STATUS:SYNC
STATUS:OK
```
Thus, this PR uses such status messages order (pattern) to determine the sync status of file/folder.

Previously, in order to determine whether the file/folder is synced or not, we were searching for `STATUS:OK` status in the socket messages. This was not so reliable as there can be multiple OK statuses for the same file/folder in the socket messages. Also, we might get a false positive in case of re-syncing the already synced file/folder.


### Related issues:
Closes https://github.com/owncloud/client/issues/9939

### Motivations
- make sync wait more reliable
- perform actions after sync is complete