### PR TITLE
[gui-tests] Wait until the connection is configured after starting client

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -138,3 +138,4 @@ loginRequiredDialog_OCC_LoginRequiredDialog = {"name": "LoginRequiredDialog", "t
 loginRequiredDialog_contentWidget_QStackedWidget = {"name": "contentWidget", "type": "QStackedWidget", "visible": 1, "window": loginRequiredDialog_OCC_LoginRequiredDialog}
 enable_experimental_feature_QMessageBox = {"type": "QMessageBox", "unnamed": 1, "visible": 1, "windowTitle": "Enable experimental feature?"}
 enable_experimental_feature_Enable_experimental_placeholder_mode_QPushButton = {"text": "Enable experimental placeholder mode", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": enable_experimental_feature_QMessageBox}
+stack_connectLabel_QLabel = {"container": settings_stack_QStackedWidget, "name": "connectLabel", "type": "QLabel", "visible": 1}

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -108,11 +108,36 @@ def getPasswordForUser(context, username):
     return getUserInfo(context, username, 'password')
 
 
+def isConnecting():
+    return "Connecting to" in str(
+        waitForObjectExists(names.stack_connectLabel_QLabel).text
+    )
+
+
+def waitUntilConnectionIsConfigured(context):
+    timeout = context.userData['maxSyncTimeout'] * 1000
+
+    result = waitFor(
+        lambda: isConnecting(),
+        timeout,
+    )
+
+    if not result:
+        raise Exception(
+            "Timeout waiting for connection to be configured for "
+            + timeout
+            + " milliseconds"
+        )
+
+
 @Given('user "|any|" has set up a client with default settings')
 def step(context, username):
     password = getPasswordForUser(context, username)
     displayName = getDisplaynameForUser(context, username)
     setUpClient(context, username, displayName, context.userData['clientConfigFile'])
+
+    waitUntilConnectionIsConfigured(context)
+
     enterUserPassword = EnterPassword()
     enterUserPassword.enterPassword(password)
 


### PR DESCRIPTION
Sometimes when starting the client `No connection configured` message appears and the tests would fail. It appears that sometimes it takes few waits to connect to the account.

In this PR, I have added the wait until the connection is confgured.

Fixes https://github.com/owncloud/client/issues/10140