### PR TITLE
Ci: Disable packaging on linux for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,9 @@ jobs:
 
     - name: Package
       run: |
-        & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --src-dir "${env:GITHUB_WORKSPACE}" --package owncloud/owncloud-client
+        if(-not $IsLinux) {
+            & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --no-cache --src-dir "${env:GITHUB_WORKSPACE}" --package owncloud/owncloud-client
+        }
 
     - name: Prepare artifacts
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Prepare artifacts
       run: |
         New-Item -ItemType Directory "${env:GITHUB_WORKSPACE}/binaries/" -ErrorAction SilentlyContinue
-        Copy-Item "$env:HOME/craft/binaries/*" "${env:GITHUB_WORKSPACE}/binaries/"
+        Copy-Item "$env:HOME/craft/binaries/*" "${env:GITHUB_WORKSPACE}/binaries/" -ErrorAction SilentlyContinue
         & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --shelve "${env:GITHUB_WORKSPACE}/.craft.shelf"
         Copy-Item "${env:GITHUB_WORKSPACE}/.craft.shelf" "${env:GITHUB_WORKSPACE}/binaries/"
 


### PR DESCRIPTION
```
[qt/stdout] Copying file /lib64/libavahi-client.so.3 to /github/home/craft/CraftMaster/linux-64-gcc/build/owncloud/owncloud-client/archive/usr/lib/libavahi-client.so.3
[qt/stdout] ERROR: Failed to copy file /lib64/libavahi-client.so.3 to /github/home/craft/CraftMaster/linux-64-gcc/build/owncloud/owncloud-client/archive/usr/lib/libavahi-client.so.3: boost::filesystem::copy_file: Invalid cross-device link: /lib64/libavahi-client.so.3, /github/home/craft/CraftMaster/linux-64-gcc/build/owncloud/owncloud-client/archive/usr/lib/libavahi-client.so.3
```