### PR TITLE
Sort spaces by priority

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -61,7 +61,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     _ui->setupUi(this);
 
     _model = new ActivityListModel(this);
-    _sortModel = new SignalledQSortFilterProxyModel(this);
+    _sortModel = new Models::SignalledQSortFilterProxyModel(this);
     _sortModel->setSourceModel(_model);
     _ui->_activityList->setModel(_sortModel);
     _sortModel->setSortRole(Models::UnderlyingDataRole);
@@ -112,7 +112,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     connect(_ui->_filterButton, &QAbstractButton::clicked, this, [this] {
         ProtocolWidget::showFilterMenu(_ui->_filterButton, _sortModel, static_cast<int>(ActivityListModel::ActivityRole::Account), tr("Account"));
     });
-    connect(_sortModel, &SignalledQSortFilterProxyModel::filterChanged, this, [this]() {
+    connect(_sortModel, &Models::SignalledQSortFilterProxyModel::filterChanged, this, [this]() {
         _ui->_filterButton->setText(CommonStrings::filterButtonText(_sortModel->filterRegExp().isEmpty() ? 0 : 1));
     });
 

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -113,7 +113,7 @@ private:
     int _notificationRequestsRunning;
 
     ActivityListModel *_model;
-    SignalledQSortFilterProxyModel *_sortModel;
+    Models::SignalledQSortFilterProxyModel *_sortModel;
     QVBoxLayout *_notificationsLayout;
 };
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -76,6 +76,11 @@ auto deployedC()
     return QStringLiteral("deployed");
 }
 
+auto priorityC()
+{
+    return QStringLiteral("priority");
+}
+
 constexpr int SettingsVersionC = 5;
 }
 
@@ -1321,6 +1326,16 @@ FolderDefinition::FolderDefinition(const QByteArray &id, const QUrl &davUrl, con
 {
 }
 
+void FolderDefinition::setPriority(uint32_t newPriority)
+{
+    _priority = newPriority;
+}
+
+uint32_t FolderDefinition::priority() const
+{
+    return _priority;
+}
+
 void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
 {
     settings.setValue(QStringLiteral("localPath"), folder.localPath());
@@ -1331,6 +1346,7 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     settings.setValue(QStringLiteral("paused"), folder.paused);
     settings.setValue(QStringLiteral("ignoreHiddenFiles"), folder.ignoreHiddenFiles);
     settings.setValue(deployedC(), folder.isDeployed());
+    settings.setValue(priorityC(), folder.priority());
 
     settings.setValue(QStringLiteral("virtualFilesMode"), Vfs::modeToString(folder.virtualFilesMode));
 
@@ -1354,6 +1370,7 @@ FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &i
     folder.ignoreHiddenFiles = settings.value(QStringLiteral("ignoreHiddenFiles"), QVariant(true)).toBool();
     folder.navigationPaneClsid = settings.value(QStringLiteral("navigationPaneClsid")).toUuid();
     folder._deployed = settings.value(deployedC(), false).toBool();
+    folder._priority = settings.value(priorityC(), 0).toInt();
 
     folder.virtualFilesMode = Vfs::Off;
     QString vfsModeString = settings.value(QStringLiteral("virtualFilesMode")).toString();

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -122,6 +122,14 @@ public:
     bool isDeployed() const;
 
 
+    /**
+     * Higher values mean more imortant
+     * Used for sorting
+     */
+    uint32_t priority() const;
+
+    void setPriority(uint32_t newPriority);
+
 private:
     FolderDefinition(const QByteArray &id, const QUrl &davUrl, const QString &displayName);
 
@@ -134,6 +142,8 @@ private:
     /// path on remote (usually no trailing /, exception "/")
     QString _targetPath;
     bool _deployed = false;
+
+    uint32_t _priority;
 
     friend class FolderMan;
 };
@@ -360,6 +370,16 @@ public:
      * We will hide the remove option and the disable/enable vfs option.
      */
     bool isDeployed() const;
+
+    auto priority()
+    {
+        return _definition.priority();
+    }
+
+    void setPriority(uint32_t p)
+    {
+        return _definition.setPriority(p);
+    }
 
 signals:
     void syncStateChange();

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1441,7 +1441,9 @@ Folder *FolderMan::addFolderFromWizard(const AccountStatePtr &accountStatePtr, c
 
 Folder *FolderMan::addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const FolderWizard::Result &config)
 {
-    return addFolderFromWizard(accountStatePtr, config.localPath, config.remotePath, config.davUrl, config.displayName, config.useVirtualFiles);
+    auto f = addFolderFromWizard(accountStatePtr, config.localPath, config.remotePath, config.davUrl, config.displayName, config.useVirtualFiles);
+    f->setPriority(config.priority);
+    return f;
 }
 
 QString FolderMan::suggestSyncFolder(const QUrl &server, const QString &displayName)

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -114,6 +114,14 @@ QString FolderWizardPrivate::remotePath() const
     return _folderWizardTargetPage ? _folderWizardTargetPage->targetPath() : QString();
 }
 
+uint32_t FolderWizardPrivate::priority() const
+{
+    if (_account->supportsSpaces()) {
+        _spacesPage->selectedSpace(Spaces::SpacesModel::Columns::Priority).toInt();
+    };
+    return 0;
+}
+
 QUrl FolderWizardPrivate::davUrl() const
 {
     if (_account->supportsSpaces()) {
@@ -203,12 +211,14 @@ FolderWizard::Result FolderWizard::result()
             d->_account->account()->setDefaultSyncRoot(d->defaultSyncRoot());
         }
     }
+
     return {
         d->davUrl(),
         localPath,
         d->remotePath(),
         d->displayName(),
         d->useVirtualFiles(),
+        d->priority(),
         d->_folderWizardSelectiveSyncPage ? d->_folderWizardSelectiveSyncPage->selectiveSyncBlackList() : QStringList()
     };
 }

--- a/src/gui/folderwizard/folderwizard.h
+++ b/src/gui/folderwizard/folderwizard.h
@@ -73,6 +73,8 @@ public:
          */
         bool useVirtualFiles;
 
+        uint32_t priority;
+
         QStringList selectiveSyncBlackList;
     };
 

--- a/src/gui/folderwizard/folderwizard_p.h
+++ b/src/gui/folderwizard/folderwizard_p.h
@@ -38,6 +38,8 @@ public:
 
     QString remotePath() const;
 
+    uint32_t priority() const;
+
     QString defaultSyncRoot() const;
 
     QUrl davUrl() const;

--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -50,13 +50,13 @@ bool persistsUntilLocalDiscovery(const OCC::ProtocolItem &data)
 }
 namespace OCC {
 
-class SyncFileItemStatusSetSortFilterProxyModel : public SignalledQSortFilterProxyModel
+class SyncFileItemStatusSetSortFilterProxyModel : public Models::SignalledQSortFilterProxyModel
 {
 public:
     using StatusSet = std::array<bool, SyncFileItem::StatusCount>;
 
     explicit SyncFileItemStatusSetSortFilterProxyModel(QObject *parent = nullptr)
-        : SignalledQSortFilterProxyModel(parent)
+        : Models::SignalledQSortFilterProxyModel(parent)
     {
         resetFilter();
     }
@@ -180,11 +180,11 @@ IssuesWidget::IssuesWidget(QWidget *parent)
     });
 
     _model = new ProtocolItemModel(20000, true, this);
-    _sortModel = new SignalledQSortFilterProxyModel(this);
-    connect(_sortModel, &SignalledQSortFilterProxyModel::filterChanged, this, &IssuesWidget::filterDidChange);
+    _sortModel = new Models::SignalledQSortFilterProxyModel(this);
+    connect(_sortModel, &Models::SignalledQSortFilterProxyModel::filterChanged, this, &IssuesWidget::filterDidChange);
     _sortModel->setSourceModel(_model);
     _statusSortModel = new SyncFileItemStatusSetSortFilterProxyModel(this);
-    connect(_statusSortModel, &SignalledQSortFilterProxyModel::filterChanged, this, &IssuesWidget::filterDidChange);
+    connect(_statusSortModel, &Models::SignalledQSortFilterProxyModel::filterChanged, this, &IssuesWidget::filterDidChange);
     _statusSortModel->setSourceModel(_sortModel);
     _statusSortModel->setSortRole(Qt::DisplayRole); // Sorting should be done based on the text in the column cells, but...
     _statusSortModel->setFilterRole(Models::UnderlyingDataRole); // ... filtering should be done on the underlying enum value.

--- a/src/gui/issueswidget.h
+++ b/src/gui/issueswidget.h
@@ -67,7 +67,7 @@ private:
     std::function<void()> addStatusFilter(QMenu *menu);
 
     ProtocolItemModel *_model;
-    SignalledQSortFilterProxyModel *_sortModel;
+    Models::SignalledQSortFilterProxyModel *_sortModel;
     SyncFileItemStatusSetSortFilterProxyModel *_statusSortModel;
 
     Ui::IssuesWidget *_ui;

--- a/src/gui/models/models.cpp
+++ b/src/gui/models/models.cpp
@@ -121,3 +121,20 @@ std::function<void()> OCC::Models::addFilterMenuItems(QMenu *menu, const QString
     };
     return resetFunction;
 }
+
+void OCC::Models::WeightedQSortFilterProxyModel::setWeightedColumn(int i)
+{
+    _weightedColumn = i;
+}
+
+bool OCC::Models::WeightedQSortFilterProxyModel::lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const
+{
+    Q_ASSERT(_weightedColumn < source_left.model()->columnCount());
+    const uint32_t w1 = source_left.siblingAtColumn(_weightedColumn).data().toInt();
+    const uint32_t w2 = source_right.siblingAtColumn(_weightedColumn).data().toInt();
+    if (w1 != w2) {
+        // always disply on top
+        return sortOrder() == Qt::SortOrder::DescendingOrder ? w1 < w2 : w1 > w2;
+    }
+    return QSortFilterProxyModel::lessThan(source_left, source_right);
+}

--- a/src/gui/models/models.cpp
+++ b/src/gui/models/models.cpp
@@ -22,12 +22,7 @@
 
 #include <functional>
 
-OCC::SignalledQSortFilterProxyModel::SignalledQSortFilterProxyModel(QObject *parent)
-    : QSortFilterProxyModel(parent)
-{
-}
-
-void OCC::SignalledQSortFilterProxyModel::setFilterFixedStringSignalled(const QString &pattern)
+void OCC::Models::SignalledQSortFilterProxyModel::setFilterFixedStringSignalled(const QString &pattern)
 {
     setFilterFixedString(pattern);
     emit filterChanged();

--- a/src/gui/models/models.h
+++ b/src/gui/models/models.h
@@ -23,19 +23,6 @@ class QMenu;
 
 namespace OCC {
 
-class SignalledQSortFilterProxyModel : public QSortFilterProxyModel
-{
-    Q_OBJECT
-
-public:
-    SignalledQSortFilterProxyModel(QObject *parent = nullptr);
-
-    void setFilterFixedStringSignalled(const QString &pattern);
-
-signals:
-    void filterChanged();
-};
-
 namespace Models {
     Q_NAMESPACE
 
@@ -44,6 +31,19 @@ namespace Models {
         StringFormatWidthRole // The width for a cvs formated column
     };
     Q_ENUM_NS(DataRoles)
+
+    class SignalledQSortFilterProxyModel : public QSortFilterProxyModel
+    {
+        Q_OBJECT
+
+    public:
+        using QSortFilterProxyModel::QSortFilterProxyModel;
+
+        void setFilterFixedStringSignalled(const QString &pattern);
+
+    signals:
+        void filterChanged();
+    };
 
     /**
      * Returns a cvs representation of a table

--- a/src/gui/models/models.h
+++ b/src/gui/models/models.h
@@ -45,6 +45,28 @@ namespace Models {
         void filterChanged();
     };
 
+
+    /**
+     * A WeightedQSortFilterProxyModel
+     * The weighted rpws will always be displayed on top, based on their weight.
+     */
+    class WeightedQSortFilterProxyModel : public QSortFilterProxyModel
+    {
+        Q_OBJECT
+    public:
+        using QSortFilterProxyModel::QSortFilterProxyModel;
+
+        /**
+         * Set the colum of the model providing the weight
+         */
+        void setWeightedColumn(int i);
+
+    protected:
+        bool lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const override;
+
+        int _weightedColumn = 0;
+    };
+
     /**
      * Returns a cvs representation of a table
      */

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -59,7 +59,7 @@ void setUpInitialSyncFolder(AccountStatePtr accountStatePtr, bool useVfs)
 
     // saves a bit of duplicate code
     auto addFolder = [folderMan, accountStatePtr, useVfs](const QString &localFolder, const QString &remotePath, const QUrl &webDavUrl, const QString &displayName = {}) {
-        folderMan->addFolderFromWizard(accountStatePtr, localFolder, remotePath, webDavUrl, displayName, useVfs);
+        return folderMan->addFolderFromWizard(accountStatePtr, localFolder, remotePath, webDavUrl, displayName, useVfs);
     };
 
     auto finalize = [accountStatePtr] {
@@ -81,7 +81,8 @@ void setUpInitialSyncFolder(AccountStatePtr accountStatePtr, bool useVfs)
                     for (const auto &d : drives) {
                         const QString name = GraphApi::Drives::getDriveDisplayName(d);
                         const QString folderName = FolderMan::instance()->findGoodPathForNewSyncFolder(localDir.filePath(name));
-                        addFolder(folderName, {}, QUrl::fromEncoded(d.getRoot().getWebDavUrl().toUtf8()), name);
+                        auto folder = addFolder(folderName, {}, QUrl::fromEncoded(d.getRoot().getWebDavUrl().toUtf8()), name);
+                        folder->setPriority(GraphApi::Drives::getDrivePriority(d));
                     }
                     finalize();
                 }

--- a/src/gui/protocolwidget.cpp
+++ b/src/gui/protocolwidget.cpp
@@ -51,8 +51,8 @@ ProtocolWidget::ProtocolWidget(QWidget *parent)
     // Build the model-view "stack":
     //  _model <- _sortModel <- _statusSortModel <- _tableView
     _model = new ProtocolItemModel(2000, false, this);
-    _sortModel = new SignalledQSortFilterProxyModel(this);
-    connect(_sortModel, &SignalledQSortFilterProxyModel::filterChanged, this, &ProtocolWidget::filterDidChange);
+    _sortModel = new Models::SignalledQSortFilterProxyModel(this);
+    connect(_sortModel, &Models::SignalledQSortFilterProxyModel::filterChanged, this, &ProtocolWidget::filterDidChange);
     _sortModel->setSourceModel(_model);
     _sortModel->setSortRole(Models::UnderlyingDataRole);
     _ui->_tableView->setModel(_sortModel);
@@ -95,7 +95,7 @@ ProtocolWidget::~ProtocolWidget()
  * @param columnName the name column on which the filter is done
  * @return
  */
-QMenu *ProtocolWidget::showFilterMenu(QWidget *parent, SignalledQSortFilterProxyModel *model, int role, const QString &columnName)
+QMenu *ProtocolWidget::showFilterMenu(QWidget *parent, Models::SignalledQSortFilterProxyModel *model, int role, const QString &columnName)
 {
     auto menu = new QMenu(parent);
     menu->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/gui/protocolwidget.h
+++ b/src/gui/protocolwidget.h
@@ -51,7 +51,7 @@ public:
     ~ProtocolWidget() override;
 
     static void showContextMenu(QWidget *parent, ProtocolItemModel *model, const QModelIndexList &items);
-    static QMenu *showFilterMenu(QWidget *parent, SignalledQSortFilterProxyModel *model, int role, const QString &columnName);
+    static QMenu *showFilterMenu(QWidget *parent, Models::SignalledQSortFilterProxyModel *model, int role, const QString &columnName);
 
 public slots:
     void slotItemCompleted(Folder *folder, const SyncFileItemPtr &item);
@@ -62,7 +62,7 @@ private slots:
 
 private:
     ProtocolItemModel *_model;
-    SignalledQSortFilterProxyModel *_sortModel;
+    Models::SignalledQSortFilterProxyModel *_sortModel;
     Ui::ProtocolWidget *_ui;
 };
 }

--- a/src/gui/spaces/spacesbrowser.cpp
+++ b/src/gui/spaces/spacesbrowser.cpp
@@ -17,9 +17,11 @@
 #include "spacesdelegate.h"
 #include "spacesmodel.h"
 
+
 #include "graphapi/drives.h"
 
 #include "gui/models/expandingheaderview.h"
+#include "gui/models/models.h"
 
 #include <QCursor>
 #include <QMenu>
@@ -34,8 +36,9 @@ SpacesBrowser::SpacesBrowser(QWidget *parent)
     ui->setupUi(this);
     _model = new SpacesModel(this);
 
-    auto *sortModel = new QSortFilterProxyModel(this);
+    auto *sortModel = new OCC::Models::WeightedQSortFilterProxyModel(this);
     sortModel->setSourceModel(_model);
+    sortModel->setWeightedColumn(static_cast<int>(SpacesModel::Columns::Priority));
 
     ui->tableView->setModel(sortModel);
 
@@ -51,6 +54,7 @@ SpacesBrowser::SpacesBrowser(QWidget *parent)
     header->hideSection(static_cast<int>(SpacesModel::Columns::WebDavUrl));
     // part of the name (see the delegate)
     header->hideSection(static_cast<int>(SpacesModel::Columns::Subtitle));
+    header->hideSection(static_cast<int>(SpacesModel::Columns::Priority));
     header->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header, &QHeaderView::customContextMenuRequested, header, [header, this] {
         auto menu = new QMenu(this);

--- a/src/gui/spaces/spacesmodel.cpp
+++ b/src/gui/spaces/spacesmodel.cpp
@@ -53,6 +53,8 @@ QVariant SpacesModel::headerData(int section, Qt::Orientation orientation, int r
                 return tr("Web Dav URL");
             case Columns::Image:
                 return tr("Image");
+            case Columns::Priority:
+                return tr("Priority");
             case Columns::ColumnCount:
                 Q_UNREACHABLE();
                 break;
@@ -101,6 +103,8 @@ QVariant SpacesModel::data(const QModelIndex &index, int role) const
             return item.getRoot().getWebDavUrl();
         case Columns::Image:
             return {};
+        case Columns::Priority:
+            return GraphApi::Drives::getDrivePriority(item);
         case Columns::ColumnCount:
             Q_UNREACHABLE();
             break;

--- a/src/gui/spaces/spacesmodel.h
+++ b/src/gui/spaces/spacesmodel.h
@@ -32,6 +32,7 @@ public:
         Subtitle,
         WebUrl,
         WebDavUrl,
+        Priority,
 
         ColumnCount
     };

--- a/src/libsync/graphapi/drives.cpp
+++ b/src/libsync/graphapi/drives.cpp
@@ -67,3 +67,13 @@ QString Drives::getDriveDisplayName(const OpenAPI::OAIDrive &drive)
     }
     return drive.getName();
 }
+
+uint32_t Drives::getDrivePriority(const OpenAPI::OAIDrive &drive)
+{
+    if (drive.getDriveType() == personalC) {
+        return 100;
+    } else if (drive.getDriveType() == shareC) {
+        return 50;
+    }
+    return 0;
+}

--- a/src/libsync/graphapi/drives.h
+++ b/src/libsync/graphapi/drives.h
@@ -34,6 +34,11 @@ namespace GraphApi {
          */
         static QString getDriveDisplayName(const OpenAPI::OAIDrive &drive);
 
+        /***
+         * Asign a priority to a drive, used for sorting
+         */
+        static uint32_t getDrivePriority(const OpenAPI::OAIDrive &drive);
+
         const QList<OpenAPI::OAIDrive> &drives() const;
 
     private:


### PR DESCRIPTION
This will ensure that the personal folder and the shares folder are always on top.

The implementation in the folder status view on the accounts view will need a follow up as it requires refactoring.