### PR TITLE
Use job, abort instead of reply()-abort()

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -365,8 +365,8 @@ void DiscoverySingleDirectoryJob::start()
 
 void DiscoverySingleDirectoryJob::abort()
 {
-    if (_lsColJob && _lsColJob->reply()) {
-        _lsColJob->reply()->abort();
+    if (_lsColJob) {
+        _lsColJob->abort();
     }
 }
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -174,14 +174,14 @@ void GETFileJob::slotMetaDataChanged()
         qCWarning(lcGetJob) << "No E-Tag reply by server, considering it invalid";
         _errorString = tr("No E-Tag received from server, check Proxy/Gateway");
         _errorStatus = SyncFileItem::NormalError;
-        reply()->abort();
+        abort();
         return;
     } else if (!_expectedEtagForResume.isEmpty() && _expectedEtagForResume != _etag) {
         qCWarning(lcGetJob) << "We received a different E-Tag for resuming!"
                             << _expectedEtagForResume << "vs" << _etag;
         _errorString = tr("We received a different E-Tag for resuming. Retrying next time.");
         _errorStatus = SyncFileItem::NormalError;
-        reply()->abort();
+        abort();
         return;
     }
 
@@ -192,7 +192,7 @@ void GETFileJob::slotMetaDataChanged()
                             << _expectedContentLength << "vs" << _contentLength;
         _errorString = tr("We received an unexpected download Content-Length.");
         _errorStatus = SyncFileItem::NormalError;
-        reply()->abort();
+        abort();
         return;
     }
 
@@ -213,14 +213,14 @@ void GETFileJob::slotMetaDataChanged()
             if (!_device->open(QIODevice::WriteOnly)) {
                 _errorString = _device->errorString();
                 _errorStatus = SyncFileItem::NormalError;
-                reply()->abort();
+                abort();
                 return;
             }
             _resumeStart = 0;
         } else {
             _errorString = tr("Server returned wrong content-range");
             _errorStatus = SyncFileItem::NormalError;
-            reply()->abort();
+            abort();
             return;
         }
     }
@@ -299,7 +299,7 @@ void GETFileJob::slotReadyRead()
             _errorString = networkReplyErrorString(*reply());
             _errorStatus = SyncFileItem::NormalError;
             qCWarning(lcGetJob) << "Error while reading from device: " << _errorString;
-            reply()->abort();
+            abort();
             return;
         }
 
@@ -308,7 +308,7 @@ void GETFileJob::slotReadyRead()
             _errorString = _device->errorString();
             _errorStatus = SyncFileItem::NormalError;
             qCWarning(lcGetJob) << "Error while writing to file" << written << read << _errorString;
-            reply()->abort();
+            abort();
             return;
         }
     }
@@ -1048,9 +1048,9 @@ void PropagateDownloadFile::slotDownloadProgress(qint64 received, qint64)
 
 void PropagateDownloadFile::abort(PropagatorJob::AbortType abortType)
 {
-    if (_job && _job->reply())
-        _job->reply()->abort();
-
+    if (_job) {
+        _job->abort();
+    }
     if (abortType == AbortType::Asynchronous) {
         emit abortFinished();
     }

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -58,9 +58,9 @@ void PropagateRemoteDelete::start()
 
 void PropagateRemoteDelete::abort(PropagatorJob::AbortType abortType)
 {
-    if (_job && _job->reply())
-        _job->reply()->abort();
-
+    if (_job) {
+        _job->abort();
+    }
     if (abortType == AbortType::Asynchronous) {
         emit abortFinished();
     }

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -69,9 +69,9 @@ void PropagateRemoteMkdir::slotStartMkcolJob()
 
 void PropagateRemoteMkdir::abort(PropagatorJob::AbortType abortType)
 {
-    if (_job && _job->reply())
-        _job->reply()->abort();
-
+    if (_job) {
+        _job->abort();
+    }
     if (abortType == AbortType::Asynchronous) {
         emit abortFinished();
     }

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -133,9 +133,9 @@ void PropagateRemoteMove::start()
 
 void PropagateRemoteMove::abort(PropagatorJob::AbortType abortType)
 {
-    if (_job && _job->reply())
-        _job->reply()->abort();
-
+    if (_job) {
+        _job->abort();
+    }
     if (abortType == AbortType::Asynchronous) {
         emit abortFinished();
     }


### PR DESCRIPTION
That way we will correctly detect the reason and not assume a timeout