### PR TITLE
Don't create redundant content widgets

### DIFF
--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -113,12 +113,15 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
 
 void HttpCredentialsGui::showDialog()
 {
-    auto *contentWidget = new BasicLoginWidget();
-    contentWidget->forceUsername(_account->davUser());
+    auto *dialog = new LoginRequiredDialog(LoginRequiredDialog::Mode::Basic, ocApp()->gui()->settingsDialog());
 
-    auto *dialog = new LoginRequiredDialog(contentWidget, ocApp()->gui()->settingsDialog());
-    dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+    // make sure it's cleaned up since it's not owned by the account settings (also prevents memory leaks)
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+
     dialog->setTopLabelText(tr("Please enter your password to log in to your account."));
+
+    auto *contentWidget = qobject_cast<BasicLoginWidget *>(dialog->contentWidget());
+    contentWidget->forceUsername(_account->davUser());
 
     // in this case, we want to use the login button
     dialog->addLogInButton();

--- a/src/gui/loginrequireddialog/loginrequireddialog.cpp
+++ b/src/gui/loginrequireddialog/loginrequireddialog.cpp
@@ -24,7 +24,7 @@
 
 namespace OCC {
 
-LoginRequiredDialog::LoginRequiredDialog(AbstractLoginWidget *contentWidget, QWidget *parent)
+LoginRequiredDialog::LoginRequiredDialog(Mode mode, QWidget *parent)
     : QDialog(parent)
     , _ui(new ::Ui::LoginRequiredDialog)
 {
@@ -41,8 +41,16 @@ LoginRequiredDialog::LoginRequiredDialog(AbstractLoginWidget *contentWidget, QWi
 
     // using a stacked widget appears to work better than a plain widget
     // we do this in the setup wizard as well
-    _ui->contentWidget->addWidget(contentWidget);
-    _ui->contentWidget->setCurrentWidget(contentWidget);
+    _ui->contentWidget->setCurrentWidget([this, mode]() -> QWidget * {
+        switch (mode) {
+        case Mode::Basic:
+            return _ui->basicLoginWidget;
+        case Mode::OAuth:
+            return _ui->oauthLoginWidget;
+        default:
+            Q_UNREACHABLE();
+        }
+    }());
 
     Utility::setModal(this);
     setFixedSize(this->minimumSize());
@@ -61,6 +69,11 @@ void LoginRequiredDialog::setTopLabelText(const QString &newText)
 void LoginRequiredDialog::addLogInButton()
 {
     _ui->rightButtonBox->addButton(tr("Log in"), QDialogButtonBox::AcceptRole);
+}
+
+QWidget *LoginRequiredDialog::contentWidget() const
+{
+    return _ui->contentWidget->currentWidget();
 }
 
 } // OCC

--- a/src/gui/loginrequireddialog/loginrequireddialog.h
+++ b/src/gui/loginrequireddialog/loginrequireddialog.h
@@ -33,7 +33,16 @@ class LoginRequiredDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit LoginRequiredDialog(AbstractLoginWidget *contentWidget, QWidget *parent = nullptr);
+    /**
+     * Defines which form is shown to the user.
+     * The form widgets are already initialized by the content widget (a stacked widget), we just need to bring the right one to the front.
+     */
+    enum class Mode {
+        Basic,
+        OAuth,
+    };
+
+    explicit LoginRequiredDialog(Mode mode, QWidget *parent = nullptr);
     ~LoginRequiredDialog() override;
 
     void setTopLabelText(const QString &newText);
@@ -43,6 +52,12 @@ public:
      * For use with HTTP basic authentication.
      */
     void addLogInButton();
+
+    /**
+     * Form widget currently shown to the user.
+     * @return form widget
+     */
+    [[nodiscard]] QWidget *contentWidget() const;
 
 private:
     ::Ui::LoginRequiredDialog *_ui;


### PR DESCRIPTION
The widgets are pre-initialized by the .ui file already, there is no need for initializing them manually.