### PR TITLE
[gui-tests] Remove unnecessary waits

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -30,8 +30,8 @@ previousErrorResultCount = 0
 # socket messages
 socket_messages = []
 
-# whether waited for context.userData['touchTimeout'] seconds or not
-# this is useful for waiting only for the first time
+# Whether wait has been made or not after account is set up
+# This is useful for waiting only for the first time
 waitedAfterSync = False
 
 
@@ -171,10 +171,12 @@ def waitUntilAppIsKilled(context, pid=0):
     timeout = context.userData['minSyncTimeout'] * 1000
     killed = waitFor(
         lambda: isAppKilled(pid),
-         timeout,
+        timeout,
     )
     if not killed:
-        test.log("Application was not terminated within {} milliseconds".format(timeout))
+        test.log(
+            "Application was not terminated within {} milliseconds".format(timeout)
+        )
 
 
 @OnScenarioEnd

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -30,6 +30,10 @@ previousErrorResultCount = 0
 # socket messages
 socket_messages = []
 
+# whether waited for context.userData['touchTimeout'] seconds or not
+# this is useful for waiting only for the first time
+waitedAfterSync = False
+
 
 @OnScenarioStart
 def hook(context):
@@ -143,6 +147,8 @@ def hook(context):
 
 
 # determines if the test scenario failed or not
+# Currently, this workaround is needed because we cannot find out a way to determine the pass/fail status of currently running test scenario.
+# And, resultCount("errors")  and resultCount("fails") return the total number of error/failed test scenarios of a test suite.
 def scenarioFailed():
     global previousFailResultCount
     global previousErrorResultCount
@@ -154,17 +160,16 @@ def scenarioFailed():
 
 @OnScenarioEnd
 def hook(context):
+    global socketConnect, socket_messages, waitedAfterSync, previousFailResultCount, previousErrorResultCount, waitedAfterSync
+
+    # reset waited after sync flag
+    waitedAfterSync = False
+
     # close socket connection and clear messages
-    global socketConnect, socket_messages
     socket_messages.clear()
     if socketConnect:
         socketConnect.connected = False
         socketConnect._sock.close()
-
-    # Currently, this workaround is needed because we cannot find out a way to determine the pass/fail status of currently running test scenario.
-    # And, resultCount("errors")  and resultCount("fails") return the total number of error/failed test scenarios of a test suite.
-    global previousFailResultCount
-    global previousErrorResultCount
 
     # capture a screenshot if there is error or test failure in the current scenario execution
     if scenarioFailed() and os.getenv('CI'):

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -72,8 +72,6 @@ def startClient(context):
         + context.userData['clientConfigDir']
     )
 
-    squish.snooze(1)
-
 
 def getPollingInterval():
     pollingInterval = '''[ownCloud]

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -40,7 +40,6 @@ sys.path.append(os.path.realpath('../../../shell_integration/nautilus/'))
 from syncstate import SocketConnect
 import functools
 
-
 socketConnect = None
 
 createdUsers = {}
@@ -542,31 +541,23 @@ def step(context, type, resource):
     'user "|any|" has created a file "|any|" with the following content inside the sync folder'
 )
 def step(context, username, filename):
-    createFile(context, filename, username)
+    fileContent = "\n".join(context.multiLineText)
+    syncPath = getUserSyncPath(context, username)
+    writeFile(join(syncPath, filename), fileContent)
 
 
 @When(
     'user "|any|" creates a file "|any|" with the following content inside the sync folder'
 )
 def step(context, username, filename):
-    createFile(context, filename, username)
-
-
-def createFile(context, filename, username=None):
     fileContent = "\n".join(context.multiLineText)
-    syncPath = None
-    if username:
-        syncPath = getUserSyncPath(context, username)
-    else:
-        syncPath = context.userData['currentUserSyncPath']
+    syncPath = getUserSyncPath(context, username)
+    waitAndWriteFile(context, join(syncPath, filename), fileContent)
 
-    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
-    # https://github.com/owncloud/client/issues/9325
-    snooze(context.userData['minSyncTimeout'])
 
-    f = open(join(syncPath, filename), "w")
-    f.write(fileContent)
-    f.close()
+def waitAndWriteFile(context, path, content):
+    waitForClientToBeReady(context)
+    writeFile(path, content)
 
 
 @When('user "|any|" creates a folder "|any|" inside the sync folder')
@@ -714,9 +705,7 @@ def step(context):
 @Given('the user has changed the content of local file "|any|" to:')
 def step(context, filename):
     fileContent = "\n".join(context.multiLineText)
-    f = open(context.userData['currentUserSyncPath'] + filename, "w")
-    f.write(fileContent)
-    f.close()
+    writeFile(join(context.userData['currentUserSyncPath'], filename), fileContent)
 
 
 @When('the user resumes the file sync on the client')
@@ -1051,12 +1040,12 @@ def step(context, username):
     enterUserPassword = EnterPassword()
     enterUserPassword.enterPassword(password)
 
+    # wait for files to sync
+    waitForInitialSyncToComplete(context)
+
 
 @Then('user "|any|" should be connect to the client-UI')
 def step(context, username):
-    # TODO: find some way to dynamically to check if files are synced
-    # It might take some time for all files to sync and connect to ther server
-    snooze(context.userData['minSyncTimeout'])
     isUserSignedIn(context, username)
 
 
@@ -1145,15 +1134,26 @@ def step(context, resource, group):
     sharingDialog.selectCollaborator(group, True)
 
 
-def overwriteFile(resource, content):
+# performing actions immediately after completing the sync from the server does not work
+# The test should wait for a while before performing the action
+# issue: https://github.com/owncloud/client/issues/8832
+def waitForClientToBeReady(context):
+    global waitedAfterSync
+    if not waitedAfterSync:
+        snooze(context.userData['minSyncTimeout'])
+        waitedAfterSync = True
+
+
+def writeFile(resource, content):
     f = open(resource, "w")
     f.write(content)
     f.close()
 
 
-def tryToOverwriteFile(context, resource, content):
+def waitAndTryToWriteFile(context, resource, content):
+    waitForClientToBeReady(context)
     try:
-        overwriteFile(resource, content)
+        writeFile(resource, content)
     except:
         pass
 
@@ -1162,38 +1162,20 @@ def tryToOverwriteFile(context, resource, content):
 def step(context, resource, content):
     print("starting file overwrite")
     resource = join(context.userData['currentUserSyncPath'], resource)
-
-    # overwriting the file immediately after it has been synced from the server seems to have some problem.
-    # The client does not see the change although the changes have already been made thus we are having a race condition
-    # So for now we add 5sec static wait
-    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
-    snooze(context.userData['minSyncTimeout'])
-
-    overwriteFile(resource, content)
-
+    waitAndWriteFile(context, resource, content)
     print("file has been overwritten")
 
 
 @When('the user tries to overwrite the file "|any|" with content "|any|"')
 def step(context, resource, content):
     resource = context.userData['currentUserSyncPath'] + resource
-    # overwriting the file immediately after it has been synced from the server seems to have some problem.
-    # The client does not see the change although the changes have already been made thus we are having a race condition
-    # So for now we add 5sec static wait
-    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
-    snooze(context.userData['minSyncTimeout'])
-    tryToOverwriteFile(context, resource, content)
+    waitAndTryToWriteFile(context, resource, content)
 
 
 @When('user "|any|" tries to overwrite the file "|any|" with content "|any|"')
 def step(context, user, resource, content):
     resource = getResourcePath(context, resource, user)
-    # overwriting the file immediately after it has been synced from the server seems to have some problem.
-    # The client does not see the change although the changes have already been made thus we are having a race condition
-    # So for now we add 5sec static wait
-    # an issue https://github.com/owncloud/client/issues/8832 has been created for it
-    snooze(context.userData['minSyncTimeout'])
-    tryToOverwriteFile(context, resource, content)
+    waitAndTryToWriteFile(context, resource, content)
 
 
 def enableVFSSupport(vfsBtnText):
@@ -1278,9 +1260,7 @@ def step(context, errorMsg):
 
 @When(r'the user deletes the (file|folder) "([^"]*)"', regexp=True)
 def step(context, itemType, resource):
-    # deleting the file immediately after it has been synced from the server seems to have some problem.
-    # issue: https://github.com/owncloud/client/issues/8832
-    snooze(context.userData['minSyncTimeout'])
+    waitForClientToBeReady(context)
 
     resourcePath = sanitizePath(context.userData['currentUserSyncPath'] + resource)
     if itemType == 'file':
@@ -1537,28 +1517,22 @@ def step(context, username):
     '''
     syncPath = getUserSyncPath(context, username)
 
-    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
-    # https://github.com/owncloud/client/issues/9325
-    snooze(context.userData['minSyncTimeout'])
+    waitForClientToBeReady(context)
 
     for row in context.table[1:]:
         filename = syncPath + row[0]
-        f = open(join(syncPath, filename), "w")
-        f.close()
+        writeFile(join(syncPath, filename), '')
 
 
 @When('user "|any|" creates the following files inside the sync folder:')
 def step(context, username):
     syncPath = getUserSyncPath(context, username)
 
-    # A file is scheduled to be synced but is marked as ignored for 5 seconds. And if we try to sync it, it will fail. So we need to wait for 5 seconds.
-    # https://github.com/owncloud/client/issues/9325
-    snooze(context.userData['minSyncTimeout'])
+    waitForClientToBeReady(context)
 
     for row in context.table[1:]:
         filename = syncPath + row[0]
-        f = open(join(syncPath, filename), "w")
-        f.close()
+        writeFile(join(syncPath, filename), '')
 
 
 @Given(

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -40,6 +40,7 @@ sys.path.append(os.path.realpath('../../../shell_integration/nautilus/'))
 from syncstate import SocketConnect
 import functools
 
+
 socketConnect = None
 
 createdUsers = {}
@@ -537,15 +538,6 @@ def step(context, type, resource):
     waitForFileOrFolderToSync(context, resource, type)
 
 
-@Given(
-    'user "|any|" has created a file "|any|" with the following content inside the sync folder'
-)
-def step(context, username, filename):
-    fileContent = "\n".join(context.multiLineText)
-    syncPath = getUserSyncPath(context, username)
-    writeFile(join(syncPath, filename), fileContent)
-
-
 @When(
     'user "|any|" creates a file "|any|" with the following content inside the sync folder'
 )
@@ -553,11 +545,6 @@ def step(context, username, filename):
     fileContent = "\n".join(context.multiLineText)
     syncPath = getUserSyncPath(context, username)
     waitAndWriteFile(context, join(syncPath, filename), fileContent)
-
-
-def waitAndWriteFile(context, path, content):
-    waitForClientToBeReady(context)
-    writeFile(path, content)
 
 
 @When('user "|any|" creates a folder "|any|" inside the sync folder')
@@ -705,7 +692,7 @@ def step(context):
 @Given('the user has changed the content of local file "|any|" to:')
 def step(context, filename):
     fileContent = "\n".join(context.multiLineText)
-    writeFile(join(context.userData['currentUserSyncPath'], filename), fileContent)
+    waitAndWriteFile(join(context.userData['currentUserSyncPath'], filename), fileContent)
 
 
 @When('the user resumes the file sync on the client')
@@ -1150,6 +1137,11 @@ def writeFile(resource, content):
     f.close()
 
 
+def waitAndWriteFile(context, path, content):
+    waitForClientToBeReady(context)
+    writeFile(path, content)
+
+
 def waitAndTryToWriteFile(context, resource, content):
     waitForClientToBeReady(context)
     try:
@@ -1508,20 +1500,6 @@ def step(context):
 @Then('VFS enabled baseline image should not match the default screenshot')
 def step(context):
     test.xvp("VP_VFS_enabled")
-
-
-@Given('user "|any|" has created the following files inside the sync folder:')
-def step(context, username):
-    '''
-    Create files without any content
-    '''
-    syncPath = getUserSyncPath(context, username)
-
-    waitForClientToBeReady(context)
-
-    for row in context.table[1:]:
-        filename = syncPath + row[0]
-        writeFile(join(syncPath, filename), '')
 
 
 @When('user "|any|" creates the following files inside the sync folder:')

--- a/test/gui/shared/steps/steps.py
+++ b/test/gui/shared/steps/steps.py
@@ -692,7 +692,9 @@ def step(context):
 @Given('the user has changed the content of local file "|any|" to:')
 def step(context, filename):
     fileContent = "\n".join(context.multiLineText)
-    waitAndWriteFile(join(context.userData['currentUserSyncPath'], filename), fileContent)
+    waitAndWriteFile(
+        join(context.userData['currentUserSyncPath'], filename), fileContent
+    )
 
 
 @When('the user resumes the file sync on the client')


### PR DESCRIPTION
This PR has the following changes:
- Remove waits where there is no need
- Wisely wait for some actions to finish (if needed)

Previously, there were waits before any action (`create`, `delete`, `rename`, and `move` file/folder). The wait was needed but only before the first action so there was no need for other waits after the first wait. Those waits accumulate and cause test cases to run for a long. Thus, this PR has refactored the test code so that there is a wait only before performing the first sync operation and other operations can be performed without waits.

Similarly, we have explicitly waited for `minSyncTimeout` i.e. `5 secs` for the AUT to be terminated thus causing unnecessary waits and long tests run. In this PR, I have checked the availability of the AUT process, determined whether it is running or not, and waited for its termination. This prevents the use of unnecessary waits.

### Motivation
Reduce tests runtime

### Results
Before: (https://drone.owncloud.com/owncloud/client/13483)
![Screenshot from 2022-10-24 11-17-20](https://user-images.githubusercontent.com/52366632/197454860-163b2627-284c-41ff-9b7d-e5cc018fab8b.png)

After:
![Screenshot from 2022-10-24 11-17-11](https://user-images.githubusercontent.com/52366632/197454873-5c23ee24-034f-43cf-bab4-2fd4d7f27a74.png)
