### PR TITLE
Update accountmanager.cpp

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -310,17 +310,19 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
 
 AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 {
-    auto urlConfig = settings.value(urlC());
-    if (!urlConfig.isValid()) {
-        // No URL probably means a corrupted entry in the account settings
-        qCWarning(lcAccountManager) << "No URL for account " << settings.group();
-        return AccountPtr();
-    }
-
     auto acc = createAccount();
-
-    acc->setUrl(urlConfig.toUrl());
-
+    
+    {
+        auto urlConfig = settings.value(urlC());
+        if (!urlConfig.isValid()) {
+            // No URL probably means a corrupted entry in the account settings
+            qCWarning(lcAccountManager) << "No URL for account " << settings.group();
+            return AccountPtr();
+        }
+        
+        acc->setUrl(urlConfig.toUrl());
+    }
+    
     acc->_davUser = settings.value(davUserC()).toString();
     acc->_displayName = settings.value(davUserDisplyNameC()).toString();
     acc->_uuid = settings.value(userUUIDC(), acc->_uuid).toUuid();
@@ -418,9 +420,8 @@ bool AccountManager::isAccountIdAvailable(const QString &id) const
             return false;
         }
     }
-    if (_additionalBlockedAccountIds.contains(id))
-        return false;
-    return true;
+    
+    return _additionalBlockedAccountIds.contains(id));
 }
 
 QString AccountManager::generateFreeAccountId() const

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -421,7 +421,7 @@ bool AccountManager::isAccountIdAvailable(const QString &id) const
         }
     }
     
-    return _additionalBlockedAccountIds.contains(id));
+    return _additionalBlockedAccountIds.contains(id);
 }
 
 QString AccountManager::generateFreeAccountId() const


### PR DESCRIPTION
- Changed the scope of urlConfig in AccountManager::loadAccountHelper to end after declaring acc's URL, where it is last used, and forwardly declared acc within the function
- Simplified the blocked account ID check in AccountManager::isAccountIdAvailable