### PR TITLE
Open the browser instead of the share dialog

### DIFF
--- a/changelog/unreleased/10206
+++ b/changelog/unreleased/10206
@@ -1,0 +1,5 @@
+Change: When connected to OCIS, open the browser instead of the sharing dialog
+
+We now open the browser and navigate to the file the user wanted to share instead of opening the legacy sharing dialog, when connected to ocis.
+
+https://github.com/owncloud/client/issues/10206 

--- a/changelog/unreleased/10206
+++ b/changelog/unreleased/10206
@@ -1,5 +1,5 @@
-Change: When connected to OCIS, open the browser instead of the sharing dialog
+Change: When connected to oCIS, open the browser instead of the sharing dialog
 
-We now open the browser and navigate to the file the user wanted to share instead of opening the legacy sharing dialog, when connected to ocis.
+When connected to oCIS, we now open the browser and navigate to the file the user wanted to share instead of opening the legacy sharing dialog.
 
 https://github.com/owncloud/client/issues/10206 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1206,47 +1206,52 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         qCWarning(lcApplication) << "Could not open share dialog for" << localPath << "no responsible folder found";
         return;
     }
-
-    const auto accountState = folder->accountState();
-
-    SyncJournalFileRecord fileRecord;
-
-    bool resharingAllowed = true; // lets assume the good
-    if (folder->journalDb()->getFileRecord(file, &fileRecord) && fileRecord.isValid()) {
-        // check the permission: Is resharing allowed?
-        if (!fileRecord._remotePerm.isNull() && !fileRecord._remotePerm.hasPermission(RemotePermissions::CanReshare)) {
-            resharingAllowed = false;
-        }
-    }
-
-    // As a first approximation, set the set of permissions that can be granted
-    // either to everything (resharing allowed) or nothing (no resharing).
-    //
-    // The correct value will be found with a propfind from ShareDialog.
-    // (we want to show the dialog directly, not wait for the propfind first)
-    SharePermissions maxSharingPermissions =
-        SharePermissionRead
-        | SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete
-        | SharePermissionShare;
-    if (!resharingAllowed) {
-        maxSharingPermissions = SharePermission(0);
-    }
-
-
-    ShareDialog *w = nullptr;
-    if (_shareDialogs.contains(localPath) && _shareDialogs[localPath]) {
-        qCInfo(lcApplication) << "Raising share dialog" << sharePath << localPath;
-        w = _shareDialogs[localPath];
+    if (folder->accountState()->account()->capabilities().filesSharing().sharing_roles) {
+        fetchPrivateLinkUrl(folder->accountState()->account(), folder->webDavUrl(), sharePath, this, [](const QUrl &url) {
+            Utility::openBrowser(url, nullptr);
+        });
     } else {
-        qCInfo(lcApplication) << "Opening share dialog" << sharePath << localPath << maxSharingPermissions;
-        w = new ShareDialog(accountState, folder->webDavUrl(), sharePath, localPath, maxSharingPermissions, startPage, settingsDialog());
-        w->setAttribute(Qt::WA_DeleteOnClose, true);
+        const auto accountState = folder->accountState();
 
-        _shareDialogs[localPath] = w;
-        connect(w, &QObject::destroyed, this, &ownCloudGui::slotRemoveDestroyedShareDialogs);
+        SyncJournalFileRecord fileRecord;
+
+        bool resharingAllowed = true; // lets assume the good
+        if (folder->journalDb()->getFileRecord(file, &fileRecord) && fileRecord.isValid()) {
+            // check the permission: Is resharing allowed?
+            if (!fileRecord._remotePerm.isNull() && !fileRecord._remotePerm.hasPermission(RemotePermissions::CanReshare)) {
+                resharingAllowed = false;
+            }
+        }
+
+        // As a first approximation, set the set of permissions that can be granted
+        // either to everything (resharing allowed) or nothing (no resharing).
+        //
+        // The correct value will be found with a propfind from ShareDialog.
+        // (we want to show the dialog directly, not wait for the propfind first)
+        SharePermissions maxSharingPermissions =
+            SharePermissionRead
+            | SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete
+            | SharePermissionShare;
+        if (!resharingAllowed) {
+            maxSharingPermissions = SharePermission(0);
+        }
+
+
+        ShareDialog *w = nullptr;
+        if (_shareDialogs.contains(localPath) && _shareDialogs[localPath]) {
+            qCInfo(lcApplication) << "Raising share dialog" << sharePath << localPath;
+            w = _shareDialogs[localPath];
+        } else {
+            qCInfo(lcApplication) << "Opening share dialog" << sharePath << localPath << maxSharingPermissions;
+            w = new ShareDialog(accountState, folder->webDavUrl(), sharePath, localPath, maxSharingPermissions, startPage, settingsDialog());
+            w->setAttribute(Qt::WA_DeleteOnClose, true);
+
+            _shareDialogs[localPath] = w;
+            connect(w, &QObject::destroyed, this, &ownCloudGui::slotRemoveDestroyedShareDialogs);
+        }
+        w->open();
+        raiseDialog(w);
     }
-    w->open();
-    raiseDialog(w);
 }
 
 void ownCloudGui::slotRemoveDestroyedShareDialogs()

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -30,6 +30,7 @@ Capabilities::Capabilities(const QVariantMap &capabilities)
     , _spaces(_capabilities.value(QStringLiteral("spaces")).toMap())
     , _status(_capabilities.value(QStringLiteral("core")).toMap().value(QStringLiteral("status")).toMap())
     , _appProviders(AppProviders::findVersion(_capabilities.value(QStringLiteral("files")).toMap().value(QStringLiteral("app_providers")).toList(), QVersionNumber({ 1, 1, 0 })))
+    , _filesSharing(_fileSharingCapabilities)
 {
 }
 
@@ -334,4 +335,14 @@ Capabilities::AppProviders Capabilities::AppProviders::findVersion(const QVarian
                              : Capabilities::AppProviders();
 }
 
+
+const FilesSharing &Capabilities::filesSharing() const
+{
+    return _filesSharing;
+}
+
+FilesSharing::FilesSharing(const QVariantMap &filesSharing)
+    : sharing_roles(filesSharing.value(QStringLiteral("sharing_roles"), false).toBool())
+{
+}
 } // namespace OCC

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -91,6 +91,25 @@ struct OWNCLOUDSYNC_EXPORT SpaceSupport
     bool isValid() const;
 };
 
+struct OWNCLOUDSYNC_EXPORT FilesSharing
+{
+    /**
+     api_enabled": true,
+    "resharing": true,
+    "group_sharing": true,
+    "sharing_roles": true,
+    "auto_accept_share": true,
+    "share_with_group_members_only": true,
+    "share_with_membership_groups_only": true,
+    "search_min_length": 3,
+    "default_permissions": 22,
+    */
+    FilesSharing(const QVariantMap &filesSharing);
+
+    // TODO: add more
+    bool sharing_roles = false;
+};
+
 /**
  * @brief The Capabilities class represents the capabilities of an ownCloud
  * server
@@ -254,6 +273,8 @@ public:
 
     const AppProviders &appProviders() const;
 
+    const FilesSharing &filesSharing() const;
+
 
     QVariantMap raw() const;
 
@@ -265,6 +286,7 @@ private:
     SpaceSupport _spaces;
     Status _status;
     AppProviders _appProviders;
+    FilesSharing _filesSharing;
 };
 }
 


### PR DESCRIPTION
When using role based sharing we no longer display the sharing dialog.

Fixes: #10206