### PR TITLE
Fix AppImages' update check

### DIFF
--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -76,15 +76,7 @@ QUrlQuery Updater::getQueryParams()
     Theme *theme = Theme::instance();
     QString platform = QStringLiteral("stranger");
     if (Utility::isLinux()) {
-#ifdef WITH_APPIMAGEUPDATER
-        if (Utility::runningInAppImage()) {
-            platform = QStringLiteral("linux-appimage-") + QSysInfo::buildCpuArchitecture();
-        } else {
-#endif
-            platform = QStringLiteral("linux");
-#ifdef WITH_APPIMAGEUPDATER
-        }
-#endif
+        platform = QStringLiteral("linux");
     } else if (Utility::isBSD()) {
         platform = QStringLiteral("bsd");
     } else if (Utility::isWindows()) {
@@ -102,6 +94,13 @@ QUrlQuery Updater::getQueryParams()
     query.addQueryItem(QStringLiteral("oem"), theme->appName());
     query.addQueryItem(QStringLiteral("buildArch"), QSysInfo::buildCpuArchitecture());
     query.addQueryItem(QStringLiteral("currentArch"), QSysInfo::currentCpuArchitecture());
+
+    // client updater server is now aware of packaging format
+    // TODO: add packaging string for other supported platforms, too
+#ifdef WITH_APPIMAGEUPDATER
+    query.addQueryItem(QStringLiteral("packaging"), QStringLiteral("AppImage"));
+#endif
+
 
     query.addQueryItem(QStringLiteral("versionsuffix"), OCC::Version::suffix());
 


### PR DESCRIPTION
We changed the updater server's behavior to properly distinguish between different kinds of packaging/bundling, which is novel to the current setup. In future releases, we are going to add this parameter for the other platforms, too, and also stop encoding the architecture into the platform string for Windows.