### PR TITLE
Fix OAuth retry

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -768,6 +768,7 @@ void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
 void AccountSettings::slotAccountStateChanged()
 {
     const AccountState::State state = _accountState ? _accountState->state() : AccountState::Disconnected;
+    qDebug() << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << state;
     if (state != AccountState::Disconnected) {
         AccountPtr account = _accountState->account();
         QUrl safeUrl(account->url());
@@ -846,7 +847,10 @@ void AccountSettings::slotAccountStateChanged()
 
                 connect(
                     cred, &HttpCredentialsGui::authorisationLinkChanged,
-                    this, &AccountSettings::slotAccountStateChanged,
+                    this, [this]() {
+                        qDebug() << "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+                        AccountSettings::slotAccountStateChanged();
+                    },
                     Qt::UniqueConnection);
 
                 connect(_askForOAuthLoginDialog, &LoginRequiredDialog::rejected, this, [this]() {
@@ -861,7 +865,7 @@ void AccountSettings::slotAccountStateChanged()
                 });
 
                 connect(cred, &HttpCredentialsGui::asked, _askForOAuthLoginDialog, [loginDialog = _askForOAuthLoginDialog, contentWidget, cred]() {
-                    if (!cred->ready()) {
+                    if (cred->ready() == AbstractCredentials::ReadyState::Retry) {
                         ocApp()->gui()->raiseDialog(loginDialog);
                         contentWidget->showRetryFrame();
                     }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -768,7 +768,6 @@ void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
 void AccountSettings::slotAccountStateChanged()
 {
     const AccountState::State state = _accountState ? _accountState->state() : AccountState::Disconnected;
-    qDebug() << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" << state;
     if (state != AccountState::Disconnected) {
         AccountPtr account = _accountState->account();
         QUrl safeUrl(account->url());
@@ -845,13 +844,7 @@ void AccountSettings::slotAccountStateChanged()
                     contentWidget->setEnabled(true);
                 });
 
-                connect(
-                    cred, &HttpCredentialsGui::authorisationLinkChanged,
-                    this, [this]() {
-                        qDebug() << "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-                        AccountSettings::slotAccountStateChanged();
-                    },
-                    Qt::UniqueConnection);
+                connect(cred, &HttpCredentialsGui::authorisationLinkChanged, this, &AccountSettings::slotAccountStateChanged, Qt::UniqueConnection);
 
                 connect(_askForOAuthLoginDialog, &LoginRequiredDialog::rejected, this, [this]() {
                     // if a user dismisses the dialog, we have no choice but signing them out

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -494,7 +494,7 @@ void AccountState::slotCredentialsAsked(AbstractCredentials *credentials)
     case AbstractCredentials::ReadyState::Error:
         setState(SignedOut);
         return;
-    default:
+    case AbstractCredentials::ReadyState::Ready:
         break;
     }
 

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -175,7 +175,7 @@ void ConnectionValidator::slotStatusFound(const QUrl &url, const QJsonObject &in
     }
 
     AbstractCredentials *creds = _account->credentials();
-    if (!creds->ready()) {
+    if (creds->ready() != AbstractCredentials::ReadyState::Ready) {
         reportResult(CredentialsNotReady);
         return;
     }

--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -164,11 +164,7 @@ void HttpCredentialsGui::restartOAuth()
     _asyncAuth.reset(new AccountBasedOAuth(_account->sharedFromThis(), this));
     connect(_asyncAuth.data(), &OAuth::result,
         this, &HttpCredentialsGui::asyncAuthResult);
-    connect(_asyncAuth.data(), &OAuth::authorisationLinkChanged,
-        this, [this]() {
-            qDebug() << "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
-            authorisationLinkChanged();
-        });
+    connect(_asyncAuth.data(), &OAuth::authorisationLinkChanged, this, &HttpCredentialsGui::authorisationLinkChanged);
     _asyncAuth->startAuthentication();
     emit authorisationLinkChanged();
 }

--- a/src/gui/creds/httpcredentialsgui.cpp
+++ b/src/gui/creds/httpcredentialsgui.cpp
@@ -87,6 +87,7 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
         showDialog();
         return;
     case OAuth::Error:
+        _ready = AbstractCredentials::ReadyState::Retry;
         emit asked();
         return;
     case OAuth::LoggedIn:
@@ -97,7 +98,7 @@ void HttpCredentialsGui::asyncAuthResult(OAuth::Result r, const QString &user,
 
     _password = token;
     _refreshToken = refreshToken;
-    _ready = true;
+    _ready = AbstractCredentials::ReadyState::Ready;
     persist();
     emit asked();
 }
@@ -126,7 +127,7 @@ void HttpCredentialsGui::showDialog()
             Q_ASSERT(contentWidget->username() == _account->davUser());
             _password = contentWidget->password();
             _refreshToken.clear();
-            _ready = true;
+            _ready = AbstractCredentials::ReadyState::Ready;
             persist();
         } else {
             Q_EMIT requestLogout();
@@ -163,8 +164,11 @@ void HttpCredentialsGui::restartOAuth()
     _asyncAuth.reset(new AccountBasedOAuth(_account->sharedFromThis(), this));
     connect(_asyncAuth.data(), &OAuth::result,
         this, &HttpCredentialsGui::asyncAuthResult);
-    connect(_asyncAuth.data(), &OAuth::destroyed,
-        this, &HttpCredentialsGui::authorisationLinkChanged);
+    connect(_asyncAuth.data(), &OAuth::authorisationLinkChanged,
+        this, [this]() {
+            qDebug() << "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+            authorisationLinkChanged();
+        });
     _asyncAuth->startAuthentication();
     emit authorisationLinkChanged();
 }

--- a/src/gui/quotainfo.cpp
+++ b/src/gui/quotainfo.cpp
@@ -79,7 +79,7 @@ bool QuotaInfo::canGetQuota() const
     AccountPtr account = _accountState->account();
     return _accountState->isConnected()
         && account->credentials()
-        && account->credentials()->ready();
+        && account->credentials()->ready() == AbstractCredentials::ReadyState::Ready;
 }
 
 QString QuotaInfo::quotaBaseFolder() const

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -34,7 +34,7 @@ ServerNotificationHandler::ServerNotificationHandler(QObject *parent)
 void ServerNotificationHandler::slotFetchNotifications(AccountStatePtr ptr)
 {
     // check connectivity and credentials
-    if (!(ptr && ptr->isConnected() && ptr->account() && ptr->account()->credentials() && ptr->account()->credentials()->ready())) {
+    if (!(ptr && ptr->isConnected() && ptr->account() && ptr->account()->credentials() && ptr->account()->credentials()->ready() == AbstractCredentials::ReadyState::Ready)) {
         deleteLater();
         return;
     }

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -210,7 +210,7 @@ void AbstractNetworkJob::slotFinished()
     // get the Date timestamp from reply
     _responseTimestamp = _reply->rawHeader("Date");
 
-    if (!reply()->attribute(QNetworkRequest::RedirectionTargetAttribute).isNull() && !(isAuthenticationJob() || reply()->request().hasRawHeader(QByteArrayLiteral("OC-Connection-Validator")))) {
+    if (!reply()->attribute(QNetworkRequest::RedirectionTargetAttribute).isNull() && !isAuthenticationJob()) {
         Q_EMIT _account->unknownConnectionState();
         qCWarning(lcNetworkJob) << this << "Unsupported redirect on" << _reply->url().toString() << "to" << reply()->attribute(QNetworkRequest::RedirectionTargetAttribute).toString();
         Q_EMIT networkError(_reply);

--- a/src/libsync/creds/abstractcredentials.h
+++ b/src/libsync/creds/abstractcredentials.h
@@ -33,6 +33,13 @@ class OWNCLOUDSYNC_EXPORT AbstractCredentials : public QObject
     Q_OBJECT
 
 public:
+    enum class ReadyState {
+        Ready,
+        Retry,
+        Error,
+    };
+    Q_ENUM(ReadyState)
+
     AbstractCredentials();
     // No need for virtual destructor - QObject already has one.
 
@@ -49,7 +56,7 @@ public:
     virtual AccessManager *createAM() const = 0;
 
     /** Whether there are credentials that can be used for a connection attempt. */
-    virtual bool ready() const = 0;
+    virtual ReadyState ready() const = 0;
 
     /** Whether fetchFromKeychain() was called before. */
     bool wasFetched() const { return _wasFetched; }

--- a/src/libsync/creds/dummycredentials.cpp
+++ b/src/libsync/creds/dummycredentials.cpp
@@ -32,9 +32,9 @@ AccessManager *DummyCredentials::createAM() const
     return new AccessManager;
 }
 
-bool DummyCredentials::ready() const
+AbstractCredentials::ReadyState DummyCredentials::ready() const
 {
-    return true;
+    return AbstractCredentials::ReadyState::Ready;
 }
 
 bool DummyCredentials::stillValid(QNetworkReply *reply)

--- a/src/libsync/creds/dummycredentials.h
+++ b/src/libsync/creds/dummycredentials.h
@@ -29,7 +29,7 @@ public:
     QString authType() const override;
     QString user() const override;
     AccessManager *createAM() const override;
-    bool ready() const override;
+    ReadyState ready() const override;
     bool stillValid(QNetworkReply *reply) override;
     void fetchFromKeychain() override;
     void askFromUser() override;

--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -56,7 +56,7 @@ public:
 
     QString authType() const override;
     AccessManager *createAM() const override;
-    bool ready() const override;
+    ReadyState ready() const override;
     void fetchFromKeychain() override;
     bool stillValid(QNetworkReply *reply) override;
     void persist() override;
@@ -91,9 +91,8 @@ protected:
     QString _previousPassword;
 
     QString _fetchErrorString;
-    bool _ready = false;
+    ReadyState _ready = AbstractCredentials::ReadyState::Ready;
     QPointer<AccountBasedOAuth> _oAuthJob;
-    bool _retryOnKeyChainError = true; // true if we haven't done yet any reading from keychain
 
     DetermineAuthTypeJob::AuthType _authType = DetermineAuthTypeJob::AuthType::Unknown;
 

--- a/src/libsync/creds/httpcredentials_p.h
+++ b/src/libsync/creds/httpcredentials_p.h
@@ -150,7 +150,7 @@ private:
             _parent->_fetchErrorString = job->error() != QKeychain::EntryNotFound ? job->errorString() : QString();
 
             _parent->_password.clear();
-            _parent->_ready = false;
+            _parent->_ready = AbstractCredentials::ReadyState::Error;
             emit _parent->fetched();
         } else {
             qCWarning(lcHttpLegacyCredentials) << "Migrated old keychain entries";
@@ -162,13 +162,13 @@ private:
                 // Still, the password can be empty which indicates a problem and
                 // the password dialog has to be opened.
                 _parent->_password = data;
-                _parent->_ready = true;
+                _parent->_ready = AbstractCredentials::ReadyState::Ready;
                 emit _parent->fetched();
             }
         }
         // If keychain data was read from legacy location, wipe these entries and store new ones
         deleteOldKeychainEntries();
-        if (_parent->_ready) {
+        if (_parent->_ready == AbstractCredentials::ReadyState::Ready) {
             _parent->persist();
             qCWarning(lcHttpLegacyCredentials) << "Migrated old keychain entries";
         }


### PR DESCRIPTION
In one of the slots for asked(), we need to be able to distinguish between "error" and "retry" situations.

I'm sure there's a more elegant way, but I don't see it currently.

Also cleans up a superfluous variable in HttpCredentials.

Fixes #10300.