### PR TITLE
macOS: Fix start-on-login migration

### DIFF
--- a/src/libsync/platform_mac.mm
+++ b/src/libsync/platform_mac.mm
@@ -76,6 +76,8 @@ MacPlatform::~MacPlatform()
 void MacPlatform::migrate()
 {
     Platform::migrate();
+
+    migrateLaunchOnStartup();
 }
 
 } // namespace OCC


### PR DESCRIPTION
... by actually calling the migration function. This got lost during the `Platform` class refactoring.