### PR TITLE
Fix encoding of Gtk bookmarks

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -32,7 +32,7 @@ void Utility::setupFavLink(const QString &folder)
 {
     // Nautilus: add to ~/.gtk-bookmarks
     QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.config/gtk-3.0/bookmarks"));
-    QByteArray folderUrl = "file://" + QUrl(folder).url(QUrl::ComponentFormattingOption::EncodeSpaces).toUtf8();
+    QByteArray folderUrl = QUrl::fromLocalFile(folder).url(QUrl::ComponentFormattingOption::EncodeSpaces).toUtf8();
     if (gtkBookmarks.open(QFile::ReadWrite)) {
         QByteArray places = gtkBookmarks.readAll();
         if (!places.contains(folderUrl)) {

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -32,7 +32,7 @@ void Utility::setupFavLink(const QString &folder)
 {
     // Nautilus: add to ~/.gtk-bookmarks
     QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.config/gtk-3.0/bookmarks"));
-    QByteArray folderUrl = QUrl::fromLocalFile(folder).toEncoded(QUrl::ComponentFormattingOption::EncodeSpaces);
+    const QByteArray folderUrl = QUrl::fromLocalFile(folder).toEncoded(QUrl::ComponentFormattingOption::EncodeSpaces);
     if (gtkBookmarks.open(QFile::ReadWrite)) {
         QByteArray places = gtkBookmarks.readAll();
         if (!places.contains(folderUrl)) {

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -32,7 +32,7 @@ void Utility::setupFavLink(const QString &folder)
 {
     // Nautilus: add to ~/.gtk-bookmarks
     QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.config/gtk-3.0/bookmarks"));
-    QByteArray folderUrl = "file://" + folder.toUtf8();
+    QByteArray folderUrl = "file://" + QUrl(folder).url(QUrl::ComponentFormattingOption::EncodeSpaces).toUtf8();
     if (gtkBookmarks.open(QFile::ReadWrite)) {
         QByteArray places = gtkBookmarks.readAll();
         if (!places.contains(folderUrl)) {

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -32,7 +32,7 @@ void Utility::setupFavLink(const QString &folder)
 {
     // Nautilus: add to ~/.gtk-bookmarks
     QFile gtkBookmarks(QDir::homePath() + QLatin1String("/.config/gtk-3.0/bookmarks"));
-    QByteArray folderUrl = QUrl::fromLocalFile(folder).url(QUrl::ComponentFormattingOption::EncodeSpaces).toUtf8();
+    QByteArray folderUrl = QUrl::fromLocalFile(folder).toEncoded(QUrl::ComponentFormattingOption::EncodeSpaces);
     if (gtkBookmarks.open(QFile::ReadWrite)) {
         QByteArray places = gtkBookmarks.readAll();
         if (!places.contains(folderUrl)) {


### PR DESCRIPTION
This should fix #10280. I could not find any other encoding issues other than spaces while testing on a variety of distributions an desktops. 

Unfortunately, there is little to no documentation on how this file should really be structured. We have not seen any issues other than with spaces in paths so far, though. We can add additional escaping in the future if needed.