### PR TITLE
Log parseables

### DIFF
--- a/changelog/unreleased/10310
+++ b/changelog/unreleased/10310
@@ -1,0 +1,6 @@
+Enhancement: Tweak logging format 
+
+The logging format is now better parseable for 3rdparty apps
+that ease debugging.
+
+https://github.com/owncloud/client/pull/10310

--- a/src/libsync/httplogger.cpp
+++ b/src/libsync/httplogger.cpp
@@ -61,7 +61,8 @@ void logHttp(const QByteArray &verb, const QString &url, const QByteArray &id, c
         if (reply->attribute(QNetworkRequest::HttpPipeliningWasUsedAttribute).toBool()) {
             stream << "Piplined,";
         }
-        stream << duration << ")";
+        const auto durationInMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+        stream << durationInMs.count() << "ms)";
     }
     stream << " " << url << " Header: { ";
     for (const auto &it : header) {

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -85,7 +85,7 @@ Logger::~Logger()
 
 QString Logger::loggerPattern()
 {
-    return QStringLiteral("%{time MM-dd hh:mm:ss:zzz} [ %{type} %{category} ]%{if-debug}\t[ %{function} ]%{endif}:\t%{message}");
+    return QStringLiteral("%{time yy-MM-dd hh:mm:ss:zzz} [ %{type} %{category} ]%{if-debug}\t[ %{function} ]%{endif}:\t%{message}");
 }
 
 bool Logger::isLoggingToFile() const


### PR DESCRIPTION
Changes the log format to:
```
22-11-23 18:38:34:438 [ info sync.httplogger ]: "5dca3f29-99a7-488b-a35d-8113302e4ba8: Response: PROPFIND 207 (duration(0h, 0min, 0s, 214ms)=214ms) ht...
```
Note 
1. The year at the beginning of the line to make the time stamp standard compatible and parseable
2. The duration in milliseconds appended to the "verbose" duration for humans...