### PR TITLE
Run the sync only once after applying all local modifications

### DIFF
--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -131,37 +131,6 @@ bool DiskFileModifier::applyModifications()
     return helper.succeeded;
 }
 
-bool DiskFileModifier::applyModificationsAndSync(FakeFolder &ff, OCC::Vfs::Mode mode)
-{
-    if (mode == OCC::Vfs::Off || mode == OCC::Vfs::WithSuffix) { // Classic mode:
-        if (!applyModifications()) {
-            return false;
-        }
-        return ff.syncOnce();
-    }
-
-    // Non-classic mode:
-
-    HelperProcess p(_rootDir, _processArguments);
-    _processArguments.clear();
-
-    do {
-        // process any pending events
-        QThread::currentThread()->eventDispatcher()->processEvents(QEventLoop::AllEvents);
-        // wait a bit to get the helper started with it's work
-        std::this_thread::sleep_for(50ms);
-        // process any output from the helper
-        QThread::currentThread()->eventDispatcher()->processEvents(QEventLoop::AllEvents);
-        // now we might need to sync
-        if (!ff.syncOnce()) {
-            return false;
-        }
-        QThread::currentThread()->eventDispatcher()->processEvents(QEventLoop::AllEvents);
-    } while (!p.finished);
-
-    return p.succeeded;
-}
-
 FileInfo FileInfo::A12_B12_C12_S12()
 {
     FileInfo fi { QString {}, {

--- a/test/testutils/syncenginetestutils.h
+++ b/test/testutils/syncenginetestutils.h
@@ -143,8 +143,7 @@ public:
     void rename(const QString &from, const QString &to) override;
     void setModTime(const QString &relativePath, const QDateTime &modTime) override;
 
-    bool applyModifications();
-    Q_REQUIRED_RESULT bool applyModificationsAndSync(FakeFolder &ff, OCC::Vfs::Mode mode);
+    Q_REQUIRED_RESULT bool applyModifications();
 
     // prevent implicit cast to quint64
     template <typename T>
@@ -640,8 +639,10 @@ public:
 
     Q_REQUIRED_RESULT bool applyLocalModificationsAndSync()
     {
-        auto mode = _syncEngine->syncOptions()._vfs->mode();
-        return _localModifier.applyModificationsAndSync(*this, mode);
+        if (!_localModifier.applyModifications()) {
+            return false;
+        }
+        return syncOnce();
     }
 
     Q_REQUIRED_RESULT bool applyLocalModificationsWithoutSync()


### PR DESCRIPTION
Applying local modifications will run the event loop, so any callbacks from cfapi (and QNAM replies) will be handled.

This change prevents the sync to interfere with e.g. hydration requests and possibly soft-fail for that reason.