### PR TITLE
Load log file count limit properly from config file

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -284,6 +284,10 @@ Application::Application(int &argc, char **argv, Platform *platform)
     }
 
     ConfigFile cfg;
+
+    // this should be called once during application startup to make sure we don't miss any messages
+    cfg.configureHttpLogging();
+
     // The timeout is initialized with an environment variable, if not, override with the value from the config
     if (AbstractNetworkJob::httpTimeout == AbstractNetworkJob::DefaultHttpTimeout) {
         AbstractNetworkJob::httpTimeout = cfg.timeout();

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -17,21 +17,22 @@
 #include "stdio.h"
 #include <iostream>
 
-#include <QDialogButtonBox>
-#include <QLayout>
-#include <QPushButton>
-#include <QLabel>
-#include <QDir>
-#include <QTextStream>
-#include <QMessageBox>
-#include <QCoreApplication>
-#include <QSettings>
 #include <QAction>
+#include <QCoreApplication>
 #include <QDesktopServices>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QLabel>
+#include <QLayout>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+#include <QTextStream>
+#include <optional>
 
 #include "configfile.h"
-#include "logger.h"
 #include "guiutility.h"
+#include "logger.h"
 #include "ui_logbrowser.h"
 
 namespace OCC {
@@ -52,8 +53,8 @@ LogBrowser::LogBrowser(QWidget *parent)
     connect(ui->enableLoggingButton, &QCheckBox::toggled, this, &LogBrowser::togglePermanentLogging);
 
     ui->httpLogButton->setChecked(ConfigFile().logHttp());
-    connect(ui->httpLogButton, &QCheckBox::toggled, this, [](bool b) {
-        ConfigFile().setLogHttp(b);
+    connect(ui->httpLogButton, &QCheckBox::toggled, this, [](bool enable) {
+        ConfigFile().configureHttpLogging(std::make_optional(enable));
     });
 
     ui->spinBox_numberOflogsToKeep->setValue(ConfigFile().automaticDeleteOldLogs());

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -15,14 +15,17 @@
 #ifndef CONFIGFILE_H
 #define CONFIGFILE_H
 
+#include "common/result.h"
 #include "owncloudlib.h"
-#include <memory>
+
 #include <QSharedPointer>
 #include <QSettings>
 #include <QString>
 #include <QVariant>
+
 #include <chrono>
-#include "common/result.h"
+#include <memory>
+#include <optional>
 
 class QWidget;
 class QHeaderView;
@@ -105,8 +108,13 @@ public:
     void setAutomaticDeleteOldLogs(int number);
 
     /** Whether to log http traffic */
-    void setLogHttp(bool b);
     bool logHttp() const;
+
+    /**
+     * Set up HTTP logging.
+     * This method should be called during application startup to make sure no messages are missed.
+     */
+    void configureHttpLogging(std::optional<bool> enable = std::nullopt);
 
     // Whether experimental UI options should be shown
     bool showExperimentalOptions() const;

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "logger.h"
+#include "configfile.h"
 #include "theme.h"
 
 #include <QCoreApplication>
@@ -65,7 +66,7 @@ Logger *Logger::instance()
 
 Logger::Logger(QObject *parent)
     : QObject(parent)
-    , _maxLogFiles(minLogsToKeepC)
+    , _maxLogFiles(std::max(ConfigFile().automaticDeleteOldLogs(), minLogsToKeepC))
 {
     qSetMessagePattern(loggerPattern());
     _crashLog.resize(crashLogSizeC);
@@ -175,7 +176,7 @@ void Logger::setLogFile(const QString &name)
 
 void Logger::setMaxLogFiles(int i)
 {
-    _maxLogFiles = std::max(i, minLogsToKeepC);
+    _maxLogFiles = std::max(i, std::max(ConfigFile().automaticDeleteOldLogs(), minLogsToKeepC));
 }
 
 void Logger::setLogDir(const QString &dir)


### PR DESCRIPTION
This commit makes sure that when starting the application, the value is populated from the config file. Previously, the value was only changed when the user set a different value in the log settings dialog.

The static initialization was removed from the constructor to prevent a cyclic dependency between the config file and logger classes (the latter uses the former to populate the value mentioned above).

Fixes #10345.