### PR TITLE
[gui-tests] Avoid use of names in step defs but use methods from page objects (part 1)

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -135,7 +135,6 @@ loginRequiredDialog_OCC_LoginRequiredDialog = {"name": "LoginRequiredDialog", "t
 loginRequiredDialog_contentWidget_QStackedWidget = {"name": "contentWidget", "type": "QStackedWidget", "visible": 1, "window": loginRequiredDialog_OCC_LoginRequiredDialog}
 enable_experimental_feature_QMessageBox = {"type": "QMessageBox", "unnamed": 1, "visible": 1, "windowTitle": "Enable experimental feature?"}
 enable_experimental_feature_Enable_experimental_placeholder_mode_QPushButton = {"text": "Enable experimental placeholder mode", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": enable_experimental_feature_QMessageBox}
-stack_connectLabel_QLabel = {"container": settings_stack_QStackedWidget, "name": "connectLabel", "type": "QLabel", "visible": 1}
 o_folderList_ownCloud_QModelIndex = {"column": 0, "container": stack_folderList_QTreeView, "text": "ownCloud", "type": "QModelIndex"}
 contentWidget_contentWidget_QStackedWidget = {"container": setupWizardWindow_contentWidget_QStackedWidget, "name": "contentWidget", "type": "QStackedWidget", "visible": 1}
 o_folderList_Personal_QModelIndex = {"column": 0, "container": stack_folderList_QTreeView, "text": "Personal", "type": "QModelIndex"}

--- a/test/gui/shared/scripts/pageObjects/Toolbar.py
+++ b/test/gui/shared/scripts/pageObjects/Toolbar.py
@@ -1,34 +1,33 @@
-import names
 import squish
 
 
 class Toolbar:
-    ACTIVITY_BUTTON = {
-        "name": "settingsdialog_toolbutton_Activity",
-        "type": "QToolButton",
-        "visible": 1,
-        "window": names.settings_OCC_SettingsDialog,
-    }
-    ADD_ACCOUNT_BUTTON = {
-        "name": "settingsdialog_toolbutton_Add account",
-        "type": "QToolButton",
-        "visible": 1,
-        "window": names.settings_OCC_SettingsDialog,
-    }
+    @staticmethod
+    def getItemSelector(item_name):
+        return {
+            "name": "settingsdialog_toolbutton_%s" % item_name,
+            "type": "QToolButton",
+            "visible": 1,
+        }
 
-    def clickActivity(self):
-        squish.clickButton(squish.waitForObject(self.ACTIVITY_BUTTON))
+    @staticmethod
+    def openActivity():
+        squish.clickButton(squish.waitForObject(Toolbar.getItemSelector("Activity")))
 
-    def clickAddAccount(self):
-        squish.clickButton(squish.waitForObject(self.ADD_ACCOUNT_BUTTON))
+    @staticmethod
+    def openNewAccountSetup():
+        squish.clickButton(squish.waitForObject(Toolbar.getItemSelector("Add account")))
 
-    def getDisplayedAccountText(self, displayname, host):
+    @staticmethod
+    def openAccount(displayname, host):
+        squish.clickButton(
+            squish.waitForObject(Toolbar.getItemSelector(displayname + "@" + host))
+        )
+
+    @staticmethod
+    def getDisplayedAccountText(displayname, host):
         return str(
             squish.waitForObjectExists(
-                {
-                    "name": "settingsdialog_toolbutton_" + displayname + "@" + host,
-                    "type": "QToolButton",
-                    "visible": 1,
-                }
+                Toolbar.getItemSelector(displayname + "@" + host)
             ).text
         )

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -15,7 +15,7 @@ Feature: adding accounts
             | server   | %local_server% |
             | user     | Alice          |
             | password | 1234           |
-        Then an account should be displayed with the displayname Alice Hansen and host %local_server_hostname%
+        Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
 
 
     Scenario: Adding multiple accounts
@@ -25,8 +25,8 @@ Feature: adding accounts
             | server   | %local_server% |
             | user     | Brian          |
             | password | AaBb2Cc3Dd4    |
-        Then an account should be displayed with the displayname Alice Hansen and host %local_server_hostname%
-        And an account should be displayed with the displayname Brian Murphy and host %local_server_hostname%
+        Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
+        And the account with displayname "Brian Murphy" and host "%local_server_hostname%" should be displayed
 
 
     @skipOnOCIS
@@ -67,5 +67,5 @@ Feature: adding accounts
             | password | 1234           |
         When the user selects vfs option in advanced section
         And the user cancels the enable experimental vfs option
-        Then an account should be displayed with the displayname Alice Hansen and host %local_server_hostname%
+        Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
         And VFS enabled baseline image should not match the default screenshot

--- a/test/gui/tst_removeAccountConnection/test.feature
+++ b/test/gui/tst_removeAccountConnection/test.feature
@@ -14,7 +14,8 @@ Feature: remove account connection
       | user     | Brian          |
       | password | AaBb2Cc3Dd4    |
     When the user removes the connection for user "Brian" and host %local_server_hostname%
-    Then an account should be displayed with the displayname Alice Hansen and host %local_server_hostname%
+    Then the account with displayname "Brian Murphy" and host "%local_server_hostname%" should not be displayed
+    But the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
 
 
   Scenario: remove the only account connection


### PR DESCRIPTION
We want to avoid using `names` (UI component selector) directly in the step def files. This will help us to maintain the selectors in the page objects. Using page object methods for UI actions is the preferred way and it helps to maintain the DRY code

Part of https://github.com/owncloud/client/issues/10353