### PR TITLE
Backport translation changes to 3.1

### DIFF
--- a/translations/.tx/config
+++ b/translations/.tx/config
@@ -6,7 +6,7 @@ source_file = client_en.ts
 source_lang = en
 file_filter = client_<lang>.ts
 type = TS
+minimum_perc = 75
 
 # de_DE holds the formal translation which we want as default
 lang_map = de_DE: de, de: de-informal, pt_PT: pt, cs_CZ: cs, et_EE: et, fi_FI: fi, ja_JP: ja, hu_HU: hu, sk_SK: client_sk, th_TH: th
-

--- a/translations/.tx/config
+++ b/translations/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[owncloud.client]
+[o:owncloud-org:p:owncloud:r:client]
 source_file = client_en.ts
 source_lang = en
 file_filter = client_<lang>.ts

--- a/translations/Makefile
+++ b/translations/Makefile
@@ -24,10 +24,9 @@ l10n-push:
 # pull all translation from transifex
 .PHONY: l10n-pull
 l10n-pull:
-	tx -d pull --force --skip --all --minimum-perc=75
+	tx -d pull --force --skip --all
 
 # tx might apply changes to .tx/config, we don't want that
 .PHONY: l10n-clean
 l10n-clean:
 	git checkout .tx/config
-

--- a/translations/Makefile
+++ b/translations/Makefile
@@ -19,12 +19,12 @@ l10n-read:
 # push the changed from l10n-read
 .PHONY: l10n-push
 l10n-push:
-	tx -d push -s --skip --no-interactive
+	tx push -s --skip --no-interactive
 
 # pull all translation from transifex
 .PHONY: l10n-pull
 l10n-pull:
-	tx -d pull --force --skip --all
+	tx pull --force --skip --all
 
 # tx might apply changes to .tx/config, we don't want that
 .PHONY: l10n-clean


### PR DESCRIPTION
The way we maintain the commands (in a `Makefile` that is tracked in the branch we want to update rather than the main branch), we need to backport these changes to our 3.1 branch.

Note for self: do it right next time.