### PR TITLE
Enable next button when pasting data using context menu, too

### DIFF
--- a/src/gui/loginrequireddialog/abstractloginwidget.h
+++ b/src/gui/loginrequireddialog/abstractloginwidget.h
@@ -9,6 +9,15 @@ namespace OCC {
 
 class AbstractLoginWidget : public QWidget
 {
+    Q_OBJECT
+
+Q_SIGNALS:
+    /**
+     * Emitted whenever the content widgets on the page have their content changed. Useful in cases where changes
+     * cannot just be detected with an event filter, e.g., when a user pastes data using the context menu.
+     */
+    void contentChanged();
+
 protected:
     explicit AbstractLoginWidget(QWidget *parent = nullptr);
 };

--- a/src/gui/loginrequireddialog/basicloginwidget.cpp
+++ b/src/gui/loginrequireddialog/basicloginwidget.cpp
@@ -44,6 +44,9 @@ BasicLoginWidget::BasicLoginWidget(QWidget *parent)
     Utility::setModal(this);
 
     setFocusProxy(_ui->usernameLineEdit);
+
+    connect(_ui->usernameLineEdit, &QLineEdit::textChanged, this, &AbstractLoginWidget::contentChanged);
+    connect(_ui->passwordLineEdit, &QLineEdit::textChanged, this, &AbstractLoginWidget::contentChanged);
 }
 
 BasicLoginWidget::~BasicLoginWidget()

--- a/src/gui/newwizard/pages/abstractsetupwizardpage.h
+++ b/src/gui/newwizard/pages/abstractsetupwizardpage.h
@@ -38,6 +38,12 @@ Q_SIGNALS:
      * Can be used to, e.g., set the focus on widgets in order to make navigation with the keyboard easier.
      */
     void pageDisplayed();
+
+    /**
+     * Emitted whenever the content widgets on the page have their content changed. Useful in cases where changes
+     * cannot just be detected with an event filter, e.g., when a user pastes data using the context menu.
+     */
+    void contentChanged();
 };
 
 }

--- a/src/gui/newwizard/pages/basiccredentialssetupwizardpage.cpp
+++ b/src/gui/newwizard/pages/basiccredentialssetupwizardpage.cpp
@@ -36,6 +36,8 @@ BasicCredentialsSetupWizardPage::BasicCredentialsSetupWizardPage(const QUrl &ser
     connect(this, &AbstractSetupWizardPage::pageDisplayed, this, [this]() {
         _ui->basicLoginWidget->setFocus();
     });
+
+    connect(_ui->basicLoginWidget, &AbstractLoginWidget::contentChanged, this, &AbstractSetupWizardPage::contentChanged);
 }
 
 BasicCredentialsSetupWizardPage *BasicCredentialsSetupWizardPage::createForWebFinger(const QUrl &serverUrl, const QString &username)

--- a/src/gui/newwizard/pages/serverurlsetupwizardpage.cpp
+++ b/src/gui/newwizard/pages/serverurlsetupwizardpage.cpp
@@ -36,6 +36,8 @@ ServerUrlSetupWizardPage::ServerUrlSetupWizardPage(const QUrl &serverUrl)
     if (!Theme::instance()->wizardUrlPostfix().isEmpty()) {
         _ui->urlLineEdit->setPostfix(Theme::instance()->wizardUrlPostfix());
     }
+
+    connect(_ui->urlLineEdit, &QLineEdit::textChanged, this, &AbstractSetupWizardPage::contentChanged);
 }
 
 QString ServerUrlSetupWizardPage::userProvidedUrl() const


### PR DESCRIPTION
This removes the now-obsolete handling via the event filter, which doesn't need to run that often anyway.

Closes #10321.