### PR TITLE
Ensure that we have a proper environment when restarting the client f…

### DIFF
--- a/admin/osx/post_install.sh.cmake
+++ b/admin/osx/post_install.sh.cmake
@@ -20,7 +20,7 @@ fi
 
 if [[ -f "${INSTALLER_TEMP}/OC_RESTART_NEEDED" ]]; then
     if [[ "${COMMAND_LINE_INSTALL}" = "" ]]; then
-        /bin/launchctl asuser "${LOGGED_IN_USER_ID}" /usr/bin/open -g "/Applications/@APPLICATION_EXECUTABLE@.app"
+        /bin/launchctl kickstart "gui/${LOGGED_IN_USER_ID}/@APPLICATION_REV_DOMAIN@"
     fi
 fi
 

--- a/changelog/unreleased/10346
+++ b/changelog/unreleased/10346
@@ -1,0 +1,3 @@
+Bugfix: Mac: Don't inherit the environment of the installer after an update
+
+https://github.com/owncloud/client/issues/10346


### PR DESCRIPTION
…from the installer

Instead of directly launching the binary we ask the system to start the registered service for us.

This is probably only possible on upgrades from 3.0+ as we used a different autostart mechanism before.

Fixes: #10346