### PR TITLE
Remove "TextLabel" texts from `QLabel`s in .ui files

### DIFF
--- a/src/gui/aboutdialog.ui
+++ b/src/gui/aboutdialog.ui
@@ -84,9 +84,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
         </widget>
        </item>
       </layout>

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -22,9 +22,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>
      </property>
@@ -68,9 +65,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="text">
-        <string>TextLabel</string>
        </property>
        <property name="textFormat">
         <enum>Qt::RichText</enum>
@@ -137,9 +131,6 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="text">
-      <string>TextLabel</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>

--- a/src/gui/folderwizard/folderwizardtargetpage.ui
+++ b/src/gui/folderwizard/folderwizardtargetpage.ui
@@ -165,9 +165,6 @@
         <property name="frameShadow">
          <enum>QFrame::Plain</enum>
         </property>
-        <property name="text">
-         <string>TextLabel</string>
-        </property>
         <property name="textFormat">
          <enum>Qt::RichText</enum>
         </property>

--- a/src/gui/notificationwidget.ui
+++ b/src/gui/notificationwidget.ui
@@ -102,9 +102,6 @@
              <pointsize>8</pointsize>
             </font>
            </property>
-           <property name="text">
-            <string>TextLabel</string>
-           </property>
            <property name="alignment">
             <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
            </property>

--- a/src/gui/proxyauthdialog.ui
+++ b/src/gui/proxyauthdialog.ui
@@ -62,9 +62,6 @@
      </item>
      <item row="0" column="1">
       <widget class="QLabel" name="proxyAddress">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
        <property name="textFormat">
         <enum>Qt::PlainText</enum>
        </property>

--- a/src/gui/sharedialog.ui
+++ b/src/gui/sharedialog.ui
@@ -24,9 +24,6 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label_icon">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
       </widget>
      </item>
      <item>

--- a/src/gui/sharelinkwidget.ui
+++ b/src/gui/sharelinkwidget.ui
@@ -332,9 +332,6 @@
        </disabled>
       </palette>
      </property>
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>
      </property>

--- a/src/gui/shareuserline.ui
+++ b/src/gui/shareuserline.ui
@@ -24,16 +24,10 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="avatar">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="sharedWith">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
        <property name="textFormat">
         <enum>Qt::PlainText</enum>
        </property>

--- a/src/gui/updater/appimageupdateavailabledialog.ui
+++ b/src/gui/updater/appimageupdateavailabledialog.ui
@@ -27,9 +27,6 @@
      </property>
      <item>
       <widget class="QLabel" name="appIconLabel">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
       </widget>
      </item>
      <item>


### PR DESCRIPTION
These are unnecessary, as they are programmatically replaced by the wanted text. They do end up in translations though, so they produce confusion there.