### PR TITLE
(Re)introduce "sync hidden files" parameter in owncloudcmd

### DIFF
--- a/changelog/unreleased/10390
+++ b/changelog/unreleased/10390
@@ -1,0 +1,6 @@
+Enhancement: (Re)introduce "sync hidden files" parameter in owncloudcmd
+
+There used to be an option to enable the synchronization of hidden files using the -h parameter which collided with the --help option and subsequently was removed.
+A new --sync-hidden-files parameter was introduced to fill in the missing feature.
+
+https://github.com/owncloud/client/issues/10390

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -331,6 +331,7 @@ CmdOptions parseOptions(const QStringList &app_args)
     auto maxRetriesOption = addOption({ { QStringLiteral("max-sync-retries") }, QStringLiteral("Retries maximum n times (default to 3)"), QStringLiteral("n") });
     auto uploadLimitOption = addOption({ { QStringLiteral("uplimit") }, QStringLiteral("Limit the upload speed of files to n KB/s"), QStringLiteral("n") });
     auto downloadLimitption = addOption({ { QStringLiteral("downlimit") }, QStringLiteral("Limit the download speed of files to n KB/s"), QStringLiteral("n") });
+    auto syncHiddenFilesOption = addOption({ { QStringLiteral("sync-hidden-files") }, QStringLiteral("Enables synchronization of hidden files") });
 
     auto logdebugOption = addOption({ { QStringLiteral("logdebug") }, QStringLiteral("More verbose logging") });
 
@@ -405,6 +406,9 @@ CmdOptions parseOptions(const QStringList &app_args)
     }
     if (parser.isSet(downloadLimitption)) {
         options.downlimit = parser.value(downloadLimitption).toInt() * 1000;
+    }
+    if (parser.isSet(syncHiddenFilesOption)) {
+        options.ignoreHiddenFiles = false;
     }
     if (parser.isSet(logdebugOption)) {
         Logger::instance()->setLogFile(QStringLiteral("-"));


### PR DESCRIPTION
There used to be an option to enable the synchronization of hidden files using the `-h` parameter which collided with the `--help` option and subsequently was removed.

A new ~`-H`~ parameter was introduced to fill in the missing feature (long form: `--sync-hidden-files`).

Closes #10390.