### PR TITLE
[gui-tests] Import test module

### DIFF
--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import test
 from os.path import join, realpath
 from squish import waitFor, snooze
 

--- a/test/gui/shared/scripts/pageObjects/SharingDialog.py
+++ b/test/gui/shared/scripts/pageObjects/SharingDialog.py
@@ -1,7 +1,6 @@
 import names
 import squish
 import object
-import test
 
 
 class SharingDialog:

--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -1,6 +1,5 @@
 import names
 import squish
-from helpers.SetupClientHelper import getClientDetails, createUserSyncPath
 
 
 class SyncConnectionWizard:


### PR DESCRIPTION
`test` module was not imported int SyncHelper, so this PR imports that module.
Also, removes unused imports

Fixes https://github.com/owncloud/client/issues/10386