### PR TITLE
Skip `testLocalFileRemoteDirConflict()` for dehydrated files

### DIFF
--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -586,6 +586,13 @@ private slots:
         fakeFolder.remoteModifier().mkdir(QStringLiteral("B/b1"));
         fakeFolder.remoteModifier().insert(QStringLiteral("B/b1/zzz"));
 
+        if (filesAreDehydrated) {
+            QSKIP("Known bug: https://github.com/owncloud/client/issues/10223");
+            // The QSKIP below is due to operations order (verified on a local machine),
+            // but the sync below already always fails in the CI. So we will be skipping
+            // this entire test until the issue is fixed.
+        }
+
         QVERIFY(fakeFolder.applyLocalModificationsAndSync());
         auto conflicts = findConflicts(fakeFolder.currentLocalState());
         conflicts += findConflicts(fakeFolder.currentLocalState().children[QStringLiteral("B")]);


### PR DESCRIPTION
This test was already partially skipped due to order-of-operations problems (see issue #10223), but on the CI the very first sync already fails. This is probably due to the same problem, so now we skip the test completely (for dehydrated files).