### PR TITLE
Reduce warning level if no dynamic registration key was fetched

### DIFF
--- a/src/libsync/creds/oauth.cpp
+++ b/src/libsync/creds/oauth.cpp
@@ -225,7 +225,7 @@ void logCredentialsJobResult(CredentialJob *credentialsJob)
     qCDebug(lcOauth) << "credentials job has finished";
 
     if (!credentialsJob->data().isValid()) {
-        qCCritical(lcOauth) << "Failed to read client id" << credentialsJob->errorString();
+        qCInfo(lcOauth) << "Failed to read client id" << credentialsJob->errorString();
     }
 }
 }


### PR DESCRIPTION
It usually just means none was set.
Fixes: #10409