### PR TITLE
[gui-tests] Add tests for space member with Editor and Manager roles

### DIFF
--- a/test/gui/shared/scripts/helpers/SpaceHelper.py
+++ b/test/gui/shared/scripts/helpers/SpaceHelper.py
@@ -184,3 +184,12 @@ def get_file_content(space_name, file_name, user=None):
             + response.text
         )
     return response.text
+
+
+def resource_exists(space_name, resource, user=None):
+    space_id = get_space_id(space_name, user)
+    url = path.join(get_dav_endpint(), space_id, resource)
+    response = send_request(url, "GET", as_user=user)
+    if response.status_code == 200:
+        return True
+    return False

--- a/test/gui/shared/steps/file_context.py
+++ b/test/gui/shared/steps/file_context.py
@@ -8,9 +8,15 @@ import shutil
 from pageObjects.AccountSetting import AccountSetting
 
 from helpers.SetupClientHelper import getResourcePath
-from helpers.FilesHelper import buildConflictedRegex, sanitizePath
 from helpers.SyncHelper import waitForClientToBeReady
 from helpers.ConfigHelper import get_config
+from helpers.FilesHelper import (
+    buildConflictedRegex,
+    sanitizePath,
+    can_read,
+    can_write,
+    read_file_content,
+)
 
 
 def folderExists(folderPath, timeout=1000):
@@ -271,3 +277,22 @@ def step(context, username, resourceType, source, destination):
         destination = ""
     destination_dir = getResourcePath(destination, username)
     shutil.move(source_dir, destination_dir)
+
+
+@Then('user "|any|" should be able to open the file "|any|" on the file system')
+def step(context, user, file_name):
+    file_path = getResourcePath(file_name, user)
+    test.compare(can_read(file_path), True, "File should be readable")
+
+
+@Then('as "|any|" the file "|any|" should have content "|any|" on the file system')
+def step(context, user, file_name, content):
+    file_path = getResourcePath(file_name, user)
+    file_content = read_file_content(file_path)
+    test.compare(file_content, content, "Comparing file content")
+
+
+@Then('user "|any|" should not be able to edit the file "|any|" on the file system')
+def step(context, user, file_name):
+    file_path = getResourcePath(file_name, user)
+    test.compare(not can_write(file_path), True, "File should not be writable")

--- a/test/gui/shared/steps/spaces_context.py
+++ b/test/gui/shared/steps/spaces_context.py
@@ -1,9 +1,8 @@
 from pageObjects.EnterPassword import EnterPassword
 
 from helpers.UserHelper import getDisplaynameForUser, getPasswordForUser
-from helpers.SetupClientHelper import setUpClient
+from helpers.SetupClientHelper import setUpClient, getResourcePath
 from helpers.SyncHelper import waitForInitialSyncToComplete
-from helpers.SetupClientHelper import getResourcePath
 from helpers.FilesHelper import can_read, can_write, read_file_content
 from helpers.SpaceHelper import (
     create_space,
@@ -11,6 +10,7 @@ from helpers.SpaceHelper import (
     create_space_file,
     add_user_to_space,
     get_file_content,
+    resource_exists,
 )
 
 
@@ -71,3 +71,13 @@ def step(context, user, file_name):
 def step(context, user, file_name, space_name, content):
     downloaded_content = get_file_content(space_name, file_name, user)
     test.compare(downloaded_content, content, "Comparing file content")
+
+
+@Then(
+    r'as "([^"]*)" the space "([^"]*)" should have (?:folder|file) "([^"]*)" in the server',
+    regexp=True,
+)
+def step(context, user, space_name, resource_name):
+    print(user, space_name, resource_name)
+    exists = resource_exists(space_name, resource_name, user)
+    test.compare(exists, True, "Resource should exist")

--- a/test/gui/shared/steps/spaces_context.py
+++ b/test/gui/shared/steps/spaces_context.py
@@ -3,7 +3,6 @@ from pageObjects.EnterPassword import EnterPassword
 from helpers.UserHelper import getDisplaynameForUser, getPasswordForUser
 from helpers.SetupClientHelper import setUpClient, getResourcePath
 from helpers.SyncHelper import waitForInitialSyncToComplete
-from helpers.FilesHelper import can_read, can_write, read_file_content
 from helpers.SpaceHelper import (
     create_space,
     create_space_folder,
@@ -46,27 +45,8 @@ def step(context, user, space_name):
     waitForInitialSyncToComplete(getResourcePath('/', user, space_name))
 
 
-@Then('user "|any|" should be able to open the file "|any|" on the file system')
-def step(context, user, file_name):
-    file_path = getResourcePath(file_name, user)
-    test.compare(can_read(file_path), True, "File should be readable")
-
-
-@Then('as "|any|" the file "|any|" should have content "|any|" on the file system')
-def step(context, user, file_name, content):
-    file_path = getResourcePath(file_name, user)
-    file_content = read_file_content(file_path)
-    test.compare(file_content, content, "Comparing file content")
-
-
-@Then('user "|any|" should not be able to edit the file "|any|" on the file system')
-def step(context, user, file_name):
-    file_path = getResourcePath(file_name, user)
-    test.compare(not can_write(file_path), True, "File should not be writable")
-
-
 @Then(
-    'as "|any|" the file "|any|" of space "|any|" should have content "|any|" in the server'
+    'as "|any|" the file "|any|" in the space "|any|" should have content "|any|" in the server'
 )
 def step(context, user, file_name, space_name, content):
     downloaded_content = get_file_content(space_name, file_name, user)
@@ -80,4 +60,4 @@ def step(context, user, file_name, space_name, content):
 def step(context, user, space_name, resource_name):
     print(user, space_name, resource_name)
     exists = resource_exists(space_name, resource_name, user)
-    test.compare(exists, True, "Resource should exist")
+    test.compare(exists, True, "Resource exists")

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -25,3 +25,13 @@ Feature: Project spaces
         And user "Alice" has set up a client with space "Project101"
         Then user "Alice" should not be able to edit the file "testfile.txt" on the file system
         Then as "Alice" the file "testfile.txt" of space "Project101" should have content "some content" in the server
+
+
+    Scenario: User with editor role can edit the file
+        Given the administrator has created a folder "planning" in space "Project101"
+        And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
+        And the administrator has added user "Alice" to space "Project101" with role "editor"
+        And user "Alice" has set up a client with space "Project101"
+        When the user overwrites the file "testfile.txt" with content "some content edited"
+        And the user waits for file "testfile.txt" to be synced
+        Then as "Alice" the file "testfile.txt" of space "Project101" should have content "some content edited" in the server

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -9,7 +9,7 @@ Feature: Project spaces
         And the administrator has created a space "Project101"
 
 
-    Scenario: User with viewer role can open the file
+    Scenario: User with Viewer role can open the file
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
@@ -18,26 +18,26 @@ Feature: Project spaces
         And as "Alice" the file "testfile.txt" should have content "some content" on the file system
 
 
-    Scenario: User with viewer role cannot edit the file
+    Scenario: User with Viewer role cannot edit the file
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with space "Project101"
         Then user "Alice" should not be able to edit the file "testfile.txt" on the file system
-        Then as "Alice" the file "testfile.txt" of space "Project101" should have content "some content" in the server
+        Then as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content" in the server
 
 
-    Scenario: User with editor role can edit the file
+    Scenario: User with Editor role can edit the file
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "editor"
         And user "Alice" has set up a client with space "Project101"
         When the user overwrites the file "testfile.txt" with content "some content edited"
         And the user waits for file "testfile.txt" to be synced
-        Then as "Alice" the file "testfile.txt" of space "Project101" should have content "some content edited" in the server
+        Then as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content edited" in the server
 
 
-    Scenario: User with manager role can add files and folders
+    Scenario: User with Manager role can add files and folders
         Given the administrator has added user "Alice" to space "Project101" with role "manager"
         And user "Alice" has set up a client with space "Project101"
         When user "Alice" creates a file "localFile.txt" with the following content inside the sync folder
@@ -46,5 +46,5 @@ Feature: Project spaces
             """
         And user "Alice" creates a folder "localFolder" inside the sync folder
         And the user waits for the files to sync
-        Then as "Alice" the file "localFile.txt" of space "Project101" should have content "test content" in the server
+        Then as "Alice" the file "localFile.txt" in the space "Project101" should have content "test content" in the server
         And as "Alice" the space "Project101" should have folder "localFolder" in the server

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -35,3 +35,16 @@ Feature: Project spaces
         When the user overwrites the file "testfile.txt" with content "some content edited"
         And the user waits for file "testfile.txt" to be synced
         Then as "Alice" the file "testfile.txt" of space "Project101" should have content "some content edited" in the server
+
+
+    Scenario: User with manager role can add files and folders
+        Given the administrator has added user "Alice" to space "Project101" with role "manager"
+        And user "Alice" has set up a client with space "Project101"
+        When user "Alice" creates a file "localFile.txt" with the following content inside the sync folder
+            """
+            test content
+            """
+        And user "Alice" creates a folder "localFolder" inside the sync folder
+        And the user waits for the files to sync
+        Then as "Alice" the file "localFile.txt" of space "Project101" should have content "test content" in the server
+        And as "Alice" the space "Project101" should have folder "localFolder" in the server


### PR DESCRIPTION
Add test cases for project space member with Editor and Manager roles

Scenarios:
```feature
Scenario: User with Editor role can edit the file
Scenario: User with Manager role can add files and folders
``` 

### Related Issues
Part of https://github.com/owncloud/QA/issues/789
Closes https://github.com/owncloud/client/issues/10428