### PR TITLE
Fix duplicate acct: in Webfinger resource ID

### DIFF
--- a/src/libsync/creds/webfinger.cpp
+++ b/src/libsync/creds/webfinger.cpp
@@ -48,7 +48,7 @@ void WebFinger::start(const QUrl &url, const QString &resourceId)
     //    GET /.well-known/webfinger?rel=http://webfinger.owncloud/rel/server-instance&resource=acct:test@owncloud.com HTTP/1.1
     if (OC_ENSURE(url.scheme() == QLatin1String("https"))) {
         QUrlQuery query;
-        query.setQueryItems({ { QStringLiteral("resource"), QString::fromUtf8(QUrl::toPercentEncoding(QStringLiteral("acct:") + resourceId)) },
+        query.setQueryItems({ { QStringLiteral("resource"), resourceId },
             { QStringLiteral("rel"), relId() } });
 
         QNetworkRequest req;


### PR DESCRIPTION
The WebFinger class expects a resource ID already. It's the caller's job to assemble the `acct:` URL, not WebFinger's.

Fixes #10471.