### PR TITLE
[ci] Notify chat with gui reports on tag events

### DIFF
--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -19,26 +19,32 @@ for server in "${SERVERS[@]}"; do
 
     LOGS=""
     GUI_LOG="${LOG_URL_PATH}/index.html"
-    SERVER_LOG="${LOG_URL_PATH}/serverlog.log"
-    STACKTRACE="${LOG_URL_PATH}/stacktrace.log"
 
     GUI_STATUS_CODE=$($CURL "$GUI_LOG")
-    SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
-    STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
 
     if [[ "$GUI_STATUS_CODE" == "200" ]]; then
         LOGS+=": [Squish Report]($GUI_LOG)"
     fi
-    if [[ "$SERVER_STATUS_CODE" == "200" ]]; then
-        LOGS+="\n> [Server log]($SERVER_LOG)  " # 2 spaces at the end act as line-break
+
+    if [ "${DRONE_BUILD_STATUS}" == "failure" ]; then
+        SERVER_LOG="${LOG_URL_PATH}/serverlog.log"
+        STACKTRACE="${LOG_URL_PATH}/stacktrace.log"
+
+        SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
+        STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
+
+        if [[ "$SERVER_STATUS_CODE" == "200" ]]; then
+            LOGS+="\n> [Server log]($SERVER_LOG)  " # 2 spaces at the end act as line-break
+        fi
+        if [[ "$STACKTRACE_STATUS_CODE" == "200" ]]; then
+            LOGS+="\n> [Stacktrace]($STACKTRACE)"
+        fi
     fi
-    if [[ "$STACKTRACE_STATUS_CODE" == "200" ]]; then
-        LOGS+="\n> [Stacktrace]($STACKTRACE)"
-    fi
+
     if [[ -n "${LOGS}" ]]; then
         LOGS="\n${server}${LOGS}"
         TEST_LOGS+="${LOGS}"
     fi
 done
 
-echo -e "$BUILD_STATUS [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" >"$1"/template.md
+echo -e "$BUILD_STATUS [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" #>"$1"/template.md

--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -47,4 +47,4 @@ for server in "${SERVERS[@]}"; do
     fi
 done
 
-echo -e "$BUILD_STATUS [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" #>"$1"/template.md
+echo -e "$BUILD_STATUS [${DRONE_REPO}#${COMMIT_SHA_SHORT}](${DRONE_BUILD_LINK}) (${DRONE_BRANCH}) by **${DRONE_COMMIT_AUTHOR}** $TEST_LOGS" >"$1"/template.md

--- a/test/gui/drone/notification_template.sh
+++ b/test/gui/drone/notification_template.sh
@@ -18,24 +18,22 @@ for server in "${SERVERS[@]}"; do
     CURL="curl --write-out %{http_code} --silent --output /dev/null"
 
     LOGS=""
-    if [ "${DRONE_BUILD_STATUS}" == "failure" ]; then
-        GUI_LOG="${LOG_URL_PATH}/index.html"
-        SERVER_LOG="${LOG_URL_PATH}/serverlog.log"
-        STACKTRACE="${LOG_URL_PATH}/stacktrace.log"
+    GUI_LOG="${LOG_URL_PATH}/index.html"
+    SERVER_LOG="${LOG_URL_PATH}/serverlog.log"
+    STACKTRACE="${LOG_URL_PATH}/stacktrace.log"
 
-        GUI_STATUS_CODE=$($CURL "$GUI_LOG")
-        SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
-        STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
+    GUI_STATUS_CODE=$($CURL "$GUI_LOG")
+    SERVER_STATUS_CODE=$($CURL "$SERVER_LOG")
+    STACKTRACE_STATUS_CODE=$($CURL "$STACKTRACE")
 
-        if [[ "$GUI_STATUS_CODE" == "200" ]]; then
-            LOGS+=": [Squish Report]($GUI_LOG)"
-        fi
-        if [[ "$SERVER_STATUS_CODE" == "200" ]]; then
-            LOGS+="\n> [Server log]($SERVER_LOG)  " # 2 spaces at the end act as line-break
-        fi
-        if [[ "$STACKTRACE_STATUS_CODE" == "200" ]]; then
-            LOGS+="\n> [Stacktrace]($STACKTRACE)"
-        fi
+    if [[ "$GUI_STATUS_CODE" == "200" ]]; then
+        LOGS+=": [Squish Report]($GUI_LOG)"
+    fi
+    if [[ "$SERVER_STATUS_CODE" == "200" ]]; then
+        LOGS+="\n> [Server log]($SERVER_LOG)  " # 2 spaces at the end act as line-break
+    fi
+    if [[ "$STACKTRACE_STATUS_CODE" == "200" ]]; then
+        LOGS+="\n> [Stacktrace]($STACKTRACE)"
     fi
     if [[ -n "${LOGS}" ]]; then
         LOGS="\n${server}${LOGS}"


### PR DESCRIPTION
For tag/release events, we want to get the Squish GUI tests reports regardless of the status of the tests (pass or fail). This helps the QA team to evaluate the test reports on releases. 