### PR TITLE
[gui-tests] Added test scenario to open log dialog

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -35,6 +35,11 @@ class AccountSetting:
         "type": "QLabel",
         "visible": 1,
     }
+    LOG_BROWSER_WINDOW = {
+        "name": "OCC__LogBrowser",
+        "type": "OCC::LogBrowser",
+        "visible": 1,
+    }
 
     @staticmethod
     def accountAction(action):
@@ -108,3 +113,19 @@ class AccountSetting:
     @staticmethod
     def confirmRemoveAllFiles():
         squish.clickButton(squish.waitForObject(AccountSetting.REMOVE_ALL_FILES))
+
+    @staticmethod
+    def pressKey(key):
+        key = "<%s>" % key.replace('"', "")
+        squish.nativeType(key)
+
+    @staticmethod
+    def isLogDialogVisible():
+        visible = False
+        try:
+            visible = squish.waitForObjectExists(
+                AccountSetting.LOG_BROWSER_WINDOW
+            ).visible
+        except:
+            pass
+        return visible

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -226,3 +226,13 @@ def step(context):
         AccountConnectionWizard.isSyncEverythingOptionChecked(),
         "Sync everything option is checked",
     )
+
+
+@When(r'^the user presses the "([^"]*)" key(?:s)?', regexp=True)
+def step(context, key):
+    AccountSetting.pressKey(key)
+
+
+@Then('the log dialog should be opened')
+def step(context):
+    test.compare(True, AccountSetting.isLogDialogVisible(), "Log dialog is opened")

--- a/test/gui/tst_checkAlltabs/test.feature
+++ b/test/gui/tst_checkAlltabs/test.feature
@@ -13,3 +13,10 @@ Feature: Visually check all tabs
             | Activity     |
             | Settings     |
             | QuitOwncloud |
+
+
+    Scenario: Open log dialog with Ctrl+l keys combination
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has set up a client with default settings
+        When the user presses the "Ctrl+l" keys
+        Then the log dialog should be opened


### PR DESCRIPTION
PR adds test scenario to open log dialog with `Ctrl+l` keys combination

### Related Issues
- part of https://github.com/owncloud/QA/issues/789