### PR TITLE
Cache specific network resources

### DIFF
--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -32,6 +32,7 @@
 #include <QUrlQuery>
 
 #include <chrono>
+#include <optional>
 
 class QUrl;
 
@@ -130,6 +131,24 @@ public:
     virtual bool needsRetry() const;
 
     void setTimeout(const std::chrono::seconds sec);
+
+    /**
+     * Configure whether to store replies in a cache configured in the corresponding network access manager (if one is set there).
+     * By default, replies are not stored in the cache. Qt normally would store all eligible resources (as configured by server policies) in the cache.
+     * See also \ref setCacheLoadControl
+     * @param storeInCache whether to store replies in the cache
+     */
+    void setStoreInCache(bool storeInCache);
+
+    /**
+     * Configure whether to load data from the cache.
+     * We inherit Qt's default behavior (which in Qt 5.15 and 6.4 is to prefer a network response but provide a cached value if the server permits it in its
+     * cache policies when the server cannot be reached).
+     * See also \ref setStoreInCache
+     * @param cacheLoadControl a policy suitable for the current job
+     */
+    void setCacheLoadControl(QNetworkRequest::CacheLoadControl cacheLoadControl);
+
 signals:
     /** Emitted on network error.
      *
@@ -212,6 +231,11 @@ private:
 
     bool _isAuthenticationJob = false;
     int _retryCount = 0;
+
+    // by default, we don't intend to store responses in the cache (if one is set in the account's access manager)
+    bool _storeInCache = false;
+    // we use Qt's default cache load behavior unless the user explicitly requests a different behavior
+    std::optional<QNetworkRequest::CacheLoadControl> _cacheLoadControl = std::nullopt;
 
     QNetworkRequest::Priority _priority = QNetworkRequest::NormalPriority;
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -25,7 +25,9 @@
 #include <QByteArray>
 #include <QNetworkAccessManager>
 #include <QNetworkCookie>
+#include <QNetworkDiskCache>
 #include <QNetworkRequest>
+#include <QPixmap>
 #include <QSharedPointer>
 #include <QSslCertificate>
 #include <QSslCipher>
@@ -34,7 +36,6 @@
 #include <QSslSocket>
 #include <QUrl>
 #include <QUuid>
-#include <QPixmap>
 
 #include <memory>
 
@@ -249,6 +250,7 @@ private:
     QSet<QSslCertificate> _approvedCerts;
     Capabilities _capabilities;
     QPointer<AccessManager> _am;
+    QPointer<QNetworkDiskCache> _networkCache = nullptr;
     QScopedPointer<AbstractCredentials> _credentials;
     bool _http2Supported = false;
 

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -346,6 +346,7 @@ const QHash<QString, qint64> &PropfindJob::sizes() const
 AvatarJob::AvatarJob(AccountPtr account, const QString &userId, int size, QObject *parent)
     : AbstractNetworkJob(account, account->url(), QStringLiteral("remote.php/dav/avatars/%1/%2.png").arg(userId, QString::number(size)), parent)
 {
+    setStoreInCache(true);
 }
 
 void AvatarJob::start()


### PR DESCRIPTION
This pull request adds a local network cache to every account. Using this cache, we can store resources locally to reduce the load on the server and also implement better offline support.

By default, network jobs' target resources are not stored in the cache and we always download the latest version. Therefore, currently, one needs to enable caching on a per-job basis. This might change in the future, since we depend on the server-side caching policy anyway.

Qt supports the common headers. In fact, Qt won't cache resources with `Cache-Control: ... must-revalidate` anyway (we had to check Qt's code base for this). We may have to either implement our own caching logic outside of `QNetworkAccessManager` or adapt the server policy.

Contributes to https://github.com/owncloud/client/issues/10519.