### PR TITLE
Replace term (un)pause with a more suitable one

### DIFF
--- a/changelog/unreleased/10231
+++ b/changelog/unreleased/10231
@@ -1,0 +1,10 @@
+Enhancement: Replace term (un)pause with a more suitable one
+
+We used the terms pause and unpause synchronization where the synchronization was actually
+terminated and restarted.
+
+Now, we use the terms stop and start synchronization, which better communicate the actual
+behavior.
+
+https://github.com/owncloud/client/issues/10231
+https://github.com/owncloud/client/issues/10529

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -657,7 +657,7 @@ void AccountSettings::slotEnableCurrentFolder(bool terminate)
             // check if a sync is still running and if so, ask if we should terminate.
             if (folder->isSyncRunning()) { // its still running
                 auto msgbox = new QMessageBox(QMessageBox::Question, tr("Sync Running"),
-                    tr("The syncing operation is running.<br/>Do you want to terminate it?"),
+                    tr("The sync operation is running.<br/>Do you want to stop it?"),
                     QMessageBox::Yes | QMessageBox::No, this);
                 msgbox->setAttribute(Qt::WA_DeleteOnClose);
                 msgbox->setDefaultButton(QMessageBox::Yes);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -714,9 +714,9 @@ void ownCloudGui::updateContextMenu()
     if (atLeastOnePaused) {
         QString text;
         if (accountList.count() > 1) {
-            text = tr("Unpause all synchronization");
+            text = tr("Restart all synchronization");
         } else {
-            text = tr("Unpause synchronization");
+            text = tr("Restart synchronization");
         }
         QAction *action = _contextMenu->addAction(text);
         connect(action, &QAction::triggered, this, &ownCloudGui::slotUnpauseAllFolders);
@@ -724,9 +724,9 @@ void ownCloudGui::updateContextMenu()
     if (atLeastOneNotPaused) {
         QString text;
         if (accountList.count() > 1) {
-            text = tr("Pause all synchronization");
+            text = tr("Stop all synchronization");
         } else {
-            text = tr("Pause synchronization");
+            text = tr("Stop synchronization");
         }
         QAction *action = _contextMenu->addAction(text);
         connect(action, &QAction::triggered, this, &ownCloudGui::slotPauseAllFolders);


### PR DESCRIPTION
This commit further unifies the wording between the context menu entries and the popup.

Fixes #10231.