### PR TITLE
Remove support for credentials encoded in urls

### DIFF
--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -96,11 +96,6 @@ protected:
                     QByteArray credHash = QByteArray(_cred->user().toUtf8() + ":" + _cred->_password.toUtf8()).toBase64();
                     req.setRawHeader("Authorization", "Basic " + credHash);
                 }
-            } else if (!request.url().password().isEmpty()) {
-                // Typically the requests to get or refresh the OAuth access token. The client
-                // credentials are put in the URL from the code making the request.
-                QByteArray credHash = request.url().userInfo().toUtf8().toBase64();
-                req.setRawHeader("Authorization", "Basic " + credHash);
             }
         }
         return AccessManager::createRequest(op, req, outgoingData);


### PR DESCRIPTION
This removes support for credentials stored in the url like `demo:demo@demo.owncloud.org`.
The 2.11 client allowed to enter such a url in the wizard, however the credentials where properly stored.
So there is no need to keep this hack around.

Do we need a changelog entry?