### PR TITLE
Allow to skip Desktop.ini icon updates

### DIFF
--- a/changelog/unreleased/10361
+++ b/changelog/unreleased/10361
@@ -1,0 +1,6 @@
+Enhancement: Implement a possebility to Desktop.ini icon updates on Windows
+
+We implemented an option wich allows to disable the automatic update of the folder icon for
+sync folders on Windows.
+
+https://github.com/owncloud/client/issues/10361

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -295,10 +295,16 @@ void Folder::prepareFolder(const QString &path)
     // First create a Desktop.ini so that the folder and favorite link show our application's icon.
     const QFileInfo desktopIniPath = QStringLiteral("%1/Desktop.ini").arg(path);
     {
+        const QString updateIconKey = QStringLiteral("%1/UpdateIcon").arg(Theme::instance()->appName());
         QSettings desktopIni(desktopIniPath.absoluteFilePath(), QSettings::IniFormat);
-        qCInfo(lcFolder) << "Creating" << desktopIni.fileName() << "to set a folder icon in Explorer.";
-        desktopIni.beginGroup(QStringLiteral(".ShellClassInfo"));
-        desktopIni.setValue(QStringLiteral("IconResource"), QDir::toNativeSeparators(qApp->applicationFilePath()));
+        if (desktopIni.value(updateIconKey, true).toBool()) {
+            qCInfo(lcFolder) << "Creating" << desktopIni.fileName() << "to set a folder icon in Explorer.";
+            desktopIni.setValue(QStringLiteral(".ShellClassInfo/IconResource"), QDir::toNativeSeparators(qApp->applicationFilePath()));
+            desktopIni.setValue(updateIconKey, true);
+        } else {
+            qCInfo(lcFolder) << "Skip icon update for" << desktopIni.fileName() << "," << updateIconKey << "is disabled";
+        }
+
         desktopIni.sync();
     }
 


### PR DESCRIPTION
The ini now contains an option that can manually be disabled
`%branding name%/UpdateIcon=true`

The value is true by default but can be changed by a user.

```
[.ShellClassInfo]
IconResource=C:\\CraftRoot\\download\\git\\owncloud\\owncloud-client\\cmake-build-debug-visual-studio\\bin\\owncloud.exe

[ownCloud]
UpdateIcon=true

```
Fixes: #10361