### PR TITLE
Fix: Set the expected download content length in the job properly.

### DIFF
--- a/changelog/unreleased/10593
+++ b/changelog/unreleased/10593
@@ -1,0 +1,3 @@
+Bugfix: Set the expected download content length in the job properly.
+
+https://github.com/owncloud/client/pull/10593

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -33,7 +33,6 @@ class OWNCLOUDSYNC_EXPORT GETFileJob : public AbstractNetworkJob
     QMap<QByteArray, QByteArray> _headers;
     QString _expectedEtagForResume;
     qint64 _expectedContentLength;
-    qint64 _contentLength;
     qint64 _resumeStart;
 
 public:
@@ -56,7 +55,6 @@ public:
         return _resumeStart;
     }
 
-    qint64 contentLength() const { return _contentLength; }
     qint64 expectedContentLength() const { return _expectedContentLength; }
     void setExpectedContentLength(qint64 size) { _expectedContentLength = size; }
 


### PR DESCRIPTION
Remove a member that was keeping the actual content length.