### PR TITLE
Reliably reset update channel

### DIFF
--- a/changelog/unreleased/10251
+++ b/changelog/unreleased/10251
@@ -1,0 +1,8 @@
+Bugfix: Fix update channel dropdown
+
+When switching to the beta update channel in testpilotcloud, a warning will
+pop up. When canceled, the selection should reset. This did not work reliably,
+especially on Linux.
+
+https://github.com/owncloud/client/issues/10251
+https://github.com/owncloud/client/pull/10609

--- a/changelog/unreleased/10251
+++ b/changelog/unreleased/10251
@@ -1,8 +1,9 @@
 Bugfix: Fix update channel dropdown
 
 When switching to the beta update channel in testpilotcloud, a warning will
-pop up. When canceled, the selection should reset. This did not work reliably,
-especially on Linux.
+pop up. When canceled, the selection should reset. This did not work reliably
+in localized clients due to the use of string comparisons. Using a numeric
+index to keep track of the old value fixes the problem.
 
 https://github.com/owncloud/client/issues/10251
 https://github.com/owncloud/client/pull/10609

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -210,6 +210,8 @@ void GeneralSettings::slotUpdateInfo()
 void GeneralSettings::slotUpdateChannelChanged(int index)
 {
 #ifdef WITH_AUTO_UPDATER
+    const auto oldChannelIndex = _ui->updateChannel->currentIndex();
+
     QString channel = index == 0 ? QStringLiteral("stable") : QStringLiteral("beta");
     if (channel == ConfigFile().updateChannel())
         return;
@@ -232,7 +234,7 @@ void GeneralSettings::slotUpdateChannelChanged(int index)
         this);
     auto acceptButton = msgBox->addButton(tr("Change update channel"), QMessageBox::AcceptRole);
     msgBox->addButton(tr("Cancel"), QMessageBox::RejectRole);
-    connect(msgBox, &QMessageBox::finished, msgBox, [this, channel, msgBox, acceptButton] {
+    connect(msgBox, &QMessageBox::finished, msgBox, [this, channel, msgBox, acceptButton, oldChannelIndex] {
         msgBox->deleteLater();
         if (msgBox->clickedButton() == acceptButton) {
             ConfigFile().setUpdateChannel(channel);
@@ -247,7 +249,7 @@ void GeneralSettings::slotUpdateChannelChanged(int index)
             }
 #endif
         } else {
-            _ui->updateChannel->setCurrentText(ConfigFile().updateChannel());
+            _ui->updateChannel->setCurrentIndex(oldChannelIndex);
         }
     });
     msgBox->open();


### PR DESCRIPTION
Fixes a minor UI bug where the update channel in testpilotcloud is not reset to its original value even if the message box that warns about the beta channel is rejected.

Fixes #10251.