### PR TITLE
Move getCoreIcon to the resource module

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -23,6 +23,8 @@
 #include "account.h"
 #include "guiutility.h"
 
+#include "resources/resources.h"
+
 #include <QFileIconProvider>
 #include <QPainter>
 #include <QApplication>
@@ -146,7 +148,7 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     // encoded in the status icon.
     if (warningCount > 0 && syncOngoing) {
         const auto warnRect = QRectF{iconRect.bottomLeft() - QPointF(0, 17), QSizeF{16, 16}};
-        const auto warnIcon = Utility::getCoreIcon(QStringLiteral("warning"));
+        const auto warnIcon = Resources::getCoreIcon(QStringLiteral("warning"));
         const QPixmap pm = warnIcon.pixmap(warnRect.size().toSize(), syncEnabled ? QIcon::Normal : QIcon::Disabled);
         painter->drawPixmap(QStyle::visualRect(option.direction, option.rect, warnRect.toRect()), pm);
     }
@@ -260,7 +262,7 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         btnOpt.arrowType = Qt::NoArrow;
         btnOpt.subControls = QStyle::SC_ToolButton;
         btnOpt.rect = optionsButtonVisualRect.toRect();
-        btnOpt.icon = Utility::getCoreIcon(QStringLiteral("more"));
+        btnOpt.icon = Resources::getCoreIcon(QStringLiteral("more"));
         int e = QApplication::style()->pixelMetric(QStyle::PM_ButtonIconSize);
         btnOpt.iconSize = QSize(e,e);
         QApplication::style()->drawComplexControl(QStyle::CC_ToolButton, &btnOpt, painter);

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -103,21 +103,6 @@ QString Utility::vfsFreeSpaceActionText()
     return QCoreApplication::translate("utility", "Free up local space");
 }
 
-
-QIcon Utility::getCoreIcon(const QString &icon_name)
-{
-    if (icon_name.isEmpty()) {
-        return {};
-    }
-    const QString theme = Theme::instance()->isUsingDarkTheme() ? QStringLiteral("dark") : QStringLiteral("light");
-    const QString path = QStringLiteral(":/client/resources/%1/%2").arg(theme, icon_name);
-    const QIcon icon(path);
-    // were we able to load the file?
-    Q_ASSERT(icon.actualSize({ 100, 100 }).isValid());
-    return icon;
-}
-
-
 void Utility::setModal(QWidget *w)
 {
     // setting both sheet and explicitly modal

--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -53,8 +53,6 @@ namespace Utility {
     /** Translated text for "free up local space" (and unpinning the item) */
     QString vfsFreeSpaceActionText();
 
-    QIcon getCoreIcon(const QString &icon_name);
-
     void startShellIntegration();
 
     QString socketApiSocketPath();

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -35,6 +35,8 @@
 #include "logger.h"
 #include "ui_logbrowser.h"
 
+#include "resources/resources.h"
+
 namespace OCC {
 
 // ==============================================================================
@@ -46,7 +48,7 @@ LogBrowser::LogBrowser(QWidget *parent)
     Utility::setModal(this);
     ui->setupUi(this);
 
-    ui->warningLabel->setPixmap(Utility::getCoreIcon(QStringLiteral("warning")).pixmap(ui->warningLabel->size()));
+    ui->warningLabel->setPixmap(Resources::getCoreIcon(QStringLiteral("warning")).pixmap(ui->warningLabel->size()));
     ui->locationLabel->setText(Logger::instance()->temporaryFolderLogDirPath());
 
     ui->enableLoggingButton->setChecked(ConfigFile().automaticLogDir());

--- a/src/gui/loginrequireddialog/CMakeLists.txt
+++ b/src/gui/loginrequireddialog/CMakeLists.txt
@@ -10,8 +10,7 @@ add_library(loginrequireddialog STATIC
     basicloginwidget.cpp
     basicloginwidget.ui
 )
-target_link_libraries(loginrequireddialog PUBLIC Qt5::Widgets libsync)
+target_link_libraries(loginrequireddialog PUBLIC Qt5::Widgets libsync owncloudResources)
 set_target_properties(loginrequireddialog PROPERTIES AUTOUIC ON AUTORCC ON)
 target_include_directories(loginrequireddialog PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 apply_common_target_settings(loginrequireddialog)
-

--- a/src/gui/loginrequireddialog/oauthloginwidget.cpp
+++ b/src/gui/loginrequireddialog/oauthloginwidget.cpp
@@ -19,6 +19,8 @@
 #include "gui/creds/httpcredentialsgui.h"
 #include "gui/guiutility.h"
 
+#include "resources/resources.h"
+
 #include <QClipboard>
 
 namespace OCC {
@@ -35,7 +37,7 @@ OAuthLoginWidget::OAuthLoginWidget(QWidget *parent)
     connect(_ui->copyUrlToClipboardButton, &QPushButton::clicked, this, &OAuthLoginWidget::copyUrlToClipboardButtonClicked);
 
     // depending on the theme we have to use a light or dark icon
-    _ui->copyUrlToClipboardButton->setIcon(Utility::getCoreIcon(QStringLiteral("copy")));
+    _ui->copyUrlToClipboardButton->setIcon(Resources::getCoreIcon(QStringLiteral("copy")));
 
     setFocusProxy(_ui->openBrowserButton);
 

--- a/src/gui/models/activitylistmodel.cpp
+++ b/src/gui/models/activitylistmodel.cpp
@@ -28,6 +28,8 @@
 #include "models.h"
 #include "networkjobs/jsonjob.h"
 
+#include "resources/resources.h"
+
 #include "activitydata.h"
 #include "activitylistmodel.h"
 
@@ -93,7 +95,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             if (!accountState->account()->avatar().isNull()) {
                 return QIcon(accountState->account()->avatar());
             } else {
-                return Utility::getCoreIcon(QStringLiteral("account"));
+                return Resources::getCoreIcon(QStringLiteral("account"));
             }
         default:
             return {};

--- a/src/gui/newwizard/CMakeLists.txt
+++ b/src/gui/newwizard/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(newwizard STATIC
 
     setupwizardcontext.cpp
 )
-target_link_libraries(newwizard PUBLIC Qt5::Widgets libsync)
+target_link_libraries(newwizard PUBLIC Qt5::Widgets libsync owncloudResources)
 set_target_properties(newwizard PROPERTIES AUTOUIC ON AUTORCC ON)
 target_include_directories(newwizard PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 apply_common_target_settings(newwizard)

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -6,6 +6,8 @@
 #include "gui/settingsdialog.h"
 #include "libsync/theme.h"
 
+#include "resources/resources.h"
+
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -29,7 +31,7 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
 
     _ui->useVfsRadioButton->setText(tr("Use &virtual files instead of downloading content immediately"));
     if (vfsModeIsExperimental) {
-        _ui->useVfsRadioButton->setIcon(Utility::getCoreIcon(QStringLiteral("warning")));
+        _ui->useVfsRadioButton->setIcon(Resources::getCoreIcon(QStringLiteral("warning")));
 
         // when a feature is experimental and experimental features are disabled globally, it should be hidden
         if (!Theme::instance()->enableExperimentalFeatures()) {

--- a/src/gui/notificationwidget.cpp
+++ b/src/gui/notificationwidget.cpp
@@ -20,6 +20,8 @@
 
 #include "ui_notificationwidget.h"
 
+#include "resources/resources.h"
+
 #include <QPushButton>
 
 namespace OCC {
@@ -140,7 +142,7 @@ void NotificationWidget::changeEvent(QEvent *e)
     case QEvent::StyleChange:
     case QEvent::PaletteChange:
     case QEvent::ThemeChange:
-        _ui->_notifIcon->setPixmap(Utility::getCoreIcon(QStringLiteral("bell")).pixmap(_ui->_notifIcon->size()));
+        _ui->_notifIcon->setPixmap(Resources::getCoreIcon(QStringLiteral("bell")).pixmap(_ui->_notifIcon->size()));
         break;
     default:
         break;

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -35,6 +35,8 @@
 #include "sharedialog.h"
 #include "theme.h"
 
+#include "resources/resources.h"
+
 #include <QDesktopServices>
 #include <QDir>
 #include <QMessageBox>
@@ -934,7 +936,7 @@ void ownCloudGui::slotUpdateProgress(Folder *folder, const ProgressInfo &progres
         && shouldShowInRecentsMenu(progress._lastCompletedItem)) {
         if (Progress::isWarningKind(progress._lastCompletedItem._status)) {
             // display a warn icon if warnings happened.
-            _actionRecent->setIcon(Utility::getCoreIcon(QStringLiteral("warning")));
+            _actionRecent->setIcon(Resources::getCoreIcon(QStringLiteral("warning")));
         }
 
         QString kindStr = Progress::asResultString(progress._lastCompletedItem);

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -29,6 +29,8 @@
 #include "accountmanager.h"
 #include "protocolwidget.h"
 
+#include "resources/resources.h"
+
 #include <QDesktopServices>
 #include <QImage>
 #include <QLabel>
@@ -167,7 +169,7 @@ public:
     void updateIcon()
     {
         if (!_iconName.isEmpty()) {
-            setIcon(Utility::getCoreIcon(_iconName));
+            setIcon(Resources::getCoreIcon(_iconName));
         }
     }
 

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -21,6 +21,8 @@
 #include "sharemanager.h"
 #include "guiutility.h"
 
+#include "resources/resources.h"
+
 #include "QProgressIndicator.h"
 #include <QBuffer>
 #include <QClipboard>
@@ -226,8 +228,7 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
     table->setRowCount(0);
     connect(table, &QTableWidget::itemSelectionChanged, this, &ShareLinkWidget::slotShareSelectionChanged);
 
-    auto deleteIcon = QIcon::fromTheme(QStringLiteral("user-trash"),
-        Utility::getCoreIcon(QStringLiteral("delete")));
+    auto deleteIcon = QIcon::fromTheme(QStringLiteral("user-trash"), Resources::getCoreIcon(QStringLiteral("delete")));
 
     for (const auto &share : shares) {
         if (share->getShareType() != Share::TypeLink) {

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -28,6 +28,8 @@
 #include "sharemanager.h"
 #include "guiutility.h"
 
+#include "resources/resources.h"
+
 #include "QProgressIndicator.h"
 #include <QBuffer>
 #include <QFileIconProvider>
@@ -374,7 +376,7 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
     }
     _ui->permissionToolButton->setMenu(menu);
     _ui->permissionToolButton->setPopupMode(QToolButton::InstantPopup);
-    _ui->permissionToolButton->setIcon(Utility::getCoreIcon(QStringLiteral("more")));
+    _ui->permissionToolButton->setIcon(Resources::getCoreIcon(QStringLiteral("more")));
 
     // If there's only a single entry in the detailed permission menu, hide it
     if (menu->actions().size() == 1) {
@@ -397,8 +399,7 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
     connect(share.data(), &Share::permissionsSet, this, &ShareUserLine::slotPermissionsSet);
     connect(share.data(), &Share::shareDeleted, this, &ShareUserLine::slotShareDeleted);
 
-    _ui->deleteShareButton->setIcon(QIcon::fromTheme(QStringLiteral("user-trash"),
-        Utility::getCoreIcon(QStringLiteral("delete"))));
+    _ui->deleteShareButton->setIcon(QIcon::fromTheme(QStringLiteral("user-trash"), Resources::getCoreIcon(QStringLiteral("delete"))));
 
     if (!share->account()->capabilities().shareResharing()) {
         _ui->permissionShare->hide();

--- a/src/gui/spaces/CMakeLists.txt
+++ b/src/gui/spaces/CMakeLists.txt
@@ -4,6 +4,6 @@ add_library(spaces
             spacesdelegate.cpp
             spacesbrowser.cpp
             spacesbrowser.ui)
-target_link_libraries(spaces PUBLIC Qt5::Widgets libsync)
+target_link_libraries(spaces PUBLIC Qt5::Widgets libsync owncloudResources)
 set_target_properties(spaces PROPERTIES AUTOUIC ON AUTORCC ON)
 apply_common_target_settings(spaces)

--- a/src/gui/spaces/spacesdelegate.cpp
+++ b/src/gui/spaces/spacesdelegate.cpp
@@ -20,6 +20,8 @@
 #include "gui/guiutility.h"
 #include "spacesmodel.h"
 
+#include "resources/resources.h"
+
 #include <QApplication>
 #include <QDesktopServices>
 #include <QMouseEvent>
@@ -161,7 +163,7 @@ QStyleOptionButton SpacesDelegate::openBrowserButtonRect(const QStyleOptionViewI
 
     opt.text = tr("Open in Web");
 
-    opt.icon = Utility::getCoreIcon(QStringLiteral("arrow-up-right-from-square"));
+    opt.icon = Resources::getCoreIcon(QStringLiteral("arrow-up-right-from-square"));
     const auto px = QApplication::style()->pixelMetric(QStyle::PM_ButtonIconSize);
     opt.iconSize = QSize { px, px };
 

--- a/src/gui/spaces/spacesmodel.cpp
+++ b/src/gui/spaces/spacesmodel.cpp
@@ -15,9 +15,12 @@
 
 #include "common/utility.h"
 // TODO: move models out from core
-#include "gui/guiutility.h"
 #include "gui/models/models.h"
 #include "networkjobs.h"
+
+#include "libsync/account.h"
+
+#include "resources/resources.h"
 
 #include <QIcon>
 #include <QPixmap>
@@ -118,7 +121,7 @@ QVariant SpacesModel::data(const QModelIndex &index, int role) const
             if (auto it = Utility::optionalFind(_images, item.getId())) {
                 return QVariant::fromValue(it->value());
             }
-            _images[item.getId()] = OCC::Utility::getCoreIcon(QStringLiteral("th-large")).pixmap(ImageSizeC);
+            _images[item.getId()] = Resources::getCoreIcon(QStringLiteral("th-large")).pixmap(ImageSizeC);
             const auto imgUrl = data(index, Models::UnderlyingDataRole).toUrl();
             if (!imgUrl.isEmpty()) {
                 auto job = new OCC::SimpleNetworkJob(_acc, imgUrl, {}, "GET", {}, {}, nullptr);

--- a/src/gui/updater/appimageupdateavailabledialog.cpp
+++ b/src/gui/updater/appimageupdateavailabledialog.cpp
@@ -40,9 +40,9 @@ AppImageUpdateAvailableDialog::AppImageUpdateAvailableDialog(const QVersionNumbe
     _ui->appIconLabel->setPixmap(theme->aboutIcon().pixmap(QSize(128, 128)));
 
     // we use custom icons to ensure a unified look on all platforms
-    _ui->buttonBox->button(QDialogButtonBox::Ok)->setIcon(Utility::getCoreIcon(QStringLiteral("check")));
-    _ui->buttonBox->button(QDialogButtonBox::Cancel)->setIcon(Utility::getCoreIcon(QStringLiteral("ban")));
-    _ui->skipButton->setIcon(Utility::getCoreIcon(QStringLiteral("step-forward")));
+    _ui->buttonBox->button(QDialogButtonBox::Ok)->setIcon(Resources::getCoreIcon(QStringLiteral("check")));
+    _ui->buttonBox->button(QDialogButtonBox::Cancel)->setIcon(Resources::getCoreIcon(QStringLiteral("ban")));
+    _ui->skipButton->setIcon(Resources::getCoreIcon(QStringLiteral("step-forward")));
 
     // the minimum size of the info label (and a few other labels) depends on their contents
     // we can't persuade the dialog to resize automatically to the recommended size in Qt Designer, so we do it manually

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -100,6 +100,7 @@ target_link_libraries(libsync
         Qt5::Network
         Qt5::Widgets
     PRIVATE
+        owncloudResources
         Qt5::Concurrent
         ZLIB::ZLIB
         qt5keychain

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "configfile.h"
 
+#include "resources/resources.h"
+
 #include <QtCore>
 #include <QtGui>
 #include <QStyle>
@@ -148,13 +150,6 @@ QIcon Theme::aboutIcon() const
     return applicationIcon();
 }
 
-bool Theme::isUsingDarkTheme() const
-{
-    //TODO: replace by a command line switch
-    static bool forceDark = qEnvironmentVariableIntValue("OWNCLOUD_FORCE_DARK_MODE") != 0;
-    return forceDark || QPalette().base().color().lightnessF() <= 0.5;
-}
-
 bool Theme::allowDarkTheme() const
 {
     return _hasBrandedColored == _hasBrandedDark;
@@ -179,7 +174,7 @@ QIcon Theme::themeTrayIcon(const QString &name, bool sysTrayMenuVisible, IconTyp
 
 QIcon Theme::themeIcon(const QString &name, Theme::IconType iconType) const
 {
-    return loadIcon((isUsingDarkTheme() && allowDarkTheme()) ? darkTheme() : coloredTheme(), name, iconType);
+    return loadIcon((Resources::isUsingDarkTheme() && allowDarkTheme()) ? darkTheme() : coloredTheme(), name, iconType);
 }
 /*
  * helper to load a icon from either the icon theme the desktop provides or from

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -115,12 +115,6 @@ public:
     virtual QIcon aboutIcon() const;
 
     /**
-     * Whether use the dark icon theme
-     * The function also ensures the theme supports the dark theme
-     */
-    bool isUsingDarkTheme() const;
-
-    /**
     * Whether the branding allows the dark theme
     */
     bool allowDarkTheme() const;

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(owncloudResources SHARED
     client.qrc
     core_theme.qrc
     loadresources.cpp
+    resources.cpp
 )
 
 generate_theme(owncloudResources OWNCLOUD_SIDEBAR_ICONS)
@@ -11,8 +12,9 @@ generate_theme(owncloudResources OWNCLOUD_SIDEBAR_ICONS)
 # make them available to the whole project
 set(OWNCLOUD_SIDEBAR_ICONS ${OWNCLOUD_SIDEBAR_ICONS} CACHE INTERNAL "Sidebar icons" FORCE)
 
-target_link_libraries(owncloudResources PUBLIC Qt5::Core)
+target_link_libraries(owncloudResources PUBLIC Qt5::Core Qt5::Gui)
 apply_common_target_settings(owncloudResources)
+target_include_directories(owncloudResources PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
 set_target_properties(owncloudResources PROPERTIES
     OUTPUT_NAME "${APPLICATION_EXECUTABLE}Resources"
@@ -40,4 +42,4 @@ if(Qt5LinguistTools_FOUND)
     )
 endif()
 
-install(TARGETS owncloudResources ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+install(TARGETS owncloudResources EXPORT ownCloudConfig ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})

--- a/src/resources/resources.cpp
+++ b/src/resources/resources.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "resources.h"
+
+#include <QPalette>
+
+using namespace OCC;
+using namespace Resources;
+
+bool OCC::Resources::isUsingDarkTheme()
+{
+    // TODO: replace by a command line switch
+    static bool forceDark = qEnvironmentVariableIntValue("OWNCLOUD_FORCE_DARK_MODE") != 0;
+    return forceDark || QPalette().base().color().lightnessF() <= 0.5;
+}
+
+QIcon OCC::Resources::getCoreIcon(const QString &icon_name)
+{
+    if (icon_name.isEmpty()) {
+        return {};
+    }
+    const QString theme = Resources::isUsingDarkTheme() ? QStringLiteral("dark") : QStringLiteral("light");
+    const QString path = QStringLiteral(":/client/resources/%1/%2").arg(theme, icon_name);
+    const QIcon icon(path);
+    // were we able to load the file?
+    Q_ASSERT(icon.actualSize({100, 100}).isValid());
+    return icon;
+}

--- a/src/resources/resources.h
+++ b/src/resources/resources.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+#include "resources/owncloudresources.h"
+
+#include <QIcon>
+
+namespace OCC::Resources {
+/**
+ * Whether use the dark icon theme
+ * The function also ensures the theme supports the dark theme
+ */
+bool OWNCLOUDRESOURCES_EXPORT isUsingDarkTheme();
+
+QIcon OWNCLOUDRESOURCES_EXPORT getCoreIcon(const QString &icon_name);
+}


### PR DESCRIPTION
We already require a QGuiApplication so keeping the core free of QGui doesn't make much sense.
This change will allow to use resources in libsync.