### PR TITLE
Fix update channel reset

### DIFF
--- a/changelog/unreleased/10251
+++ b/changelog/unreleased/10251
@@ -7,3 +7,4 @@ index to keep track of the old value fixes the problem.
 
 https://github.com/owncloud/client/issues/10251
 https://github.com/owncloud/client/pull/10609
+https://github.com/owncloud/client/pull/10627

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -139,6 +139,11 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     if (Theme::instance()->forceVirtualFilesOption() && VfsPluginManager::instance().bestAvailableVfsMode() == Vfs::WindowsCfApi) {
         _ui->groupBox_non_vfs->hide();
     }
+
+    // we want to attach the known english identifiers which are also used within the configuration file as user data inside the data model
+    // that way, when we intend to reset to the original selection when the dialog, we can look up the config file's stored value in the data model
+    _ui->updateChannel->addItem(tr("stable"), QStringLiteral("stable"));
+    _ui->updateChannel->addItem(tr("beta"), QStringLiteral("beta"));
 }
 
 GeneralSettings::~GeneralSettings()
@@ -202,16 +207,14 @@ void GeneralSettings::slotUpdateInfo()
 
     // Channel selection
     _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == QLatin1String("beta") ? 1 : 0);
-    connect(_ui->updateChannel, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-        this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
+    connect(_ui->updateChannel, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralSettings::slotUpdateChannelChanged,
+        Qt::UniqueConnection);
 #endif
 }
 
 void GeneralSettings::slotUpdateChannelChanged(int index)
 {
 #ifdef WITH_AUTO_UPDATER
-    const auto oldChannelIndex = _ui->updateChannel->currentIndex();
-
     QString channel = index == 0 ? QStringLiteral("stable") : QStringLiteral("beta");
     if (channel == ConfigFile().updateChannel())
         return;
@@ -234,7 +237,7 @@ void GeneralSettings::slotUpdateChannelChanged(int index)
         this);
     auto acceptButton = msgBox->addButton(tr("Change update channel"), QMessageBox::AcceptRole);
     msgBox->addButton(tr("Cancel"), QMessageBox::RejectRole);
-    connect(msgBox, &QMessageBox::finished, msgBox, [this, channel, msgBox, acceptButton, oldChannelIndex] {
+    connect(msgBox, &QMessageBox::finished, msgBox, [this, channel, msgBox, acceptButton, index] {
         msgBox->deleteLater();
         if (msgBox->clickedButton() == acceptButton) {
             ConfigFile().setUpdateChannel(channel);
@@ -249,7 +252,10 @@ void GeneralSettings::slotUpdateChannelChanged(int index)
             }
 #endif
         } else {
-            _ui->updateChannel->setCurrentIndex(oldChannelIndex);
+            const auto oldChannel = _ui->updateChannel->findData(ConfigFile().updateChannel());
+            Q_ASSERT(oldChannel >= 0);
+            Q_ASSERT(oldChannel <= 1);
+            _ui->updateChannel->setCurrentIndex(oldChannel);
         }
     });
     msgBox->open();

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -265,16 +265,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <item>
-             <property name="text">
-              <string>stable</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>beta</string>
-             </property>
-            </item>
            </widget>
           </item>
           <item>


### PR DESCRIPTION
We need to keep our own copy of the old index to be able to reliably reset the selection if the dialog is rejected.