### PR TITLE
Fix modal dialogs

### DIFF
--- a/changelog/unreleased/10621
+++ b/changelog/unreleased/10621
@@ -1,0 +1,5 @@
+Bugfix: UI freeze when multiple modal dialogs displayed on macOS
+
+Due to incorrect handling of the dialogs, the UI could freeze.
+
+https://github.com/owncloud/client/issues/10621

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -23,7 +23,6 @@ AboutDialog::AboutDialog(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::AboutDialog)
 {
-    Utility::setModal(this);
     ui->setupUi(this);
     setWindowTitle(tr("About %1").arg(Theme::instance()->appNameGUI()));
     ui->aboutText->setText(Theme::instance()->about());

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -805,7 +805,7 @@ void AccountSettings::slotAccountStateChanged()
 
             showConnectionLabel(tr("Reauthorization required."));
 
-            _askForOAuthLoginDialog->show();
+            _askForOAuthLoginDialog->open();
             ocApp()->gui()->raiseDialog(_askForOAuthLoginDialog);
 
             QTimer::singleShot(0, [contentWidget]() {

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -348,7 +348,7 @@ void AccountState::checkConnectivity(bool blockJobs)
                     setState(SignedOut);
                 });
 
-                _tlsDialog->show();
+                _tlsDialog->open();
             }
         }
         if (_tlsDialog) {

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -166,7 +166,6 @@ FolderWizard::FolderWizard(const AccountStatePtr &account, QWidget *parent)
     : QWizard(parent)
     , d_ptr(new FolderWizardPrivate(this, account))
 {
-    Utility::setModal(this);
     setWindowTitle(tr("Add Folder Sync Connection"));
     setOptions(QWizard::CancelButtonOnLeft);
     setButtonText(QWizard::FinishButton, tr("Add Sync Connection"));

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -102,14 +102,3 @@ QString Utility::vfsFreeSpaceActionText()
 {
     return QCoreApplication::translate("utility", "Free up local space");
 }
-
-void Utility::setModal(QWidget *w)
-{
-    // setting both sheet and explicitly modal
-    // can cause window stacking issues
-#ifdef Q_OS_MAC
-    w->setWindowFlags(Qt::Sheet);
-#else
-    w->setWindowModality(Qt::ApplicationModal);
-#endif
-}

--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -57,9 +57,6 @@ namespace Utility {
 
     QString socketApiSocketPath();
 
-    // applies window flags and modality
-    void setModal(QWidget *w);
-
 } // namespace Utility
 } // namespace OCC
 

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -37,7 +37,6 @@ IgnoreListEditor::IgnoreListEditor(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::IgnoreListEditor)
 {
-    Utility::setModal(this);
     ui->setupUi(this);
 
     ConfigFile cfgFile;

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -45,7 +45,6 @@ LogBrowser::LogBrowser(QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::LogBrowser)
 {
-    Utility::setModal(this);
     ui->setupUi(this);
 
     ui->warningLabel->setPixmap(Resources::getCoreIcon(QStringLiteral("warning")).pixmap(ui->warningLabel->size()));

--- a/src/gui/loginrequireddialog/basicloginwidget.cpp
+++ b/src/gui/loginrequireddialog/basicloginwidget.cpp
@@ -48,8 +48,6 @@ BasicLoginWidget::BasicLoginWidget(QWidget *parent)
         _ui->usernameLineEdit->setPlaceholderText(Theme::instance()->userIDHint());
     }
 
-    Utility::setModal(this);
-
     setFocusProxy(_ui->usernameLineEdit);
 
     connect(_ui->usernameLineEdit, &QLineEdit::textChanged, this, &AbstractLoginWidget::contentChanged);

--- a/src/gui/loginrequireddialog/loginrequireddialog.cpp
+++ b/src/gui/loginrequireddialog/loginrequireddialog.cpp
@@ -51,8 +51,6 @@ LoginRequiredDialog::LoginRequiredDialog(Mode mode, QWidget *parent)
             Q_UNREACHABLE();
         }
     }());
-
-    Utility::setModal(this);
 }
 
 LoginRequiredDialog::~LoginRequiredDialog()

--- a/src/gui/loginrequireddialog/oauthloginwidget.cpp
+++ b/src/gui/loginrequireddialog/oauthloginwidget.cpp
@@ -31,7 +31,6 @@ OAuthLoginWidget::OAuthLoginWidget(QWidget *parent)
 {
     _ui->setupUi(this);
 
-    Utility::setModal(this);
 
     connect(_ui->openBrowserButton, &QPushButton::clicked, this, &OAuthLoginWidget::openBrowserButtonClicked);
     connect(_ui->copyUrlToClipboardButton, &QPushButton::clicked, this, &OAuthLoginWidget::copyUrlToClipboardButtonClicked);

--- a/src/gui/newwizard/jobs/resolveurljobfactory.cpp
+++ b/src/gui/newwizard/jobs/resolveurljobfactory.cpp
@@ -115,7 +115,7 @@ CoreJob *ResolveUrlJobFactory::startJob(const QUrl &url, QObject *parent)
             setJobError(job, QApplication::translate("ResolveUrlJobFactory", "User rejected invalid SSL certificate"));
         });
 
-        tlsErrorDialog->show();
+        tlsErrorDialog->open();
         ocApp()->gui()->raiseDialog(tlsErrorDialog);
     });
 

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -79,7 +79,6 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
 
     connect(_ui->chooseLocalDirectoryButton, &QToolButton::clicked, this, [=]() {
         auto dialog = new QFileDialog(ocApp()->gui()->settingsDialog(), tr("Select the local folder"), defaultSyncTargetDir);
-        Utility::setModal(dialog);
         dialog->setFileMode(QFileDialog::Directory);
         dialog->setOption(QFileDialog::ShowDirsOnly);
 

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -78,7 +78,7 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
     }
 
     connect(_ui->chooseLocalDirectoryButton, &QToolButton::clicked, this, [=]() {
-        auto dialog = new QFileDialog(ocApp()->gui()->settingsDialog(), tr("Select the local folder"), defaultSyncTargetDir);
+        auto dialog = new QFileDialog(this, tr("Select the local folder"), defaultSyncTargetDir);
         dialog->setFileMode(QFileDialog::Directory);
         dialog->setOption(QFileDialog::ShowDirsOnly);
 
@@ -88,8 +88,7 @@ AccountConfiguredWizardPage::AccountConfiguredWizardPage(const QString &defaultS
 
             _ui->localDirectoryLineEdit->setText(QDir::toNativeSeparators(directory));
         });
-
-        ocApp()->gui()->raiseDialog(dialog);
+        dialog->open();
     });
 
     // this should be handled on application startup, too

--- a/src/gui/newwizard/setupwizardwindow.cpp
+++ b/src/gui/newwizard/setupwizardwindow.cpp
@@ -35,7 +35,6 @@ SetupWizardWindow::SetupWizardWindow(SettingsDialog *parent)
     : QDialog(parent)
     , _ui(new ::Ui::SetupWizardWindow)
 {
-    Utility::setModal(this);
     setWindowFlag(Qt::WindowCloseButtonHint, false);
 
     _ui->setupUi(this);
@@ -161,7 +160,7 @@ void SetupWizardWindow::reject()
         // call the base implementation
         QDialog::reject();
     });
-    messageBox->show();
+    messageBox->open();
     ocApp()->gui()->raiseDialog(messageBox);
 }
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1179,15 +1179,20 @@ void ownCloudGui::slotHelp()
 void ownCloudGui::raiseDialog(QWidget *raiseWidget)
 {
     auto window = ocApp()->gui()->settingsDialog();
+    auto *dialog = qobject_cast<QDialog *>(raiseWidget);
     OC_ASSERT(window);
-    OC_ASSERT_X(!qobject_cast<QDialog *>(raiseWidget) || raiseWidget->parentWidget() == window, "raiseDialog should only be called with modal dialogs");
+    OC_ASSERT_X(!dialog || raiseWidget->parentWidget() == window, "raiseDialog should only be called with modal dialogs");
     if (!window) {
         return;
     }
     window->showNormal();
     window->raise();
-    raiseWidget->showNormal();
-    raiseWidget->raise();
+    if (dialog && !dialog->isVisible()) {
+        dialog->open();
+    } else {
+        raiseWidget->showNormal();
+        raiseWidget->raise();
+    }
     window->activateWindow();
     raiseWidget->activateWindow();
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1097,7 +1097,7 @@ void ownCloudGui::runNewAccountWizard()
             });
 
         // all we have to do is show the dialog...
-        _wizardController->window()->show();
+        _wizardController->window()->open();
         // ... and bring it to the front
         raiseDialog(_wizardController->window());
     }

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -59,6 +59,11 @@ public:
 
     bool checkAccountExists(bool openSettings);
 
+    /**
+     * Raises our main Window to the front with the raiseWidget in focus.
+     * If raiseWidget is a dialog and not visible yet, ->open will be called.
+     * For normal widgets we call showNormal.
+     */
     static void raiseDialog(QWidget *raiseWidget);
     void setupOverlayIcons();
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -251,11 +251,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
         auto box = new QMessageBox(QMessageBox::Question, tr("Quit %1").arg(appNameGui),
             tr("Are you sure you want to quit %1?").arg(appNameGui), QMessageBox::Yes | QMessageBox::No, this);
         box->setAttribute(Qt::WA_DeleteOnClose);
-        Utility::setModal(box);
         connect(box, &QMessageBox::accepted, this, [] {
             qApp->quit();
         });
-        box->show();
+        box->open();
     });
     _ui->toolBar->addAction(quitAction);
 

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -60,7 +60,6 @@ ShareDialog::ShareDialog(AccountStatePtr accountState,
     , _progressIndicator(nullptr)
     , _baseUrl(baseUrl)
 {
-    Utility::setModal(this);
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName(QStringLiteral("SharingDialog"));
 

--- a/src/gui/tlserrordialog.cpp
+++ b/src/gui/tlserrordialog.cpp
@@ -41,12 +41,7 @@ TlsErrorDialog::TlsErrorDialog(const QList<QSslError> &sslErrors, const QString 
     connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, [this]() {
         accept();
     });
-    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
-        reject();
-    });
-
-    // of course, we require an answer from the user, they may not proceed with anything else
-    setModal(true);
+    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() { reject(); });
 }
 
 TlsErrorDialog::~TlsErrorDialog()

--- a/src/gui/tlserrordialog.cpp
+++ b/src/gui/tlserrordialog.cpp
@@ -38,10 +38,8 @@ TlsErrorDialog::TlsErrorDialog(const QList<QSslError> &sslErrors, const QString 
 
     // FIXME: add checkbox for second confirmation
 
-    connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, [this]() {
-        accept();
-    });
-    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, [this]() { reject(); });
+    connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, &TlsErrorDialog::accept);
+    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, &TlsErrorDialog::reject);
 }
 
 TlsErrorDialog::~TlsErrorDialog()

--- a/src/gui/updater/appimageupdateavailabledialog.cpp
+++ b/src/gui/updater/appimageupdateavailabledialog.cpp
@@ -29,9 +29,6 @@ AppImageUpdateAvailableDialog::AppImageUpdateAvailableDialog(const QVersionNumbe
 {
     _ui->setupUi(this);
 
-    // we want an immediate response from the user
-    setModal(true);
-
     const auto *theme = Theme::instance();
 
     // the strings in the .ui file are not marked for translation, they're just placeholders

--- a/src/gui/updater/appimageupdater.cpp
+++ b/src/gui/updater/appimageupdater.cpp
@@ -184,7 +184,7 @@ void AppImageUpdater::versionInfoArrived(const UpdateInfo &info)
         appImageUpdaterShim->startUpdateInBackground();
     });
 
-    dialog->show();
+    dialog->open();
     ownCloudGui::raiseDialog(dialog);
 }
 


### PR DESCRIPTION
    Eliminate Utility::setModal and rather call ->open() on all dialogs

    Utility::setModal was also setting Qt::ApplicationModal however
    it appears Qt never cared and always set Qt::WindowModal.
    https://github.com/qt/qtbase/blame/4ee4fc18b4067b90efa46ca9baba74f53b54d9ec/src/widgets/dialogs/qdialog.cpp#L543

    Setting Qt::Sheet is also handled in open();

    Fixes: #10621