### PR TITLE
[gui-tests] Update expected oauth2 login successful message

### DIFF
--- a/test/gui/webUI/login.spec.js
+++ b/test/gui/webUI/login.spec.js
@@ -48,7 +48,5 @@ test("oC10 login @oauth", async ({ page }) => {
   // authorize
   await page.click("button >> text=Authorize");
   // confirm successful login
-  await expect(page.locator("span.error")).toContainText(
-    "The application was authorized successfully"
-  );
+  await expect(page.locator("h1")).toContainText("Login Successful");
 });


### PR DESCRIPTION
Previously, the successfully authorized message was
`The application was authorized successfully`
and now it is
`Login Successful`

Fixes https://github.com/owncloud/client/issues/10674