### PR TITLE
Prevent selection of too long path on Windows

### DIFF
--- a/changelog/unreleased/10352
+++ b/changelog/unreleased/10352
@@ -1,3 +1,6 @@
-Bugfix: Check for long paths when these are not enabled on Windows
+Enhancement: Check for long paths when these are not enabled on Windows
 
+https://github.com/owncloud/client/issues/10264
 https://github.com/owncloud/client/pull/10352
+https://github.com/owncloud/client/issues/10677
+https://github.com/owncloud/client/pull/10679

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -156,6 +156,9 @@ namespace FileSystem {
     bool OCSYNC_EXPORT isFileLocked(const QString &fileName, LockMode mode);
 
 #ifdef Q_OS_WIN
+
+    bool OCSYNC_EXPORT longPathsEnabledOnWindows();
+
     /**
      * Returns the file system used at the given path.
      */

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1172,6 +1172,12 @@ QString FolderMan::checkPathValidityRecursive(const QString &path)
 
 #ifdef Q_OS_WIN
     Utility::NtfsPermissionLookupRAII ntfs_perm;
+
+    if (path.size() > MAX_PATH) {
+        if (!FileSystem::longPathsEnabledOnWindows()) {
+            return tr("The path '%1' is too long. Please enable long paths in the Windows settings or choose a different folder.").arg(path);
+        }
+    }
 #endif
     const QFileInfo selFile(path);
     if (numberOfSyncJournals(selFile.filePath()) != 0) {
@@ -1220,6 +1226,7 @@ QString FolderMan::checkPathValidityForNewFolder(const QString &path) const
                 .arg(QDir::toNativeSeparators(path));
         }
     }
+
     const auto result = checkPathValidityRecursive(path);
     if (!result.isEmpty()) {
         return tr("%1 Please pick another one!").arg(result);


### PR DESCRIPTION
Additionally the length to the db is irrelevant for this check

![image](https://user-images.githubusercontent.com/200626/230325331-b7b0051a-0b6a-47fe-98c8-b227a6b170c2.png)

![image](https://user-images.githubusercontent.com/200626/230326546-1b7faee8-b459-4a3f-b0c2-59d62ae98e1f.png)

