### PR TITLE
Ensure account uuid doesn't change during lifetime

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -437,7 +437,7 @@ int main(int argc, char **argv)
         qSetMessagePattern(Logger::loggerPattern());
     }
 
-    ctx.account = Account::create();
+    ctx.account = Account::create(QUuid::createUuid());
 
     if (!ctx.account) {
         qCritical() << "Could not initialize account!";

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -13,13 +13,15 @@
  */
 
 #include "accountmanager.h"
+#include "account.h"
+#include "common/asserts.h"
 #include "configfile.h"
 #include "creds/credentialmanager.h"
 #include "proxyauthhandler.h"
-#include "common/asserts.h"
-#include <theme.h>
-#include <creds/httpcredentialsgui.h>
 #include <cookiejar.h>
+#include <creds/httpcredentialsgui.h>
+#include <theme.h>
+
 #include <QSettings>
 #include <QDir>
 #include <QNetworkAccessManager>
@@ -317,13 +319,12 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
         return AccountPtr();
     }
 
-    auto acc = createAccount();
+    auto acc = createAccount(settings.value(userUUIDC(), QVariant::fromValue(QUuid::createUuid())).toUuid());
 
     acc->setUrl(urlConfig.toUrl());
 
     acc->_davUser = settings.value(davUserC()).toString();
     acc->_displayName = settings.value(davUserDisplyNameC()).toString();
-    acc->_uuid = settings.value(userUUIDC(), acc->_uuid).toUuid();
     acc->setCapabilities(settings.value(capabilitesC()).value<QVariantMap>());
     acc->setDefaultSyncRoot(settings.value(defaultSyncRootC()).toString());
 
@@ -395,9 +396,9 @@ void AccountManager::deleteAccount(AccountStatePtr account)
     emit accountRemoved(account);
 }
 
-AccountPtr AccountManager::createAccount()
+AccountPtr AccountManager::createAccount(const QUuid &uuid)
 {
-    AccountPtr acc = Account::create();
+    AccountPtr acc = Account::create(uuid);
     connect(acc.data(), &Account::proxyAuthenticationRequired,
         ProxyAuthHandler::instance(), &ProxyAuthHandler::handleProxyAuthenticationRequired);
     return acc;

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -80,7 +80,7 @@ public:
      * Creates an account and sets up some basic handlers.
      * Does *not* add the account to the account manager just yet.
      */
-    static AccountPtr createAccount();
+    static AccountPtr createAccount(const QUuid &uuid);
 
     /**
      * Returns the list of settings keys that can't be read because

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -113,7 +113,7 @@ void SetupWizardAccountBuilder::setWebFingerUsername(const QString &username)
 
 AccountPtr SetupWizardAccountBuilder::build()
 {
-    auto newAccountPtr = Account::create();
+    auto newAccountPtr = Account::create(QUuid::createUuid());
 
     Q_ASSERT(!_serverUrl.isEmpty() && _serverUrl.isValid());
     newAccountPtr->setUrl(_serverUrl);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -41,9 +41,9 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcAccount, "sync.account", QtInfoMsg)
 
-Account::Account(QObject *parent)
+Account::Account(const QUuid &uuid, QObject *parent)
     : QObject(parent)
-    , _uuid(QUuid::createUuid())
+    , _uuid(uuid)
     , _capabilities(QVariantMap())
     , _jobQueue(this)
     , _queueGuard(&_jobQueue)
@@ -52,9 +52,9 @@ Account::Account(QObject *parent)
     qRegisterMetaType<AccountPtr>("AccountPtr");
 }
 
-AccountPtr Account::create()
+AccountPtr Account::create(const QUuid &uuid)
 {
-    AccountPtr acc = AccountPtr(new Account);
+    AccountPtr acc = AccountPtr(new Account(uuid));
     acc->setSharedThis(acc);
     return acc;
 }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -74,7 +74,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
     Q_PROPERTY(QUrl url MEMBER _url)
 
 public:
-    static AccountPtr create();
+    static AccountPtr create(const QUuid &uuid);
     ~Account() override;
 
     AccountPtr sharedFromThis();
@@ -234,7 +234,7 @@ protected Q_SLOTS:
     void slotCredentialsAsked();
 
 private:
-    Account(QObject *parent = nullptr);
+    Account(const QUuid &uuid, QObject *parent = nullptr);
     void setSharedThis(AccountPtr sharedThis);
 
     QWeakPointer<Account> _sharedThis;

--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -121,7 +121,7 @@ public:
 
     virtual void test() {
         fakeAm = new FakeAM({});
-        account = OCC::Account::create();
+        account = Account::create(QUuid::createUuid());
         account->setUrl(sOAuthTestServer);
         // the account seizes ownership over the qnam in account->setCredentials(...) by keeping a shared pointer on it
         // therefore, we should never call fakeAm->setThis(...)

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -28,7 +28,7 @@ namespace TestUtils {
     AccountPtr createDummyAccount()
     {
         // don't use the account manager to create the account, it would try to use widgets
-        auto acc = Account::create();
+        auto acc = Account::create(QUuid::createUuid());
         HttpCredentialsTest *cred = new HttpCredentialsTest(QStringLiteral("testuser"), QStringLiteral("secret"));
         acc->setCredentials(cred);
         acc->setUrl(QUrl(QStringLiteral("http://localhost/owncloud")));


### PR DESCRIPTION
For the unit tests and the cmd client we will get a different uuid every run, this means we will leave the caches behind.