### PR TITLE
Fix setup of OAuth2 accounts

### DIFF
--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -43,6 +43,14 @@ QString HttpBasicAuthenticationStrategy::davUser()
     return _username;
 }
 
+void HttpBasicAuthenticationStrategy::setDavUser(const QString &user)
+{
+    // the fetched username should always match the one the user gave us
+    Q_ASSERT(user == _username);
+    // however, as a fallback, in production, we will overwrite our current value with the one we fetched
+    _username = user;
+}
+
 QString HttpBasicAuthenticationStrategy::username() const
 {
     return _username;
@@ -77,6 +85,13 @@ bool OAuth2AuthenticationStrategy::isValid()
 QString OAuth2AuthenticationStrategy::davUser()
 {
     return _davUser;
+}
+
+void OAuth2AuthenticationStrategy::setDavUser(const QString &user)
+{
+    // should be called only once
+    Q_ASSERT(_davUser.isEmpty());
+    _davUser = user;
 }
 
 FetchUserInfoJobFactory OAuth2AuthenticationStrategy::makeFetchUserInfoJobFactory(QNetworkAccessManager *nam)

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -49,6 +49,7 @@ public:
      * @return username for use with WebDAV
      */
     virtual QString davUser() = 0;
+    virtual void setDavUser(const QString &user) = 0;
 
     virtual FetchUserInfoJobFactory makeFetchUserInfoJobFactory(QNetworkAccessManager *nam) = 0;
 };
@@ -63,6 +64,7 @@ public:
     bool isValid() override;
 
     QString davUser() override;
+    void setDavUser(const QString &user) override;
 
     // access is needed to be able to check these credentials against the server
     QString username() const;
@@ -85,7 +87,7 @@ public:
     bool isValid() override;
 
     QString davUser() override;
-    void setDavUser(const QString &user);
+    void setDavUser(const QString &user) override;
 
     FetchUserInfoJobFactory makeFetchUserInfoJobFactory(QNetworkAccessManager *nam) override;
 

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -171,7 +171,9 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState)
             connect(fetchUserInfoJob, &CoreJob::finished, this, [this, fetchUserInfoJob] {
                 if (fetchUserInfoJob->success()) {
                     auto result = fetchUserInfoJob->result().value<FetchUserInfoResult>();
+
                     _context->accountBuilder().setDisplayName(result.displayName());
+                    _context->accountBuilder().authenticationStrategy()->setDavUser(result.userName());
                     changeStateTo(SetupWizardState::AccountConfiguredState);
                 } else {
                     _context->window()->showErrorMessage(QStringLiteral("Failed to retrieve user information from server"));


### PR DESCRIPTION
It's not great to add the setter to the common interface, but still much better than casting the pointer and conditionally executing that method.

Fixes #10682.