### PR TITLE
Bump minimal Win32 API version to Win8

### DIFF
--- a/cmake/modules/OCApplyCommonSettings.cmake
+++ b/cmake/modules/OCApplyCommonSettings.cmake
@@ -25,6 +25,14 @@ function(apply_common_target_settings_soft targetName)
                 -Werror=switch
         )
     endif()
+    if(WIN32)
+        target_compile_definitions(${targetName} PRIVATE
+                # Get APIs from from Win8 onwards.
+                _WIN32_WINNT=_WIN32_WINNT_WIN8
+                WINVER=_WIN32_WINNT_WIN8
+                NTDDI_VERSION=NTDDI_WIN10_RS2
+        )
+    endif()
 endfunction()
 
 # common target settings that are used by all important targets

--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -41,15 +41,8 @@ if(NO_MSG_HANDLER)
     target_compile_definitions(csync PUBLIC -DNO_MSG_HANDLER=1)
 endif()
 
-if(WIN32)
-    target_compile_definitions(csync
-        PUBLIC __USE_MINGW_ANSI_STDIO=1
-               NOMINMAX
-               # Get APIs from from Vista onwards.
-               _WIN32_WINNT=0x0600
-               WINVER=0x0600
-               NTDDI_VERSION=0x0A000003
-    )
+if(MINGWS)
+    target_compile_definitions(csync PUBLIC __USE_MINGW_ANSI_STDIO=1)
 endif()
 
 generate_export_header(csync


### PR DESCRIPTION
This is so we can use the secure identifier APIs.