### PR TITLE
Disbale gui tests against oc10 on PRs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -114,8 +114,11 @@ def main(ctx):
                     check_starlark(build_trigger) + \
                     changelog(ctx, trigger = build_trigger) + \
                     unit_test_pipeline(ctx, "clang", "clang++", "Debug", "Ninja", trigger = build_trigger) + \
-                    gui_test_pipeline(ctx, trigger = build_trigger) + \
                     gui_test_pipeline(ctx, trigger = build_trigger, server_version = ocis_server_version, server_type = "ocis")
+
+        # run gui tests against oc10 server only if the build title contains "gui-tests"
+        if "oc10-gui-tests" in ctx.build.title.lower():
+            pipelines += gui_test_pipeline(ctx, trigger = build_trigger, server_version = oc10_server_version, server_type = "oc10")
 
     return pipelines
 


### PR DESCRIPTION
Disable squish tests pipeline for oc10 server.

The oc10 pipeline finishes in around 30 mins and the CI is somehow delaying developers to act fast on PRs. Even though the tests run in parallel, we have limited Squish license due to which if there are several PRs then some CI build will get stuck waiting for the license.

However, the tests against oc10 server can be enabled for the PRs by simply adding `oc10-gui-tests` in the PR title.

#### Results:
1. Normal PR (without `oc10-gui-tests` in the title): https://drone.owncloud.com/owncloud/client/14915
2. PR with `oc10-gui-tests` in the title: https://drone.owncloud.com/owncloud/client/14916