### PR TITLE
Remove usage of deprecated QNetworkConfigurationManager

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -368,10 +368,6 @@ Application::Application(int &argc, char **argv, Platform *platform)
     // Also check immediately
     QTimer::singleShot(0, this, &Application::slotCheckConnection);
 
-    // Can't use onlineStateChanged because it is always true on modern systems because of many interfaces
-    connect(&_networkConfigurationManager, &QNetworkConfigurationManager::configurationChanged,
-        this, &Application::slotSystemOnlineConfigurationChanged);
-
 #ifdef WITH_AUTO_UPDATER
     // Update checks
     UpdaterScheduler *updaterScheduler = new UpdaterScheduler(this);
@@ -437,16 +433,6 @@ void Application::slotCleanup()
 
     _gui->slotShutdown();
     _gui->deleteLater();
-}
-
-// FIXME: This is not ideal yet since a ConnectionValidator might already be running and is in
-// progress of timing out in some seconds.
-// Maybe we need 2 validators, one triggered by timer, one by network configuration changes?
-void Application::slotSystemOnlineConfigurationChanged(const QNetworkConfiguration &cnf)
-{
-    if (cnf.state() & QNetworkConfiguration::Active) {
-        QMetaObject::invokeMethod(this, "slotCheckConnection", Qt::QueuedConnection);
-    }
 }
 
 void Application::slotCheckConnection()

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -19,7 +19,6 @@
 #include <QPointer>
 #include <QQueue>
 #include <QTimer>
-#include <QNetworkConfigurationManager>
 
 #include "3rdparty/qtsingleapplication/qtsingleapplication.h"
 
@@ -100,7 +99,6 @@ protected slots:
     void slotCleanup();
     void slotAccountStateAdded(AccountStatePtr accountState) const;
     void slotAccountStateRemoved() const;
-    void slotSystemOnlineConfigurationChanged(const QNetworkConfiguration &);
 
 private:
     /**
@@ -127,7 +125,6 @@ private:
 
     ClientProxy _proxy;
 
-    QNetworkConfigurationManager _networkConfigurationManager;
     QTimer _checkConnectionTimer;
 
     QScopedPointer<FolderMan> _folderManager;

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -14,7 +14,6 @@
 
 #include <QAuthenticator>
 #include <QLoggingCategory>
-#include <QNetworkConfiguration>
 #include <QNetworkCookie>
 #include <QNetworkCookieJar>
 #include <QNetworkProxy>
@@ -37,10 +36,6 @@ Q_LOGGING_CATEGORY(lcAccessManager, "sync.accessmanager", QtInfoMsg)
 AccessManager::AccessManager(QObject *parent)
     : QNetworkAccessManager(parent)
 {
-#ifndef Q_OS_LINUX
-    // Atempt to workaround for https://github.com/owncloud/client/issues/3969
-    setConfiguration(QNetworkConfiguration());
-#endif
     setCookieJar(new CookieJar);
 
     connect(this, &AccessManager::sslErrors, this, [this](QNetworkReply *reply, const QList<QSslError> &errors) {


### PR DESCRIPTION
Fixes: #10744

Will be implemented again in #10745.