### PR TITLE
libre-graph-api-cpp-qt-client static

### DIFF
--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -11,8 +11,12 @@ if (NOT TARGET OpenAPI::LibreGraphAPI)
     FetchContent_Populate(LibreGraphAPISrc
                         QUIET
                         GIT_REPOSITORY https://github.com/owncloud/libre-graph-api-cpp-qt-client.git
-                        GIT_TAG v${LibreGraphAPIVersion})
+                        GIT_TAG v${LibreGraphAPIVersion}
+    )
+    set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS OFF)
     add_subdirectory(${libregraphapisrc_SOURCE_DIR}/client ${libregraphapisrc_BINARY_DIR}/client EXCLUDE_FROM_ALL)
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
 endif()
 
 set(libsync_SRCS


### PR DESCRIPTION
Ecm set the symbols visibility to hidden, libre-graph-api-cpp-qt-client has no idea about visibility and does not explicitly set it. The result is a binary without symbols.

Force libre-graph-api-cpp-qt-client to build static libs.