### PR TITLE
Use theme methods instead of macros for application name

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -19,7 +19,6 @@
 #include "asserts.h"
 #include "common/chronoelapsedtimer.h"
 #include "common/utility.h"
-#include "config.h"
 #include "filesystembase.h"
 
 #include <QCoreApplication>

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -16,7 +16,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include "config.h"
 
 #include "common/asserts.h"
 #include "common/filesystembase.h"

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -40,8 +40,6 @@
 #include "updater/ocupdater.h"
 #endif
 
-#include "config.h"
-
 #if defined(Q_OS_WIN)
 #include <windows.h>
 #endif
@@ -508,7 +506,7 @@ void Application::setupTranslations()
 
 void Application::openVirtualFile(const QString &filename)
 {
-    QString virtualFileExt = QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX);
+    QString virtualFileExt = Theme::instance()->appDotVirtualFileSuffix();
     if (!filename.endsWith(virtualFileExt)) {
         qWarning(lcApplication) << "Can only handle file ending in .owncloud. Unable to open" << filename;
         return;

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -12,8 +12,6 @@
  * for more details.
  */
 
-#include "config.h"
-
 #include <cerrno>
 #include <sys/inotify.h>
 #include <unistd.h>

--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -11,9 +11,7 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-#include "config.h"
 
-#include "folder.h"
 #include "folderwatcher.h"
 #include "folderwatcher_mac.h"
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -34,7 +34,6 @@
 
 #include "ignorelisteditor.h"
 
-#include "config.h"
 #include "translations.h"
 
 #include <QDir>

--- a/src/gui/lockwatcher.h
+++ b/src/gui/lockwatcher.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "config.h"
 #include "filesystem.h"
 
 #include <QList>

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -23,7 +23,6 @@
 #include "resources/loadresources.h"
 
 #include "common/version.h"
-#include "csync/config.h"
 #include "gui/translations.h"
 #include "libsync/logger.h"
 
@@ -245,7 +244,7 @@ int main(int argc, char **argv)
     QApplication app(argc, argv);
     // TODO: Can't set this without breaking current config paths
     //    setOrganizationName(QLatin1String(APPLICATION_VENDOR));
-    app.setOrganizationDomain(QStringLiteral(APPLICATION_REV_DOMAIN));
+    app.setOrganizationDomain(Theme::instance()->orgDomainName());
     app.setApplicationName(Theme::instance()->appName());
     app.setWindowIcon(Theme::instance()->applicationIcon());
     app.setApplicationVersion(Theme::instance()->versionSwitchOutput());

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -26,8 +26,6 @@
 #include "common/asserts.h"
 #include "common/syncjournalfilerecord.h"
 #include "common/version.h"
-#include "config.h"
-#include "configfile.h"
 #include "filesystem.h"
 #include "folder.h"
 #include "folderman.h"

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -20,8 +20,6 @@
 #include "sharedialog.h" // for the ShareDialogStartPage
 #include "common/syncjournalfilerecord.h"
 
-#include "config.h"
-
 #if defined(Q_OS_MAC)
 #include "socketapisocket_mac.h"
 #else

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -14,7 +14,6 @@
 
 #include "systray.h"
 #include "theme.h"
-#include "config.h"
 
 #ifdef USE_FDO_NOTIFICATIONS
 #include <QDBusConnection>

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -75,9 +75,10 @@ void Systray::showMessage(const QString &title, const QString &message, const QI
 #else
 #ifdef USE_FDO_NOTIFICATIONS
     if (QDBusInterface(NOTIFICATIONS_SERVICE_C(), NOTIFICATIONS_PATH_C(), NOTIFICATIONS_IFACE_C()).isValid()) {
-        QList<QVariant> args = QList<QVariant>() << Theme::instance()->appNameGUI() << quint32(0) << QStringLiteral(APPLICATION_ICON_NAME)
-                                                 << title << message << QStringList() << QVariantMap() << qint32(-1);
-        QDBusMessage method = QDBusMessage::createMethodCall(NOTIFICATIONS_SERVICE_C(), NOTIFICATIONS_PATH_C(), NOTIFICATIONS_IFACE_C(), QStringLiteral("Notify"));
+        QList<QVariant> args = QList<QVariant>() << Theme::instance()->appNameGUI() << quint32(0) << Theme::instance()->applicationIconName() << title
+                                                 << message << QStringList() << QVariantMap() << qint32(-1);
+        QDBusMessage method =
+            QDBusMessage::createMethodCall(NOTIFICATIONS_SERVICE_C(), NOTIFICATIONS_PATH_C(), NOTIFICATIONS_IFACE_C(), QStringLiteral("Notify"));
         method.setArguments(args);
         QDBusConnection::sessionBus().asyncCall(method);
     } else

--- a/src/gui/translations.cpp
+++ b/src/gui/translations.cpp
@@ -17,9 +17,6 @@
 
 #include "translations.h"
 
-#include "config.h"
-#include "theme.h"
-
 #include <QApplication>
 #include <QLoggingCategory>
 #include <QDir>

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -744,7 +744,7 @@ bool ConfigFile::monoIcons() const
     bool monoDefault = false; // On Mac we want bw by default
 #ifdef Q_OS_MAC
     // OEM themes are not obliged to ship mono icons
-    monoDefault = (0 == (strcmp("ownCloud", APPLICATION_NAME)));
+    monoDefault = Theme::instance()->appNameGUI() == QStringLiteral("ownCloud");
 #endif
     return settings.value(monoIconsC(), monoDefault).toBool();
 }

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include "config.h"
-
 #include <QString>
 #include <ctime>
 #include <functional>

--- a/src/libsync/owncloudtheme.cpp
+++ b/src/libsync/owncloudtheme.cpp
@@ -21,8 +21,6 @@
 #include <QCoreApplication>
 
 #include "common/utility.h"
-#include "common/version.h"
-#include "config.h"
 
 namespace OCC {
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -14,7 +14,6 @@
 
 #include "propagatedownload.h"
 #include "account.h"
-#include "config.h"
 #include "filesystem.h"
 #include "networkjobs.h"
 #include "owncloudpropagator_p.h"

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -14,7 +14,6 @@
 
 #include "propagateupload.h"
 #include "account.h"
-#include "config.h"
 #include "filesystem.h"
 #include "networkjobs.h"
 #include "owncloudpropagator_p.h"

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -12,7 +12,6 @@
  * for more details.
  */
 
-#include "config.h"
 #include "propagateupload.h"
 #include "owncloudpropagator_p.h"
 #include "networkjobs.h"

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -145,7 +145,12 @@ QString Theme::configFileName() const
 
 QIcon Theme::applicationIcon() const
 {
-    return themeUniversalIcon(QStringLiteral(APPLICATION_ICON_NAME "-icon"));
+    return themeUniversalIcon(applicationIconName() + QStringLiteral("-icon"));
+}
+
+QString Theme::applicationIconName() const
+{
+    return QStringLiteral(APPLICATION_ICON_NAME);
 }
 
 QIcon Theme::aboutIcon() const

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -138,6 +138,16 @@ QString Theme::appName() const
     return QStringLiteral(APPLICATION_SHORTNAME);
 }
 
+QString Theme::appDotVirtualFileSuffix() const
+{
+    return QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX);
+}
+
+QString Theme::orgDomainName() const
+{
+    return QStringLiteral(APPLICATION_REV_DOMAIN);
+}
+
 QString Theme::configFileName() const
 {
     return QStringLiteral(APPLICATION_EXECUTABLE ".cfg");

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -84,6 +84,10 @@ public:
      */
     virtual QString appName() const;
 
+    virtual QString appDotVirtualFileSuffix() const;
+
+    virtual QString orgDomainName() const;
+
     /**
      * @brief configFileName
      * @return the name of the config file.

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -115,6 +115,7 @@ public:
     QIcon themeUniversalIcon(const QString &name, IconType iconType = IconType::BrandedIcon) const;
 
     virtual QIcon applicationIcon() const;
+    virtual QString applicationIconName() const;
     virtual QIcon aboutIcon() const;
 
     /**

--- a/src/plugins/vfs/suffix/vfs_suffix.cpp
+++ b/src/plugins/vfs/suffix/vfs_suffix.cpp
@@ -19,6 +19,7 @@
 #include "common/syncjournaldb.h"
 #include "filesystem.h"
 #include "syncfileitem.h"
+#include "theme.h"
 
 namespace OCC {
 
@@ -38,7 +39,7 @@ Vfs::Mode VfsSuffix::mode() const
 
 QString VfsSuffix::fileSuffix() const
 {
-    return QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX);
+    return Theme::instance()->appDotVirtualFileSuffix();
 }
 
 void VfsSuffix::startImpl(const VfsSetupParams &params)
@@ -48,7 +49,7 @@ void VfsSuffix::startImpl(const VfsSetupParams &params)
     // files that were synced before vfs was enabled.
     QByteArrayList toWipe;
     params.journal->getFilesBelowPath("", [&toWipe](const SyncJournalFileRecord &rec) {
-        if (!rec.isVirtualFile() && rec._path.endsWith(APPLICATION_DOTVIRTUALFILE_SUFFIX))
+        if (!rec.isVirtualFile() && rec._path.endsWith(Theme::instance()->appDotVirtualFileSuffix().toUtf8()))
             toWipe.append(rec._path);
     });
     for (const auto &path : toWipe) {

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -7,8 +7,10 @@
 
 #include "testutils/syncenginetestutils.h"
 #include "testutils/testutils.h"
+
 #include <QtTest>
 #include <syncengine.h>
+#include <theme.h>
 
 using namespace OCC;
 
@@ -994,7 +996,7 @@ private slots:
         {
             if (vfsMode == Vfs::WithSuffix)
             {
-                return QStringLiteral("%1" APPLICATION_DOTVIRTUALFILE_SUFFIX).arg(s);
+                return QStringLiteral("%1%2").arg(s, Theme::instance()->appDotVirtualFileSuffix());
             }
             return s;
         };


### PR DESCRIPTION
And also for the application icon name. There is one left in the common sources, but those cannot depend on libsync, so that's left alone.