### PR TITLE
[full-ci][gui-tests] Disable legacy migration for the test accounts

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -106,6 +106,7 @@ def setUpClient(username, displayName, space="Personal"):
     0/Folders/1/virtualFilesMode=off
     0/dav_user={davUserName}
     0/display-name={displayUserName}
+    0/http_CredentialVersion=1
     0/http_oauth={oauth}
     0/http_user={davUserName}
     0/url={local_server}


### PR DESCRIPTION
Included `0/http_CredentialVersion=1` in the account config. This will disable the migration code.

Hoping not to see this failure with this
https://github.com/owncloud/client/issues/10140