### PR TITLE
Fix encoding isuse

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -197,7 +197,7 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(QStringView path, bool excludeC
     // Filter out characters not allowed in a filename on windows
     // see https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file
     for (auto c : path) {
-        if (c.toLatin1() < 32) {
+        if (c.unicode() < 32) {
             return CSYNC_FILE_EXCLUDE_INVALID_CHAR;
         }
         if (std::find_if(


### PR DESCRIPTION
toLatin1 returns 0 for chars > 0xff