### PR TITLE
Don't emit folder watcher changes every 1s

### DIFF
--- a/changelog/unreleased/10825
+++ b/changelog/unreleased/10825
@@ -1,0 +1,7 @@
+Enhancement: Reduce how often file changes are handled
+
+We no longer handle file changes every 1s but gather them for 10s and handle them then.
+
+This should reduce the amount of unnecessary checksum computations and attempted syncs.
+
+https://github.com/owncloud/client/pull/10825 

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -37,7 +37,7 @@
 using namespace std::chrono_literals;
 
 namespace {
-constexpr auto notificationTimeoutC = 1s;
+constexpr auto notificationTimeoutC = 10s;
 }
 
 namespace OCC {
@@ -134,7 +134,7 @@ void FolderWatcher::startNotificationTestWhenReady()
         f.open(QIODevice::WriteOnly | QIODevice::Append);
     }
 
-    QTimer::singleShot(5s, this, [this]() {
+    QTimer::singleShot(notificationTimeoutC + 5s, this, [this]() {
         if (!_testNotificationPath.isEmpty())
             emit becameUnreliable(tr("The watcher did not receive a test notification."));
         _testNotificationPath.clear();

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -7,9 +7,13 @@
 
 #include <QtTest>
 
+#include "common/chronoelapsedtimer.h"
 #include "common/utility.h"
 #include "folderwatcher.h"
 #include "testutils/testutils.h"
+
+using namespace std::chrono_literals;
+
 namespace {
 class FolderWatcherForTests : public OCC::FolderWatcher
 {
@@ -92,9 +96,10 @@ class TestFolderWatcher : public QObject
 
     bool waitForPathChanged(const QString &path)
     {
-        QElapsedTimer t;
-        t.start();
-        while (t.elapsed() < 5000) {
+        Utility::ChronoElapsedTimer t;
+        // Current interval is 10s, if we didn't get a change in 15s something did not work
+        // https://github.com/owncloud/client/blob/82b5a1e1bb2b05503e0774d3be5e328c4cd207e2/src/gui/folderwatcher.cpp#L40-L40
+        while (t.duration() < 15s) {
             // Check if it was already reported as changed by the watcher
             for (int i = 0; i < _pathChangedSpy->size(); ++i) {
                 const auto &args = _pathChangedSpy->at(i);
@@ -102,7 +107,7 @@ class TestFolderWatcher : public QObject
                     return true;
             }
             // Wait a bit and test again (don't bother checking if we timed out or not)
-            _pathChangedSpy->wait(200);
+            _pathChangedSpy->wait(1000);
         }
         return false;
     }


### PR DESCRIPTION
We currently gather changes for up to 1s and then handle them.
Often we then ignore them as nothing, interesting for us, changed.

This change increases the interval to 10s.
If the file changed 50 times in that interval we will now only check once instead of about 10 times.

Note: When we detect a change it does not mean instant upload, we will evaluate the file and queue it for the next sync run. 

Estimated impact: Less noise in the logs, slight performance improvements.
