### PR TITLE
[gui-tests][full-ci] Add server app setup steps

### DIFF
--- a/test/gui/shared/scripts/helpers/UserHelper.py
+++ b/test/gui/shared/scripts/helpers/UserHelper.py
@@ -1,8 +1,19 @@
 import os
 import requests
+from base64 import b64encode
 from helpers.ConfigHelper import get_config
 
 createdUsers = {}
+
+
+def basic_auth_header(user=None):
+    # default admin auth
+    token = b64encode(b"admin:admin").decode()
+    if user:
+        password = getPasswordForUser(user)
+        token = b64encode(("%s:%s" % (user, password)).encode()).decode()
+    return {"Authorization": "Basic " + token}
+
 
 # gets all users information created in a test scenario
 def getCreatedUsersFromMiddleware():

--- a/test/gui/shared/scripts/helpers/api/HttpHelper.py
+++ b/test/gui/shared/scripts/helpers/api/HttpHelper.py
@@ -1,0 +1,30 @@
+import requests
+from helpers.UserHelper import basic_auth_header
+
+requests.packages.urllib3.disable_warnings()
+
+
+def send_request(url, method, body=None, headers={}, user=None):
+    auth_header = basic_auth_header(user)
+    headers.update(auth_header)
+    return requests.request(method, url, data=body, headers=headers, verify=False)
+
+
+def get(url, headers={}, user=None):
+    return send_request(url=url, method="GET", headers=headers, user=user)
+
+
+def post(url, body=None, headers={}, user=None):
+    return send_request(url, "POST", body, headers, user)
+
+
+def put(url, body=None, headers={}, user=None):
+    return send_request(url, "PUT", body, headers, user)
+
+
+def delete(url, headers={}, user=None):
+    return send_request(url=url, method="DELETE", headers=headers, user=user)
+
+
+def mkcol(url, headers={}, user=None):
+    return send_request(url=url, method="MKCOL", headers=headers, user=user)

--- a/test/gui/shared/scripts/helpers/api/Provisioning.py
+++ b/test/gui/shared/scripts/helpers/api/Provisioning.py
@@ -1,0 +1,45 @@
+from os import path
+import json
+
+import helpers.api.HttpHelper as request
+from helpers.ConfigHelper import get_config
+
+
+def get_ocs_url():
+    return path.join(get_config('localBackendUrl'), 'ocs', "v2.php", 'cloud')
+
+
+def format_json(url):
+    return url + "?format=json"
+
+
+def checkSuccessOcsStatus(response):
+    if response.text:
+        ocs_code = json.loads(response.text)['ocs']['meta']['statuscode']
+        if ocs_code not in [100, 200]:
+            raise Exception("Request failed." + response.text)
+    else:
+        raise Exception(
+            "No OCS response body. HTTP status was " + str(response.status_code)
+        )
+
+
+def enable_app(app_name):
+    url = format_json(path.join(get_ocs_url(), "apps", app_name))
+    response = request.post(url)
+    checkSuccessOcsStatus(response)
+
+
+def disable_app(app_name):
+    url = format_json(path.join(get_ocs_url(), "apps", app_name))
+    response = request.delete(url)
+    checkSuccessOcsStatus(response)
+
+
+def setup_app(app_name, action):
+    if action.startswith('enable'):
+        enable_app(app_name)
+    elif action.startswith('disable'):
+        disable_app(app_name)
+    else:
+        raise Exception("Unknown action: " + action)

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -2,6 +2,7 @@ import urllib.request
 import json
 from os import path
 from helpers.ConfigHelper import get_config
+from helpers.api.Provisioning import setup_app
 
 
 def executeStepThroughMiddleware(context, step):
@@ -47,3 +48,8 @@ def step(context, stepPart1, stepPart2):
 @Then(r"^(.*) on the server$", regexp=True)
 def step(context, stepPart1):
     executeStepThroughMiddleware(context, "Then " + stepPart1)
+
+
+@Given('app "|any|" has been "|any|" in the server')
+def step(context, app_name, action):
+    setup_app(app_name, action)

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -21,7 +21,7 @@ Feature:  Logout users
 
   @skipOnOCIS
   Scenario: login with oauth2 enabled
-      Given app "oauth2" has been "enabled" on the server
+      Given app "oauth2" has been "enabled" in the server
       And the user has started the client
       When the user adds the following account with oauth2 enabled:
           | server   | %local_server% |


### PR DESCRIPTION
Removed the use of oc10 app setup step from middleware and added it locally in python.

Renamed step:
```diff
- Given app "oauth2" has been "enabled" on the server
+ Given app "oauth2" has been "enabled" in the server
```

Part of https://github.com/owncloud/client/issues/10432