### PR TITLE
Qt6: Don't follow redirects

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -157,6 +157,9 @@ void AbstractNetworkJob::sendRequest(const QByteArray &verb,
     _verb = verb;
 
     _request = req;
+    // we don't follow redirects, if we receive one the ConnectionValidor is triggered
+    _request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
+
     _request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, _storeInCache);
 
     if (_cacheLoadControl.has_value()) {


### PR DESCRIPTION
Explicitly set attribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy); This used to be the default in Qt5.

Fixes: #10832