### PR TITLE
[tests-only][full-ci] Then step implementation in python for asserting the content of the file in the server

### DIFF
--- a/test/gui/shared/scripts/helpers/api/webdav_helper.py
+++ b/test/gui/shared/scripts/helpers/api/webdav_helper.py
@@ -8,17 +8,26 @@ def get_webdav_url():
     return path.join(get_config('localBackendUrl'), "remote.php", "dav", 'files')
 
 
-def resource_exists(user, resource):
+def get_resource_path(user, resource):
     resource = resource.strip('/')
     encoded_resource_path = [
         urllib.parse.quote(path, safe='') for path in resource.split('/')
     ]
     encoded_resource_path = '/'.join(encoded_resource_path)
     url = path.join(get_webdav_url(), user, encoded_resource_path)
-    response = request.propfind(url, user=user)
+    return url
+
+
+def resource_exists(user, resource):
+    response = request.propfind(get_resource_path(user, resource), user=user)
     if response.status_code == 207:
         return True
     elif response.status_code == 404:
         return False
     else:
         raise Exception(f"Server returned status code: {response.status_code}")
+
+
+def get_file_content(user, resource):
+    response = request.get(get_resource_path(user, resource), user=user)
+    return response.text

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -77,3 +77,13 @@ def step(context, user_name, resource_name):
         True,
         f"Resource '{resource_name}' should exist, but does not",
     )
+
+
+@Then('as "|any|" the file "|any|" should have the content "|any|" in the server')
+def step(context, user_name, file_name, content):
+    text_content = webdav.get_file_content(user_name, file_name)
+    test.compare(
+        text_content,
+        content,
+        f"File '{file_name}' should have content '{content}' but found '{text_content}'",
+    )

--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -14,4 +14,4 @@ Feature: edit files
         And user "Alice" has set up a client with default settings
         When the user overwrites the file "S@mpleFile!With,$pecial?Characters.txt" with content "overwrite ownCloud test text file"
         And the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced
-        Then as "Alice" the file "S@mpleFile!With,$pecial?Characters.txt" on the server should have the content "overwrite ownCloud test text file"
+        Then as "Alice" the file "S@mpleFile!With,$pecial?Characters.txt" should have the content "overwrite ownCloud test text file" in the server 

--- a/test/gui/tst_moveFilesFolders/test.feature
+++ b/test/gui/tst_moveFilesFolders/test.feature
@@ -21,7 +21,7 @@ Feature: move file and folder
         When user "Alice" moves file "folder1/folder2/folder3/folder4/folder5/lorem.txt" to "/" in the sync folder
         And user "Alice" moves folder "folder1/folder2/folder3/folder4/folder5/test-folder" to "/" in the sync folder
         And the user waits for the files to sync
-        Then as "Alice" the file "lorem.txt" on the server should have the content "ownCloud"
+        Then as "Alice" the file "lorem.txt" should have the content "ownCloud" in the server 
         And as "Alice" folder "test-folder" should exist in the server
         And as "Alice" file "folder1/folder2/folder3/folder4/folder5/lorem.txt" should not exist in the server
         And as "Alice" folder "folder1/folder2/folder3/folder4/folder5/test-folder" should not exist in the server

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -203,10 +203,10 @@ Feature: Sharing
         And the user waits for file "textfile.txt" to be synced
         And the user overwrites the file "simple-folder/textfile.txt" with content "overwrite file inside a folder"
         And the user waits for file "simple-folder/textfile.txt" to be synced
-        Then as "Brian" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"
-        And as "Brian" the file "textfile.txt" on the server should have the content "overwrite file in the root"
-        And as "Alice" the file "simple-folder/textfile.txt" on the server should have the content "overwrite file inside a folder"
-        And as "Alice" the file "textfile.txt" on the server should have the content "overwrite file in the root"
+        Then as "Brian" the file "simple-folder/textfile.txt" should have the content "overwrite file inside a folder" in the server
+        And as "Brian" the file "textfile.txt" should have the content "overwrite file in the root" in the server
+        And as "Alice" the file "simple-folder/textfile.txt" should have the content "overwrite file inside a folder" in the server
+        And as "Alice" the file "textfile.txt" should have the content "overwrite file in the root" in the server
 
 
     Scenario: sharee tries to edit content of files shared without write permission
@@ -220,10 +220,10 @@ Feature: Sharing
         When the user tries to overwrite the file "Parent/textfile.txt" with content "overwrite file inside a folder"
         And the user tries to overwrite the file "textfile.txt" with content "overwrite file in the root"
         And the user waits for file "textfile.txt" to have sync error
-        Then as "Brian" the file "Parent/textfile.txt" on the server should have the content "file inside a folder"
-        And as "Brian" the file "textfile.txt" on the server should have the content "file in the root"
-        And as "Alice" the file "Parent/textfile.txt" on the server should have the content "file inside a folder"
-        And as "Alice" the file "textfile.txt" on the server should have the content "file in the root"
+        Then as "Brian" the file "Parent/textfile.txt" should have the content "file inside a folder" in the server
+        And as "Brian" the file "textfile.txt" should have the content "file in the root" in the server
+        And as "Alice" the file "Parent/textfile.txt" should have the content "file inside a folder" in the server
+        And as "Alice" the file "textfile.txt" should have the content "file in the root" in the server
 
 
     Scenario: sharee edits shared files and again try to edit after write permission is revoked
@@ -244,10 +244,10 @@ Feature: Sharing
         And user "Brian" tries to overwrite the file "textfile.txt" with content "overwrite ownCloud test text file"
         And user "Brian" tries to overwrite the file "FOLDER/simple.txt" with content "overwrite some content"
         And user "Brian" waits for file "textfile.txt" to have sync error
-        Then as "Brian" the file "textfile.txt" on the server should have the content "ownCloud test text file"
-        And as "Brian" the file "FOLDER/simple.txt" on the server should have the content "some content"
-        And as "Alice" the file "textfile.txt" on the server should have the content "ownCloud test text file"
-        And as "Alice" the file "FOLDER/simple.txt" on the server should have the content "some content"
+        Then as "Brian" the file "textfile.txt" should have the content "ownCloud test text file" in the server
+        And as "Brian" the file "FOLDER/simple.txt" should have the content "some content" in the server
+        And as "Alice" the file "textfile.txt" should have the content "ownCloud test text file" in the server
+        And as "Alice" the file "FOLDER/simple.txt" should have the content "some content" in the server
 
 
     Scenario: sharee creates a file and a folder inside a shared folder

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -15,7 +15,7 @@ Feature: Syncing files
             test content
             """
         And the user waits for file "lorem-for-upload.txt" to be synced
-        Then as "Alice" the file "lorem-for-upload.txt" on the server should have the content "test content"
+        Then as "Alice" the file "lorem-for-upload.txt" should have the content "test content" in the server 
 
 
     Scenario: Syncing all files and folders from the server


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
These `Then` step implementation asserts whether the given resource(file/folder) is present on the server or not.

Renamed step:

```diff
-Then as "<user>" the file "<fileName>" should have the content "<content>  on the server"
+Then as "<user>" the file "<fileName>" should have the content "<content> in the server "
```
Part of https://github.com/owncloud/client/issues/10432
