### PR TITLE
Add missing PR link to the changelog

### DIFF
--- a/changelog/unreleased/10866
+++ b/changelog/unreleased/10866
@@ -1,3 +1,5 @@
 Change: Remove support for client side system proxy credentials
 
 We removed the support to query and store credentials for the system proxy.
+
+https://github.com/owncloud/client/pull/10866


### PR DESCRIPTION
Changelog was missing the link and the changelog pipeline in drone-ci complains about it.
Added the correct link to the changelog

Fixes https://github.com/owncloud/client/issues/10870