### PR TITLE
[CI] Use default clone step in changelog pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -314,25 +314,7 @@ def changelog(ctx):
         "kind": "pipeline",
         "type": "docker",
         "name": "changelog",
-        "clone": {
-            "disable": True,
-        },
         "steps": [
-            {
-                "name": "clone",
-                "image": PLUGINS_GIT_ACTION,
-                "settings": {
-                    "actions": [
-                        "clone",
-                    ],
-                    "remote": "https://github.com/%s" % (repo_slug),
-                    "branch": ctx.build.source if ctx.build.event == "pull_request" else "master",
-                    "path": dir["base"],
-                    "netrc_machine": "github.com",
-                    "netrc_username": from_secret("github_username"),
-                    "netrc_password": from_secret("github_token"),
-                },
-            },
             {
                 "name": "generate",
                 "image": TOOLHIPPIE_CALENS,


### PR DESCRIPTION
Changelog pipeline in other branches such as 4, pulls the master branch but it should pull the branch 4.

See build: https://drone.owncloud.com/owncloud/client/15458/1/2

Removed the clone step from changelog pipeline so that default clone step is used that clones the target branch (clones the respective branch that triggered the build)