### PR TITLE
[ci] Make changelog push to the master branch only

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -308,8 +308,6 @@ def gui_tests_format():
     }]
 
 def changelog(ctx):
-    repo_slug = ctx.build.source_repo if ctx.build.source_repo else ctx.repo.slug
-
     return [{
         "kind": "pipeline",
         "type": "docker",
@@ -359,6 +357,9 @@ def changelog(ctx):
                             "refs/tags/**",
                         ],
                     },
+                    "branch": [
+                        "master",
+                    ],
                 },
             },
         ],


### PR DESCRIPTION
Nightly fail: https://drone.owncloud.com/owncloud/client/15538

Currently, changelog pipeline in 4 branch tries to push the diff to the master branch.
As per https://github.com/owncloud/client/pull/10895#issuecomment-1569749623, we only push changelog on master branch only