### PR TITLE
[tests-only][full-ci] Then step implementation for checking public link in the server

### DIFF
--- a/test/gui/shared/scripts/helpers/api/sharing_helper.py
+++ b/test/gui/shared/scripts/helpers/api/sharing_helper.py
@@ -1,0 +1,47 @@
+import json
+from os import path
+from types import MappingProxyType
+from helpers.ConfigHelper import get_config
+import helpers.api.HttpHelper as request
+import helpers.api.Provisioning as provisioning
+
+
+share_types = MappingProxyType(
+    {"user": 0, "group": 1, "public_link": 3, "federated_cloud_share": 6}
+)
+
+
+def get_share_url():
+    return provisioning.format_json(
+        path.join(
+            get_config('localBackendUrl'),
+            'ocs',
+            'v2.php',
+            'apps',
+            'files_sharing',
+            'api',
+            'v1',
+            'shares',
+        )
+    )
+
+
+def get_public_link_shares(user):
+    public_shares_list = []
+    response = request.get(get_share_url(), user=user)
+    provisioning.checkSuccessOcsStatus(response)
+    shares = json.loads(response.text)['ocs']['data']
+
+    for share in shares:
+        if share["share_type"] == share_types["public_link"]:
+            public_shares_list.append(share)
+    return public_shares_list
+
+
+def has_public_link_share(user, resource_name):
+    public_shares = get_public_link_shares(user)
+    if public_shares:
+        for share in public_shares:
+            if share["file_target"].strip('\/') == resource_name:
+                return True
+    return False

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -4,6 +4,7 @@ from os import path
 from helpers.ConfigHelper import get_config
 from helpers.api.Provisioning import setup_app
 import helpers.api.webdav_helper as webdav
+import helpers.api.sharing_helper as sharing_helper
 
 
 def executeStepThroughMiddleware(context, step):
@@ -86,4 +87,28 @@ def step(context, user_name, file_name, content):
         text_content,
         content,
         f"File '{file_name}' should have content '{content}' but found '{text_content}'",
+    )
+
+
+@Then(
+    r'as user "([^"].*)" the (?:file|folder) "([^"].*)" should have a public link in the server',
+    regexp=True,
+)
+def step(context, user_name, resource_name):
+    has_link_share = sharing_helper.has_public_link_share(user_name, resource_name)
+    test.compare(
+        has_link_share,
+        True,
+        f"Resource '{resource_name}' does not have public link share",
+    )
+
+
+@Then(
+    r'as user "([^"].*)" the (?:file|folder) "([^"].*)" should not have any public link in the server',
+    regexp=True,
+)
+def step(context, user_name, resource_name):
+    has_link_share = sharing_helper.has_public_link_share(user_name, resource_name)
+    test.compare(
+        has_link_share, False, f"Resource '{resource_name}' have public link share"
     )

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -423,10 +423,10 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
         And the user closes the sharing dialog
-        Then as user "Alice" the file "textfile0.txt" should have a public link on the server
+        Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" on the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
-        Then as user "Alice" the folder "simple-folder" should have a public link on the server
+        Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder/child" without password from the last created public link by "Alice" on the server
 
 
@@ -436,10 +436,10 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
         And the user closes the sharing dialog
-        Then as user "Alice" the file "textfile0.txt" should have a public link on the server
+        Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" on the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
-        Then as user "Alice" the folder "simple-folder" should have a public link on the server
+        Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder" with password "<password>" from the last created public link by "Alice" on the server
         Examples:
             | password     |
@@ -454,7 +454,7 @@ Feature: Sharing
             | name     | Public-link   |
         And user "Alice" has set up a client with default settings
         When the user deletes the public link for file "textfile0.txt"
-        Then as user "Alice" the file "/textfile0.txt" should not have any public link on the server
+        Then as user "Alice" the file "/textfile0.txt" should not have any public link in the server
 
 
     Scenario: sharing of a file by public link with password and changing the password
@@ -466,7 +466,7 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user changes the password of public link "Public-link" to "password1234" using the client-UI
-        Then as user "Alice" the file "textfile0.txt" should have a public link on the server
+        Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "password1234" from the last created public link by "Alice" on the server
 
 
@@ -478,7 +478,7 @@ Feature: Sharing
             | expireDate | %default%    |
         And the user closes the sharing dialog
         Then the expiration date of the last public link of file "textfile.txt" should be "%default%"
-        And as user "Alice" the file "textfile.txt" should have a public link on the server
+        And as user "Alice" the file "textfile.txt" should have a public link in the server
 
     @issue-9321
     Scenario: simple sharing of file and folder by public link with expiration date
@@ -488,14 +488,14 @@ Feature: Sharing
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | expireDate | 2031-10-14   |
-        Then as user "Alice" the file "textfile.txt" should have a public link on the server
+        Then as user "Alice" the file "textfile.txt" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-10-14 |
         When the user closes the sharing dialog
         And the user creates a new public link with following settings using the client-UI:
             | path       | FOLDER     |
             | expireDate | 2031-12-30 |
-        Then as user "Alice" the file "FOLDER" should have a public link on the server
+        Then as user "Alice" the folder "FOLDER" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-12-30 |
 
@@ -507,7 +507,7 @@ Feature: Sharing
             | path       | textfile.txt |
             | password   | pass123      |
             | expireDate | 2031-10-14   |
-        Then as user "Alice" the file "textfile.txt" should have a public link on the server
+        Then as user "Alice" the file "textfile.txt" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-10-14 |
         And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" on the server


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
These `Then` step implementation for checking public link in the server

Renamed step:

```diff
-Then as user "<user>" the file "<fileName>" should have a public link on the server
-Then as user "<user>" the folder "<folderName>" should have a public link on the server
-Then as user "<user>" the file "<fileName>" should not have any public link on the server
-Then as user "<user>" the folder "<folderName>" should not have any public link on the server

+Then as user "<user>" the file "<fileName>" should have a public link in the server
+Then as user "<user>" the folder "<folderName>" should have a public link in the server
+Then as user "<user>" the file "<fileName>" should not have any public link in the server
+Then as user "<user>" the folder "<folderName>" should not have any public link in the server
```
Part of https://github.com/owncloud/client/issues/10432
