### PR TITLE
Fix hard to read error message

### DIFF
--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -40,7 +40,7 @@ QString Progress::asResultString(const SyncFileItem &item)
             return QCoreApplication::translate("progress", "Uploaded");
         }
     case CSYNC_INSTRUCTION_CONFLICT:
-        return QCoreApplication::translate("progress", "Server version downloaded, copied changed local file into conflict file");
+        return QCoreApplication::translate("progress", "Server version downloaded, local copy was backed up as conflict file");
     case CSYNC_INSTRUCTION_REMOVE:
         return QCoreApplication::translate("progress", "Deleted");
     case CSYNC_INSTRUCTION_EVAL_RENAME:


### PR DESCRIPTION
A verb-used-as-adjective after a verb is very confusing: "copied changed local file", and problematic as it was used when a sync *conflict* occurred. This now reads "renamed local copy".

Fixes: #10568