### PR TITLE
Fix possible deadlock during log setup

### DIFF
--- a/changelog/unreleased/10905
+++ b/changelog/unreleased/10905
@@ -1,0 +1,5 @@
+Bugfix: Possible deadlock during log setup
+
+If an error occured during the setup of the log file, it was possible that the client got deadlocked.
+
+https://github.com/owncloud/client/pull/10905

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -96,7 +96,7 @@ private:
     bool _doFileFlush = false;
     bool _logDebug = false;
     QScopedPointer<QTextStream> _logstream;
-    mutable QMutex _mutex;
+    mutable QRecursiveMutex _mutex;
     QString _logDirectory;
     bool _temporaryFolderLogDir = false;
     QSet<QString> _logRules;


### PR DESCRIPTION
This mainly affects https://github.com/owncloud/client/blob/e6d0be936f43754ccfc7b9a18f0e0ac6358d1b5a/src/libsync/logger.cpp#L153 which tries to load our plugins and qt plugins.