### PR TITLE
Sanitize libcloudproviders DBus path

### DIFF
--- a/THEME.cmake
+++ b/THEME.cmake
@@ -24,6 +24,9 @@ endif()
 if(NOT DEFINED APPLICATION_CLOUDPROVIDERS_DBUS_PATH)
     set(APPLICATION_CLOUDPROVIDERS_DBUS_PATH "/${APPLICATION_CLOUDPROVIDERS_DBUS_NAME}")
     string(REPLACE "." "/" APPLICATION_CLOUDPROVIDERS_DBUS_PATH ${APPLICATION_CLOUDPROVIDERS_DBUS_PATH})
+    # sanitize string to valid characters, see https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-marshaling-object-path
+    # note: as we just inserted some /, we may not replace them
+    string(REGEX REPLACE "[^a-zA-Z0-9_/]" "_" APPLICATION_CLOUDPROVIDERS_DBUS_PATH ${APPLICATION_CLOUDPROVIDERS_DBUS_PATH})
 endif()
 
 # need this logic to not mess with re/uninstallations via macosx.pkgproj


### PR DESCRIPTION
DBus paths may only contain a subset of the characters that are valid for domain names. This commit replaces all offending characters with underscores.