### PR TITLE
Create config file backup with every update

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -75,7 +75,7 @@ bool Application::configVersionMigration()
 
     // Did the client version change?
     // (The client version is adjusted further down)
-    const bool versionChanged = QVersionNumber::fromString(configFile.clientVersionString()) != OCC::Version::version();
+    const bool versionChanged = QVersionNumber::fromString(configFile.clientVersionWithBuildNumberString()) != OCC::Version::versionWithBuildNumber();
 
     // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
@@ -121,7 +121,7 @@ bool Application::configVersionMigration()
             settings->remove(badKey);
     }
 
-    configFile.setClientVersionString(OCC::Version::version().toString());
+    configFile.setClientVersionWithBuildNumberString(OCC::Version::versionWithBuildNumber().toString());
     return true;
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -68,6 +68,9 @@ const QString targetChunkUploadDurationC() { return QStringLiteral("targetChunkU
 const QString automaticLogDirC() { return QStringLiteral("logToTemporaryLogDir"); }
 const QString numberOfLogsToKeepC() { return QStringLiteral("numberOfLogsToKeep"); }
 const QString showExperimentalOptionsC() { return QStringLiteral("showExperimentalOptions"); }
+
+// The key `clientVersion` stores the version *with* build number of the config file. It is named
+// this way, because before 5.0, only the version *without* build number was stored.
 const QString clientVersionC() { return QStringLiteral("clientVersion"); }
 
 const QString proxyHostC() { return QStringLiteral("Proxy/host"); }
@@ -327,7 +330,7 @@ QString ConfigFile::excludeFileFromSystem()
 QString ConfigFile::backup() const
 {
     QString baseFile = configFile();
-    auto versionString = clientVersionString();
+    auto versionString = clientVersionWithBuildNumberString();
     if (!versionString.isEmpty())
         versionString.prepend(QLatin1Char('_'));
     const QString backupFile =
@@ -808,13 +811,13 @@ bool ConfigFile::showExperimentalOptions() const
     return settings.value(showExperimentalOptionsC(), false).toBool();
 }
 
-QString ConfigFile::clientVersionString() const
+QString ConfigFile::clientVersionWithBuildNumberString() const
 {
     auto settings = makeQSettings();
     return settings.value(clientVersionC(), QString()).toString();
 }
 
-void ConfigFile::setClientVersionString(const QString &version)
+void ConfigFile::setClientVersionWithBuildNumberString(const QString &version)
 {
     auto settings = makeQSettings();
     settings.setValue(clientVersionC(), version);

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -184,8 +184,8 @@ public:
 
     /** The client version that last used this settings file.
         Updated by configVersionMigration() at client startup. */
-    QString clientVersionString() const;
-    void setClientVersionString(const QString &version);
+    QString clientVersionWithBuildNumberString() const;
+    void setClientVersionWithBuildNumberString(const QString &version);
 
     /**  Returns a new settings pre-set in a specific group. */
     static std::unique_ptr<QSettings> settingsWithGroup(const QString &group);


### PR DESCRIPTION
The version number stored in the config file now includes the build number. So when the build number changes between RCs, alphas, betas etc, there will be a backup made of the "old" configuration.

Fixes: #10789