### PR TITLE
[tests-only] [full-ci] Implement `Then` step for downloading file from public link

### DIFF
--- a/test/gui/shared/scripts/helpers/UserHelper.py
+++ b/test/gui/shared/scripts/helpers/UserHelper.py
@@ -6,12 +6,14 @@ from helpers.ConfigHelper import get_config
 createdUsers = {}
 
 
-def basic_auth_header(user=None):
-    # default admin auth
-    token = b64encode(b"admin:admin").decode()
-    if user:
+def basic_auth_header(user=None, password=None):
+    if not user and not password:
+        user = 'admin'
+        password = 'admin'
+    elif not user == 'public' and not password:
         password = getPasswordForUser(user)
-        token = b64encode(("%s:%s" % (user, password)).encode()).decode()
+
+    token = b64encode(("%s:%s" % (user, password)).encode()).decode()
     return {"Authorization": "Basic " + token}
 
 

--- a/test/gui/shared/scripts/helpers/api/HttpHelper.py
+++ b/test/gui/shared/scripts/helpers/api/HttpHelper.py
@@ -4,14 +4,16 @@ from helpers.UserHelper import basic_auth_header
 requests.packages.urllib3.disable_warnings()
 
 
-def send_request(url, method, body=None, headers={}, user=None):
-    auth_header = basic_auth_header(user)
+def send_request(url, method, body=None, headers={}, user=None, password=None):
+    auth_header = basic_auth_header(user, password)
     headers.update(auth_header)
     return requests.request(method, url, data=body, headers=headers, verify=False)
 
 
-def get(url, headers={}, user=None):
-    return send_request(url=url, method="GET", headers=headers, user=user)
+def get(url, headers={}, user=None, password=None):
+    return send_request(
+        url=url, method="GET", headers=headers, user=user, password=password
+    )
 
 
 def post(url, body=None, headers={}, user=None):
@@ -30,5 +32,5 @@ def mkcol(url, headers={}, user=None):
     return send_request(url=url, method="MKCOL", headers=headers, user=user)
 
 
-def propfind(url, body=None, headers={}, user=None):
-    return send_request(url, "PROPFIND", body, headers, user)
+def propfind(url, body=None, headers={}, user=None, password=None):
+    return send_request(url, "PROPFIND", body, headers, user, password)

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -112,3 +112,36 @@ def step(context, user_name, resource_name):
     test.compare(
         has_link_share, False, f"Resource '{resource_name}' have public link share"
     )
+
+
+@Then(
+    r'the public should be able to download the (?:file|folder) "([^"].*)" without password from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, link_creator):
+    downloaded = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name
+    )
+    test.compare(downloaded, True, "Could not download public share")
+
+
+@Then(
+    r'the public should not be able to download the (?:file|folder) "([^"].*)" from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, link_creator):
+    downloaded = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name
+    )
+    test.compare(downloaded, False, "Could download public share")
+
+
+@Then(
+    r'the public should be able to download the (?:file|folder) "([^"].*)" with password "([^"].*)" from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, public_link_password, link_creator):
+    downloaded = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name, public_link_password
+    )
+    test.compare(downloaded, True, "Could not download public share")

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -424,7 +424,7 @@ Feature: Sharing
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
         And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
-        And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder/child" without password from the last created public link by "Alice" on the server
@@ -437,7 +437,7 @@ Feature: Sharing
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
         And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
-        And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder" with password "<password>" from the last created public link by "Alice" on the server
@@ -510,7 +510,7 @@ Feature: Sharing
         Then as user "Alice" the file "textfile.txt" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-10-14 |
-        And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" in the server
 
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
@@ -574,7 +574,7 @@ Feature: Sharing
             | permissions | create         |
             | path        | /simple-folder |
             | name        | Public link    |
-        And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" on the server
+        And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" in the server
 
 
     Scenario Outline: change collaborator permissions of a file & folder


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
These `Then` step implementation asserts whether the given resource(file/folder) is present on the server or not.

Renamed step:

```diff
-Then the public should be able to download the file "<fileName>" without password from the last created public link by "<user>" on the server
-Then the public should not be able to download the file "<fileName>" from the last created public link by "<user>" on the server
-Then the public should be able to download the file "<fileName>" with password "<password>" from the last created public link by "<user>" on the server

+Then the public should be able to download the file "<fileName>" without password from the last created public link by "<user>" in the server
+Then the public should not be able to download the file "<fileName>" from the last created public link by "<user>" in the server
+Then the public should be able to download the file "<fileName>" with password "<password>" from the last created public link by "<user>" in the server
```
Part of https://github.com/owncloud/client/issues/10432