### PR TITLE
Possible speedup for recompilation (translations)

### DIFF
--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -30,8 +30,12 @@ generate_export_header(owncloudResources
 
 # Handle Translations, pick all client_* files from trans directory.
 file(GLOB client_translations ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
-qt_add_translation(client_compiled_translations ${client_translations})
-target_sources(owncloudResources PRIVATE ${client_compiled_translations})
+if (${QT_VERSION_MAJOR} GREATER_EQUAL 6 AND ${QT_VERSION_MAJOR} GREATER_EQUAL 2)
+    qt_add_lrelease(owncloudResources TS_FILES ${client_translations} QM_FILES_OUTPUT_VARIABLE client_compiled_translations)
+else()
+    qt_add_translation(client_compiled_translations ${client_translations})
+    target_sources(owncloudResources PRIVATE ${client_compiled_translations})
+endif()
 add_resources_to_target(
     TARGET owncloudResources
     PREFIX translations


### PR DESCRIPTION
qt_add_translation also invokes lupdate which might invalidate the generated files.
We don't need to call lupdate as we explicitly call it in the translation sync.

Requires Qt 6.2