### PR TITLE
Remove unused code

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -297,44 +297,7 @@ int main(int argc, char **argv)
             return 1;
         }
 #endif
-        // TODO: still needed? Move to platform
-        // We can't call isSystemTrayAvailable with appmenu-qt5 begause it hides the systemtray
-        // (issue #4693)
-        if (qgetenv("QT_QPA_PLATFORMTHEME") != "appmenu-qt5") {
-            if (!QSystemTrayIcon::isSystemTrayAvailable()) {
-                // If the systemtray is not there, we will wait one second for it to maybe start
-                // (eg boot time) then we show the settings dialog if there is still no systemtray.
-                // On XFCE however, we show a message box with explainaition how to install a systemtray.
-                qCInfo(lcMain) << "System tray is not available, waiting...";
-                Utility::sleep(1);
 
-                auto desktopSession = qgetenv("XDG_CURRENT_DESKTOP").toLower();
-                if (desktopSession.isEmpty()) {
-                    desktopSession = qgetenv("DESKTOP_SESSION").toLower();
-                }
-                if (desktopSession == "xfce") {
-                    int attempts = 0;
-                    while (!QSystemTrayIcon::isSystemTrayAvailable()) {
-                        attempts++;
-                        if (attempts >= 30) {
-                            qCWarning(lcMain) << "System tray unavailable (xfce)";
-                            warnSystray();
-                            break;
-                        }
-                        Utility::sleep(1);
-                    }
-                }
-
-                if (QSystemTrayIcon::isSystemTrayAvailable()) {
-                    ocApp->tryTrayAgain();
-                } else if (desktopSession != "ubuntu") {
-                    qCInfo(lcMain) << "System tray still not available, showing window and trying again later";
-                    QTimer::singleShot(10s, ocApp, &Application::tryTrayAgain);
-                } else {
-                    qCInfo(lcMain) << "System tray still not available, but assuming it's fine on 'ubuntu' desktop";
-                }
-            }
-        }
     } else {
         // if the application is already running, notify it.
         qCInfo(lcMain) << "Already running, exiting...";


### PR DESCRIPTION
With Qt6 the `appmenu-qt5` is never available, so remove the codition and the else-clause.