### PR TITLE
Fix misleading message

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -155,7 +155,7 @@ void ActivityWidget::showLabels()
     t.clear();
     QSetIterator<QString> i(_accountsWithoutActivities);
     while (i.hasNext()) {
-        t.append(tr("<br/>Account %1 does not have activities enabled.").arg(i.next()));
+        t.append(tr("<br/>Account %1 does not provide activities.").arg(i.next()));
     }
     _ui->_bottomLabel->setTextFormat(Qt::RichText);
     _ui->_bottomLabel->setText(t);

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -155,7 +155,7 @@ void ActivityWidget::showLabels()
     t.clear();
     QSetIterator<QString> i(_accountsWithoutActivities);
     while (i.hasNext()) {
-        t.append(tr("<br/>Account %1 does not provide activities.").arg(i.next()));
+        t.append(tr("<br/>%1 does not provide activities.").arg(i.next()));
     }
     _ui->_bottomLabel->setTextFormat(Qt::RichText);
     _ui->_bottomLabel->setText(t);


### PR DESCRIPTION
Some servers do not provide activities at all. In that case, the label should not read "have activities enabled", because that implies that they could be provided, but are disabled. Which is misleading.