### PR TITLE
Do not set stylesheets globally in application setup code

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -228,10 +228,6 @@ Application::Application(Platform *platform, bool debugMode, QObject *parent)
 
     FolderMan::instance()->setupFolders();
 
-    // Enable word wrapping of QInputDialog (#4197)
-    // TODO:
-    qApp->setStyleSheet(QStringLiteral("QInputDialog QLabel { qproperty-wordWrap:1; }"));
-
     connect(AccountManager::instance(), &AccountManager::accountAdded, this, &Application::slotAccountStateAdded);
     connect(AccountManager::instance(), &AccountManager::accountRemoved, this, &Application::slotAccountStateRemoved);
     for (const auto &ai : AccountManager::instance()->accounts()) {


### PR DESCRIPTION
This was introduced in #4197, but as far as we can tell, it is not needed anymore.

Fixes: #10763