### PR TITLE
[tests-only] [full-ci] Verify field of public link share response

### DIFF
--- a/test/gui/shared/scripts/helpers/UserHelper.py
+++ b/test/gui/shared/scripts/helpers/UserHelper.py
@@ -6,12 +6,14 @@ from helpers.ConfigHelper import get_config
 createdUsers = {}
 
 
-def basic_auth_header(user=None):
-    # default admin auth
-    token = b64encode(b"admin:admin").decode()
-    if user:
+def basic_auth_header(user=None, password=None):
+    if not user and not password:
+        user = 'admin'
+        password = 'admin'
+    elif not user == 'public' and not password:
         password = getPasswordForUser(user)
-        token = b64encode(("%s:%s" % (user, password)).encode()).decode()
+
+    token = b64encode(("%s:%s" % (user, password)).encode()).decode()
     return {"Authorization": "Basic " + token}
 
 

--- a/test/gui/shared/scripts/helpers/api/HttpHelper.py
+++ b/test/gui/shared/scripts/helpers/api/HttpHelper.py
@@ -4,14 +4,16 @@ from helpers.UserHelper import basic_auth_header
 requests.packages.urllib3.disable_warnings()
 
 
-def send_request(url, method, body=None, headers={}, user=None):
-    auth_header = basic_auth_header(user)
+def send_request(url, method, body=None, headers={}, user=None, password=None):
+    auth_header = basic_auth_header(user, password)
     headers.update(auth_header)
     return requests.request(method, url, data=body, headers=headers, verify=False)
 
 
-def get(url, headers={}, user=None):
-    return send_request(url=url, method="GET", headers=headers, user=user)
+def get(url, headers={}, user=None, password=None):
+    return send_request(
+        url=url, method="GET", headers=headers, user=user, password=password
+    )
 
 
 def post(url, body=None, headers={}, user=None):
@@ -30,5 +32,5 @@ def mkcol(url, headers={}, user=None):
     return send_request(url=url, method="MKCOL", headers=headers, user=user)
 
 
-def propfind(url, body=None, headers={}, user=None):
-    return send_request(url, "PROPFIND", body, headers, user)
+def propfind(url, body=None, headers={}, user=None, password=None):
+    return send_request(url, "PROPFIND", body, headers, user, password)

--- a/test/gui/shared/scripts/helpers/api/sharing_helper.py
+++ b/test/gui/shared/scripts/helpers/api/sharing_helper.py
@@ -26,6 +26,10 @@ def get_share_url():
     )
 
 
+def get_public_endpoint():
+    return path.join(get_config('localBackendUrl'), 'remote.php', 'dav', 'public-files')
+
+
 def get_public_link_shares(user):
     public_shares_list = []
     response = request.get(get_share_url(), user=user)
@@ -45,3 +49,43 @@ def has_public_link_share(user, resource_name):
             if share["file_target"].strip('\/') == resource_name:
                 return True
     return False
+
+
+def get_last_created_public_link(user):
+    last_stime = 0
+    share = False
+    public_link_shares = get_public_link_shares(user)
+    for share_link in public_link_shares:
+        if last_stime < share_link["stime"]:
+            share = share_link
+            last_stime = share_link["stime"]
+    if not share:
+        raise Exception('Last public link share could not be found')
+    else:
+        return share
+
+
+def check_share_field(user, field_name, field_value):
+    share = get_last_created_public_link(user)
+    if field_name == 'expiration':
+        value = share.get(field_name).split(' ', 1)[0]
+    else:
+        value = share.get(field_name)
+    if field_name in share and field_value == value:
+        return True
+    else:
+        return False
+
+
+def download_last_public_link_resource(user, resource, public_link_password=None):
+    share = get_last_created_public_link(user)
+    api_url = provisioning.format_json(
+        path.join(get_public_endpoint(), share["token"], resource)
+    )
+    response = request.get(api_url, user='public', password=public_link_password)
+    if response.status_code == 200:
+        return True
+    elif response.status_code == 404:
+        return False
+    else:
+        raise Exception(f"Server returned status code: {response.status_code}")

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -112,3 +112,50 @@ def step(context, user_name, resource_name):
     test.compare(
         has_link_share, False, f"Resource '{resource_name}' have public link share"
     )
+
+
+@Then(
+    r'the public should be able to download the (?:file|folder) "([^"].*)" without password from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, link_creator):
+    file_download = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name
+    )
+    test.compare(file_download, True, "Could not download public share")
+
+
+@Then(
+    r'the public should not be able to download the (?:file|folder) "([^"].*)" from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, link_creator):
+    file_download = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name
+    )
+    test.compare(file_download, False, "Could download public share")
+
+
+@Then(
+    r'the public should be able to download the (?:file|folder) "([^"].*)" with password "([^"].*)" from the last created public link by "([^"].*)" in the server',
+    regexp=True,
+)
+def step(context, resource_name, public_link_password, link_creator):
+    file_download = sharing_helper.download_last_public_link_resource(
+        link_creator, resource_name, public_link_password
+    )
+    test.compare(file_download, True, "Could not download public share")
+
+
+@Then(
+    r'the last public link share response of user "([^"].*)" should include the following fields in the server',
+    regexp=True,
+)
+def step(context, link_creator):
+    field_name = context.table[0][0]
+    field_value = context.table[0][1]
+    test.compare(
+        sharing_helper.check_share_field(link_creator, field_name, field_value),
+        True,
+        "Could not find given field name and field value",
+    )

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -424,7 +424,7 @@ Feature: Sharing
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
         And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
-        And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder/child" without password from the last created public link by "Alice" on the server
@@ -437,7 +437,7 @@ Feature: Sharing
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
         And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
-        And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" on the server
+        And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder" with password "<password>" from the last created public link by "Alice" on the server
@@ -489,15 +489,15 @@ Feature: Sharing
             | path       | textfile.txt |
             | expireDate | 2031-10-14   |
         Then as user "Alice" the file "textfile.txt" should have a public link in the server
-        And the last public link share response of user "Alice" should include the following fields on the server
-            | expireDate | 2031-10-14 |
+        And the last public link share response of user "Alice" should include the following fields in the server
+            | expiration | 2031-10-14 |
         When the user closes the sharing dialog
         And the user creates a new public link with following settings using the client-UI:
             | path       | FOLDER     |
             | expireDate | 2031-12-30 |
         Then as user "Alice" the folder "FOLDER" should have a public link in the server
-        And the last public link share response of user "Alice" should include the following fields on the server
-            | expireDate | 2031-12-30 |
+        And the last public link share response of user "Alice" should include the following fields in the server
+            | expiration | 2031-12-30 |
 
     @issue-9321
     Scenario: simple sharing of a file by public link with password and expiration date
@@ -508,9 +508,9 @@ Feature: Sharing
             | password   | pass123      |
             | expireDate | 2031-10-14   |
         Then as user "Alice" the file "textfile.txt" should have a public link in the server
-        And the last public link share response of user "Alice" should include the following fields on the server
-            | expireDate | 2031-10-14 |
-        And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" on the server
+        And the last public link share response of user "Alice" should include the following fields in the server
+            | expiration | 2031-10-14 |
+        And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" in the server
 
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
@@ -523,8 +523,8 @@ Feature: Sharing
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user edits the public link named "Public link" of file "textfile0.txt" changing following
             | expireDate | 2038-07-21 |
-        Then the last public link share response of user "Alice" should include the following fields on the server
-            | expireDate | 2038-07-21 |
+        Then the last public link share response of user "Alice" should include the following fields in the server
+            | expiration | 2038-07-21 |
 
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for folder using client-UI
@@ -538,8 +538,8 @@ Feature: Sharing
         When the user opens the public links dialog of "simple-folder" using the client-UI
         And the user edits the public link named "Public link" of file "simple-folder" changing following
             | expireDate | 2038-07-21 |
-        Then the last public link share response of user "Alice" should include the following fields on the server
-            | expireDate | 2038-07-21 |
+        Then the last public link share response of user "Alice" should include the following fields in the server
+            | expiration | 2038-07-21 |
 
 
     Scenario Outline: simple sharing of folder by public link with different roles
@@ -574,7 +574,7 @@ Feature: Sharing
             | permissions | create         |
             | path        | /simple-folder |
             | name        | Public link    |
-        And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" on the server
+        And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" in the server
 
 
     Scenario Outline: change collaborator permissions of a file & folder


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
These `Then` step implementation asserts whether the given resource(file/folder) is present on the server or not.

Renamed step:

```diff
-Then the last public link share response of user "<user>" should include the following fields on the server
-| <field_name> | <value> |

+Then the last public link share response of user "<user>" should include the following fields in the server
+<field_name> | <value> |
```
Part of https://github.com/owncloud/client/issues/10432