### PR TITLE
Unify enum handling with generic utility function templates

### DIFF
--- a/src/common/checksumalgorithms.cpp
+++ b/src/common/checksumalgorithms.cpp
@@ -42,11 +42,7 @@ template <>
 QString Utility::enumToString(CheckSums::Algorithm algo)
 {
     const auto n = toString(algo);
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     return QString::fromUtf8(n.data(), static_cast<int>(n.size()));
-#else
-    return QString::fromUtf8(n.data(), n.size());
-#endif
 }
 
 #include "moc_checksumalgorithms.cpp"

--- a/src/common/checksumalgorithms.cpp
+++ b/src/common/checksumalgorithms.cpp
@@ -26,7 +26,7 @@ CheckSums::Algorithm CheckSums::fromByteArray(const QByteArray &s)
         // ensure to run the check only once
         static bool once = [] {
             for (const auto &a : All) {
-                const QString s = CheckSums::toQString(a.first);
+                const QString s = Utility::enumToString(a.first);
                 if (s != s.toUpper()) {
                     return false;
                 }
@@ -36,6 +36,17 @@ CheckSums::Algorithm CheckSums::fromByteArray(const QByteArray &s)
         return once;
     }());
     return fromName(s.toUpper().constData());
+}
+
+template <>
+QString Utility::enumToString(CheckSums::Algorithm algo)
+{
+    const auto n = toString(algo);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    return QString::fromUtf8(n.data(), static_cast<int>(n.size()));
+#else
+    return QString::fromUtf8(n.data(), n.size());
+#endif
 }
 
 #include "moc_checksumalgorithms.cpp"

--- a/src/common/checksumalgorithms.h
+++ b/src/common/checksumalgorithms.h
@@ -19,6 +19,7 @@
 
 #include "constexpr_list.h"
 #include "ocsynclib.h"
+#include "utility.h"
 
 #include <QCryptographicHash>
 #include <QString>
@@ -110,5 +111,11 @@ namespace CheckSums {
     }
 
     OCSYNC_EXPORT Algorithm fromByteArray(const QByteArray &s);
+} // namespace CheckSums
+
+namespace Utility {
+    template <>
+    OCSYNC_EXPORT QString enumToString(CheckSums::Algorithm algo);
 }
-}
+
+} // namespace OCC

--- a/src/common/checksumalgorithms.h
+++ b/src/common/checksumalgorithms.h
@@ -113,9 +113,7 @@ namespace CheckSums {
     OCSYNC_EXPORT Algorithm fromByteArray(const QByteArray &s);
 } // namespace CheckSums
 
-namespace Utility {
-    template <>
-    OCSYNC_EXPORT QString enumToString(CheckSums::Algorithm algo);
-}
+template <>
+OCSYNC_EXPORT QString Utility::enumToString(CheckSums::Algorithm algo);
 
 } // namespace OCC

--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -146,7 +146,7 @@ QByteArray ChecksumHeader::makeChecksumHeader() const
     if (!isValid()) {
         return {};
     }
-    return CheckSums::toQString(_checksumType).toUtf8() + ':' + _checksum;
+    return Utility::enumToString(_checksumType).toUtf8() + ':' + _checksum;
 }
 
 CheckSums::Algorithm ChecksumHeader::type() const
@@ -312,7 +312,7 @@ QByteArray ComputeChecksum::computeNow(QIODevice *device, CheckSums::Algorithm a
         if (crypto.addData(device)) {
             return crypto.result().toHex();
         }
-        qCWarning(lcChecksums) << "Failed to compoute checksum" << CheckSums::toQString(algorithm);
+        qCWarning(lcChecksums) << "Failed to compoute checksum" << Utility::enumToString(algorithm);
         return {};
     }
     case CheckSums::Algorithm::ADLER32:

--- a/src/common/pinstate.cpp
+++ b/src/common/pinstate.cpp
@@ -14,3 +14,24 @@
 
 #include "pinstate.h"
 #include "moc_pinstate.cpp"
+
+#include <QCoreApplication>
+
+using namespace OCC;
+
+template <>
+QString Utility::enumToDisplayName(VfsItemAvailability availability)
+{
+    switch (availability) {
+    case VfsItemAvailability::AlwaysLocal:
+        return QCoreApplication::translate("pinstate", "Always available locally");
+    case VfsItemAvailability::AllHydrated:
+        return QCoreApplication::translate("pinstate", "Currently available locally");
+    case VfsItemAvailability::Mixed:
+        return QCoreApplication::translate("pinstate", "Some available online only");
+    case VfsItemAvailability::AllDehydrated:
+    case VfsItemAvailability::OnlineOnly:
+        return QCoreApplication::translate("pinstate", "Available online only");
+    }
+    Q_UNREACHABLE();
+}

--- a/src/common/pinstate.cpp
+++ b/src/common/pinstate.cpp
@@ -30,6 +30,7 @@ QString Utility::enumToDisplayName(VfsItemAvailability availability)
     case VfsItemAvailability::Mixed:
         return QCoreApplication::translate("pinstate", "Some available online only");
     case VfsItemAvailability::AllDehydrated:
+        [[fallthrough]];
     case VfsItemAvailability::OnlineOnly:
         return QCoreApplication::translate("pinstate", "Available online only");
     }

--- a/src/common/pinstate.h
+++ b/src/common/pinstate.h
@@ -16,6 +16,7 @@
 #define PINSTATE_H
 
 #include "ocsynclib.h"
+#include "utility.h"
 
 #include <QObject>
 
@@ -129,6 +130,8 @@ Q_ENUM_NS(VfsItemAvailability)
 }
 using namespace PinStateEnums;
 
+template <>
+OCSYNC_EXPORT QString Utility::enumToDisplayName(VfsItemAvailability availability);
 }
 
 #endif

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1921,7 +1921,7 @@ int SyncJournalDb::mapChecksumType(CheckSums::Algorithm checksumType)
     }
 
     // the type is mapped as utf8
-    const auto typeName = CheckSums::toQString(checksumType).toUtf8();
+    const auto typeName = Utility::enumToString(checksumType).toUtf8();
     // Ensure the checksum type is in the db
     {
         const auto query = _queryManager.get(PreparedSqlQueryManager::InsertChecksumTypeQuery, QByteArrayLiteral("INSERT OR IGNORE INTO checksumtype (name) VALUES (?1)"), _db);

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -347,7 +347,7 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
     }
 
     template <class E>
-    OCSYNC_EXPORT QString enumToString(E value)
+    QString enumToString(E value)
     {
         return QString::fromUtf8(QMetaEnum::fromType<E>().valueToKeys(value));
     }

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -347,7 +347,7 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
     }
 
     template <class E>
-    QString enumToString(E value)
+    OCSYNC_EXPORT QString enumToString(E value)
     {
         return QString::fromUtf8(QMetaEnum::fromType<E>().valueToKeys(value));
     }

--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -255,8 +255,8 @@ QString Utility::enumToString(Vfs::Mode mode)
         return QStringLiteral("suffix");
     case Vfs::Mode::WindowsCfApi:
         return QStringLiteral("wincfapi");
-    default:
-        [[fallthrough]];
+    case Vfs::Mode::Off:
+        return QStringLiteral("off");
     }
-    return QStringLiteral("off");
+    Q_UNREACHABLE();
 }

--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -41,20 +41,6 @@ QString Vfs::underlyingFileName(const QString &fileName) const
 
 Vfs::~Vfs() = default;
 
-QString Vfs::modeToString(Mode mode)
-{
-    // Note: Strings are used for config and must be stable
-    switch (mode) {
-    case Off:
-        return QStringLiteral("off");
-    case WithSuffix:
-        return QStringLiteral("suffix");
-    case WindowsCfApi:
-        return QStringLiteral("wincfapi");
-    }
-    return QStringLiteral("off");
-}
-
 Optional<Vfs::Mode> Vfs::modeFromString(const QString &str)
 {
     // Note: Strings are used for config and must be stable
@@ -258,4 +244,19 @@ const VfsPluginManager &VfsPluginManager::instance()
         _instance = new VfsPluginManager();
     }
     return *_instance;
+}
+
+template <>
+QString Utility::enumToString(Vfs::Mode mode)
+{
+    // Note: Strings are used for config and must be stable
+    switch (mode) {
+    case Vfs::Mode::WithSuffix:
+        return QStringLiteral("suffix");
+    case Vfs::Mode::WindowsCfApi:
+        return QStringLiteral("wincfapi");
+    default:
+        [[fallthrough]];
+    }
+    return QStringLiteral("off");
 }

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -298,9 +298,7 @@ private:
     mutable QMap<Vfs::Mode, bool> _pluginCache;
 };
 
-namespace Utility {
-    template <>
-    OCSYNC_EXPORT QString enumToString(Vfs::Mode mode);
-} // namespace Utility
+template <>
+OCSYNC_EXPORT QString Utility::enumToString(Vfs::Mode mode);
 
 } // namespace OCC

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -19,6 +19,7 @@
 #include "pinstate.h"
 #include "result.h"
 #include "syncfilestatus.h"
+#include "utility.h"
 
 #include <QObject>
 #include <QScopedPointer>
@@ -125,7 +126,6 @@ public:
     };
     Q_ENUM(ConvertToPlaceholderResult)
 
-    static QString modeToString(Mode mode);
     static Optional<Mode> modeFromString(const QString &str);
 
     static Result<void, QString> checkAvailability(const QString &path, OCC::Vfs::Mode mode);
@@ -297,5 +297,10 @@ private:
 
     mutable QMap<Vfs::Mode, bool> _pluginCache;
 };
+
+namespace Utility {
+    template <>
+    OCSYNC_EXPORT QString enumToString(Vfs::Mode mode);
+} // namespace Utility
 
 } // namespace OCC

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1402,7 +1402,7 @@ void FolderDefinition::save(QSettings &settings, const FolderDefinition &folder)
     settings.setValue(deployedC(), folder.isDeployed());
     settings.setValue(priorityC(), folder.priority());
 
-    settings.setValue(QStringLiteral("virtualFilesMode"), Vfs::modeToString(folder.virtualFilesMode));
+    settings.setValue(QStringLiteral("virtualFilesMode"), Utility::enumToString(folder.virtualFilesMode));
 
     // Prevent loading of profiles in old clients
     settings.setValue(versionC(), maxSettingsVersion());

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -748,10 +748,9 @@ void FolderMan::slotScheduleFolderByTime()
         if (f->consecutiveFailingSyncs() > 1)
             syncAgainDelay = std::chrono::seconds(60); // 60s for each further attempt
         if (syncAgain && msecsSinceSync > syncAgainDelay) {
-            qCInfo(lcFolderMan) << "Scheduling folder" << f->path()
-                                << ", the last" << f->consecutiveFailingSyncs() << "syncs failed"
+            qCInfo(lcFolderMan) << "Scheduling folder" << f->path() << ", the last" << f->consecutiveFailingSyncs() << "syncs failed"
                                 << ", anotherSyncNeeded" << f->syncEngine().isAnotherSyncNeeded()
-                                << ", last status:" << f->syncResult().statusString()
+                                << ", last status:" << Utility::enumToDisplayName(f->syncResult().status())
                                 << ", time since last sync:" << msecsSinceSync.count();
 
             scheduleFolder(f);

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1035,43 +1035,15 @@ QString FolderMan::trayTooltipStatusString(
 {
     QString folderMessage;
     switch (result.status()) {
-    case SyncResult::Undefined:
-        folderMessage = tr("Undefined State.");
-        break;
-    case SyncResult::NotYetStarted:
-        folderMessage = tr("Waiting to start syncing.");
-        break;
-    case SyncResult::SyncPrepare:
-        folderMessage = tr("Preparing for sync.");
-        break;
-    case SyncResult::SyncRunning:
-        folderMessage = tr("Sync is running.");
-        break;
     case SyncResult::Success:
         [[fallthrough]];
     case SyncResult::Problem:
         if (result.hasUnresolvedConflicts()) {
             folderMessage = tr("Sync was successful, unresolved conflicts.");
-        } else {
-            folderMessage = tr("Last Sync was successful.");
+            break;
         }
-        break;
-    case SyncResult::Error:
-        folderMessage = tr("Sync Error.");
-        break;
-    case SyncResult::SetupError:
-        folderMessage = tr("Setup Error.");
-        break;
-    case SyncResult::SyncAbortRequested:
-        folderMessage = tr("User Abort.");
-        break;
-    case SyncResult::Paused:
-        folderMessage = tr("Sync is paused.");
-        break;
-    case SyncResult::Offline:
-        folderMessage = tr("Offline.");
-        break;
-        // no default case on purpose, check compiler warnings
+    default:
+        return Utility::enumToDisplayName(result.status());
     }
     if (paused) {
         // sync is disabled.

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -341,7 +341,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             return progress._progressString;
         }
         if (accountConnected) {
-            return tr("%1\n%2").arg(Theme::instance()->statusHeaderText(f->syncResult().status()), QDir::toNativeSeparators(folderInfo._folder->path()));
+            return tr("%1\n%2").arg(Utility::enumToDisplayName(f->syncResult().status()), QDir::toNativeSeparators(folderInfo._folder->path()));
         } else {
             return tr("Signed out\n%1").arg(QDir::toNativeSeparators(folderInfo._folder->path()));
         }
@@ -1149,7 +1149,7 @@ void FolderStatusModel::slotFolderSyncStateChange(Folder *f)
         pi = SubFolderInfo::Progress();
     } else if (state == SyncResult::SyncPrepare) {
         pi = SubFolderInfo::Progress();
-        pi._overallSyncString = Theme::instance()->statusHeaderText(SyncResult::SyncPrepare);
+        pi._overallSyncString = Utility::enumToDisplayName(SyncResult::SyncPrepare);
     } else if (state == SyncResult::Problem || state == SyncResult::Success) {
         // Reset the progress info after a sync.
         pi = SubFolderInfo::Progress();

--- a/src/gui/guiutility.cpp
+++ b/src/gui/guiutility.cpp
@@ -76,23 +76,6 @@ bool Utility::openEmailComposer(const QString &subject, const QString &body, QWi
     return true;
 }
 
-QString Utility::vfsCurrentAvailabilityText(VfsItemAvailability availability)
-{
-    switch(availability) {
-    case VfsItemAvailability::AlwaysLocal:
-        return QCoreApplication::translate("utility", "Always available locally");
-    case VfsItemAvailability::AllHydrated:
-        return QCoreApplication::translate("utility", "Currently available locally");
-    case VfsItemAvailability::Mixed:
-        return QCoreApplication::translate("utility", "Some available online only");
-    case VfsItemAvailability::AllDehydrated:
-        return QCoreApplication::translate("utility", "Available online only");
-    case VfsItemAvailability::OnlineOnly:
-        return QCoreApplication::translate("utility", "Available online only");
-    }
-    Q_UNREACHABLE();
-}
-
 QString Utility::vfsPinActionText()
 {
     return QCoreApplication::translate("utility", "Make always available locally");

--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -41,12 +41,6 @@ namespace Utility {
     bool openEmailComposer(const QString &subject, const QString &body,
         QWidget *errorWidgetParent);
 
-    /** Returns a translated string indicating the current availability.
-     *
-     * This will be used in context menus to describe the current state.
-     */
-    QString vfsCurrentAvailabilityText(VfsItemAvailability availability);
-
     /** Translated text for "making items always available locally" */
     QString vfsPinActionText();
 

--- a/src/gui/libcloudproviders/libcloudproviders.cpp
+++ b/src/gui/libcloudproviders/libcloudproviders.cpp
@@ -12,8 +12,8 @@
  * for more details.
  */
 
-#include <cloudprovidersaccountexporter.h>
-#include <cloudprovidersproviderexporter.h>
+#include <cloudproviders/cloudprovidersaccountexporter.h>
+#include <cloudproviders/cloudprovidersproviderexporter.h>
 #include <gio/gio.h>
 #include <glib.h>
 

--- a/src/gui/libcloudproviders/libcloudproviders.cpp
+++ b/src/gui/libcloudproviders/libcloudproviders.cpp
@@ -12,8 +12,8 @@
  * for more details.
  */
 
-#include <cloudproviders/cloudprovidersaccountexporter.h>
-#include <cloudproviders/cloudprovidersproviderexporter.h>
+#include <cloudprovidersaccountexporter.h>
+#include <cloudprovidersproviderexporter.h>
 #include <gio/gio.h>
 #include <glib.h>
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -206,7 +206,7 @@ void ownCloudGui::slotSyncStateChange(Folder *folder)
 
     auto result = folder->syncResult();
 
-    qCInfo(lcApplication) << "Sync state changed for folder " << folder->remoteUrl().toString() << ": " << result.statusString();
+    qCInfo(lcApplication) << "Sync state changed for folder " << folder->remoteUrl().toString() << ": " << Utility::enumToDisplayName(result.status());
 
     if (result.status() == SyncResult::NotYetStarted) {
         _settingsDialog->slotRefreshActivity(folder->accountState());

--- a/src/gui/settingsdialog_mac.mm
+++ b/src/gui/settingsdialog_mac.mm
@@ -35,7 +35,7 @@ void setActivationPolicy(ActivationPolicy policy)
 
     if (mode != NSApp.activationPolicy) {
         if (![NSApp setActivationPolicy:mode]) {
-            qWarning() << "setActivationPolicy" << OCC::Utility::enumToString > (policy) << "failed";
+            qWarning() << "setActivationPolicy" << static_cast<int>(policy) << "failed";
         }
     }
 }

--- a/src/gui/settingsdialog_mac.mm
+++ b/src/gui/settingsdialog_mac.mm
@@ -13,6 +13,7 @@
  */
 
 #include "settingsdialog_mac.h"
+#include "common/utility.h"
 
 #import <AppKit/AppKit.h>
 #include <QDebug>
@@ -34,7 +35,7 @@ void setActivationPolicy(ActivationPolicy policy)
 
     if (mode != NSApp.activationPolicy) {
         if (![NSApp setActivationPolicy:mode]) {
-            qWarning() << "setActivationPolicy" << static_cast<int>(policy) << "failed";
+            qWarning() << "setActivationPolicy" << OCC::Utility::enumToString > (policy) << "failed";
         }
     }
 }

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1108,8 +1108,7 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
         // TODO: Should be a submenu, should use icons
         auto makePinContextMenu = [&](bool makeAvailableLocally, bool freeSpace) {
             listener->sendMessage(QStringLiteral("MENU_SEPARATOR:d::"));
-            listener->sendMessage(QStringLiteral("MENU_ITEM:CURRENT_PIN:d:")
-                + Utility::vfsCurrentAvailabilityText(*combined));
+            listener->sendMessage(QStringLiteral("MENU_ITEM:CURRENT_PIN:d:") + Utility::enumToDisplayName(combined.get()));
             listener->sendMessage(QStringLiteral("MENU_ITEM:MAKE_AVAILABLE_LOCALLY:")
                 + (makeAvailableLocally ? QStringLiteral(":") : QStringLiteral("d:"))
                 + Utility::vfsPinActionText());

--- a/src/libsync/propagateuploadtus.cpp
+++ b/src/libsync/propagateuploadtus.cpp
@@ -85,8 +85,8 @@ SimpleNetworkJob *PropagateUploadFileTUS::makeCreationWithUploadJob(QNetworkRequ
     auto addMetaData = [&encodedMetaData](const QByteArray &key, const QByteArray &value) { encodedMetaData << key + ' ' + value.toBase64(); };
     addMetaData(QByteArrayLiteral("filename"), propagator()->fullRemotePath(_item->_file).toUtf8());
     // in difference to the old protocol the algrithm and the value are space seperated
-    addMetaData(QByteArrayLiteral("checksum"), CheckSums::toQString(checksumHeader.type()).toUtf8() + ' ' + checksumHeader.checksum());
-    addMetaData(QByteArrayLiteral("mtime"), QByteArray::number(_item->_modtime));
+    addMetaData(QByteArrayLiteral("checksum"), Utility::enumToString(checksumHeader.type()).toUtf8() + ' ' + checksumHeader.checksum());
+    addMetaData(QByteArrayLiteral("mtime"), QByteArray::number(static_cast<int>(_item->_modtime)));
 
     request->setRawHeader(QByteArrayLiteral("Upload-Metadata"), encodedMetaData.join(','));
     request->setRawHeader(QByteArrayLiteral("Upload-Length"), QByteArray::number(_item->_size));

--- a/src/libsync/propagateuploadtus.cpp
+++ b/src/libsync/propagateuploadtus.cpp
@@ -86,7 +86,7 @@ SimpleNetworkJob *PropagateUploadFileTUS::makeCreationWithUploadJob(QNetworkRequ
     addMetaData(QByteArrayLiteral("filename"), propagator()->fullRemotePath(_item->_file).toUtf8());
     // in difference to the old protocol the algrithm and the value are space seperated
     addMetaData(QByteArrayLiteral("checksum"), Utility::enumToString(checksumHeader.type()).toUtf8() + ' ' + checksumHeader.checksum());
-    addMetaData(QByteArrayLiteral("mtime"), QByteArray::number(static_cast<int>(_item->_modtime)));
+    addMetaData(QByteArrayLiteral("mtime"), QByteArray::number(static_cast<int64_t>(_item->_modtime)));
 
     request->setRawHeader(QByteArrayLiteral("Upload-Metadata"), encodedMetaData.join(','));
     request->setRawHeader(QByteArrayLiteral("Upload-Length"), QByteArray::number(_item->_size));

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -34,43 +34,43 @@ void SyncResult::reset()
     *this = SyncResult();
 }
 
-QString SyncResult::statusString() const
+template <>
+QString Utility::enumToDisplayName(SyncResult::Status status)
 {
     QString re;
-    Status stat = status();
 
-    switch (stat) {
-    case Undefined:
+    switch (status) {
+    case SyncResult::Status::Undefined:
         re = QStringLiteral("Undefined");
         break;
-    case NotYetStarted:
+    case SyncResult::Status::NotYetStarted:
         re = QStringLiteral("Not yet Started");
         break;
-    case SyncRunning:
+    case SyncResult::Status::SyncRunning:
         re = QStringLiteral("Sync Running");
         break;
-    case Success:
+    case SyncResult::Status::Success:
         re = QStringLiteral("Success");
         break;
-    case Error:
+    case SyncResult::Status::Error:
         re = QStringLiteral("Error");
         break;
-    case SetupError:
+    case SyncResult::Status::SetupError:
         re = QStringLiteral("SetupError");
         break;
-    case SyncPrepare:
+    case SyncResult::Status::SyncPrepare:
         re = QStringLiteral("SyncPrepare");
         break;
-    case Problem:
+    case SyncResult::Status::Problem:
         re = QStringLiteral("Success, some files were ignored.");
         break;
-    case SyncAbortRequested:
+    case SyncResult::Status::SyncAbortRequested:
         re = QStringLiteral("Sync Request aborted by user");
         break;
-    case Paused:
+    case SyncResult::Status::Paused:
         re = QStringLiteral("Sync Paused");
         break;
-    case Offline:
+    case SyncResult::Status::Offline:
         re = QStringLiteral("Offline");
         break;
     }

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -37,44 +37,31 @@ void SyncResult::reset()
 template <>
 QString Utility::enumToDisplayName(SyncResult::Status status)
 {
-    QString re;
-
     switch (status) {
     case SyncResult::Status::Undefined:
-        re = QStringLiteral("Undefined");
-        break;
+        return QStringLiteral("Undefined");
     case SyncResult::Status::NotYetStarted:
-        re = QStringLiteral("Not yet Started");
-        break;
+        return QStringLiteral("Awaiting sync");
     case SyncResult::Status::SyncRunning:
-        re = QStringLiteral("Sync Running");
-        break;
+        return QStringLiteral("Sync running");
     case SyncResult::Status::Success:
-        re = QStringLiteral("Success");
-        break;
+        return QStringLiteral("Success");
     case SyncResult::Status::Error:
-        re = QStringLiteral("Error");
-        break;
+        return QStringLiteral("Error");
     case SyncResult::Status::SetupError:
-        re = QStringLiteral("SetupError");
-        break;
+        return QStringLiteral("Setup error");
     case SyncResult::Status::SyncPrepare:
-        re = QStringLiteral("SyncPrepare");
-        break;
+        return QStringLiteral("Preparing to sync");
     case SyncResult::Status::Problem:
-        re = QStringLiteral("Success, some files were ignored.");
-        break;
+        return QStringLiteral("Success, some files were ignored.");
     case SyncResult::Status::SyncAbortRequested:
-        re = QStringLiteral("Sync Request aborted by user");
-        break;
+        return QStringLiteral("Aborting sync");
     case SyncResult::Status::Paused:
-        re = QStringLiteral("Sync Paused");
-        break;
+        return QStringLiteral("Sync paused");
     case SyncResult::Status::Offline:
-        re = QStringLiteral("Offline");
-        break;
+        return QStringLiteral("Offline");
     }
-    return re;
+    Q_UNREACHABLE();
 }
 
 void SyncResult::setStatus(Status stat)

--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -19,6 +19,7 @@
 #include <QHash>
 #include <QDateTime>
 
+#include "common/utility.h"
 #include "owncloudlib.h"
 #include "syncfileitem.h"
 
@@ -61,7 +62,6 @@ public:
 
     void setStatus(Status);
     Status status() const;
-    QString statusString() const;
     QDateTime syncTime() const;
 
     bool foundFilesNotSynced() const { return _foundFilesNotSynced; }
@@ -118,6 +118,9 @@ private:
 
     friend class TrayOverallStatusResult;
 };
+
+template <>
+OWNCLOUDSYNC_EXPORT QString Utility::enumToDisplayName(SyncResult::Status status);
 }
 
 #endif

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -424,8 +424,8 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
         "Using virtual files plugin: %5%7"
         "%6")
         .arg(appName(), _version, qtVersionString, QSslSocket::sslLibraryVersionString(),
-            Vfs::modeToString(VfsPluginManager::instance().bestAvailableVfsMode()), QSysInfo::productType() % QLatin1Char('-') % QSysInfo::kernelVersion(), br,
-            gitUrl);
+            Utility::enumToString(VfsPluginManager::instance().bestAvailableVfsMode()), QSysInfo::productType() % QLatin1Char('-') % QSysInfo::kernelVersion(),
+            br, gitUrl);
 }
 
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -86,48 +86,6 @@ Theme::~Theme()
 {
 }
 
-QString Theme::statusHeaderText(SyncResult::Status status) const
-{
-    QString resultStr;
-
-    switch (status) {
-    case SyncResult::Undefined:
-        resultStr = QCoreApplication::translate("theme", "Status undefined");
-        break;
-    case SyncResult::NotYetStarted:
-        resultStr = QCoreApplication::translate("theme", "Waiting to start sync");
-        break;
-    case SyncResult::SyncRunning:
-        resultStr = QCoreApplication::translate("theme", "Sync is running");
-        break;
-    case SyncResult::Success:
-        resultStr = QCoreApplication::translate("theme", "Sync Success");
-        break;
-    case SyncResult::Problem:
-        resultStr = QCoreApplication::translate("theme", "Sync Success, some files were ignored.");
-        break;
-    case SyncResult::Error:
-        resultStr = QCoreApplication::translate("theme", "Sync Error");
-        break;
-    case SyncResult::SetupError:
-        resultStr = QCoreApplication::translate("theme", "Setup Error");
-        break;
-    case SyncResult::SyncPrepare:
-        resultStr = QCoreApplication::translate("theme", "Preparing to sync");
-        break;
-    case SyncResult::SyncAbortRequested:
-        resultStr = QCoreApplication::translate("theme", "Aborting...");
-        break;
-    case SyncResult::Paused:
-        resultStr = QCoreApplication::translate("theme", "Sync is paused");
-        break;
-    case SyncResult::Offline:
-        resultStr = QCoreApplication::translate("theme", "Offline");
-        break;
-    }
-    return resultStr;
-}
-
 QString Theme::appNameGUI() const
 {
     return QStringLiteral(APPLICATION_NAME);

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -129,8 +129,6 @@ public:
     */
     bool allowDarkTheme() const;
 
-    virtual QString statusHeaderText(SyncResult::Status) const;
-
     /**
      * Characteristics: bool if more than one sync folder is allowed
      */

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -94,16 +94,17 @@ namespace TestUtils {
         static const auto algorithmNames = [] {
             QVariantList out;
             for (const auto &a : CheckSums::All) {
-                out.append(CheckSums::toQString(a.first));
+                out.append(Utility::enumToString(a.first));
             }
             return out;
         }();
-        return {
-            { "core", QVariantMap { { "status", QVariantMap { { "installed", "1" }, { "maintenance", "0" }, { "needsDbUpgrade", "0" }, { "version", "10.11.0.0" }, { "versionstring", "10.11.0" }, { "edition", "Community" }, { "productname", "Infinite Scale" }, { "product", "Infinite Scale" }, { "productversion", "2.0.0-beta1+7c2e3201b" } } } } },
-            { "files", QVariantList {} },
-            { "dav", QVariantMap { { "chunking", "1.0" } } },
-            { "checksums", QVariantMap { { "preferredUploadType", CheckSums::toQString(algo) }, { "supportedTypes", algorithmNames } } }
-        };
+        return {{"core",
+                    QVariantMap{{"status",
+                        QVariantMap{{"installed", "1"}, {"maintenance", "0"}, {"needsDbUpgrade", "0"}, {"version", "10.11.0.0"}, {"versionstring", "10.11.0"},
+                            {"edition", "Community"}, {"productname", "Infinite Scale"}, {"product", "Infinite Scale"},
+                            {"productversion", "2.0.0-beta1+7c2e3201b"}}}}},
+            {"files", QVariantList{}}, {"dav", QVariantMap{{"chunking", "1.0"}}},
+            {"checksums", QVariantMap{{"preferredUploadType", Utility::enumToString(algo)}, {"supportedTypes", algorithmNames}}}};
     }
 }
 }


### PR DESCRIPTION
Fixes #9043 among others.

Unfortunately, formatting of nested function calls and constructions of `QVariantMap`s has degraded. We may have to invest some time into adapting our clang-format config.