### PR TITLE
[tests-only] [full-ci] Implement `Then` step for verifying number of items in the folder 

### DIFF
--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -145,3 +145,16 @@ def step(context, resource_name, public_link_password, link_creator):
         link_creator, resource_name, public_link_password
     )
     test.compare(downloaded, True, "Could not download public share")
+
+
+@Then(
+    r'as user "([^"].*)" folder "([^"].*)" should contain "([^"].*)" items in the server',
+    regexp=True,
+)
+def step(context, user_name, folder_name, items_number):
+    total_items = webdav.get_folder_items_count(user_name, folder_name)
+    test.compare(
+        total_items,
+        items_number,
+        f"Folder should contain {items_number} items",
+    )

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -351,9 +351,9 @@ Feature: Syncing files
         And the user waits for folder "folder1" to be synced
         And the user waits for folder "folder2" to be synced
         Then as "Alice" folder "folder1" should exist in the server
-        And as user "Alice" folder "folder1" should contain "500" items on the server
+        And as user "Alice" folder "folder1" should contain "500" items in the server
         And as "Alice" folder "folder2" should exist in the server
-        And as user "Alice" folder "folder2" should contain "500" items on the server
+        And as user "Alice" folder "folder2" should contain "500" items in the server
 
 
     Scenario: Skip sync folder configuration


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
These `Then` step implementation asserts whether the given resource(file/folder) is present on the server or not.

Renamed step:

```diff
-Then as user "<user>" folder "<folderName>" should contain "<number>" items on the server

+Then as user "<user>" folder "<folderName>" should contain "<number>" items in the server
```
Part of https://github.com/owncloud/client/issues/10432