### PR TITLE
If all files are removed on either sync side abort the sync

### DIFF
--- a/changelog/unreleased/8360
+++ b/changelog/unreleased/8360
@@ -1,0 +1,9 @@
+Enhancement: Change how all files deleted is handled
+
+When the client detects that all files are deleted on either side of the sync,
+the client now aborts the sync and asks for a user decision.
+Afterwords a new sync is started.
+
+Previously we blocked the current sync until the user responded which could lead to unwanted side effects.
+
+https://github.com/owncloud/client/issues/8360

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -403,7 +403,7 @@ public slots:
     void slotTerminateSync();
 
     // connected to the corresponding signals in the SyncEngine
-    void slotAboutToRemoveAllFiles(SyncFileItem::Direction, const std::function<void(bool)> &abort);
+    void slotAboutToRemoveAllFiles(SyncFileItem::Direction);
 
     /**
       * Starts a sync operation
@@ -587,6 +587,9 @@ private:
      * The vfs mode instance (created by plugin) to use. Never null.
      */
     QSharedPointer<Vfs> _vfs;
+
+    // allow that all files are removed in the next run
+    bool _allowRemoveAllOnce = false;
 
     friend class SpaceMigration;
 };

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -145,6 +145,10 @@ public:
 
     auto getPropagator() { return _propagator; } // for the test
 
+
+    bool isPromtRemoveAllFiles() const;
+    void setPromtRemoveAllFiles(bool promtRemoveAllFiles);
+
 signals:
     // During update, before reconcile
     void rootEtag(const QString &, const QDateTime &);
@@ -167,9 +171,10 @@ signals:
     /**
      * Emited when the sync engine detects that all the files have been removed or change.
      * This usually happen when the server was reset or something.
-     * Call abort(true) slot connected from this signal to abort the sync.
+     * SyncFileItem::Down indicates all files where removed on the server
+     * SyncFileItem::Up indicates all files where removed locally
      */
-    void aboutToRemoveAllFiles(SyncFileItem::Direction direction, std::function<void(bool)> abort);
+    void aboutToRemoveAllFiles(SyncFileItem::Direction direction);
 
     // A new folder was discovered and was not synced because of the confirmation feature
     void newBigFolder(const QString &folder, bool isExternal);
@@ -250,13 +255,6 @@ private:
     Utility::StopWatch _stopWatch;
 
     /**
-     * check if we are allowed to propagate everything, and if we are not, adjust the instructions
-     * to recover
-     */
-    void checkForPermission(SyncFileItemSet &syncItems);
-    RemotePermissions getPermissions(const QString &file) const;
-
-    /**
      * Instead of downloading files from the server, upload the files to the server
      */
     void restoreOldFiles(SyncFileItemSet &syncItems);
@@ -292,5 +290,7 @@ private:
 
     // destructor called
     bool _goingDown = false;
+
+    bool _promptRemoveAllFiles = true;
 };
 }

--- a/test/testsyncvirtualfiles.cpp
+++ b/test/testsyncvirtualfiles.cpp
@@ -82,6 +82,8 @@ private slots:
         QFETCH(bool, doLocalDiscovery);
 
         FakeFolder fakeFolder{ FileInfo() };
+        fakeFolder.syncEngine().setPromtRemoveAllFiles(false);
+
         setupVfs(fakeFolder);
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         ItemCompletedSpy completeSpy(fakeFolder);
@@ -310,6 +312,7 @@ private slots:
     void testVirtualFileDownload()
     {
         FakeFolder fakeFolder{ FileInfo() };
+        fakeFolder.syncEngine().setPromtRemoveAllFiles(false);
         setupVfs(fakeFolder);
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         ItemCompletedSpy completeSpy(fakeFolder);

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -942,13 +942,6 @@ FakeFolder::FakeFolder(const FileInfo &fileTemplate, OCC::Vfs::Mode vfsMode, boo
     // Ignore temporary files from the download. (This is in the default exclude list, but we don't load it)
     _syncEngine->excludedFiles().addManualExclude(QStringLiteral("]*.~*"));
 
-    // handle aboutToRemoveAllFiles with a timeout in case our test does not handle it
-    QObject::connect(_syncEngine.get(), &OCC::SyncEngine::aboutToRemoveAllFiles, _syncEngine.get(), [this](OCC::SyncFileItem::Direction, const std::function<void(bool)> &callback) {
-        QTimer::singleShot(1s, _syncEngine.get(), [callback] {
-            callback(false);
-        });
-    });
-
     auto vfs = _syncEngine->syncOptions()._vfs;
     if (vfsMode != vfs->mode()) {
         vfs.reset(OCC::VfsPluginManager::instance().createVfsFromPlugin(vfsMode).release());


### PR DESCRIPTION
Instead of pausing the current sync we now abort the sync, ask the user and start a second sync

Fixes: #8360