### PR TITLE
Remove removed accounts from activitywidget.cpp

### DIFF
--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -199,11 +199,6 @@ private:
 };
 }
 
-inline size_t qHash(const OCC::AccountStatePtr &acs, size_t seed)
-{
-    return qHash(acs.data(), seed);
-}
-
 Q_DECLARE_METATYPE(OCC::AccountState *)
 Q_DECLARE_METATYPE(OCC::AccountStatePtr)
 

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -489,6 +489,9 @@ ActivitySettings::ActivitySettings(QWidget *parent)
 
     // We want the protocol be the default
     _tab->setCurrentIndex(1);
+
+    connect(AccountManager::instance(), &AccountManager::accountRemoved, this,
+        [this](const AccountStatePtr &accountStatePtr) { _timeSinceLastCheck.take(accountStatePtr); });
 }
 
 void ActivitySettings::setNotificationRefreshInterval(std::chrono::milliseconds interval)

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -162,7 +162,7 @@ private:
     IssuesWidget *_issuesWidget;
     QProgressIndicator *_progressIndicator;
     QTimer _notificationCheckTimer;
-    QHash<AccountStatePtr, QElapsedTimer> _timeSinceLastCheck;
+    QHash<AccountState *, QElapsedTimer> _timeSinceLastCheck;
 };
 }
 #endif // ActivityWIDGET_H

--- a/src/gui/models/activitylistmodel.h
+++ b/src/gui/models/activitylistmodel.h
@@ -73,9 +73,9 @@ private:
     void startFetchJob(AccountStatePtr s);
     void combineActivityLists();
 
-    QMap<AccountStatePtr, ActivityList> _activityLists;
+    QMap<AccountState *, ActivityList> _activityLists;
     ActivityList _finalList;
-    QSet<AccountStatePtr> _currentlyFetching;
+    QMap<AccountState *, AbstractNetworkJob *> _currentlyFetching;
 
     friend class TestActivityModel;
 };

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -207,10 +207,6 @@ void ownCloudGui::slotSyncStateChange(Folder *folder)
     auto result = folder->syncResult();
 
     qCInfo(lcApplication) << "Sync state changed for folder " << folder->remoteUrl().toString() << ": " << Utility::enumToDisplayName(result.status());
-
-    if (result.status() == SyncResult::NotYetStarted) {
-        _settingsDialog->slotRefreshActivity(folder->accountState());
-    }
 }
 
 void ownCloudGui::slotFoldersChanged()

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -61,8 +61,6 @@ public slots:
     void showActivityPage();
     void showIssuesList();
     void slotSwitchPage(QAction *action);
-    void slotRefreshActivity(const AccountStatePtr &accountState);
-    void slotRefreshActivityAccountStateSender();
     void slotAccountAvatarChanged();
     void slotAccountDisplayNameChanged();
 


### PR DESCRIPTION
I debugged a bit more and it turned out that the activitywidget.cpp class was keeping a reference to the shared pointer.
This commit only cleans the internal state which was previously guarded in the sender.

Testing: Please test removal of an account followed with interactions with the activities view.