### PR TITLE
Update the description of the commandline switch `-s`

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -127,7 +127,7 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     parser.addOption(showSettingsLegacyOption);
 
     auto showOption =
-        addOption({{QStringLiteral("s"), QStringLiteral("show")}, QStringLiteral("Show the main window. By default the client is started in the background.")});
+        addOption({{QStringLiteral("s"), QStringLiteral("show")}, QStringLiteral("Start with the main window visible, or if it is already running, bring it to the front. By default, the client launches in the background.")});
     auto quitInstanceOption = addOption({{QStringLiteral("q"), QStringLiteral("quit")}, QStringLiteral("Quit the running instance.")});
     auto logFileOption = addOption({QStringLiteral("logfile"), QStringLiteral("Write log to file (use - to write to stdout)."), QStringLiteral("filename")});
     auto logDirOption = addOption({QStringLiteral("logdir"), QStringLiteral("Write each sync log output in a new file in folder."), QStringLiteral("name")});


### PR DESCRIPTION
Fixes: #10996


```
Usage: C:\CraftRoot\download\git\owncloud\owncloud-client\cmake-build-debug\bin\owncloud.exe [options] [<vfs file>]
ownCloud version 5.0.0-git
File synchronization desktop utility.


For more information, see https://www.owncloud.com

Options:
  -?, -h, --help         Displays help on commandline options.
  --help-all             Displays help including Qt specific options.
  -v, --version          Displays version information.
  -s, --show             Start with the main window visible, or if it is already running, bring it to the front. By default, the client launches in the background.
  -q, --quit             Quit the running instance.
  --logfile <filename>   Write log to file (use - to write to stdout).
  --logdir <name>        Write each sync log output in a new file in folder.
  --logflush             Flush the log file after every write.
  --logdebug             Output debug-level messages in the log.
  --language <language>  Override UI language.
  --list-languages       Lists available translations, see --language.
  --confdir <dirname>    Use the given configuration folder.
  --debug                Enable debug mode.

Arguments:
  vfs file               Virtual file system file to be opened (optional).
```