### PR TITLE
Fix persisting filter settings in activity tab

### DIFF
--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -145,19 +145,23 @@ private:
 
     void restoreFilter()
     {
-        StatusSet filter;
+        StatusSet filter = {};
         bool filterNeedsReset = true; // If there is no filter, the `true` value will cause a reset.
-        QStringList checked = ConfigFile().issuesWidgetFilter();
+        std::optional<QStringList> checked = ConfigFile().issuesWidgetFilter();
 
-        for (const QString &s : checked) {
-            auto status = Utility::stringToEnum<SyncFileItem::Status>(s);
-            if (static_cast<int8_t>(status) == -1) {
-                // The string value is not a valid enum value, so stop processing, and queue a reset.
-                filterNeedsReset = true;
-                break;
-            } else {
-                filter[status] = true;
-                filterNeedsReset = false;
+        if (checked.has_value()) {
+            // There is a filter, but it can be empty (user unchecked all checkboxes), and in that case we do not want to reset the filter.
+            filterNeedsReset = false;
+
+            for (const QString &s : checked.value()) {
+                auto status = Utility::stringToEnum<SyncFileItem::Status>(s);
+                if (static_cast<int8_t>(status) == -1) {
+                    // The string value is not a valid enum value, so stop processing, and queue a reset.
+                    filterNeedsReset = true;
+                    break;
+                } else {
+                    filter[status] = true;
+                }
             }
         }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -140,10 +140,14 @@ bool ConfigFile::optionalDesktopNotifications() const
     return settings.value(optionalDesktopNoficationsC(), true).toBool();
 }
 
-QStringList ConfigFile::issuesWidgetFilter() const
+std::optional<QStringList> ConfigFile::issuesWidgetFilter() const
 {
     auto settings = makeQSettings();
-    return settings.value(issuesWidgetFilterC()).toStringList();
+    if (settings.contains(issuesWidgetFilterC())) {
+        return settings.value(issuesWidgetFilterC()).toStringList();
+    }
+
+    return {};
 }
 
 void ConfigFile::setIssuesWidgetFilter(const QStringList &checked)

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -155,7 +155,7 @@ public:
     bool optionalDesktopNotifications() const;
     void setOptionalDesktopNotifications(bool show);
 
-    QStringList issuesWidgetFilter() const;
+    std::optional<QStringList> issuesWidgetFilter() const;
     void setIssuesWidgetFilter(const QStringList &checked);
 
     std::chrono::seconds timeout() const;


### PR DESCRIPTION
There were two issues: first, the StatusSet was not initialised, thus containing random values. Second, no difference was made between an empty filter list, and an absent filter list (the latter would cause the filter to be reset). Both are fixed now.

Fixes: #10881