### PR TITLE
[tests-only] [full-ci] Given step implementation for creating folder in the server

### DIFF
--- a/test/gui/shared/scripts/helpers/api/webdav_helper.py
+++ b/test/gui/shared/scripts/helpers/api/webdav_helper.py
@@ -48,3 +48,11 @@ def get_folder_items_count(user, folder_name):
             ):
                 total_items += 1
     return str(total_items)
+
+
+def create_folder(user, folder_name):
+    url = get_resource_path(user, folder_name)
+    response = request.mkcol(url, user=user)
+    assert (
+        response.status_code == 201
+    ), f"Could not create the folder: {folder_name} for user {user}"

--- a/test/gui/shared/steps/file_context.py
+++ b/test/gui/shared/steps/file_context.py
@@ -146,7 +146,6 @@ def step(context, filePath):
 @Then(r'^the (file|folder) "([^"]*)" should exist on the file system$', regexp=True)
 def step(context, resourceType, resource):
     resourcePath = getResourcePath(resource)
-    print(resourcePath)
     resourceExists = False
     if resourceType == 'file':
         resourceExists = fileExists(resourcePath, get_config('maxSyncTimeout') * 1000)

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -154,7 +154,10 @@ def step(context, resource_name, public_link_password, link_creator):
 def step(context, user_name, folder_name, items_number):
     total_items = webdav.get_folder_items_count(user_name, folder_name)
     test.compare(
-        total_items,
-        items_number,
-        f"Folder should contain {items_number} items",
+        total_items, items_number, f"Folder should contain {items_number} items"
     )
+
+
+@Given('user "|any|" has created folder "|any|" in the server')
+def step(context, user, folder_name):
+    webdav.create_folder(user, folder_name)

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -81,7 +81,7 @@ Feature: adding accounts
 
     @skipOnOC10
     Scenario: Add space manually from sync connection window
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And the user has started the client
         And the user has added the following account information:
             | server   | %local_server% |

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -22,7 +22,7 @@ Feature: deleting files and folders
 
     @issue-9439
     Scenario Outline: Delete a folder
-        Given user "Alice" has created folder "<folderName>" on the server
+        Given user "Alice" has created folder "<folderName>" in the server
         And user "Alice" has set up a client with default settings
         When the user deletes the folder "<folderName>"
         And the user waits for the files to sync
@@ -36,11 +36,11 @@ Feature: deleting files and folders
     Scenario: Delete a file and a folder
         Given user "Alice" has uploaded file with content "test file 1" to "textfile1.txt" on the server
         And user "Alice" has uploaded file with content "test file 2" to "textfile2.txt" on the server
-        And user "Alice" has created folder "test-folder1" on the server
-        And user "Alice" has created folder "test-folder2" on the server
+        And user "Alice" has created folder "test-folder1" in the server
+        And user "Alice" has created folder "test-folder2" in the server
         And user "Alice" has set up a client with default settings
         When the user deletes the file "textfile1.txt"
-        And the user deletes the folder "test-folder1" 
+        And the user deletes the folder "test-folder1"
         And the user waits for the files to sync
         Then as "Alice" file "textfile1.txt" should not exist in the server
         And as "Alice" folder "test-folder1" should not exist in the server

--- a/test/gui/tst_moveFilesFolders/test.feature
+++ b/test/gui/tst_moveFilesFolders/test.feature
@@ -7,29 +7,29 @@ Feature: move file and folder
 
     Background:
         Given user "Alice" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "folder1" on the server
-        And user "Alice" has created folder "folder1/folder2" on the server
-        And user "Alice" has created folder "folder1/folder2/folder3" on the server
-        And user "Alice" has created folder "folder1/folder2/folder3/folder4" on the server
-        And user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5" on the server
+        And user "Alice" has created folder "folder1" in the server
+        And user "Alice" has created folder "folder1/folder2" in the server
+        And user "Alice" has created folder "folder1/folder2/folder3" in the server
+        And user "Alice" has created folder "folder1/folder2/folder3/folder4" in the server
+        And user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5" in the server
 
 
     Scenario: Move folder and file from level 5 sub-folder to sync root
-        Given user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5/test-folder" on the server
+        Given user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5/test-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud" to "folder1/folder2/folder3/folder4/folder5/lorem.txt" on the server
         And user "Alice" has set up a client with default settings
         When user "Alice" moves file "folder1/folder2/folder3/folder4/folder5/lorem.txt" to "/" in the sync folder
         And user "Alice" moves folder "folder1/folder2/folder3/folder4/folder5/test-folder" to "/" in the sync folder
         And the user waits for the files to sync
-        Then as "Alice" the file "lorem.txt" should have the content "ownCloud" in the server 
+        Then as "Alice" the file "lorem.txt" should have the content "ownCloud" in the server
         And as "Alice" folder "test-folder" should exist in the server
         And as "Alice" file "folder1/folder2/folder3/folder4/folder5/lorem.txt" should not exist in the server
         And as "Alice" folder "folder1/folder2/folder3/folder4/folder5/test-folder" should not exist in the server
 
 
     Scenario: Move two folders and a file down to the level 5 sub-folder
-        And user "Alice" has created folder "test-folder1" on the server
-        And user "Alice" has created folder "test-folder2" on the server
+        And user "Alice" has created folder "test-folder1" in the server
+        And user "Alice" has created folder "test-folder2" in the server
         And user "Alice" has uploaded file with content "ownCloud test" to "testFile.txt" on the server
         And user "Alice" has set up a client with default settings
         When user "Alice" moves folder "test-folder1" to "folder1/folder2/folder3/folder4/folder5" in the sync folder

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -13,7 +13,7 @@ Feature: Sharing
     @smokeTest
     Scenario: simple sharing with user
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user adds "Brian Murphy" as collaborator of resource "textfile0.txt" with permissions "edit,share" using the client-UI
@@ -26,8 +26,8 @@ Feature: Sharing
 
     Scenario: sharing file and folder with user who has some other shares
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "shared" on the server
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "shared" in the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
         And user "Alice" has uploaded file with content "shared file" to "sharedfile.txt" on the server
         And user "Alice" has shared folder "shared" on the server with user "Brian" with "all" permissions
@@ -45,7 +45,7 @@ Feature: Sharing
 
     Scenario: sharing file/folder with a user that has special characters as username
         Given user "Speci@l_Name-.+" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "FOLDER" on the server
+        And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
@@ -59,7 +59,7 @@ Feature: Sharing
 
     Scenario: Share files/folders with special characters in their name
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "SampleFolder,With,$pecial?Characters" on the server
+        And user "Alice" has created folder "SampleFolder,With,$pecial?Characters" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/$ample1?.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user adds "Brian Murphy" as collaborator of resource "SampleFolder,With,$pecial?Characters" with permissions "edit,share" using the client-UI
@@ -72,7 +72,7 @@ Feature: Sharing
 
     Scenario: try to share a file/folder with a user to whom the file has already been shared
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "SharedFolder" on the server
+        And user "Alice" has created folder "SharedFolder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
         And user "Alice" has shared folder "SharedFolder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -88,7 +88,7 @@ Feature: Sharing
 
     Scenario: try to self share a file/folder
         Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
-        And user "Alice" has created folder "OwnFolder" on the server
+        And user "Alice" has created folder "OwnFolder" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         And the user selects "Alice Hansen" as collaborator of resource "textfile.txt" using the client-UI
@@ -147,7 +147,7 @@ Feature: Sharing
     Scenario: Collaborator should not see to whom a file/folder is shared.
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has created folder "Folder" on the server
+        And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share" permission
         And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share" permission
         And user "Brian" has set up a client with default settings
@@ -163,7 +163,7 @@ Feature: Sharing
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Brian" has been added to group "grp1" on the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user adds group "grp1" as collaborator of resource "textfile0.txt" with permissions "edit,share" using the client-UI
         Then group "grp1" should be listed in the collaborators list for file "textfile0.txt" with permissions "edit,share" on the client-UI
@@ -178,7 +178,7 @@ Feature: Sharing
         And group "grp1" has been created on the server
         And user "Brian" on the server has been added to group "grp1"
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has created folder "Folder" on the server
+        And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share, update" permission
         And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share, update" permission
         And user "Alice" has shared file "/textfile0.txt" on the server with group "grp1" with "read, share, update" permission
@@ -192,7 +192,7 @@ Feature: Sharing
 
 
     Scenario: sharee edits content of files shared by sharer
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "file inside a folder" to "simple-folder/textfile.txt" on the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
@@ -210,7 +210,7 @@ Feature: Sharing
 
 
     Scenario: sharee tries to edit content of files shared without write permission
-        Given user "Alice" has created folder "Parent" on the server
+        Given user "Alice" has created folder "Parent" in the server
         And user "Alice" has uploaded file with content "file inside a folder" to "Parent/textfile.txt" on the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
@@ -228,7 +228,7 @@ Feature: Sharing
 
     Scenario: sharee edits shared files and again try to edit after write permission is revoked
         Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
-        And user "Alice" has created folder "FOLDER" on the server
+        And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "some content" to "FOLDER/simple.txt" on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -251,7 +251,7 @@ Feature: Sharing
 
 
     Scenario: sharee creates a file and a folder inside a shared folder
-        Given user "Alice" has created folder "Parent" on the server
+        Given user "Alice" has created folder "Parent" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -269,7 +269,7 @@ Feature: Sharing
 
 
     Scenario: sharee tries to create a file and a folder inside a shared folder without write permission
-        Given user "Alice" has created folder "Parent" on the server
+        Given user "Alice" has created folder "Parent" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
@@ -288,7 +288,7 @@ Feature: Sharing
 
     Scenario: sharee renames the shared file and folder
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
-        And user "Alice" has created folder "FOLDER" on the server
+        And user "Alice" has created folder "FOLDER" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
@@ -310,7 +310,7 @@ Feature: Sharing
     @issue-9439
     Scenario: sharee deletes a file and folder shared by sharer
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
-        And user "Alice" has created folder "Folder" on the server
+        And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "all" permissions
@@ -326,7 +326,7 @@ Feature: Sharing
 
     Scenario: sharee tries to delete shared file and folder without permissions
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
-        And user "Alice" has created folder "Folder" on the server
+        And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "read" permissions
@@ -344,7 +344,7 @@ Feature: Sharing
     Scenario: reshare a file/folder
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "FOLDER" on the server
+        And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -360,7 +360,7 @@ Feature: Sharing
     Scenario: try to reshare a file/folder shared without share permission
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "FOLDER" on the server
+        And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
@@ -374,7 +374,7 @@ Feature: Sharing
     Scenario: unshare a shared file and folder
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" on the server
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has shared file "textfile0.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
@@ -418,8 +418,8 @@ Feature: Sharing
     @smokeTest
     Scenario: simple sharing of file and folder by public link without password
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has created folder "simple-folder" on the server
-        And user "Alice" has created folder "simple-folder/child" on the server
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "simple-folder/child" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
         And the user closes the sharing dialog
@@ -432,7 +432,7 @@ Feature: Sharing
 
     Scenario Outline: simple sharing of file and folder by public link with password
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
         And the user closes the sharing dialog
@@ -482,7 +482,7 @@ Feature: Sharing
 
     @issue-9321
     Scenario: simple sharing of file and folder by public link with expiration date
-        Given user "Alice" has created folder "FOLDER" on the server
+        Given user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
@@ -528,7 +528,7 @@ Feature: Sharing
 
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for folder using client-UI
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created a public link on the server with following settings
             | path        | simple-folder                |
             | name        | Public link                  |
@@ -543,7 +543,7 @@ Feature: Sharing
 
 
     Scenario Outline: simple sharing of folder by public link with different roles
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for folder "simple-folder" using the client-UI with these details:
             | role | <role> |
@@ -562,7 +562,7 @@ Feature: Sharing
 
 
     Scenario: sharing a folder by public link with "Uploader" role and check if file can be downloaded
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created file "simple-folder/lorem.txt" on the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for folder "simple-folder" using the client-UI with these details:
@@ -579,7 +579,7 @@ Feature: Sharing
 
     Scenario Outline: change collaborator permissions of a file & folder
         Given the administrator on the server has set the default folder for received shares to "Shares"
-        And user "Alice" has created folder "simple-folder" on the server
+        And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created file "lorem.txt" on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -15,12 +15,12 @@ Feature: Syncing files
             test content
             """
         And the user waits for file "lorem-for-upload.txt" to be synced
-        Then as "Alice" the file "lorem-for-upload.txt" should have the content "test content" in the server 
+        Then as "Alice" the file "lorem-for-upload.txt" should have the content "test content" in the server
 
 
     Scenario: Syncing all files and folders from the server
-        Given user "Alice" has created folder "simple-folder" on the server
-        And user "Alice" has created folder "large-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "large-folder" in the server
         And user "Alice" has uploaded file on the server with content "test content" to "uploaded-lorem.txt"
         And user "Alice" has set up a client with default settings
         Then the file "uploaded-lorem.txt" should exist on the file system
@@ -56,8 +56,8 @@ Feature: Syncing files
 
     @skipOnOCIS
     Scenario: Sync all is selected by default
-        Given user "Alice" has created folder "simple-folder" on the server
-        And user "Alice" has created folder "large-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "large-folder" in the server
         And the user has started the client
         And the user has added the following account information:
             | server   | %local_server% |
@@ -70,8 +70,8 @@ Feature: Syncing files
 
     @skipOnOCIS
     Scenario: Sync only one folder from the server
-        Given user "Alice" has created folder "simple-folder" on the server
-        And user "Alice" has created folder "large-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "large-folder" in the server
         And the user has started the client
         And the user has added the following account information:
             | server   | %local_server% |
@@ -88,11 +88,11 @@ Feature: Syncing files
 
     @issue-9733 @skipOnOCIS
     Scenario: sort folders list by name and size
-        Given user "Alice" has created folder "123Folder" on the server
+        Given user "Alice" has created folder "123Folder" in the server
         And user "Alice" has uploaded file on the server with content "small" to "123Folder/lorem.txt"
-        And user "Alice" has created folder "aFolder" on the server
+        And user "Alice" has created folder "aFolder" in the server
         And user "Alice" has uploaded file on the server with content "more contents" to "aFolder/lorem.txt"
-        And user "Alice" has created folder "bFolder" on the server
+        And user "Alice" has created folder "bFolder" in the server
         And the user has started the client
         And the user has added the following account information:
             | server   | %local_server% |
@@ -143,7 +143,7 @@ Feature: Syncing files
 
 
     Scenario: Many subfolders can be synced
-        Given user "Alice" has created folder "parent" on the server
+        Given user "Alice" has created folder "parent" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "parent/subfolderEmpty1" inside the sync folder
         And user "Alice" creates a folder "parent/subfolderEmpty2" inside the sync folder
@@ -198,7 +198,7 @@ Feature: Syncing files
 
     @issue-9281
     Scenario: Verify that you can create a subfolder with long name
-        Given user "Alice" has created folder "Folder1" on the server
+        Given user "Alice" has created folder "Folder1" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" inside the sync folder
         And the user waits for folder "Folder1/really long folder name with some spaces and special char such as $%ñ&" to be synced
@@ -216,7 +216,7 @@ Feature: Syncing files
 
 
     Scenario: Filenames that are rejected by the server are reported
-        Given user "Alice" has created folder "Folder1" on the server
+        Given user "Alice" has created folder "Folder1" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a file "Folder1/a\\a.txt" with the following content inside the sync folder
             """
@@ -229,7 +229,7 @@ Feature: Syncing files
 
 
     Scenario Outline: Verify one empty folder with a length longer than the allowed limit will not be synced
-        Given user "Alice" has created folder "<foldername>" on the server
+        Given user "Alice" has created folder "<foldername>" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a folder "<foldername>/<foldername>" inside the sync folder
         And user "Alice" creates a folder "<foldername>/<foldername>/<foldername>" inside the sync folder
@@ -246,8 +246,8 @@ Feature: Syncing files
 
 
     Scenario: Invalid system names are synced in linux
-        Given user "Alice" has created folder "CON" on the server
-        And user "Alice" has created folder "test%" on the server
+        Given user "Alice" has created folder "CON" in the server
+        And user "Alice" has created folder "test%" in the server
         And user "Alice" has uploaded file on the server with content "server content" to "/PRN"
         And user "Alice" has uploaded file on the server with content "server content" to "/foo%"
         And user "Alice" has set up a client with default settings
@@ -262,7 +262,7 @@ Feature: Syncing files
 
 
     Scenario: various types of files can be synced from server to client
-        Given user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file "testavatar.png" to "simple-folder/testavatar.png" on the server
         And user "Alice" has uploaded file "testavatar.jpg" to "simple-folder/testavatar.jpg" on the server
         And user "Alice" has uploaded file "testavatar.jpeg" to "simple-folder/testavatar.jpeg" on the server


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
This `Given` step implementation creates folder in the server.

Renamed step:

```diff
-Given user "<user>" has created folder "<folderName>" on the server
+Given user "<user>" has created folder "<folderName>" in the server
```
Part of https://github.com/owncloud/client/issues/10432
