### PR TITLE
Handle "selected sync destination is unusable" case better in setup wizard

### DIFF
--- a/src/gui/newwizard/enums.h
+++ b/src/gui/newwizard/enums.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "common/utility.h"
-#include "enums.h"
 
 #include <QObject>
 

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.cpp
@@ -187,4 +187,9 @@ bool AccountConfiguredWizardPage::validateInput()
     // nothing to validate here
     return true;
 }
+
+void AccountConfiguredWizardPage::setShowAdvancedSettings(bool showAdvancedSettings)
+{
+    _ui->advancedConfigGroupBox->setChecked(showAdvancedSettings);
+}
 }

--- a/src/gui/newwizard/pages/accountconfiguredwizardpage.h
+++ b/src/gui/newwizard/pages/accountconfiguredwizardpage.h
@@ -39,6 +39,8 @@ public:
 
     bool validateInput() override;
 
+    void setShowAdvancedSettings(bool showAdvancedSettings);
+
 private:
     ::Ui::AccountConfiguredWizardPage *_ui;
 };

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -184,6 +184,11 @@ void SetupWizardAccountBuilder::setDefaultSyncTargetDir(const QString &syncTarge
     _defaultSyncTargetDir = syncTargetDir;
 }
 
+QString SetupWizardAccountBuilder::defaultSyncTargetDir() const
+{
+    return _defaultSyncTargetDir;
+}
+
 QString SetupWizardAccountBuilder::legacyWebFingerUsername() const
 {
     return _legacyWebFingerUsername;

--- a/src/gui/newwizard/setupwizardaccountbuilder.h
+++ b/src/gui/newwizard/setupwizardaccountbuilder.h
@@ -145,6 +145,7 @@ public:
 
     // getter is not needed at the moment
     void setDefaultSyncTargetDir(const QString &syncTargetDir);
+    QString defaultSyncTargetDir() const;
 
     /**
      * Store custom CA certificate for the newly built account.

--- a/src/gui/newwizard/setupwizardcontroller.h
+++ b/src/gui/newwizard/setupwizardcontroller.h
@@ -20,6 +20,7 @@
 #include "pages/abstractsetupwizardpage.h"
 #include "setupwizardaccountbuilder.h"
 #include "setupwizardcontext.h"
+#include "setupwizardcontroller_p.h"
 #include "setupwizardwindow.h"
 #include "states/abstractsetupwizardstate.h"
 
@@ -53,7 +54,7 @@ Q_SIGNALS:
     void finished(AccountPtr newAccount, SyncMode syncMode, const QVariantMap &dynamicRegistrationData);
 
 private:
-    void changeStateTo(SetupWizardState nextState);
+    void changeStateTo(SetupWizardState nextState, SetupWizardControllerPrivate::ChangeReason reason = SetupWizardControllerPrivate::ChangeReason::Default);
 
     SetupWizardContext *_context = nullptr;
 

--- a/src/gui/newwizard/setupwizardcontroller_p.h
+++ b/src/gui/newwizard/setupwizardcontroller_p.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QtGlobal>
+
+namespace OCC::Wizard::SetupWizardControllerPrivate {
+
+Q_NAMESPACE
+
+enum class ChangeReason {
+    Default,
+    EvaluationFailed,
+};
+Q_ENUM_NS(ChangeReason)
+
+}


### PR DESCRIPTION
Fixes #10680.

This PR makes sure to "unhide" the advanced settings whenever the selected/default sync root is unavailable (tested with `/dev/null`). It also remembers the user's last input, initializing the sync root with a default value only once, allowing users to easily edit their last value.

Note: this does _not_, in any way, block the Finish button. We never live-check such data anywhere else (e.g., checking "can we login already", asking upon every single button press to enable the button only once it works). It's by design to run more advanced checks when the user clicks on "Next" resp. "Finish".

![screenshot_2023-07-12_12-07-31](https://github.com/owncloud/client/assets/80399010/07a27d05-1091-471b-ba8e-924d946e5afa)
