### PR TITLE
Fix power notification handling on macOS

### DIFF
--- a/src/libsync/platform_mac.mm
+++ b/src/libsync/platform_mac.mm
@@ -120,7 +120,15 @@ private:
             /* Announces that the system is beginning to power the device tree; most devices
              * are still unavailable at this point.
              */
-            qCInfo(OCC::lcPlatform) << "System power message: system will power on.";
+            /* From the documentation:
+             *
+             * - kIOMessageSystemWillPowerOn is delivered at early wakeup time, before most hardware
+             * has been powered on. Be aware that any attempts to access disk, network, the display,
+             * etc. may result in errors or blocking your process until those resources become
+             * available.
+             *
+             * So we do NOT log this event.
+             */
             break;
 
         case kIOMessageSystemHasPoweredOn:


### PR DESCRIPTION
We tried to log when we got a `kIOMessageSystemWillPowerOn`, which could cause errors. This notification is not useful to us, so just don't log anything. The notification `kIOMessageSystemHasPoweredOn` is useful, and we log that, so that should be sufficient.