### PR TITLE
[tests-only] [full-ci] Upload file in server

### DIFF
--- a/test/gui/shared/scripts/helpers/api/webdav_helper.py
+++ b/test/gui/shared/scripts/helpers/api/webdav_helper.py
@@ -56,3 +56,11 @@ def create_folder(user, folder_name):
     assert (
         response.status_code == 201
     ), f"Could not create the folder: {folder_name} for user {user}"
+
+
+def create_file(user, file_name, contents):
+    url = get_resource_path(user, file_name)
+    response = request.put(url, body=contents, user=user)
+    assert (
+        response.status_code == 201
+    ), f"Could not create file '{file_name}' for user {user}"

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -161,3 +161,8 @@ def step(context, user_name, folder_name, items_number):
 @Given('user "|any|" has created folder "|any|" in the server')
 def step(context, user, folder_name):
     webdav.create_folder(user, folder_name)
+
+
+@Given('user "|any|" has uploaded file with content "|any|" to "|any|" in the server')
+def step(context, user, file_content, file_name):
+    webdav.create_file(user, file_name, file_content)

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -10,7 +10,7 @@ Feature: deleting files and folders
 
     @issue-9439
     Scenario Outline: Delete a file
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "<fileName>" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "<fileName>" in the server
         And user "Alice" has set up a client with default settings
         When the user deletes the file "<fileName>"
         And the user waits for the files to sync
@@ -34,8 +34,8 @@ Feature: deleting files and folders
 
 
     Scenario: Delete a file and a folder
-        Given user "Alice" has uploaded file with content "test file 1" to "textfile1.txt" on the server
-        And user "Alice" has uploaded file with content "test file 2" to "textfile2.txt" on the server
+        Given user "Alice" has uploaded file with content "test file 1" to "textfile1.txt" in the server
+        And user "Alice" has uploaded file with content "test file 2" to "textfile2.txt" in the server
         And user "Alice" has created folder "test-folder1" in the server
         And user "Alice" has created folder "test-folder2" in the server
         And user "Alice" has set up a client with default settings

--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -10,7 +10,7 @@ Feature: edit files
 
 
     Scenario: Modify orignal content of a file with special character
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "S@mpleFile!With,$pecial?Characters.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "S@mpleFile!With,$pecial?Characters.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user overwrites the file "S@mpleFile!With,$pecial?Characters.txt" with content "overwrite ownCloud test text file"
         And the user waits for file "S@mpleFile!With,$pecial?Characters.txt" to be synced

--- a/test/gui/tst_moveFilesFolders/test.feature
+++ b/test/gui/tst_moveFilesFolders/test.feature
@@ -16,7 +16,7 @@ Feature: move file and folder
 
     Scenario: Move folder and file from level 5 sub-folder to sync root
         Given user "Alice" has created folder "folder1/folder2/folder3/folder4/folder5/test-folder" in the server
-        And user "Alice" has uploaded file with content "ownCloud" to "folder1/folder2/folder3/folder4/folder5/lorem.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud" to "folder1/folder2/folder3/folder4/folder5/lorem.txt" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" moves file "folder1/folder2/folder3/folder4/folder5/lorem.txt" to "/" in the sync folder
         And user "Alice" moves folder "folder1/folder2/folder3/folder4/folder5/test-folder" to "/" in the sync folder
@@ -30,7 +30,7 @@ Feature: move file and folder
     Scenario: Move two folders and a file down to the level 5 sub-folder
         And user "Alice" has created folder "test-folder1" in the server
         And user "Alice" has created folder "test-folder2" in the server
-        And user "Alice" has uploaded file with content "ownCloud test" to "testFile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test" to "testFile.txt" in the server
         And user "Alice" has set up a client with default settings
         When user "Alice" moves folder "test-folder1" to "folder1/folder2/folder3/folder4/folder5" in the sync folder
         And user "Alice" moves folder "test-folder2" to "folder1/folder2/folder3/folder4/folder5" in the sync folder
@@ -45,7 +45,7 @@ Feature: move file and folder
 
 
     Scenario: Rename a file and a folder
-        Given user "Alice" has uploaded file with content "test file 1" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "test file 1" to "textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user renames a file "textfile.txt" to "lorem.txt"
         And the user renames a folder "folder1" to "FOLDER"

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -14,7 +14,7 @@ Feature: Sharing
     Scenario: simple sharing with user
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user adds "Brian Murphy" as collaborator of resource "textfile0.txt" with permissions "edit,share" using the client-UI
         And the user adds "Brian Murphy" as collaborator of resource "simple-folder" with permissions "edit,share" using the client-UI
@@ -28,8 +28,8 @@ Feature: Sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "shared" in the server
         And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
-        And user "Alice" has uploaded file with content "shared file" to "sharedfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
+        And user "Alice" has uploaded file with content "shared file" to "sharedfile.txt" in the server
         And user "Alice" has shared folder "shared" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "sharedfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
@@ -46,7 +46,7 @@ Feature: Sharing
     Scenario: sharing file/folder with a user that has special characters as username
         Given user "Speci@l_Name-.+" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "FOLDER" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         And the user adds "Speci@l_Name-.+" as collaborator of resource "textfile.txt" with permissions "edit,share" using the client-UI
@@ -60,7 +60,7 @@ Feature: Sharing
     Scenario: Share files/folders with special characters in their name
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "SampleFolder,With,$pecial?Characters" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/$ample1?.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/$ample1?.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user adds "Brian Murphy" as collaborator of resource "SampleFolder,With,$pecial?Characters" with permissions "edit,share" using the client-UI
         And the user adds "Brian Murphy" as collaborator of resource "$ample1?.txt" with permissions "edit,share" using the client-UI
@@ -73,7 +73,7 @@ Feature: Sharing
     Scenario: try to share a file/folder with a user to whom the file has already been shared
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "SharedFolder" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has shared folder "SharedFolder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
@@ -87,7 +87,7 @@ Feature: Sharing
 
 
     Scenario: try to self share a file/folder
-        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has created folder "OwnFolder" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
@@ -102,7 +102,7 @@ Feature: Sharing
     Scenario: search for users with minimum autocomplete characters
         Given user "TestUser1" has been created on the server with default attributes and without skeleton files
         And user "TestUser2" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         And the user searches for collaborator with autocomplete characters "Tes" using the client-UI
@@ -118,7 +118,7 @@ Feature: Sharing
         And user "TestUser1" has been created on the server with default attributes and without skeleton files
         And user "TestUser2" has been created on the server with default attributes and without skeleton files
         And user "TestUser3" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "textfile.txt" on the server with user "Carol" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "TestUser1" with "all" permissions
@@ -136,7 +136,7 @@ Feature: Sharing
 
     @issue-7459
     Scenario: Progress indicator should not be visible after unselecting the password protection checkbox while sharing through public link
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user toggles the password protection using the client-UI
@@ -146,7 +146,7 @@ Feature: Sharing
 
     Scenario: Collaborator should not see to whom a file/folder is shared.
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share" permission
         And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share" permission
@@ -162,7 +162,7 @@ Feature: Sharing
         Given group "grp1" has been created on the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Brian" has been added to group "grp1" on the server
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user adds group "grp1" as collaborator of resource "textfile0.txt" with permissions "edit,share" using the client-UI
@@ -177,7 +177,7 @@ Feature: Sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And group "grp1" has been created on the server
         And user "Brian" on the server has been added to group "grp1"
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share, update" permission
         And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share, update" permission
@@ -193,8 +193,8 @@ Feature: Sharing
 
     Scenario: sharee edits content of files shared by sharer
         Given user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has uploaded file with content "file inside a folder" to "simple-folder/textfile.txt" on the server
-        And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "file inside a folder" to "simple-folder/textfile.txt" in the server
+        And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -211,8 +211,8 @@ Feature: Sharing
 
     Scenario: sharee tries to edit content of files shared without write permission
         Given user "Alice" has created folder "Parent" in the server
-        And user "Alice" has uploaded file with content "file inside a folder" to "Parent/textfile.txt" on the server
-        And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "file inside a folder" to "Parent/textfile.txt" in the server
+        And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
@@ -227,9 +227,9 @@ Feature: Sharing
 
 
     Scenario: sharee edits shared files and again try to edit after write permission is revoked
-        Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has created folder "FOLDER" in the server
-        And user "Alice" has uploaded file with content "some content" to "FOLDER/simple.txt" on the server
+        And user "Alice" has uploaded file with content "some content" to "FOLDER/simple.txt" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared folder "FOLDER" on the server with user "Brian" with "all" permissions
@@ -287,7 +287,7 @@ Feature: Sharing
 
 
     Scenario: sharee renames the shared file and folder
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "FOLDER" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -309,7 +309,7 @@ Feature: Sharing
 
     @issue-9439
     Scenario: sharee deletes a file and folder shared by sharer
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -325,7 +325,7 @@ Feature: Sharing
 
 
     Scenario: sharee tries to delete shared file and folder without permissions
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
@@ -345,7 +345,7 @@ Feature: Sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "FOLDER" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -361,7 +361,7 @@ Feature: Sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
         And user "Alice" has created folder "FOLDER" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
@@ -373,7 +373,7 @@ Feature: Sharing
 
     Scenario: unshare a shared file and folder
         Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has shared file "textfile0.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
@@ -391,7 +391,7 @@ Feature: Sharing
         Given user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
         And user "David" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user adds following collaborators of resource "textfile0.txt" using the client-UI
             | user         | permissions |
@@ -406,7 +406,7 @@ Feature: Sharing
 
     @issue-7423
     Scenario: unshare a reshared file
-        Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Brian" has been created on the server with default attributes and without skeleton files
         And user "Carol" has been created on the server with default attributes and without skeleton files
         And user "Alice" has shared folder "textfile.txt" on the server with user "Brian"
@@ -417,7 +417,7 @@ Feature: Sharing
 
     @smokeTest
     Scenario: simple sharing of file and folder by public link without password
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created folder "simple-folder/child" in the server
         And user "Alice" has set up a client with default settings
@@ -431,7 +431,7 @@ Feature: Sharing
 
 
     Scenario Outline: simple sharing of file and folder by public link with password
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
@@ -448,7 +448,7 @@ Feature: Sharing
 
 
     Scenario: sharing of a file by public link and deleting the link
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created a public link on the server with following settings
             | path     | textfile0.txt |
             | name     | Public-link   |
@@ -458,7 +458,7 @@ Feature: Sharing
 
 
     Scenario: sharing of a file by public link with password and changing the password
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created a public link on the server with following settings
             | path     | textfile0.txt |
             | name     | Public-link   |
@@ -471,7 +471,7 @@ Feature: Sharing
 
 
     Scenario: simple sharing of a file by public link with default expiration date
-        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
@@ -483,7 +483,7 @@ Feature: Sharing
     @issue-9321
     Scenario: simple sharing of file and folder by public link with expiration date
         Given user "Alice" has created folder "FOLDER" in the server
-        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
@@ -501,7 +501,7 @@ Feature: Sharing
 
     @issue-9321
     Scenario: simple sharing of a file by public link with password and expiration date
-        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
@@ -514,7 +514,7 @@ Feature: Sharing
 
     @skip @issue-9321
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
-        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" on the server
+        Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created a public link on the server with following settings
             | path       | textfile0.txt |
             | name       | Public link   |


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
This `Given` step implementation uploads file with some contents in the server.

Renamed step:

```diff
-Given user "<user>" has uploaded file with content "<content>" to "<fileName>" on the server
+Given user "<user>" has uploaded file with content "<content>" to "<fileName>" in the server
```
Part of https://github.com/owncloud/client/issues/10432
