### PR TITLE
Remove saving of legacy `Multifolders` settings entry

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -773,7 +773,6 @@ void Folder::saveToSettings() const
     removeFromSettings();
 
     auto settings = _accountState->settings();
-    QString settingsGroup = QStringLiteral("Multifolders");
 
     // True if the folder path appears in only one account
     bool oneAccountOnly = true;
@@ -784,12 +783,13 @@ void Folder::saveToSettings() const
         }
     }
 
+    QString settingsGroup;
     if (virtualFilesEnabled() || _saveInFoldersWithPlaceholders) {
         // If virtual files are enabled or even were enabled at some point,
         // save the folder to a group that will not be read by older (<2.5.0) clients.
         // The name is from when virtual files were called placeholders.
         settingsGroup = QStringLiteral("FoldersWithPlaceholders");
-    } else if (oneAccountOnly) {
+    } else {
         settingsGroup = QStringLiteral("Folders");
     }
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -204,7 +204,8 @@ qsizetype FolderMan::setupFolders()
 
         process(QStringLiteral("Folders"), false);
         process(QStringLiteral("FoldersWithPlaceholders"), true);
-        // See Folder::saveToSettings for details about why these exists.
+        // We don't save to `Multifolders` anymore, but for backwards compatibility we will just
+        // read it like it is a `Folders` entry.
         process(QStringLiteral("Multifolders"), false);
 
         settings->endGroup(); // Finished processing this account.


### PR DESCRIPTION
The feature that this settings group relates to is not supported for quite some time.

Fixes: #9117