### PR TITLE
Fix KDSingleApplication related startup bug

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -362,33 +362,6 @@ void Utility::crash()
     *a = 1;
 }
 
-// read the output of the owncloud --version command from the owncloud
-// version that is on disk. This works for most versions of the client,
-// because clients that do not yet know the --version flag return the
-// version in the first line of the help output :-)
-//
-// This version only delivers output on linux, as Mac and Win get their
-// restarting from the installer.
-QString Utility::versionOfInstalledBinary(const QString &command)
-{
-    QString binary(command);
-    if (binary.isEmpty()) {
-        binary = qApp->arguments()[0];
-    }
-    QStringList params;
-    params << QStringLiteral("--version");
-    QProcess process;
-    process.start(binary, params);
-    process.waitForFinished(); // sets current thread to sleep and waits for pingProcess end
-    QByteArray re = process.readAllStandardOutput();
-    qCDebug(lcUtility) << Q_FUNC_INFO << re;
-    int newline = re.indexOf('\n');
-    if (newline > 0) {
-        re.truncate(newline);
-    }
-    return QString::fromUtf8(re.trimmed());
-}
-
 QString Utility::timeAgoInWords(const QDateTime &dt, const QDateTime &from)
 {
     QDateTime now = QDateTime::currentDateTimeUtc();

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -15,6 +15,7 @@
 #ifndef OCUPDATER_H
 #define OCUPDATER_H
 
+#include <QDateTime>
 #include <QObject>
 #include <QTemporaryFile>
 #include <QTimer>
@@ -210,7 +211,7 @@ public:
 
 private:
     void versionInfoArrived(const UpdateInfo &info) override;
-    QString _runningAppVersion;
+    const QDateTime _initialAppMTime;
 };
 }
 

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -105,21 +105,6 @@ private slots:
         QCOMPARE(durationToDescriptiveString1(current.msecsTo(current.addDays(2).addSecs(23 * 60 * 60))), QString::fromLatin1("3 day(s)"));
     }
 
-    void testVersionOfInstalledBinary()
-    {
-        // pass the cmd client from our build dir
-        // this is a bit inaccurate as it does not test the "real thing"
-        // but cmd and gui have the same --version handler by now
-        // and cmd works without X in CI
-        QString ver = versionOfInstalledBinary(QStringLiteral(OWNCLOUDCMD_BIN_PATH));
-        qDebug() << "Version of installed ownCloud Binary: " << ver;
-        QVERIFY(!ver.isEmpty());
-
-        QRegularExpression rx(QStringLiteral("ownCloud \\d+\\.\\d+\\.\\d+.*"), QRegularExpression::CaseInsensitiveOption);
-        qDebug() << rx.pattern() << rx.match(ver);
-        QVERIFY(rx.match(ver).isValid());
-    }
-
     void testTimeAgo()
     {
         // Both times in same timezone


### PR DESCRIPTION
In order to notify users of the traditional Linux packages (which are usually updated by the package managers as they are shipped from repositories and therefore lack integrated updater), the updater regularly called itself with `--version` to recognize whether its own version changed (i.e., the package was updated in the background while the client was running).

Due to a change in the commandline parsing, this approach no longer works as `--version` is evaluated only after KDSingleApplication was initialized, causing the client to terminate after a few seconds and therefore rendering it unusable.

The new approach focuses on the application binary's `mtime`. Whenever it changed compared to the timestamp we initially saved when the client started, we assume the binary has changed, i.e., the package was updated in the background.

This approach does not attempt to discover and prevent downgrades. Any change causes a notification to the user, prompting them to restart.