### PR TITLE
Add space id to folder and use it

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1178,13 +1178,6 @@ void Folder::slotWatcherUnreliable(const QString &message)
     ocApp()->gui()->raiseDialog(msgBox);
 }
 
-void Folder::scheduleThisFolderSoon()
-{
-    if (!_scheduleSelfTimer.isActive()) {
-        _scheduleSelfTimer.start();
-    }
-}
-
 void Folder::registerFolderWatcher()
 {
     if (!_folderWatcher.isNull()) {

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -294,17 +294,6 @@ public:
       */
     bool isFileExcludedRelative(const QString &relativePath) const;
 
-    /** Calls schedules this folder on the FolderMan after a short delay.
-     *
-     * This should be used in situations where a sync should be triggered
-     * because a local file was modified. Syncs don't upload files that were
-     * modified too recently, and this delay ensures the modification is
-     * far enough in the past.
-     *
-     * The delay doesn't reset with subsequent calls.
-     */
-    void scheduleThisFolderSoon();
-
     /** virtual files of some kind are enabled
      *
      * This is independent of whether new files will be virtual. It's possible to have this enabled

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -51,9 +51,9 @@ class LocalDiscoveryTracker;
 class FolderDefinition
 {
 public:
-    static auto createNewFolderDefinition(const QUrl &davUrl, const QString &displayName = {})
+    static auto createNewFolderDefinition(const QUrl &davUrl, const QString &spaceId, const QString &displayName = {})
     {
-        return FolderDefinition(QUuid::createUuid().toByteArray(QUuid::WithoutBraces), davUrl, displayName);
+        return FolderDefinition(QUuid::createUuid().toByteArray(QUuid::WithoutBraces), davUrl, spaceId, displayName);
     }
 
     /// path to the journal, usually relative to localPath
@@ -84,19 +84,20 @@ public:
     /// journalPath relative to localPath.
     QString absoluteJournalPath() const;
 
-    QString localPath() const
-    {
-        return _localPath;
-    }
-    QString targetPath() const
-    {
-        return _targetPath;
-    }
-    const QUrl &webDavUrl() const
-    {
-        Q_ASSERT(_webDavUrl.isValid());
-        return _webDavUrl;
-    }
+    QString localPath() const;
+
+    QString targetPath() const;
+
+    QUrl webDavUrl() const;
+
+    // could change in the case of spaces
+    void setWebDavUrl(const QUrl &url) { _webDavUrl = url; }
+
+    // when using spaces we don't store the dav url but the space id
+    // this id is then used to look up the dav url
+    QString spaceId() const;
+
+    void setSpaceId(const QString &spaceId) { _spaceId = spaceId; }
 
     const QByteArray &id() const;
 
@@ -108,7 +109,6 @@ public:
      */
     bool isDeployed() const;
 
-
     /**
      * Higher values mean more imortant
      * Used for sorting
@@ -118,9 +118,12 @@ public:
     void setPriority(uint32_t newPriority);
 
 private:
-    FolderDefinition(const QByteArray &id, const QUrl &davUrl, const QString &displayName);
+    FolderDefinition(const QByteArray &id, const QUrl &davUrl, const QString &spaceId, const QString &displayName);
 
+    // oc10 and as cache for ocis
     QUrl _webDavUrl;
+
+    QString _spaceId;
     /// For legacy reasons this can be a string, new folder objects will use a uuid
     QByteArray _id;
     QString _displayName;
@@ -194,6 +197,11 @@ public:
      * The full remote webdav url
      */
     QUrl webDavUrl() const;
+
+    /**
+     * The space Id (empty for oc10)
+     */
+    QString spaceId() const;
 
     /**
      * remote folder path, always with a trailing /

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -126,7 +126,7 @@ public:
      * Adds a folder for an account. Used to be part of the wizard code base. Constructs the folder definition from the parameters.
      * In case Wizard::SyncMode::SelectiveSync is used, nullptr is returned.
      */
-    Folder *addFolderFromWizard(const AccountStatePtr &accountStatePtr, const QString &localFolder, const QString &remotePath, const QUrl &webDavUrl, const QString &displayName, bool useVfs);
+    Folder *addFolderFromWizard(const AccountStatePtr &accountStatePtr, FolderDefinition &&definition, bool useVfs);
     Folder *addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const FolderWizard::Result &config);
 
     /** Removes a folder */

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -103,7 +103,7 @@ QString FolderWizardPrivate::initialLocalPath() const
 {
     if (_account->supportsSpaces()) {
         return FolderMan::instance()->findGoodPathForNewSyncFolder(
-            defaultSyncRoot(), _spacesPage->selectedSpace(Spaces::SpacesModel::Columns::Name).toString());
+            defaultSyncRoot(), _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::Name).toString());
     }
     return defaultSyncRoot();
 }
@@ -116,7 +116,7 @@ QString FolderWizardPrivate::remotePath() const
 uint32_t FolderWizardPrivate::priority() const
 {
     if (_account->supportsSpaces()) {
-        return _spacesPage->selectedSpace(Spaces::SpacesModel::Columns::Priority).toInt();
+        return _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::Priority).toInt();
     };
     return 0;
 }
@@ -124,7 +124,7 @@ uint32_t FolderWizardPrivate::priority() const
 QUrl FolderWizardPrivate::davUrl() const
 {
     if (_account->supportsSpaces()) {
-        auto url = _spacesPage->selectedSpace(Spaces::SpacesModel::Columns::WebDavUrl).toUrl();
+        auto url = _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::WebDavUrl).toUrl();
         if (!url.path().endsWith(QLatin1Char('/'))) {
             url.setPath(url.path() + QLatin1Char('/'));
         }
@@ -133,10 +133,18 @@ QUrl FolderWizardPrivate::davUrl() const
     return _account->account()->davUrl();
 }
 
+QString FolderWizardPrivate::spaceId() const
+{
+    if (_account->supportsSpaces()) {
+        return _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::SpaceId).toString();
+    }
+    return {};
+}
+
 QString FolderWizardPrivate::displayName() const
 {
     if (_account->supportsSpaces()) {
-        return _spacesPage->selectedSpace(Spaces::SpacesModel::Columns::Name).toString();
+        return _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::Name).toString();
     };
     return QString();
 }
@@ -212,6 +220,7 @@ FolderWizard::Result FolderWizard::result()
 
     return {
         d->davUrl(), //
+        d->spaceId(), //
         localPath, //
         d->remotePath(), //
         d->displayName(), //

--- a/src/gui/folderwizard/folderwizard.h
+++ b/src/gui/folderwizard/folderwizard.h
@@ -50,9 +50,15 @@ public:
     struct Result
     {
         /***
-         * The webdav url for the sync connection.
+-         * The webdav url for the sync connection.
          */
         QUrl davUrl;
+
+        /***
+         * The id of the space or empty in case of ownCloud 10.
+         */
+        QString spaceId;
+
         /***
          * The local folder used for the sync.
          */

--- a/src/gui/folderwizard/folderwizard_p.h
+++ b/src/gui/folderwizard/folderwizard_p.h
@@ -43,6 +43,7 @@ public:
     QString defaultSyncRoot() const;
 
     QUrl davUrl() const;
+    QString spaceId() const;
     bool useVirtualFiles() const;
     QString displayName() const;
 

--- a/src/gui/folderwizard/spacespage.cpp
+++ b/src/gui/folderwizard/spacespage.cpp
@@ -39,7 +39,7 @@ bool OCC::SpacesPage::isComplete() const
     return ui->widget->currentSpace().isValid();
 }
 
-QVariant OCC::SpacesPage::selectedSpace(Spaces::SpacesModel::Columns column) const
+QVariant OCC::SpacesPage::selectedSpaceData(Spaces::SpacesModel::Columns column) const
 {
     return ui->widget->currentSpace().siblingAtColumn(static_cast<int>(column)).data();
 }

--- a/src/gui/folderwizard/spacespage.h
+++ b/src/gui/folderwizard/spacespage.h
@@ -36,7 +36,7 @@ public:
     bool isComplete() const override;
 
 
-    QVariant selectedSpace(Spaces::SpacesModel::Columns column) const;
+    QVariant selectedSpaceData(Spaces::SpacesModel::Columns column) const;
 
 private:
     Ui::SpacesPage *ui;

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -68,8 +68,12 @@ void setUpInitialSyncFolder(AccountStatePtr accountStatePtr, bool useVfs)
     auto folderMan = FolderMan::instance();
 
     // saves a bit of duplicate code
-    auto addFolder = [folderMan, accountStatePtr, useVfs](const QString &localFolder, const QString &remotePath, const QUrl &webDavUrl, const QString &displayName = {}) {
-        return folderMan->addFolderFromWizard(accountStatePtr, localFolder, remotePath, webDavUrl, displayName, useVfs);
+    auto addFolder = [folderMan, accountStatePtr, useVfs](const QString &localFolder, const QString &remotePath, const QUrl &davUrl,
+                         const QString &spaceId = {}, const QString &displayName = {}) {
+        auto def = FolderDefinition::createNewFolderDefinition(davUrl, spaceId, displayName);
+        def.setLocalPath(localFolder);
+        def.setTargetPath(remotePath);
+        return folderMan->addFolderFromWizard(accountStatePtr, std::move(def), useVfs);
     };
 
     auto finalize = [accountStatePtr] {
@@ -96,7 +100,7 @@ void setUpInitialSyncFolder(AccountStatePtr accountStatePtr, bool useVfs)
                     for (const auto *space : spaces) {
                         const QString name = space->displayName();
                         const QString folderName = FolderMan::instance()->findGoodPathForNewSyncFolder(localDir, name);
-                        auto folder = addFolder(folderName, {}, QUrl(space->drive().getRoot().getWebDavUrl()), name);
+                        auto folder = addFolder(folderName, {}, QUrl(space->drive().getRoot().getWebDavUrl()), space->drive().getRoot().getId(), name);
                         folder->setPriority(space->priority());
                         // save the new priority
                         folder->saveToSettings();

--- a/src/gui/scheduling/etagwatcher.cpp
+++ b/src/gui/scheduling/etagwatcher.cpp
@@ -63,7 +63,7 @@ ETagWatcher::ETagWatcher(FolderMan *folderMan, QObject *parent)
             if (info.first->accountState()->supportsSpaces()) {
                 // we could also connect to the spaceChanged signal but for now this will keep it closer to oc10
                 // ensure we already know about the space (startup)
-                if (auto *space = info.first->accountState()->account()->spacesManager()->spaceByUrl(info.first->webDavUrl())) {
+                if (auto *space = info.first->accountState()->account()->spacesManager()->space(info.first->spaceId())) {
                     updateEtag(info.first, space->drive().getRoot().getETag());
                 }
             } else {

--- a/src/gui/spaces/spacesbrowser.cpp
+++ b/src/gui/spaces/spacesbrowser.cpp
@@ -59,6 +59,7 @@ SpacesBrowser::SpacesBrowser(QWidget *parent)
     header->hideSection(static_cast<int>(SpacesModel::Columns::Subtitle));
     header->hideSection(static_cast<int>(SpacesModel::Columns::Priority));
     header->hideSection(static_cast<int>(SpacesModel::Columns::Enabled));
+    header->hideSection(static_cast<int>(SpacesModel::Columns::SpaceId));
     header->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(header, &QHeaderView::customContextMenuRequested, header, [header, this] {
         auto menu = new QMenu(this);

--- a/src/gui/spaces/spacesmodel.cpp
+++ b/src/gui/spaces/spacesmodel.cpp
@@ -62,9 +62,10 @@ QVariant SpacesModel::headerData(int section, Qt::Orientation orientation, int r
                 return tr("Priority");
             case Columns::Enabled:
                 return tr("Enabled");
-            default:
+            case Columns::SpaceId:
+                return tr("SpaceId");
+            case Columns::ColumnCount:
                 Q_UNREACHABLE();
-                break;
             }
         }
     }
@@ -112,9 +113,12 @@ QVariant SpacesModel::data(const QModelIndex &index, int role) const
             return {};
         case Columns::Priority:
             return space->priority();
-        default:
+        case Columns::SpaceId:
+            return space->drive().getRoot().getId();
+        case Columns::Enabled:
+            return !space->disabled();
+        case Columns::ColumnCount:
             Q_UNREACHABLE();
-            break;
         }
         break;
     case Qt::DecorationRole:

--- a/src/gui/spaces/spacesmodel.h
+++ b/src/gui/spaces/spacesmodel.h
@@ -37,6 +37,7 @@ public:
         WebDavUrl,
         Priority,
         Enabled,
+        SpaceId,
 
         ColumnCount,
     };

--- a/src/libsync/graphapi/spacesmanager.h
+++ b/src/libsync/graphapi/spacesmanager.h
@@ -42,7 +42,7 @@ namespace GraphApi {
         QVector<Space *> spaces() const;
 
         // deprecated: we need to migrate to id based spaces
-        Space *spaceByUrl(const QUrl &url) const;
+        [[deprecated("Use space(const QString &id)")]] Space *spaceByUrl(const QUrl &url) const;
 
         Account *account() const;
 

--- a/test/testspacesmigration/testspacesmigration.cpp
+++ b/test/testspacesmigration/testspacesmigration.cpp
@@ -24,7 +24,7 @@ private:
 
     auto addFolder(AccountStatePtr accountState, const QString &localPath, const QString &remotePath)
     {
-        auto d = OCC::FolderDefinition::createNewFolderDefinition(accountState->account()->davUrl());
+        auto d = OCC::FolderDefinition::createNewFolderDefinition(accountState->account()->davUrl(), {});
         Q_ASSERT(localPath.startsWith(QLatin1Char('/')));
         d.setLocalPath(_tmp.path() + localPath);
         d.setTargetPath(remotePath);

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -40,7 +40,7 @@ namespace TestUtils {
     FolderDefinition createDummyFolderDefinition(const AccountPtr &account, const QString &path)
     {
         // TODO: legacy
-        auto d = OCC::FolderDefinition::createNewFolderDefinition(account->davUrl());
+        auto d = OCC::FolderDefinition::createNewFolderDefinition(account->davUrl(), {});
         d.setLocalPath(path);
         d.setTargetPath(path);
         return d;


### PR DESCRIPTION
  Ideally we would no longer need to store the webdav url for spaces, but while the client is starting up or we are offline when starting the client, we don't have the relevant information available.

Fixes: #10936