### PR TITLE
Fix QStringBuilder crash 10976

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
         cmd.setProcessChannelMode(QProcess::ForwardedChannels);
         cmd.setInputChannelMode(QProcess::ForwardedInputChannel);
 
-        const QString app = [] {
+        const QString app = []() -> QString {
 #ifdef Q_OS_WIN
             return QCoreApplication::applicationFilePath().chopped(4) + QStringLiteral("cmd.exe");
 #else


### PR DESCRIPTION
The lambda was returning a QStringBuilder and casting it to QString when its content was out of scope.