### PR TITLE
Hide owncloudcmd from app menu on Linux

### DIFF
--- a/owncloudcmd.desktop.in
+++ b/owncloudcmd.desktop.in
@@ -9,3 +9,4 @@ GenericName=Folder Sync Commandline
 Icon=@APPLICATION_ICON_NAME@
 Keywords=@APPLICATION_NAME@;syncing;file;sharing;
 X-AppImage-Integrate=false
+NoDisplay=true


### PR DESCRIPTION
Ubuntu does not show the full application name which leads to confusion, and the application is not interactive either.