### PR TITLE
Ci: Don't run clang tidy on pr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,7 @@ jobs:
         }
 
     - name: Clang tidy
+      if: github.event_name != 'pull_request'
       run: |
         & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c --run python3 -m pip install clang-html
         & "${env:GITHUB_WORKSPACE}/.github/workflows/.craft.ps1" -c libs/llvm


### PR DESCRIPTION
The output has limited use for now and slows down the build enormously.