### PR TITLE
Fix the login dialog appearing for logged out accounts

### DIFF
--- a/changelog/unreleased/10351
+++ b/changelog/unreleased/10351
@@ -1,3 +1,3 @@
-Bugfix: Authenticaiton dialog appears again and again
+Bugfix: Authentication dialog no longer appears again and again
 
 https://github.com/owncloud/client/issues/10351

--- a/changelog/unreleased/10351
+++ b/changelog/unreleased/10351
@@ -1,0 +1,3 @@
+Bugfix: Authenticaiton dialog appears again and again
+
+https://github.com/owncloud/client/issues/10351

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -292,12 +292,12 @@ void AccountState::tagLastSuccessfullETagRequest(const QDateTime &tp)
 
 void AccountState::checkConnectivity(bool blockJobs)
 {
-    if (_state != Connected) {
-        setState(Connecting);
-    }
-    qCWarning(lcAccountState) << "checkConnectivity blocking:" << blockJobs;
     if (isSignedOut() || _waitingForNewCredentials) {
         return;
+    }
+    qCWarning(lcAccountState) << "checkConnectivity blocking:" << blockJobs;
+    if (_state != Connected) {
+        setState(Connecting);
     }
     if (_tlsDialog) {
         qCDebug(lcAccountState) << "Skip checkConnectivity, waiting for tls dialog";


### PR DESCRIPTION
I don't think this was the original looping issue but a new one introduced with the connecting state in 4.0

Fixes: #10351