### PR TITLE
Don't use FoldersWithPlaceholders in settings

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -754,9 +754,6 @@ void Folder::setVirtualFilesEnabled(bool enabled)
 
         _definition.virtualFilesMode = newMode;
         startVfs();
-        if (newMode != Vfs::Off) {
-            _saveInFoldersWithPlaceholders = true;
-        }
         saveToSettings();
     }
 }
@@ -778,17 +775,7 @@ void Folder::saveToSettings() const
 
     auto settings = _accountState->settings();
 
-    QString settingsGroup;
-    if (virtualFilesEnabled() || _saveInFoldersWithPlaceholders) {
-        // If virtual files are enabled or even were enabled at some point,
-        // save the folder to a group that will not be read by older (<2.5.0) clients.
-        // The name is from when virtual files were called placeholders.
-        settingsGroup = QStringLiteral("FoldersWithPlaceholders");
-    } else {
-        settingsGroup = QStringLiteral("Folders");
-    }
-
-    settings->beginGroup(settingsGroup);
+    settings->beginGroup(QStringLiteral("Folders"));
     // Note: Each of these groups might have a "version" tag, but that's
     //       currently unused.
     settings->beginGroup(QString::fromUtf8(_definition.id()));

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -305,10 +305,6 @@ public:
      */
     void scheduleThisFolderSoon();
 
-    /** Used to have placeholders: save in placeholder config section */
-    void setSaveInFoldersWithPlaceholders() { _saveInFoldersWithPlaceholders = true; }
-
-
     /** virtual files of some kind are enabled
      *
      * This is independent of whether new files will be virtual. It's possible to have this enabled
@@ -503,15 +499,6 @@ private:
     QScopedPointer<SyncRunFileLog> _fileLog;
 
     QTimer _scheduleSelfTimer;
-
-    /** Whether the folder should be saved in that settings group
-     *
-     * If it was read from there it had virtual files enabled at some
-     * point and might still have db entries or suffix-virtual files even
-     * if they are disabled right now. This flag ensures folders that
-     * were in that group once never go back.
-     */
-    bool _saveInFoldersWithPlaceholders = false;
 
     /** Whether a vfs mode switch is pending
      *

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -293,7 +293,7 @@ private:
     // restarts the application (Linux only)
     void restartApplication();
 
-    void setupFoldersHelper(QSettings &settings, AccountStatePtr account, bool foldersWithPlaceholders);
+    void setupFoldersHelper(QSettings &settings, AccountStatePtr account);
 
     QSet<Folder *> _disabledFolders;
     QVector<Folder *> _folders;

--- a/test/testfoldermigration.cpp
+++ b/test/testfoldermigration.cpp
@@ -92,7 +92,7 @@ private slots:
         AccountManager::instance()->restore();
 
         settings->beginGroup(QStringLiteral("0/Folders"));
-        TestUtils::folderMan()->setupFoldersHelper(*settings.get(), AccountManager::instance()->accounts().first(), false);
+        TestUtils::folderMan()->setupFoldersHelper(*settings.get(), AccountManager::instance()->accounts().first());
         settings->endGroup();
 
         QCOMPARE(journalPaths.first(), settings->value(QStringLiteral("0/Folders/1/journalPath")));


### PR DESCRIPTION
FoldersWithPlaceholders and Folders are the exact same thing. Originally the name was chosen to prevent loading after downgrades. We don't support downgrades so no need to mess up the config file.

Fixes: #11097