### PR TITLE
Make SyncFileItem::Status more robust to changes

### DIFF
--- a/src/gui/issueswidget.cpp
+++ b/src/gui/issueswidget.cpp
@@ -384,40 +384,23 @@ std::function<void(void)> IssuesWidget::addStatusFilter(QMenu *menu)
     const auto initialFilter = _statusSortModel->filter();
 
     { // Add all errors under 1 action:
-        const std::vector<SyncFileItem::Status> ErrorStatusItems = {
-            SyncFileItem::Status::FatalError,
-            SyncFileItem::Status::NormalError,
-            SyncFileItem::Status::SoftError,
-            SyncFileItem::Status::DetailError,
-        };
-
-        auto action = menu->addAction(Utility::enumToDisplayName(SyncFileItem::NormalError), this, [this, ErrorStatusItems](bool checked) {
+        auto action = menu->addAction(Utility::enumToDisplayName(SyncFileItem::NormalError), this, [this](bool checked) {
             auto currentFilter = _statusSortModel->filter();
-            for (const auto &item : ErrorStatusItems) {
+            for (const auto &item : SyncFileItem::ErrorStatusItems) {
                 currentFilter[item] = checked;
             }
             _statusSortModel->setFilter(currentFilter);
         });
         action->setCheckable(true);
-        action->setChecked(initialFilter[ErrorStatusItems[0]]);
+        action->setChecked(initialFilter[SyncFileItem::ErrorStatusItems[0]]);
         statusFilterGroup->addAction(action);
     }
     menu->addSeparator();
 
-    // Add the other non-error items:
-    const std::vector<SyncFileItem::Status> OtherStatusItems = {
-        SyncFileItem::Status::Conflict, //
-        SyncFileItem::Status::FileIgnored, //
-        SyncFileItem::Status::Restoration, //
-        SyncFileItem::Status::BlacklistedError, //
-        SyncFileItem::Status::Excluded, //
-        SyncFileItem::Status::Message, //
-        SyncFileItem::Status::FilenameReserved, //
-    };
-    // list of OtherStatusItems with the localised name
+    // list of OtherDisplayableStatusItems with the localised name
     std::vector<std::pair<QString, SyncFileItem::Status>> otherStatusItems;
-    otherStatusItems.reserve(OtherStatusItems.size());
-    for (const auto &item : OtherStatusItems) {
+    otherStatusItems.reserve(SyncFileItem::OtherDisplayableStatusItems.size());
+    for (const auto &item : SyncFileItem::OtherDisplayableStatusItems) {
         otherStatusItems.emplace_back(Utility::enumToDisplayName(item), item);
     }
     std::sort(otherStatusItems.begin(), otherStatusItems.end(), [](const auto &a, const auto &b) {

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -51,9 +51,6 @@ public:
     Q_ENUM(Direction)
 
     enum Status : uint8_t { // stored in 4 bits
-        // IMPORTANT: if something changes in this enum, please check `IssuesWidget::addStatusFilter`
-        // if it needs adjustment. The same for `SyncFileItemStatusSetSortFilterProxyModel`.
-
         NoStatus,
 
         FatalError, ///< Error that causes the sync to stop
@@ -112,6 +109,27 @@ public:
         StatusCount
     };
     Q_ENUM(Status)
+
+    static constexpr std::array<Status, 4> ErrorStatusItems = {
+        FatalError,
+        NormalError,
+        SoftError,
+        DetailError,
+    };
+
+    static constexpr std::array<Status, 7> OtherDisplayableStatusItems = {
+        Conflict,
+        FileIgnored,
+        Restoration,
+        BlacklistedError,
+        Excluded,
+        Message,
+        FilenameReserved,
+    };
+
+    // We don't include NoStatus or Success in here
+    static_assert(
+        ErrorStatusItems.size() + OtherDisplayableStatusItems.size() == StatusCount - 2, "ErrorStatusItems or OtherDisplayableStatusItems is incomplete");
 
     SyncJournalFileRecord toSyncJournalFileRecordWithInode(const QString &localFileName) const;
 


### PR DESCRIPTION
The GUI uses this to display and filter status messages. To make sure we have all displayable status items listed, they are now in `SyncFileItem` together with a static assert to check we covered all items. This should make adding/removing status items less error-prone.

Fixes: #10960