### PR TITLE
Change local collision to follow the ownCloud convention

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -786,8 +786,8 @@ QString FolderMan::checkPathValidityForNewFolder(const QString &path) const
 
 QString FolderMan::findGoodPathForNewSyncFolder(const QString &basePath, const QString &newFolder) const
 {
-    // reserve 3 characters to allow appending of a number 0-100
-    const QString normalisedPath = FileSystem::createPortableFileName(basePath, FileSystem::pathEscape(newFolder), 3);
+    // reserve extra characters to allow appending of a number
+    const QString normalisedPath = FileSystem::createPortableFileName(basePath, FileSystem::pathEscape(newFolder), std::string_view(" (100)").size());
 
     // If the parent folder is a sync folder or contained in one, we can't
     // possibly find a valid sync folder inside it.
@@ -801,12 +801,12 @@ QString FolderMan::findGoodPathForNewSyncFolder(const QString &basePath, const Q
     // Count attempts and give up eventually
     {
         QString folder = normalisedPath;
-        for (int attempt = 2; attempt < 100; ++attempt) {
+        for (int attempt = 2; attempt <= 100; ++attempt) {
             if (!QFileInfo::exists(folder)
                 && FolderMan::instance()->checkPathValidityForNewFolder(folder).isEmpty()) {
                 return canonicalPath(folder);
             }
-            folder = normalisedPath + QString::number(attempt);
+            folder = normalisedPath + QStringLiteral(" (%1)").arg(attempt);
         }
     }
     // we failed to find a non existing path

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -180,22 +180,24 @@ private slots:
         QVERIFY(folderman->addFolder(
             newAccountState.get(), TestUtils::createDummyFolderDefinition(newAccountState->account(), dirPath + QStringLiteral("/sub/ownCloud/"))));
         QVERIFY(folderman->addFolder(
-            newAccountState.get(), TestUtils::createDummyFolderDefinition(newAccountState->account(), dirPath + QStringLiteral("/ownCloud2/"))));
+            newAccountState.get(), TestUtils::createDummyFolderDefinition(newAccountState->account(), dirPath + QStringLiteral("/ownCloud (2)/"))));
 
         // TEST
 
         QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("oc")), dirPath + QStringLiteral("/oc"));
-        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud")), dirPath + QStringLiteral("/ownCloud3"));
-        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2")), dirPath + QStringLiteral("/ownCloud22"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud")), dirPath + QStringLiteral("/ownCloud (3)"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2")), dirPath + QStringLiteral("/ownCloud2 (2)"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud (2)")), dirPath + QStringLiteral("/ownCloud (2) (2)"));
         QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2/foo")), dirPath + QStringLiteral("/ownCloud2_foo"));
         QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2/bar")), dirPath + QStringLiteral("/ownCloud2_bar"));
-        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("sub")), dirPath + QStringLiteral("/sub2"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("sub")), dirPath + QStringLiteral("/sub (2)"));
 
         // REMOVE ownCloud2 from the filesystem, but keep a folder sync'ed to it.
         // We should still not suggest this folder as a new folder.
-        QDir(dirPath + QStringLiteral("/ownCloud2/")).removeRecursively();
-        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud")), dirPath + QStringLiteral("/ownCloud3"));
-        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2")), QString(dirPath + QStringLiteral("/ownCloud22")));
+        QDir(dirPath + QStringLiteral("/ownCloud (2)/")).removeRecursively();
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud")), dirPath + QStringLiteral("/ownCloud (3)"));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud2")), QString(dirPath + QStringLiteral("/ownCloud2 (2)")));
+        QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("ownCloud (2)")), QString(dirPath + QStringLiteral("/ownCloud (2) (2)")));
 
         // make sure people can't do evil stuff
         QCOMPARE(folderman->findGoodPathForNewSyncFolder(dirPath, QStringLiteral("../../../Bo/b")), QString(dirPath + QStringLiteral("/___Bo_b")));


### PR DESCRIPTION
If the default folder name exists, a different one was offered in the form of "ownCloud2". This is now changed to follow the ownCloud convention, and "ownCloud (2)" is now offered.