### PR TITLE
Unittest: Ignore unknown requests

### DIFF
--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -16,6 +16,7 @@
 #include <thread>
 
 using namespace std::chrono_literals;
+using namespace std::chrono;
 
 namespace {
 inline auto chunkingNgUploadPathC()
@@ -888,8 +889,12 @@ QNetworkReply *FakeAM::createRequest(QNetworkAccessManager::Operation op, const 
     }
     if (!reply) {
         const QString fileName = getFilePathFromUrl(newRequest.url());
-        Q_ASSERT(!fileName.isNull()); // we only expect webdav request for which we might get an empty sting but  not a null string
-        if (_errorPaths.contains(fileName)) {
+        if (fileName.isNull()) {
+            // we don't actually handle this case but thats ok for now
+            newRequest.setTransferTimeout(duration_cast<milliseconds>(5min).count());
+            qWarning() << "Ignoring request to" << newRequest.url();
+            reply = new FakeHangingReply(op, newRequest, this);
+        } else if (_errorPaths.contains(fileName)) {
             reply = new FakeErrorReply { op, newRequest, this, _errorPaths[fileName] };
         }
     }


### PR DESCRIPTION
In canse a request is not supported let it time out. We assume we don't care and hope the unit test will finish before it times out.

This fixes the problem where a unit test takes too long and the connection validator is triggered.