### PR TITLE
Don't start a timer per changed file

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -632,6 +632,7 @@ int Folder::slotWipeErrorBlacklist()
 void Folder::slotWatchedPathsChanged(const QSet<QString> &paths, ChangeReason reason)
 {
     Q_ASSERT(isReady());
+    bool needSync = false;
     for (const auto &path : paths) {
         Q_ASSERT(FileSystem::isChildPathOf(path, this->path()));
 
@@ -706,10 +707,10 @@ void Folder::slotWatchedPathsChanged(const QSet<QString> &paths, ChangeReason re
         warnOnNewExcludedItem(record, relativePath);
 
         emit watchedFileChangedExternally(path);
-
-        // Also schedule this folder for a sync, but only after some delay:
-        // The sync will not upload files that were changed too recently.
-        QTimer::singleShot(SyncEngine::minimumFileAgeForUpload, this, [this] { FolderMan::instance()->scheduler()->enqueueFolder(this); });
+        needSync = true;
+    }
+    if (needSync) {
+        FolderMan::instance()->scheduler()->enqueueFolder(this);
     }
 }
 


### PR DESCRIPTION
The client used to emit a file changed event for every single change. In order to prevent pointless syncs it delayed the sync by 2s. This created a QTimer for every singe change.

Since 5.0 we gather changes for 10s and only then handle the changes, so no delay should be needed anymore.