### PR TITLE
Do not create default sync root when loading accounts

### DIFF
--- a/changelog/unreleased/10919
+++ b/changelog/unreleased/10919
@@ -1,0 +1,9 @@
+Bugfix: Do not create default sync root when loading accounts
+
+Creating the default sync root is only needed at initial setup. If a
+user chooses to point all folders for Spaces outside that default sync
+root, and deletes the default sync root folder, it will now no longer be
+created.
+
+https://github.com/owncloud/client/issues/10919
+https://github.com/owncloud/client/pull/11128

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -215,6 +215,9 @@ FolderWizard::Result FolderWizard::result()
     if (!d->_account->account()->hasDefaultSyncRoot()) {
         if (FileSystem::isChildPathOf(localPath, d->defaultSyncRoot())) {
             d->_account->account()->setDefaultSyncRoot(d->defaultSyncRoot());
+            if (!QFileInfo::exists(d->defaultSyncRoot())) {
+                OC_ASSERT(QDir().mkpath(d->defaultSyncRoot()));
+            }
         }
     }
 

--- a/src/gui/newwizard/setupwizardaccountbuilder.cpp
+++ b/src/gui/newwizard/setupwizardaccountbuilder.cpp
@@ -17,6 +17,9 @@
 #include "gui/accountmanager.h"
 #include "networkjobs/fetchuserinfojobfactory.h"
 
+#include <QDir>
+#include <QFileInfo>
+
 namespace OCC::Wizard {
 
 AbstractAuthenticationStrategy::~AbstractAuthenticationStrategy() { }
@@ -135,6 +138,9 @@ AccountPtr SetupWizardAccountBuilder::build()
 
     if (!_defaultSyncTargetDir.isEmpty()) {
         newAccountPtr->setDefaultSyncRoot(_defaultSyncTargetDir);
+        if (!QFileInfo::exists(_defaultSyncTargetDir)) {
+            OC_ASSERT(QDir().mkpath(_defaultSyncTargetDir));
+        }
     }
 
     return newAccountPtr;

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -354,9 +354,6 @@ void Account::setDefaultSyncRoot(const QString &syncRoot)
     Q_ASSERT(_defaultSyncRoot.isEmpty());
     if (!syncRoot.isEmpty()) {
         _defaultSyncRoot = syncRoot;
-        if (!QFileInfo::exists(syncRoot)) {
-            OC_ASSERT(QDir().mkpath(syncRoot));
-        }
     }
 }
 


### PR DESCRIPTION
Creating the default sync root is only needed at initial setup. If a user chooses to point all folders for Spaces outside that default sync root, and deletes the default sync root folder, it should not be re-created.

Fixes: #10919