### PR TITLE
Fix crash when database version check fails

### DIFF
--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -89,8 +89,6 @@ private:
     QString _userEnforcedLanguage;
     QString _displayLanguage;
 
-    QScopedPointer<FolderMan> _folderManager;
-
     static Application *_instance;
     friend Application *ocApp();
 };

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -119,6 +119,7 @@ FolderMan *FolderMan::instance()
 
 FolderMan::~FolderMan()
 {
+    unloadAndDeleteAllFolders();
     qDeleteAll(_folders);
     _instance = nullptr;
 }

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -88,6 +88,7 @@ public:
 
     static QString checkPathValidityRecursive(const QString &path);
 
+    explicit FolderMan(QObject *parent = nullptr);
     ~FolderMan() override;
 
     /**
@@ -318,9 +319,7 @@ private:
     mutable QMap<QString, Result<void, QString>> _unsupportedConfigurationError;
 
     static FolderMan *_instance;
-    explicit FolderMan(QObject *parent = nullptr);
     friend class OCC::Application;
-    friend OCC::FolderMan *OCC::TestUtils::folderMan();
     friend class ::TestFolderMigration;
 };
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -319,7 +319,6 @@ int main(int argc, char **argv)
     const auto platform = Platform::create();
 
     // Create the (Q)Application instance:
-
     QApplication app(argc, argv);
     // TODO: Can't set this without breaking current config paths
     //    setOrganizationName(QLatin1String(APPLICATION_VENDOR));
@@ -330,94 +329,7 @@ int main(int argc, char **argv)
 
     KDSingleApplication singleApplication;
 
-    if (singleApplication.isPrimaryInstance()) {
-        // Check if the user upgraded or downgraded. We do this as early as possible, to detect
-        // a possible downgrade.
-        if (!checkClientVersion()) {
-            return -1;
-        }
-
-        const auto options = parseOptions(app.arguments());
-
-        setupLogging(options);
-
-        platform->setApplication(&app);
-
-        QScopedPointer<FolderMan> folderManager(new FolderMan);
-
-        if (!AccountManager::instance()->restore()) {
-            // If there is an error reading the account settings, try again
-            // after a couple of seconds, if that fails, give up.
-            // (non-existence is not an error)
-            Utility::sleep(5);
-            if (!AccountManager::instance()->restore()) {
-                qCCritical(lcApplication) << "Could not read the account settings, quitting";
-                QMessageBox::critical(nullptr, QCoreApplication::translate("account loading", "Error accessing the configuration file"),
-                    QCoreApplication::translate("account loading", "There was an error while accessing the configuration file at %1.")
-                        .arg(ConfigFile::configFile()),
-                    QMessageBox::Close);
-                return -1;
-            }
-        }
-
-        // Setup the folders. This includes a downgrade-detection, in which case the return value
-        // is empty. Note that the value 0 (zero) is a valid return value (non-empty), in which case
-        // the dialog is not shown.
-        if (!FolderMan::instance()->setupFolders().has_value()) {
-            // Empty return value: there was a downgrade detected on one of the databases
-            showDowngradeDialog();
-            return -1;
-        }
-
-        FolderMan::instance()->setSyncEnabled(true);
-
-        auto ocApp = new OCC::Application(platform.get(), options.debugMode, &app);
-
-        if (AccountManager::instance()->accounts().isEmpty()) {
-            // display the wizard if we don't have an account yet
-            QTimer::singleShot(0, ocApp->gui(), &ownCloudGui::runNewAccountWizard);
-        }
-
-        QObject::connect(platform.get(), &Platform::requestAttention, ocApp->gui(), &ownCloudGui::slotShowSettings);
-
-        QObject::connect(&singleApplication, &KDSingleApplication::messageReceived, ocApp, [&](const QByteArray &message) {
-            const QString msg = QString::fromUtf8(message);
-            qCInfo(lcMain) << Q_FUNC_INFO << msg;
-            if (msg.startsWith(msgParseOptionsC())) {
-                const QStringList optionsStrings = msg.mid(msgParseOptionsC().size()).split(QLatin1Char('|'));
-                CommandLineOptions options = parseOptions(optionsStrings);
-                if (options.show) {
-                    ocApp->gui()->slotShowSettings();
-                }
-                if (options.quitInstance) {
-                    qApp->quit();
-                }
-                if (!options.fileToOpen.isEmpty()) {
-                    QTimer::singleShot(0, ocApp, [ocApp, fileToOpen = options.fileToOpen] { ocApp->openVirtualFile(fileToOpen); });
-                }
-            }
-        });
-
-        if (options.show) {
-            ocApp->gui()->slotShowSettings();
-        }
-        if (!options.fileToOpen.isEmpty()) {
-            QTimer::singleShot(0, ocApp, [ocApp, fileToOpen = options.fileToOpen] { ocApp->openVirtualFile(fileToOpen); });
-        }
-
-        platform->startServices();
-
-#ifdef WITH_AUTO_UPDATER
-        // if handleStartup returns true, main()
-        // needs to terminate here, e.g. because
-        // the updater is triggered
-        Updater *updater = Updater::instance();
-        if (updater && updater->handleStartup()) {
-            return 1;
-        }
-#endif
-
-    } else {
+    if (!singleApplication.isPrimaryInstance()) {
         // if the application is already running, notify it.
         qCInfo(lcMain) << "Already running, exiting...";
         if (app.isSessionRestored()) {
@@ -432,8 +344,95 @@ int main(int argc, char **argv)
             if (!singleApplication.sendMessage((msgParseOptionsC() + msg).toUtf8()))
                 return -1;
         }
+
         return 0;
     }
+
+    // Check if the user upgraded or downgraded. We do this as early as possible, to detect
+    // a possible downgrade.
+    if (!checkClientVersion()) {
+        return -1;
+    }
+
+    const auto options = parseOptions(app.arguments());
+
+    setupLogging(options);
+
+    platform->setApplication(&app);
+
+    QScopedPointer<FolderMan> folderManager(new FolderMan);
+
+    if (!AccountManager::instance()->restore()) {
+        // If there is an error reading the account settings, try again
+        // after a couple of seconds, if that fails, give up.
+        // (non-existence is not an error)
+        Utility::sleep(5);
+        if (!AccountManager::instance()->restore()) {
+            qCCritical(lcApplication) << "Could not read the account settings, quitting";
+            QMessageBox::critical(nullptr, QCoreApplication::translate("account loading", "Error accessing the configuration file"),
+                QCoreApplication::translate("account loading", "There was an error while accessing the configuration file at %1.")
+                    .arg(ConfigFile::configFile()),
+                QMessageBox::Close);
+            return -1;
+        }
+    }
+
+    // Setup the folders. This includes a downgrade-detection, in which case the return value
+    // is empty. Note that the value 0 (zero) is a valid return value (non-empty), in which case
+    // the dialog is not shown.
+    if (!FolderMan::instance()->setupFolders().has_value()) {
+        // Empty return value: there was a downgrade detected on one of the databases
+        showDowngradeDialog();
+        return -1;
+    }
+
+    FolderMan::instance()->setSyncEnabled(true);
+
+    auto ocApp = new OCC::Application(platform.get(), options.debugMode, &app);
+
+    if (AccountManager::instance()->accounts().isEmpty()) {
+        // display the wizard if we don't have an account yet
+        QTimer::singleShot(0, ocApp->gui(), &ownCloudGui::runNewAccountWizard);
+    }
+
+    QObject::connect(platform.get(), &Platform::requestAttention, ocApp->gui(), &ownCloudGui::slotShowSettings);
+
+    QObject::connect(&singleApplication, &KDSingleApplication::messageReceived, ocApp, [&](const QByteArray &message) {
+        const QString msg = QString::fromUtf8(message);
+        qCInfo(lcMain) << Q_FUNC_INFO << msg;
+        if (msg.startsWith(msgParseOptionsC())) {
+            const QStringList optionsStrings = msg.mid(msgParseOptionsC().size()).split(QLatin1Char('|'));
+            CommandLineOptions options = parseOptions(optionsStrings);
+            if (options.show) {
+                ocApp->gui()->slotShowSettings();
+            }
+            if (options.quitInstance) {
+                qApp->quit();
+            }
+            if (!options.fileToOpen.isEmpty()) {
+                QTimer::singleShot(0, ocApp, [ocApp, fileToOpen = options.fileToOpen] { ocApp->openVirtualFile(fileToOpen); });
+            }
+        }
+    });
+
+    if (options.show) {
+        ocApp->gui()->slotShowSettings();
+    }
+    if (!options.fileToOpen.isEmpty()) {
+        QTimer::singleShot(0, ocApp, [ocApp, fileToOpen = options.fileToOpen] { ocApp->openVirtualFile(fileToOpen); });
+    }
+
+    platform->startServices();
+
+#ifdef WITH_AUTO_UPDATER
+    // if handleStartup returns true, main()
+    // needs to terminate here, e.g. because
+    // the updater is triggered
+    Updater *updater = Updater::instance();
+    if (updater && updater->handleStartup()) {
+        return 1;
+    }
+#endif
 
     return app.exec();
 }


### PR DESCRIPTION
The check is done after the application constructor is run. In this constructor, a couple of signals get fired, which in turn queues showing the GUI window (e.g. an account is logged out, and needs new authentication). When the version check fails, it brings up a (modal) dialog, and the event loop is spun, which also brings up the GUI window. Somewhere halfway this, the quit button is clicked, tearing down the application with a half-way set up window. This causes a crash somewhere deep in a child-widget-deletion process.

The fix is to move even more out of the application constructor, so the full check can be done before any other GUI code is run. This comes down to setting up the account manager and the folder manager in the main function.

Fixes: #11135