### PR TITLE
[ci] update the trigger branch to 5 for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -60,7 +60,7 @@ notify_channels = {
 
 branch_ref = [
     "refs/heads/master",
-    "refs/heads/4**",
+    "refs/heads/5**",
 ]
 
 trigger_ref = branch_ref + [


### PR DESCRIPTION
Updated the build trigger branch to 5. This will enable tests in nightly which is currently skipped. See https://drone.owncloud.com/owncloud/client/16501