### PR TITLE
Add qpa info to version info

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -374,6 +374,10 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
             gitUrl = gitSHA1(format) + br;
         }
     }
+    QStringList sysInfo = {QStringLiteral("OS: %1-%2").arg(QSysInfo::productType(), QSysInfo::kernelVersion())};
+    if (auto guiApp = qobject_cast<QGuiApplication *>(qApp)) {
+        sysInfo << QStringLiteral("QPA: %1").arg(guiApp->platformName());
+    }
 
     return QCoreApplication::translate("ownCloudTheme::aboutVersions()",
         "%1 %2%7"
@@ -382,8 +386,7 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
         "Using virtual files plugin: %5%7"
         "%6")
         .arg(appName(), _version, qtVersionString, QSslSocket::sslLibraryVersionString(),
-            Utility::enumToString(VfsPluginManager::instance().bestAvailableVfsMode()), QSysInfo::productType() % QLatin1Char('-') % QSysInfo::kernelVersion(),
-            br, gitUrl);
+            Utility::enumToString(VfsPluginManager::instance().bestAvailableVfsMode()), sysInfo.join(br), br, gitUrl);
 }
 
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -375,6 +375,7 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
         }
     }
     QStringList sysInfo = {QStringLiteral("OS: %1-%2").arg(QSysInfo::productType(), QSysInfo::kernelVersion())};
+    // may be called by both GUI and CLI, but we can display QPA only for the former
     if (auto guiApp = qobject_cast<QGuiApplication *>(qApp)) {
         sysInfo << QStringLiteral("QPA: %1").arg(guiApp->platformName());
     }


### PR DESCRIPTION
# Old

```
ownCloud 5.0.0-git [c8c2d9](https://github.com/owncloud/client/commit/c8c2d927da5bb3ce88ce9eee620e5b659f13667d)
Libraries Qt 6.4.3, OpenSSL 3.1.2 1 Aug 2023
Using virtual files plugin: wincfapi
windows-10.0.22621
```

# New

```
ownCloud 5.0.0-git [c8c2d9](https://github.com/owncloud/client/commit/c8c2d927da5bb3ce88ce9eee620e5b659f13667d)
Libraries Qt 6.4.3, OpenSSL 3.1.2 1 Aug 2023
Using virtual files plugin: wincfapi
OS: windows-10.0.22621
QPA: windows
```
On linux this will tell us whether wayland or xcb is used.
