### PR TITLE
[gui-tests][full-ci] fix sync status pattern

### DIFF
--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -52,7 +52,7 @@ SYNC_PATTERNS = {
     # the pattern can be of TWO types depending on the available resources (files/folders)
     'initial': [
         # when syncing empty account (hidden files are ignored)
-        [SYNC_STATUS['UPDATE'], SYNC_STATUS['OK']],
+        [SYNC_STATUS['OK'], SYNC_STATUS['REGISTER']],
         # when syncing an account that has some files/folders
         [SYNC_STATUS['SYNC'], SYNC_STATUS['OK']],
     ],


### PR DESCRIPTION
Sync pattern (sync messages pattern) for syncing account that _doesn't have any files_ in the server has changed.
Pattern was changed along with PR https://github.com/owncloud/client/pull/11153

Before:
```bash
STATUS:OK:/tmp/client-bdd/Alice/
STATUS:OK:/tmp/client-bdd/Alice/
REGISTER_PATH:/tmp/client-bdd/Alice
STATUS:OK:/tmp/client-bdd/Alice
UPDATE_VIEW:/tmp/client-bdd/Alice
STATUS:OK:/tmp/client-bdd/Alice
STATUS:OK:/tmp/client-bdd/Alice
STATUS:OK:/tmp/client-bdd/Alice
UPDATE_VIEW:/tmp/client-bdd/Alice
```
Current:
```bash
STATUS:OK:/tmp/client-bdd/Alice/
STATUS:OK:/tmp/client-bdd/Alice/
STATUS:OK:/tmp/client-bdd/Alice
STATUS:OK:/tmp/client-bdd/Alice
REGISTER_PATH:/tmp/client-bdd/Alice
```

Current sync messages don't contain `UPDATE_VIEW` message

Fixes https://github.com/owncloud/client/issues/11179