### PR TITLE
Create config file backup for any version change

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -229,11 +229,12 @@ bool checkClientVersion()
     auto configVersion = QVersionNumber::fromString(configFile.clientVersionWithBuildNumberString());
     auto clientVersion = OCC::Version::versionWithBuildNumber();
 
-    if (configVersion.majorVersion() == clientVersion.majorVersion()) {
-        // no migration needed
+    if (configVersion == clientVersion) {
+        // no config backup needed
         return true;
     }
 
+    // We allow downgrades as long as the major version stays the same.
     if (clientVersion.majorVersion() < configVersion.majorVersion()) {
         // We refuse to downgrade, too much can go wrong.
         showDowngradeDialog();


### PR DESCRIPTION
We now do a backup of the config file for any version change of the client, not only when the major version changes.

We do still allow downgrades as long as the major version does not change.

Fixes: #10789