### PR TITLE
Signal AppKit that we are fine with SecureCoding

### DIFF
--- a/src/libsync/platform_mac.mm
+++ b/src/libsync/platform_mac.mm
@@ -34,6 +34,7 @@ Q_LOGGING_CATEGORY(lcPlatform, "platform.macos")
 
 @interface OwnAppDelegate : NSObject <NSApplicationDelegate>
 - (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag;
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app;
 
 @property (readwrite) OCC::MacPlatform *platform;
 @end
@@ -44,6 +45,14 @@ Q_LOGGING_CATEGORY(lcPlatform, "platform.macos")
 - (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag
 {
     Q_EMIT _platform->requestAttention();
+    return YES;
+}
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    Q_UNUSED(app)
+
+    // We do not use `NSCoder` classes (nor does Qt), nor override the `initWithCoder` method, so we are fine with SecureCoding.
     return YES;
 }
 


### PR DESCRIPTION
Since macOS 12 there is a feature to do object de-serialization more secure (secure coding). Starting with with macOS 14, AppKit starts to emit a warning (on the command-line) when an application does not support this feature.

We, nor Qt, use object (de)serialization with `NSCoder`, so we can safely signal back to AppKit that we are fine with secure coding.

This surpresses the AppKit warning:

Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES.

Fixes: #11191