### PR TITLE
Fix "Add sync folder" using an existing invalid location

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -796,7 +796,7 @@ QString FolderMan::checkPathValidityForNewFolder(const QString &path) const
     return {};
 }
 
-QString FolderMan::findGoodPathForNewSyncFolder(const QString &basePath, const QString &newFolder) const
+QString FolderMan::findGoodPathForNewSyncFolder(const QString &basePath, const QString &newFolder)
 {
     // reserve extra characters to allow appending of a number
     const QString normalisedPath = FileSystem::createPortableFileName(basePath, FileSystem::pathEscape(newFolder), std::string_view(" (100)").size());

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -188,7 +188,7 @@ public:
      * subfolder of ~ would be a good candidate. When that happens \a basePath
      * is returned.
      */
-    QString findGoodPathForNewSyncFolder(const QString &basePath, const QString &newFolder) const;
+    static QString findGoodPathForNewSyncFolder(const QString &basePath, const QString &newFolder);
 
     /**
      * While ignoring hidden files can theoretically be switched per folder,

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -102,10 +102,12 @@ FolderWizardPrivate::FolderWizardPrivate(FolderWizard *q, const AccountStatePtr 
 QString FolderWizardPrivate::initialLocalPath() const
 {
     if (_account->supportsSpaces()) {
-        return FolderMan::instance()->findGoodPathForNewSyncFolder(
-            defaultSyncRoot(), _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::Name).toString());
+        return FolderMan::findGoodPathForNewSyncFolder(defaultSyncRoot(), _spacesPage->selectedSpaceData(Spaces::SpacesModel::Columns::Name).toString());
     }
-    return defaultSyncRoot();
+
+    // Split default sync root:
+    const QFileInfo path(defaultSyncRoot());
+    return FolderMan::findGoodPathForNewSyncFolder(path.path(), path.fileName());
 }
 
 QString FolderWizardPrivate::remotePath() const


### PR DESCRIPTION
After changes to `FolderWizardPrivate::initialLocalPath`, the non-spaces case was returning the default sync root, not a new path.

Fixes: #11231