### PR TITLE
[tests-only] [full-ci] Fix test for assertion of account connection by waiting for element if not found 

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -111,6 +111,21 @@ class AccountSetting:
             )
 
     @staticmethod
+    def waitUntilAccountIsConnected(displayname, server, timeout=5000):
+        result = squish.waitFor(
+            lambda: AccountSetting.isUserSignedIn(displayname, server),
+            timeout,
+        )
+
+        if not result:
+            raise Exception(
+                "Timeout waiting for the account to be connected for "
+                + str(timeout)
+                + " milliseconds"
+            )
+        return result
+
+    @staticmethod
     def confirmRemoveAllFiles():
         squish.clickButton(squish.waitForObject(AccountSetting.REMOVE_ALL_FILES))
 

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -119,7 +119,7 @@ def step(context, username):
     displayname = getDisplaynameForUser(username)
     server = get_config('localBackendUrl')
     test.compare(
-        AccountSetting.isUserSignedIn(displayname, server),
+        AccountSetting.waitUntilAccountIsConnected(displayname, server),
         True,
         "User '%s' is connected" % username,
     )


### PR DESCRIPTION
### Description
This pr modifies the step for asserting the connection of account to the server by waiting for 5000ms(default) if the element is not found.
`
Then user "Alice" should be connect to the client-UI
`
### Related issue
Fixes https://github.com/owncloud/client/issues/11217
