### PR TITLE
Remove unused command line option `--language`

### DIFF
--- a/changelog/unreleased/11245
+++ b/changelog/unreleased/11245
@@ -1,0 +1,8 @@
+Change: Remove unused command line option --language
+
+This option was used before the UI language could be chosen in the
+settings. The option --list-languages is also removed, as it no longer
+serves a purpose.
+
+https://github.com/owncloud/client/issues/11245
+https://github.com/owncloud/client/pull/11270

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -267,23 +267,18 @@ void Application::setupTranslations()
     qCDebug(lcApplication) << "UI languages:" << uiLanguages;
 
     // the user can also set a locale in the settings, so we need to load the config file
-    ConfigFile cfg;
+    const ConfigFile cfg;
 
-    // we need to track the enforced languages separately, since we need to distinguish between locale-provided
-    // and user-enforced ones below
-    QSet<QString> enforcedLanguages;
+    // we need to track the enforced language separately, since we need to distinguish between locale-provided
+    // and user-enforced one below
+    const QString enforcedLocale = cfg.uiLanguage();
+    qCDebug(lcApplication) << "Enforced language:" << enforcedLocale;
 
-    // note that user-enforced languages are prioritized over the theme enforced one
-    // to make testing easier, --language overrides the setting from the config file
-    // as we are prepending to the list of languages, the list passed to the loop must be sorted with ascending priority
-    for (const auto &enforcedLocale : {cfg.uiLanguage(), _userEnforcedLanguage}) {
-        if (!enforcedLocale.isEmpty()) {
-            enforcedLanguages.insert(enforcedLocale);
-            uiLanguages.prepend(enforcedLocale);
-        }
+    // note that user-enforced language are prioritized over the theme enforced one
+    // to make testing easier.
+    if (!enforcedLocale.isEmpty()) {
+        uiLanguages.prepend(enforcedLocale);
     }
-
-    qCDebug(lcApplication) << "Enforced languages:" << enforcedLanguages;
 
     QTranslator *translator = new QTranslator(this);
     QTranslator *qtTranslator = new QTranslator(this);
@@ -341,7 +336,7 @@ void Application::setupTranslations()
             // not mess with the system locale, though
             // if we did, we would enforce a locale for no apparent reason
             // see https://github.com/owncloud/client/issues/8608 for more information
-            if (enforcedLanguages.contains(lang)) {
+            if (enforcedLocale == lang) {
                 QLocale newLocale(lang);
                 qCDebug(lcApplication) << "language" << lang << "was enforced, changing default locale to" << newLocale;
                 QLocale::setDefault(newLocale);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -88,7 +88,6 @@ private:
     QPointer<ownCloudGui> _gui = {};
 
     const bool _debugMode = false;
-    QString _userEnforcedLanguage;
     QString _displayLanguage;
 
     static Application *_instance;

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -82,8 +82,6 @@ struct CommandLineOptions
 
     bool debugMode = false;
 
-    QString userEnforcedLanguage;
-
     QString fileToOpen;
 };
 
@@ -128,8 +126,6 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     auto logDirOption = addOption({QStringLiteral("logdir"), QStringLiteral("Write each sync log output in a new file in folder."), QStringLiteral("name")});
     auto logFlushOption = addOption({QStringLiteral("logflush"), QStringLiteral("Flush the log file after every write.")});
     auto logDebugOption = addOption({QStringLiteral("logdebug"), QStringLiteral("Output debug-level messages in the log.")});
-    auto languageOption = addOption({QStringLiteral("language"), QStringLiteral("Override UI language."), QStringLiteral("language")});
-    auto listLanguagesOption = addOption({QStringLiteral("list-languages"), QStringLiteral("Lists available translations, see --language.")});
     auto confDirOption = addOption({QStringLiteral("confdir"), QStringLiteral("Use the given configuration folder."), QStringLiteral("dirname")});
     auto debugOption = addOption({QStringLiteral("debug"), QStringLiteral("Enable debug mode.")});
     addOption({QStringLiteral("cmd"), QStringLiteral("Forward all arguments to the cmd client. This argument must be the first.")});
@@ -173,25 +169,6 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     if (parser.isSet(debugOption)) {
         out.logDebug = true;
         out.debugMode = true;
-    }
-    if (parser.isSet(languageOption)) {
-        const auto languageValue = parser.value(languageOption);
-
-        // fail if the language is unknown
-        if (!Translations::listAvailableTranslations().contains(languageValue)) {
-            displayHelpText(
-                QStringLiteral("Error: unknown language \"%1\" (use --list-languages to get a complete list of supported translations)").arg(languageValue));
-            std::exit(1);
-        } else {
-            out.userEnforcedLanguage = languageValue;
-        }
-    }
-    if (parser.isSet(listLanguagesOption)) {
-        const auto translationSet = Translations::listAvailableTranslations();
-        auto availableTranslations = QStringList{translationSet.cbegin(), translationSet.cend()};
-        availableTranslations.sort(Qt::CaseInsensitive);
-        displayHelpText(QStringLiteral("Available translations: %1").arg(availableTranslations.join(QStringLiteral(", "))));
-        std::exit(1);
     }
 
     auto positionalArguments = parser.positionalArguments();


### PR DESCRIPTION
This option was used before the UI language could be chosen in the settings.

Fixes: #11245

Todo: changelog entry