### PR TITLE
Fix possible crash when starting shell integration

### DIFF
--- a/changelog/unreleased/11288
+++ b/changelog/unreleased/11288
@@ -1,0 +1,8 @@
+Bugfix: fix crash on start-up when starting shell integration
+
+A possible crash has been fixed that could occur during start-up, when
+the shell integration started doing requests before the client itself
+completed starting up.
+
+https://github.com/owncloud/client/issues/11280
+https://github.com/owncloud/client/pull/11288

--- a/changelog/unreleased/11288
+++ b/changelog/unreleased/11288
@@ -1,4 +1,4 @@
-Bugfix: fix crash on start-up when starting shell integration
+Bugfix: Fix crash on start-up when starting shell integration
 
 A possible crash has been fixed that could occur during start-up, when
 the shell integration started doing requests before the client itself

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -26,6 +26,7 @@
 #include "common/version.h"
 #include "gui/translations.h"
 #include "libsync/logger.h"
+#include "socketapi/socketapi.h"
 
 #include <kdsingleapplication.h>
 
@@ -389,7 +390,7 @@ int main(int argc, char **argv)
         return -1;
     }
 
-    FolderMan::instance()->setSyncEnabled(true);
+    folderManager->setSyncEnabled(true);
 
     auto ocApp = Application::createInstance(platform.get(), options.debugMode);
 
@@ -441,6 +442,9 @@ int main(int argc, char **argv)
     if (AccountManager::instance()->accounts().isEmpty()) {
         QTimer::singleShot(0, ocApp->gui(), &ownCloudGui::runNewAccountWizard);
     }
+
+    // Now that everything is up and running, start accepting connections/requests from the shell integration.
+    folderManager->socketApi()->startShellIntegration();
 
     return app.exec();
 }

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -53,6 +53,8 @@ public:
     explicit SocketApi(QObject *parent = nullptr);
     ~SocketApi() override;
 
+    void startShellIntegration();
+
 public slots:
     void registerAccount(const AccountPtr &a);
     void unregisterAccount(const AccountPtr &a);
@@ -155,6 +157,7 @@ private:
 
     QString buildRegisterPathMessage(const QString &path);
 
+    QString _socketPath;
     QSet<Folder *> _registeredFolders;
     QSet<AccountPtr> _registeredAccounts;
     QMap<SocketApiSocket *, QSharedPointer<SocketListener>> _listeners;


### PR DESCRIPTION
The shell integration was started while the folder manager was being instantiated. It could happen that callbacks came in when this was not yet completed, resulting in a crash when calling back into the (incomplete) folder manager.

Now shell integration is started after all other startup work has been completed.

Fixes: #11280