### PR TITLE
Work/load translations early

### DIFF
--- a/changelog/unreleased/11300
+++ b/changelog/unreleased/11300
@@ -1,0 +1,10 @@
+Change: Make messages translatable that occur early in start-up
+
+These messages include the command-line messages (both errors and the
+help text). To do this, the deprecated `--confdir` option has been
+removed. This option was only used on windows before roaming profiles
+were supported.
+
+https://github.com/owncloud/client/issues/11142
+https://github.com/owncloud/client/issues/11246
+https://github.com/owncloud/client/pull/11300

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -47,7 +47,7 @@ class Application : public QObject
 {
     Q_OBJECT
 public:
-    static std::unique_ptr<Application> createInstance(Platform *platform, bool debugMode);
+    static std::unique_ptr<Application> createInstance(Platform *platform, const QString &displayLanguage, bool debugMode);
     ~Application();
 
     bool debugMode();
@@ -72,8 +72,6 @@ public slots:
     void tryTrayAgain();
 
 protected:
-    void setupTranslations();
-
     bool eventFilter(QObject *obj, QEvent *event) override;
 
 protected slots:
@@ -83,7 +81,7 @@ protected slots:
     void slotAccountStateRemoved() const;
 
 private:
-    explicit Application(Platform *platform, bool debugMode);
+    explicit Application(Platform *platform, const QString &displayLanguage, bool debugMode);
 
     QPointer<ownCloudGui> _gui = {};
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -95,9 +95,9 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     QString descriptionText;
     QTextStream descriptionTextStream(&descriptionText);
 
-    descriptionTextStream
-        << QStringLiteral("%1 version %2\r\nFile synchronization desktop utility.").arg(Theme::instance()->appName(), OCC::Version::displayString())
-        << Qt::endl;
+    descriptionTextStream << QApplication::translate("CommandLine", "%1 version %2\r\nFile synchronization desktop utility.")
+                                 .arg(Theme::instance()->appName(), OCC::Version::displayString())
+                          << Qt::endl;
 
     if (Theme::instance()->appName() == QLatin1String("ownCloud")) {
         descriptionTextStream
@@ -122,19 +122,21 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     parser.addOption(showSettingsLegacyOption);
 
     auto showOption = addOption({{QStringLiteral("s"), QStringLiteral("show")},
-        QStringLiteral(
+        QApplication::translate("CommandLine",
             "Start with the main window visible, or if it is already running, bring it to the front. By default, the client launches in the background.")});
-    auto quitInstanceOption = addOption({{QStringLiteral("q"), QStringLiteral("quit")}, QStringLiteral("Quit the running instance.")});
-    auto logFileOption = addOption({QStringLiteral("logfile"), QStringLiteral("Write log to file (use - to write to stdout)."), QStringLiteral("filename")});
-    auto logDirOption = addOption({QStringLiteral("logdir"), QStringLiteral("Write each sync log output in a new file in folder."), QStringLiteral("name")});
-    auto logFlushOption = addOption({QStringLiteral("logflush"), QStringLiteral("Flush the log file after every write.")});
-    auto logDebugOption = addOption({QStringLiteral("logdebug"), QStringLiteral("Output debug-level messages in the log.")});
-    auto debugOption = addOption({QStringLiteral("debug"), QStringLiteral("Enable debug mode.")});
-    addOption({QStringLiteral("cmd"), QStringLiteral("Forward all arguments to the cmd client. This argument must be the first.")});
+    auto quitInstanceOption = addOption({{QStringLiteral("q"), QStringLiteral("quit")}, QApplication::translate("CommandLine", "Quit the running instance.")});
+    auto logFileOption = addOption(
+        {QStringLiteral("logfile"), QApplication::translate("CommandLine", "Write log to file (use - to write to stdout)."), QStringLiteral("filename")});
+    auto logDirOption = addOption(
+        {QStringLiteral("logdir"), QApplication::translate("CommandLine", "Write each sync log output in a new file in folder."), QStringLiteral("name")});
+    auto logFlushOption = addOption({QStringLiteral("logflush"), QApplication::translate("CommandLine", "Flush the log file after every write.")});
+    auto logDebugOption = addOption({QStringLiteral("logdebug"), QApplication::translate("CommandLine", "Output debug-level messages in the log.")});
+    auto debugOption = addOption({QStringLiteral("debug"), QApplication::translate("CommandLine", "Enable debug mode.")});
+    addOption({QStringLiteral("cmd"), QApplication::translate("CommandLine", "Forward all arguments to the cmd client. This argument must be the first.")});
 
     // virtual file system parameters (optional)
-    parser.addPositionalArgument(
-        QStringLiteral("vfs file"), QStringLiteral("Virtual file system file to be opened (optional)."), {QStringLiteral("[<vfs file>]")});
+    parser.addPositionalArgument(QStringLiteral("vfs file"), QApplication::translate("CommandLine", "Virtual file system file to be opened (optional)."),
+        {QStringLiteral("[<vfs file>]")});
 
     parser.process(arguments);
 
@@ -150,7 +152,7 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     }
     if (parser.isSet(logDirOption)) {
         if (parser.isSet(logFileOption)) {
-            displayHelpText(QStringLiteral("--logfile and --logdir are mutually exclusive"));
+            displayHelpText(QApplication::translate("CommandLine", "--logfile and --logdir are mutually exclusive"));
             std::exit(1);
         }
         out.logDir = parser.value(logDirOption);

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -127,7 +127,6 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     auto logDirOption = addOption({QStringLiteral("logdir"), QStringLiteral("Write each sync log output in a new file in folder."), QStringLiteral("name")});
     auto logFlushOption = addOption({QStringLiteral("logflush"), QStringLiteral("Flush the log file after every write.")});
     auto logDebugOption = addOption({QStringLiteral("logdebug"), QStringLiteral("Output debug-level messages in the log.")});
-    auto confDirOption = addOption({QStringLiteral("confdir"), QStringLiteral("Use the given configuration folder."), QStringLiteral("dirname")});
     auto debugOption = addOption({QStringLiteral("debug"), QStringLiteral("Enable debug mode.")});
     addOption({QStringLiteral("cmd"), QStringLiteral("Forward all arguments to the cmd client. This argument must be the first.")});
 
@@ -159,13 +158,6 @@ CommandLineOptions parseOptions(const QStringList &arguments)
     }
     if (parser.isSet(logDebugOption)) {
         out.logDebug = true;
-    }
-    if (parser.isSet(confDirOption)) {
-        const auto confDir = parser.value(confDirOption);
-        if (!ConfigFile::setConfDir(confDir)) {
-            displayHelpText(QStringLiteral("Invalid path passed to --confdir"));
-            std::exit(1);
-        }
     }
     if (parser.isSet(debugOption)) {
         out.logDebug = true;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -150,6 +150,7 @@ public:
     bool moveToTrash() const;
     void setMoveToTrash(bool);
 
+    /// Used for testing, so we do not change the user's config file.
     static bool setConfDir(const QString &value);
 
     bool optionalDesktopNotifications() const;


### PR DESCRIPTION
Remove the `--confdir` option and load translations before any messages are shown.

Fixes #11246. Fixes #11142.

Waits on #11316.