### PR TITLE
[gui-tests][full-ci] use `XDG_CONFIG_HOME` with custom location for AUT during squish tests

### DIFF
--- a/test/gui/envs.txt
+++ b/test/gui/envs.txt
@@ -1,0 +1,1 @@
+XDG_CONFIG_HOME=/tmp/owncloudtest/

--- a/test/gui/shared/scripts/helpers/ConfigHelper.py
+++ b/test/gui/shared/scripts/helpers/ConfigHelper.py
@@ -8,11 +8,11 @@ def read_env_file():
     envs = {}
     script_path = os.path.dirname(os.path.realpath(__file__))
     env_path = os.path.abspath(os.path.join(script_path, '..', '..', '..', 'envs.txt'))
-    with open(env_path) as f:
+    with open(env_path, "rt", encoding="UTF-8") as f:
         for line in f:
             if line.startswith('#'):
                 continue
-            key, value = line.split('=')
+            key, value = line.split('=', 1)
             envs[key] = value.strip()
     return envs
 

--- a/test/gui/shared/scripts/helpers/ConfigHelper.py
+++ b/test/gui/shared/scripts/helpers/ConfigHelper.py
@@ -3,6 +3,27 @@ import builtins
 from tempfile import gettempdir
 from configparser import ConfigParser
 
+
+def read_env_file():
+    envs = {}
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    env_path = os.path.abspath(os.path.join(script_path, '..', '..', '..', 'envs.txt'))
+    with open(env_path) as f:
+        for line in f:
+            if line.startswith('#'):
+                continue
+            key, value = line.split('=')
+            envs[key] = value.strip()
+    return envs
+
+
+def get_config_from_env_file(env):
+    envs = read_env_file()
+    if env in envs:
+        return envs[env]
+    raise Exception('Environment "%s" not found in envs.txt' % env)
+
+
 # map environment variables to config keys
 CONFIG_ENV_MAP = {
     'localBackendUrl': 'BACKEND_HOST',
@@ -30,7 +51,9 @@ CONFIG = {
     'clientLogFile': '-',
     'clientRootSyncPath': '/tmp/client-bdd/',
     'tempFolderPath': gettempdir() + '/client-bdd/temp/',
-    'clientConfigDir': os.path.expanduser("~/.config/ownCloud"),
+    'clientConfigDir': os.path.join(
+        get_config_from_env_file("XDG_CONFIG_HOME"), "ownCloud"
+    ),
     'guiTestReportDir': os.path.abspath('../reports/'),
     'ocis': False,
     'custom_lib': os.path.abspath('../shared/scripts/custom_lib'),

--- a/test/gui/shared/scripts/helpers/ConfigHelper.py
+++ b/test/gui/shared/scripts/helpers/ConfigHelper.py
@@ -30,7 +30,7 @@ CONFIG = {
     'clientLogFile': '-',
     'clientRootSyncPath': '/tmp/client-bdd/',
     'tempFolderPath': gettempdir() + '/client-bdd/temp/',
-    'clientConfigDir': '/tmp/owncloud-client/',
+    'clientConfigDir': os.path.expanduser("~/.config/ownCloud"),
     'guiTestReportDir': os.path.abspath('../reports/'),
     'ocis': False,
     'custom_lib': os.path.abspath('../shared/scripts/custom_lib'),

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -84,8 +84,6 @@ def startClient():
         + get_config('clientLogFile')
         + " --logdebug"
         + " --logflush"
-        + " --confdir "
-        + get_config('clientConfigDir')
     )
 
 

--- a/test/gui/suite.conf
+++ b/test/gui/suite.conf
@@ -1,5 +1,5 @@
 AUT=owncloud --showsettings
-ENVVARS=envvars
+ENVVARS=envs.txt
 HOOK_SUB_PROCESSES=false
 IMPLICITAUTSTART=false
 LANGUAGE=Python


### PR DESCRIPTION
`--confdir` option is deprecated and about to be removed in https://github.com/owncloud/client/pull/11300.
So, squish tests makes use of `XDG_CONFIG_HOME` env to set custom config location (i.e. `/tmp/owncloudtest/`) for owncloud during the test execution

NOTE: env `XDG_CONFIG_HOME` is only available for the AUT context so not available for the squish and test script

~NOTE: we have to come up with something for running tests locally with Squish.~
~**WARN: NOT RECOMMENDED to run gui-tests on local machine (doing so will remove existing client configs)**~