### PR TITLE
[tests-only] [full-ci] add test for verifying options of settings tab

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -49,3 +49,4 @@ o_folderList_ownCloud_QModelIndex = {"column": 0, "container": stack_folderList_
 contentWidget_contentWidget_QStackedWidget = {"container": setupWizardWindow_contentWidget_QStackedWidget, "name": "contentWidget", "type": "QStackedWidget", "visible": 1}
 o_folderList_Personal_QModelIndex = {"column": 0, "container": stack_folderList_QTreeView, "text": "Personal", "type": "QModelIndex"}
 add_Folder_Sync_Connection_tableView_QTableView = {"name": "tableView","type": "QTableView","visible": 1,"window": add_Folder_Sync_Connection_OCC_FolderWizard}
+stack_scrollArea_QScrollArea = {"container": settings_stack_QStackedWidget, "name": "scrollArea", "type": "QScrollArea", "visible": 1}

--- a/test/gui/shared/scripts/pageObjects/Settings.py
+++ b/test/gui/shared/scripts/pageObjects/Settings.py
@@ -1,0 +1,96 @@
+import names
+import squish
+
+
+class Settings:
+    CHECKBOX_OPTION_ITEM = {
+        "container": names.stack_scrollArea_QScrollArea,
+        "type": "QCheckBox",
+        "visible": 1,
+    }
+    NETWORK_OPTION_ITEM = {
+        "container": names.stack_scrollArea_QScrollArea,
+        "type": "QGroupBox",
+        "visible": 1,
+    }
+    ABOUT_BUTTON = {
+        "container": names.settings_stack_QStackedWidget,
+        "name": "about_pushButton",
+        "type": "QPushButton",
+        "visible": 1,
+    }
+    ABOUT_DIALOG = {
+        "name": "OCC__AboutDialog",
+        "type": "OCC::AboutDialog",
+        "visible": 1,
+    }
+    ABOUT_DIALOG_OK_BUTTON = {
+        "text": "OK",
+        "type": "QPushButton",
+        "unnamed": 1,
+        "visible": 1,
+        "window": ABOUT_DIALOG,
+    }
+
+    GENERAL_OPTIONS_MAP = {
+        "Start on Login": "autostartCheckBox",
+        "Use Monochrome Icons in the system tray": "monoIconsCheckBox",
+        "Language": "languageDropdown",
+        "Show desktop Notifications": "desktopNotificationsCheckBox",
+    }
+    ADVANCED_OPTION_MAP = {
+        "Sync hidden files": "syncHiddenFilesCheckBox",
+        "Show crash reporter": "",
+        "Edit ignored files": "ignoredFilesButton",
+        "Log settings": "logSettingsButton",
+        "Ask for confirmation before synchronizing folders larger than 500 MB": "newFolderLimitCheckBox",
+        "Ask for confirmation before synchronizing external storages": "newExternalStorage",
+    }
+    NETWORK_OPTION_MAP = {
+        "Proxy Settings": "proxyGroupBox",
+        "Download Bandwidth": "downloadBox",
+        "Upload Bandwidth": "uploadBox",
+    }
+
+    @staticmethod
+    def get_checkbox_option_selector(name):
+        selector = Settings.CHECKBOX_OPTION_ITEM.copy()
+        selector.update({"name": name})
+        if name == "languageDropdown":
+            selector.update({"type": "QComboBox"})
+        elif name == "ignoredFilesButton" or name == "logSettingsButton":
+            selector.update({"type": "QPushButton"})
+        return selector
+
+    @staticmethod
+    def get_network_option_selector(name):
+        selector = Settings.NETWORK_OPTION_ITEM.copy()
+        selector.update({"name": name})
+        return selector
+
+    @staticmethod
+    def check_general_option(option):
+        selector = Settings.GENERAL_OPTIONS_MAP[option]
+        squish.waitForObjectExists(Settings.get_checkbox_option_selector(selector))
+
+    @staticmethod
+    def check_advanced_option(option):
+        selector = Settings.ADVANCED_OPTION_MAP[option]
+        squish.waitForObjectExists(Settings.get_checkbox_option_selector(selector))
+
+    @staticmethod
+    def check_network_option(option):
+        selector = Settings.NETWORK_OPTION_MAP[option]
+        squish.waitForObjectExists(Settings.get_network_option_selector(selector))
+
+    @staticmethod
+    def open_about_button():
+        squish.clickButton(squish.waitForObject(Settings.ABOUT_BUTTON))
+
+    @staticmethod
+    def wait_for_about_dialog_to_be_visible():
+        squish.waitForObjectExists(Settings.ABOUT_DIALOG)
+
+    @staticmethod
+    def close_about_dialog():
+        squish.clickButton(squish.waitForObjectExists(Settings.ABOUT_DIALOG_OK_BUTTON))

--- a/test/gui/shared/scripts/pageObjects/Toolbar.py
+++ b/test/gui/shared/scripts/pageObjects/Toolbar.py
@@ -31,3 +31,7 @@ class Toolbar:
                 Toolbar.getItemSelector(displayname + "@" + host)
             ).text
         )
+
+    @staticmethod
+    def open_settings_tab():
+        squish.clickButton(squish.waitForObject(Toolbar.getItemSelector("Settings")))

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -166,3 +166,8 @@ def step(context, user, folder_name):
 @Given('user "|any|" has uploaded file with content "|any|" to "|any|" in the server')
 def step(context, user, file_content, file_name):
     webdav.create_file(user, file_name, file_content)
+
+
+@When("the user clicks on the settings tab")
+def step(context):
+    Toolbar.open_settings_tab()

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -2,6 +2,7 @@ from pageObjects.SyncConnectionWizard import SyncConnectionWizard
 from pageObjects.SyncConnection import SyncConnection
 from pageObjects.Toolbar import Toolbar
 from pageObjects.Activity import Activity
+from pageObjects.Settings import Settings
 
 from helpers.SetupClientHelper import getResourcePath
 from helpers.ConfigHelper import get_config
@@ -173,3 +174,31 @@ def step(context, folderName):
 @When('the user syncs the "|any|" space')
 def step(context, spaceName):
     SyncConnectionWizard.syncSpace(spaceName)
+
+
+@Then('the settings tab should have the following options in the general section:')
+def step(context):
+    for item in context.table:
+        Settings.check_general_option(item[0])
+
+
+@Then('the settings tab should have the following options in the advanced section:')
+def step(context):
+    for item in context.table:
+        Settings.check_advanced_option(item[0])
+
+
+@Then('the settings tab should have the following options in the network section:')
+def step(context):
+    for item in context.table:
+        Settings.check_network_option(item[0])
+
+
+@When('the user opens the about dialog')
+def step(context):
+    Settings.open_about_button()
+
+
+@Then('the about dialog should be opened')
+def step(context):
+    Settings.wait_for_about_dialog_to_be_visible()

--- a/test/gui/tst_checkAlltabs/test.feature
+++ b/test/gui/tst_checkAlltabs/test.feature
@@ -20,3 +20,26 @@ Feature: Visually check all tabs
         And user "Alice" has set up a client with default settings
         When the user presses the "Ctrl+l" keys
         Then the log dialog should be opened
+
+
+    Scenario: Verify various setting options in Settings tab
+        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has set up a client with default settings
+        When the user clicks on the settings tab
+        Then the settings tab should have the following options in the general section:
+            | Start on Login                           |
+            | Use Monochrome Icons in the system tray  |
+            | Show desktop Notifications               |
+            | Language                                 |
+        And the settings tab should have the following options in the advanced section:
+            | Sync hidden files                                                    |
+            | Edit ignored files                                                   |
+            | Log settings                                                         |
+            | Ask for confirmation before synchronizing folders larger than 500 MB |
+            | Ask for confirmation before synchronizing external storages          |
+        And the settings tab should have the following options in the network section:
+            | Proxy Settings     |
+            | Download Bandwidth |
+            | Upload Bandwidth   |
+        When the user opens the about dialog
+        Then the about dialog should be opened


### PR DESCRIPTION
Added test scenario for verifying options of `Settings Tab`
**General Settings**
    Checkboxes:
  
  -   Launch on System Startup
  -   Use Monochrome Icons
  -   Show Desktop Notifications
  -   Language option

**Advanced**
Checkboxes:

- Show sync folders in Explorer's Navigation Pane (Windows) :x: 
- Sync hidden files
- Show crash reporter :x: 

Buttons:

- Edit Ignored Files - opens Ignored files dialog
- Log Settings

Non VFS mode checkboxes:

- Ask for confirmation before synchronizing folders larger than 500 MB
- Ask for confirmation before synchronizing external storages

**Network**

- Proxy Settings
- Download Bandwidth
- Upload Bandwidth sections

**Version**
- Updates section (Channels are only available in testpilotcloud and on Mac we don't have the update info section)
- About button - opens About ownCloud dialog when clicked