### PR TITLE
Ci: Github actions use python 3.11 for now

### DIFF
--- a/.github/workflows/.craft.ps1
+++ b/.github/workflows/.craft.ps1
@@ -1,5 +1,7 @@
 if ($IsWindows) {
     $python=(py -V:3.11 -c "import sys; print(sys.executable)")
+} elseif ($IsMacOS) {
+    $python = (Get-Command "python3.11").Source
 } else {
     $python = (Get-Command python3).Source
 }


### PR DESCRIPTION
Craft has issues with python3.12 which are fixed upstream, we however pinned the craft revision.