### PR TITLE
Include recent change events in local discover

### DIFF
--- a/changelog/unreleased/11347
+++ b/changelog/unreleased/11347
@@ -1,0 +1,5 @@
+Enhancement: Include recent changes in scheduled syncs
+
+When starting a new sync we now also include the recent change events in the discovery.
+
+https://github.com/owncloud/client/pull/11347

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -963,6 +963,10 @@ void Folder::startSync()
 
     setDirtyNetworkLimits();
 
+    // get the latest touched files
+    // this will enque this folder again, it doesn't matter
+    slotWatchedPathsChanged(_folderWatcher->popChangeSet(), Folder::ChangeReason::Other);
+
     const std::chrono::milliseconds fullLocalDiscoveryInterval = ConfigFile().fullLocalDiscoveryInterval();
     const bool hasDoneFullLocalDiscovery = _timeSinceLastFullLocalDiscovery.isValid();
     // negative fullLocalDiscoveryInterval means we don't require periodic full runs

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -80,6 +80,10 @@ public:
     /// For testing linux behavior only
     int testLinuxWatchCount() const;
 
+    // pop the accumulated changes
+    QSet<QString> popChangeSet();
+
+
 signals:
     /** Emitted when one of the watched directories or one
      *  of the contained files is changed. */


### PR DESCRIPTION
Since 5.0 we accumulate changes for 10s, include accumulated changes when starting a sync.