### PR TITLE
[tests-only] [full-ci] test for uploading file in remote folder with selective sync

### DIFF
--- a/test/gui/shared/scripts/helpers/api/webdav_helper.py
+++ b/test/gui/shared/scripts/helpers/api/webdav_helper.py
@@ -64,3 +64,9 @@ def create_file(user, file_name, contents):
     assert (
         response.status_code == 201
     ), f"Could not create file '{file_name}' for user {user}"
+
+
+def delete_resource(user, resource):
+    url = get_resource_path(user, resource)
+    response = request.delete(url, user=user)
+    assert response.status_code == 204, f"Could not delete folder '{resource}'"

--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -107,8 +107,7 @@ class SyncConnectionWizard:
         SyncConnectionWizard.nextStep()
 
     @staticmethod
-    def selectFoldersToSync(folders):
-        # first deselect all
+    def deselectAllRemoteFolders():
         squish.mouseClick(
             squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
             11,
@@ -116,16 +115,45 @@ class SyncConnectionWizard:
             squish.Qt.NoModifier,
             squish.Qt.LeftButton,
         )
+
+    @staticmethod
+    def selectFoldersToSync(folders):
+        # first deselect all
+        SyncConnectionWizard.deselectAllRemoteFolders()
         for folder in folders:
-            # added a new key 'text' to dictionary SYNC_DIALOG_FOLDER_TREE
-            SyncConnectionWizard.SYNC_DIALOG_FOLDER_TREE['text'] = folder
-            squish.mouseClick(
-                squish.waitForObject(SyncConnectionWizard.SYNC_DIALOG_FOLDER_TREE),
-                11,
-                11,
-                squish.Qt.NoModifier,
-                squish.Qt.LeftButton,
-            )
+            folder_levels = folder.strip("/").split("/")
+            parent_selector = None
+            for sub_folder in folder_levels:
+                if not parent_selector:
+                    SyncConnectionWizard.SYNC_DIALOG_FOLDER_TREE['text'] = sub_folder
+                    parent_selector = SyncConnectionWizard.SYNC_DIALOG_FOLDER_TREE
+                    selector = parent_selector
+                else:
+                    selector = {
+                        "column": '0',
+                        "container": parent_selector,
+                        "text": sub_folder,
+                        "type": 'QModelIndex',
+                    }
+                if (
+                    len(folder_levels) == 1
+                    or folder_levels.index(sub_folder) == len(folder_levels) - 1
+                ):
+                    squish.mouseClick(
+                        squish.waitForObject(selector),
+                        11,
+                        11,
+                        squish.Qt.NoModifier,
+                        squish.Qt.LeftButton,
+                    )
+                else:
+                    squish.doubleClick(
+                        squish.waitForObject(selector),
+                        65,
+                        7,
+                        squish.Qt.NoModifier,
+                        squish.Qt.LeftButton,
+                    )
 
     @staticmethod
     def sortBy(headerText):

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -171,3 +171,13 @@ def step(context, user, file_content, file_name):
 @When("the user clicks on the settings tab")
 def step(context):
     Toolbar.open_settings_tab()
+
+
+@When('user "|any|" uploads file with content "|any|" to "|any|" in the server')
+def step(context, user, file_content, file_name):
+    webdav.create_file(user, file_name, file_content)
+
+
+@When('user "|any|" deletes the folder "|any|" in the server')
+def step(context, user, folder_name):
+    webdav.delete_resource(user, folder_name)

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -202,3 +202,13 @@ def step(context):
 @Then('the about dialog should be opened')
 def step(context):
     Settings.wait_for_about_dialog_to_be_visible()
+
+
+@When('the user adds the folder sync connection')
+def step(context):
+    SyncConnectionWizard.addSyncConnection()
+
+
+@When("user unselects all the remote folders")
+def step(context):
+    SyncConnectionWizard.deselectAllRemoteFolders()

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -58,6 +58,8 @@ Feature: Syncing files
     Scenario: Sync all is selected by default
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created folder "large-folder" in the server
+        And user "Alice" has uploaded file with content "test content" to "testFile.txt" in the server
+        And user "Alice" has uploaded file with content "lorem content" to "lorem.txt" in the server
         And the user has started the client
         And the user has entered the following account information:
             | server   | %local_server% |
@@ -67,6 +69,13 @@ Feature: Syncing files
         And the user sets the sync path in sync connection wizard
         And the user selects "ownCloud" as a remote destination folder
         Then the sync all checkbox should be checked
+        When user unselects all the remote folders
+        And the user adds the folder sync connection
+        And the user waits for the files to sync
+        Then the file "testFile.txt" should exist on the file system
+        And the file "lorem.txt" should exist on the file system
+        But the folder "simple-folder" should not exist on the file system
+        And the folder "large-folder" should not exist on the file system
 
     @skipOnOCIS
     Scenario: Sync only one folder from the server
@@ -85,6 +94,20 @@ Feature: Syncing files
             | simple-folder |
         Then the folder "simple-folder" should exist on the file system
         But the folder "large-folder" should not exist on the file system
+        When user "Alice" uploads file with content "some content" to "simple-folder/lorem.txt" in the server
+        And user "Alice" uploads file with content "ownCloud" to "large-folder/lorem.txt" in the server
+        And user "Alice" creates a file "simple-folder/localFile.txt" with the following content inside the sync folder
+            """
+            test content
+            """
+        And the user waits for the files to sync
+        Then the file "simple-folder/lorem.txt" should exist on the file system
+        And the file "large-folder/lorem.txt" should not exist on the file system
+        And as "Alice" file "simple-folder/localFile.txt" should exist in the server
+        When the user deletes the folder "simple-folder"
+        And the user waits for the files to sync
+        Then as "Alice" folder "simple-folder" should not exist in the server
+
 
     @issue-9733 @skipOnOCIS
     Scenario: sort folders list by name and size
@@ -390,6 +413,10 @@ Feature: Syncing files
     @skipOnOCIS
     Scenario: sync remote folder to a local sync folder having special characters
         Given user "Alice" has created folder "~`!@#$^&()-_=+{[}];',)" in the server
+        And user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has created folder "test-folder" in the server
+        And user "Alice" has created folder "test-folder/sub-folder1" in the server
+        And user "Alice" has created folder "test-folder/sub-folder2" in the server
         And user "Alice" has created folder "~test%" in the server
         And the user has created a folder "~`!@#$^&()-_=+{[}];',)PRN%" in temp folder
         And the user has started the client
@@ -401,7 +428,15 @@ Feature: Syncing files
         And the user sets the temp folder "~`!@#$^&()-_=+{[}];',)PRN%" as local sync path in sync connection wizard
         And the user selects "ownCloud" as a remote destination folder
         And the user selects the following folders to sync:
-            | folder                 |
-            | ~`!@#$^&()-_=+{[}];',) |
+            | folder                  |
+            | ~`!@#$^&()-_=+{[}];',)  |
+            | simple-folder           |
+            | test-folder/sub-folder2 |
         Then the folder "~`!@#$^&()-_=+{[}];',)" should exist on the file system
+        And the folder "simple-folder" should exist on the file system
         But the folder "~test%" should not exist on the file system
+        When user "Alice" deletes the folder "simple-folder" in the server
+        And the user waits for the files to sync
+        Then the folder "simple-folder" should not exist on the file system
+        And the folder "test-folder/sub-folder2" should exist on the file system
+        And the folder "test-folder/sub-folder1" should not exist on the file system


### PR DESCRIPTION
Refactored test scenario to cover the test cases related to selective sync with oc10 server:

1. Verify that the subfolders that you unselect are not synced
2. Upload some files from the server in a folder which is selected to be synced
3. Upload some files from the file explorer in the synced folder
4. Upload some files from the server in a folder which is not synced
5. Delete a synced folder from the file explorer
6. Delete a synced folder from the server
7. Verify that when you unselect all the folders, the root files continue to sync

Related Issue: https://github.com/owncloud/QA/issues/789