### PR TITLE
Fix current CPU architecture detection with rosetta2

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -127,15 +127,10 @@ static QLatin1String platform()
 QByteArray Utility::userAgentString()
 {
     return QStringLiteral("Mozilla/5.0 (%1) mirall/%2 (%3, %4-%5 ClientArchitecture: %6 OsArchitecture: %7)")
-        .arg(platform(),
-            OCC::Version::displayString(),
+        .arg(platform(), OCC::Version::displayString(),
             // accessing the theme to fetch the string is rather difficult
             // since this is only needed server-side to identify clients, the app name (as of 2.9, the short name) is good enough
-            qApp->applicationName(),
-            QSysInfo::productType(),
-            QSysInfo::kernelVersion(),
-            QSysInfo::buildCpuArchitecture(),
-            QSysInfo::currentCpuArchitecture())
+            qApp->applicationName(), QSysInfo::productType(), QSysInfo::kernelVersion(), QSysInfo::buildCpuArchitecture(), Utility::currentCpuArch())
         .toLatin1();
 }
 
@@ -621,6 +616,13 @@ QString Utility::formatRFC1123Date(const QDateTime &date)
 {
     return date.toUTC().toString(RFC1123PatternC());
 }
+
+#ifndef Q_OS_MAC
+QString Utility::currentCpuArch()
+{
+    return QSysInfo::currentCpuArchitecture();
+}
+#endif
 
 } // namespace OCC
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -323,6 +323,9 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
 
     OCSYNC_EXPORT QDateTime parseRFC1123Date(const QString &date);
     OCSYNC_EXPORT QString formatRFC1123Date(const QDateTime &date);
+
+    // replacement for QSysInfo::currentCpuArchitecture() that respects macOS's rosetta2
+    OCSYNC_EXPORT QString currentCpuArch();
 } // Utility namespace
 /** @} */ // \addtogroup
 

--- a/src/common/utility_mac.mm
+++ b/src/common/utility_mac.mm
@@ -32,6 +32,8 @@
 #import <Foundation/NSFileManager.h>
 #import <Foundation/NSUserDefaults.h>
 
+#include <sys/sysctl.h>
+
 namespace OCC {
 
 void Utility::setupFavLink(const QString &folder)
@@ -254,5 +256,20 @@ bool Utility::hasDarkSystray()
     return false;
 }
 #endif
+
+QString Utility::currentCpuArch()
+{
+    int ret = 0;
+    size_t size = sizeof(ret);
+
+    // ret will be 1 if the process is translated (most likely with rosetta2)
+    if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1) {
+        if (errno != ENOENT) {
+            return QStringLiteral("arm64");
+        }
+    }
+
+    return QSysInfo::currentCpuArchitecture();
+}
 
 } // namespace OCC

--- a/src/common/utility_mac.mm
+++ b/src/common/utility_mac.mm
@@ -259,17 +259,21 @@ bool Utility::hasDarkSystray()
 
 QString Utility::currentCpuArch()
 {
-    int ret = 0;
-    size_t size = sizeof(ret);
+    static const QString rv = []() {
+        int ret = 0;
+        size_t size = sizeof(ret);
 
-    // ret will be 1 if the process is translated (most likely with rosetta2)
-    if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1) {
-        if (errno != ENOENT) {
-            return QStringLiteral("arm64");
+        // ret will be 1 if the process is translated (most likely with rosetta2)
+        if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1) {
+            if (errno != ENOENT) {
+                return QStringLiteral("arm64");
+            }
         }
-    }
 
-    return QSysInfo::currentCpuArchitecture();
+        return QSysInfo::currentCpuArchitecture();
+    }();
+
+    return rv;
 }
 
 } // namespace OCC

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -87,7 +87,7 @@ QUrlQuery Updater::getQueryParams()
     query.addQueryItem(QStringLiteral("platform"), platform);
     query.addQueryItem(QStringLiteral("oem"), theme->appName());
     query.addQueryItem(QStringLiteral("buildArch"), QSysInfo::buildCpuArchitecture());
-    query.addQueryItem(QStringLiteral("currentArch"), QSysInfo::currentCpuArchitecture());
+    query.addQueryItem(QStringLiteral("currentArch"), Utility::currentCpuArch());
 
     // client updater server is now aware of packaging format
     // TODO: add packaging string for other supported platforms, too

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -374,7 +374,8 @@ QString Theme::aboutVersions(Theme::VersionFormat format) const
             gitUrl = gitSHA1(format) + br;
         }
     }
-    QStringList sysInfo = {QStringLiteral("OS: %1-%2").arg(QSysInfo::productType(), QSysInfo::kernelVersion())};
+    QStringList sysInfo = {QStringLiteral("OS: %1-%2 (build arch: %3, CPU arch: %4)")
+                               .arg(QSysInfo::productType(), QSysInfo::kernelVersion(), QSysInfo::buildCpuArchitecture(), Utility::currentCpuArch())};
     // may be called by both GUI and CLI, but we can display QPA only for the former
     if (auto guiApp = qobject_cast<QGuiApplication *>(qApp)) {
         sysInfo << QStringLiteral("QPA: %1").arg(guiApp->platformName());


### PR DESCRIPTION
This PR uses a syscall to properly detect whether the application is running inside of macOS's rosetta2 emulator. It replaces uses of `QSysInfo::currentCpuArchitecture()` with a custom in our code.

It further extends the about dialog to show the detected build and CPU architectures.

This is a preparation for #10757.

Please note that the formatting changes are forced by clang-format. I'm not a fan of them.