### PR TITLE
[tests-only] [full-ci] skip GUI tests related to suffix vfs

### DIFF
--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -59,6 +59,7 @@ Feature: adding accounts
         Then credentials wizard should be visible
 
 
+    @skip @issue-11393
     Scenario: Adding account with vfs enabled
         Given the user has started the client
         And the user has entered the following account information:
@@ -70,6 +71,7 @@ Feature: adding accounts
         Then VFS enabled baseline image should match the default screenshot
 
 
+    @skip @issue-11393
     Scenario: Try to enable experimental vfs option and cancel it
         Given the user has started the client
         And the user has entered the following account information:

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -1,3 +1,4 @@
+@skip @issue-11393
 Feature: Enable/disable virtual file support
 
     As a user


### PR DESCRIPTION
In this pr GUI tests related to suffix vfs are skipped but not removed as those tests might work for Windows.

Related pr: https://github.com/owncloud/client/pull/11365
Part of https://github.com/owncloud/client/issues/11393