### PR TITLE
Fix switching vfs during a sync

### DIFF
--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -313,10 +313,6 @@ public:
     bool virtualFilesEnabled() const;
     void setVirtualFilesEnabled(bool enabled);
 
-    /** Whether user desires a switch that couldn't be executed yet, see member */
-    bool isVfsOnOffSwitchPending() const { return _vfsOnOffPending; }
-    void setVfsOnOffSwitchPending(bool pending) { _vfsOnOffPending = pending; }
-
     /** Whether this folder should show selective sync ui */
     bool supportsSelectiveSync() const;
 
@@ -500,14 +496,6 @@ private:
     QScopedPointer<SyncRunFileLog> _fileLog;
 
     QTimer _scheduleSelfTimer;
-
-    /** Whether a vfs mode switch is pending
-     *
-     * When the user desires that vfs be switched on/off but it hasn't been
-     * executed yet (syncs are still running), some options should be hidden,
-     * disabled or different.
-     */
-    bool _vfsOnOffPending = false;
 
     /**
      * Setting up vfs is a async operation


### PR DESCRIPTION
With the previous implementation it was possible that we started to swap the back end while a sync was running.
This change ensures that 
- the current sync is aborted
- the sync is paused
- the backend is switched
- the sync is unpaused
- we sync

For testing please start a sync (an upload with throttling enabled) and disable/enable vfs.
Things to watch out for.
- Selective sync
- dehydrated files