### PR TITLE
Remove styling from the warning label in the "Add Folder" dialog

### DIFF
--- a/src/gui/folderwizard/folderwizardsourcepage.ui
+++ b/src/gui/folderwizard/folderwizardsourcepage.ui
@@ -37,84 +37,11 @@
    </item>
    <item>
     <widget class="QLabel" name="warnLabel">
-     <property name="palette">
-      <palette>
-       <active>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>192</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </active>
-       <inactive>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>192</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </inactive>
-       <disabled>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>192</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>192</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </disabled>
-      </palette>
-     </property>
-     <property name="autoFillBackground">
-      <bool>true</bool>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <property name="text">
       <string/>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
-     </property>
-     <property name="margin">
-      <number>3</number>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The styling caused unreadable warning/error messages when the OS theme was set to dark: the text color would be white, but the background was styled to be white too.

The message is still noticable: normally there is no text in the label, so an error or warning message showing up will be noticed.

Fixes: https://github.com/owncloud/client/issues/11243