### PR TITLE
Send kernel and OS version information to update server

### DIFF
--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -103,6 +103,15 @@ QUrlQuery Updater::getQueryParams()
         query.addQueryItem(QStringLiteral("channel"), channel);
     }
 
+    // requested by #11328
+    // we use the names Qt gives us instead of inventing our own labels
+    // see https://doc.qt.io/qt-6/qsysinfo.html#productVersion
+    query.addQueryItem(QStringLiteral("kernelType"), QSysInfo::kernelType());
+    query.addQueryItem(QStringLiteral("kernelVersion"), QSysInfo::kernelVersion());
+    query.addQueryItem(QStringLiteral("productType"), QSysInfo::productType());
+    query.addQueryItem(QStringLiteral("productVersion"), QSysInfo::productVersion());
+    qDebug() << QSysInfo::productVersion();
+
     return query;
 }
 

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -110,7 +110,6 @@ QUrlQuery Updater::getQueryParams()
     query.addQueryItem(QStringLiteral("kernelVersion"), QSysInfo::kernelVersion());
     query.addQueryItem(QStringLiteral("productType"), QSysInfo::productType());
     query.addQueryItem(QStringLiteral("productVersion"), QSysInfo::productVersion());
-    qDebug() << QSysInfo::productVersion();
 
     return query;
 }


### PR DESCRIPTION
This will allow us implementing some additional logic in the update server to prevent updates on now-incompatible products and give users better feedback in such situations.

Fixes #11328.