### PR TITLE
Add new EdDSA pubkey to Info.plist

### DIFF
--- a/src/gui/MacOSXBundleInfo.plist
+++ b/src/gui/MacOSXBundleInfo.plist
@@ -32,6 +32,8 @@
         <string>dsa_pub.pem</string>
         <key>SUPublicEDKey</key>
         <string>F9ZGRXJE7XbQb2Kt36hwaBO4rYjkXYHiNS5hd+MkyKY=</string>
+        <key>SUAllowsAutomaticUpdates</key>
+        <string>NO</string>
 
 <key>UTExportedTypeDeclarations</key>
 <array>

--- a/src/gui/MacOSXBundleInfo.plist
+++ b/src/gui/MacOSXBundleInfo.plist
@@ -4,7 +4,7 @@
 <dict>
         <key>NSPrincipalClass</key>
         <string>NSApplication</string>
-	<key>CFBundleDevelopmentRegion</key>
+        <key>CFBundleDevelopmentRegion</key>
         <string>English</string>
         <key>CFBundleExecutable</key>
         <string>${APPLICATION_EXECUTABLE}</string>
@@ -30,6 +30,8 @@
         <false/>
         <key>SUPublicDSAKeyFile</key>
         <string>dsa_pub.pem</string>
+        <key>SUPublicEDKey</key>
+        <string>F9ZGRXJE7XbQb2Kt36hwaBO4rYjkXYHiNS5hd+MkyKY=</string>
 
 <key>UTExportedTypeDeclarations</key>
 <array>


### PR DESCRIPTION
We sign our updates with both EdDSA and classic DSA now to

1. allow seamless upgrades for 5.x and before to the new versions (they should already support EdDSA but don't know the key, hence using DSA along with EdDSA allows them to build a chain of trust; once on 6.x, they will be using EdDSA anyway)
1. allow 6.x+ to update to newer versions (Sparkle in there rejects DSA and demands EdDSA, so that's fixed by now)

Sparkle looks up the key in the bundle's `Info.plist`, so we need to add it to that file. Then, upgrades on 6.x should work smoothly.

To test:

1. test an upgrade from 5.x and before (I suggest 5.2.0 and the latest 4.x release) to 6.x using our force-update server
1. test an upgrade from 6.x using our force-update server