### PR TITLE
Update release_template.md

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -16,7 +16,6 @@ __TODO__:
 * [ ] QA: Check the translations coming from transifex: https://github.com/owncloud/client/commits/ -> Filter based on a release branch/tag and search for `[tx] updated client translations from transifex [skip ci]`
 * [ ] DEV: Check for new OpenSSL version 
 * [ ] DEV: Update [dependencies](https://confluence.owncloud.com/display/OG/Dependencies)
-* [ ] DEV: Update [SBOM](https://cloud.owncloud.com/f/6072843)
 * [ ] DEV: For a major release create `X` version branch
   * [ ] QA: In drone adjust the branch for nightly [GUI tests](https://confluence.owncloud.com/display/OG/Squish+Testing#SquishTesting-Prerequisite) @individual-it
 * [ ] QA: Communicate documentation changes  
@@ -76,6 +75,7 @@ __TODO__:
 * [ ] QA: Update lines 4 and 5 of [install docs](https://github.com/owncloud/docs-client-desktop/blob/master/modules/ROOT/pages/installing.adoc) with the final build number. Merge into master and backport to the respective branch
 * [ ] QA: Check that [documentation](https://doc.owncloud.com/desktop/next/) offers the new version
 * [ ] DEV: Merge version branch into master
+* [ ] DEV: Update [SBOM](https://cloud.owncloud.com/f/6072843)
 
 ### [Marketing and Communication](https://confluence.owncloud.com/display/OG/Marketing+and+Communication)
    

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -15,7 +15,7 @@ __TODO__:
 * [ ] Update [supported platforms](https://doc.owncloud.com/desktop/next/installing.html#system-requirements) @michaelstingl
 * [ ] QA: Check the translations coming from transifex: https://github.com/owncloud/client/commits/ -> Filter based on a release branch/tag and search for `[tx] updated client translations from transifex [skip ci]`
 * [ ] DEV: Check for new OpenSSL version 
-* [ ] DEV: Check [dependencies](https://confluence.owncloud.com/display/OG/Dependencies) for updates
+* [ ] DEV: Update [dependencies](https://confluence.owncloud.com/display/OG/Dependencies) for updates
 * [ ] DEV: Update [SBOM](https://cloud.owncloud.com/f/6072843)
 * [ ] DEV: For a major release create `X` version branch
   * [ ] QA: In drone adjust the branch for nightly [GUI tests](https://confluence.owncloud.com/display/OG/Squish+Testing#SquishTesting-Prerequisite) @individual-it

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -15,7 +15,7 @@ __TODO__:
 * [ ] Update [supported platforms](https://doc.owncloud.com/desktop/next/installing.html#system-requirements) @michaelstingl
 * [ ] QA: Check the translations coming from transifex: https://github.com/owncloud/client/commits/ -> Filter based on a release branch/tag and search for `[tx] updated client translations from transifex [skip ci]`
 * [ ] DEV: Check for new OpenSSL version 
-* [ ] DEV: Update [dependencies](https://confluence.owncloud.com/display/OG/Dependencies) for updates
+* [ ] DEV: Update [dependencies](https://confluence.owncloud.com/display/OG/Dependencies)
 * [ ] DEV: Update [SBOM](https://cloud.owncloud.com/f/6072843)
 * [ ] DEV: For a major release create `X` version branch
   * [ ] QA: In drone adjust the branch for nightly [GUI tests](https://confluence.owncloud.com/display/OG/Squish+Testing#SquishTesting-Prerequisite) @individual-it

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -22,7 +22,7 @@ __TODO__:
 * [ ] QA: Communicate documentation changes  
    * [ ] Inform ``#documentation-internal`` (@mmattel) about the start of testing phase (latest a week before the release!). They'll prepare a PR with respective doc version
    * [ ] Open issues in ``docs-client-desktop`` repo for already known doc-relevant items and mark them accordingly, e.g. backport to 2.X.x necessary
-* [ ] Decide if the prerelease stage will be public or internat @michaelstingl 
+* [ ] Decide if the prerelease stage will be public or internal @michaelstingl 
 * [ ] Announce feature freeze in ``#release_coordination`` channel before Beta build
 * [ ] Announce string freeze in ``#release_coordination`` channel a few days later
    * [ ] Inform ``#documentation-internal`` about it so that they can do the translations


### PR DESCRIPTION
This is the update from last retro. We said 

"Update release template to include "Update dependencies" rather than "Check dependencies" and include "Update SBOM""

SBOM was already there so I'm not sure if you meant something else with it?