### PR TITLE
[full-ci] fix: skipOnOC10 tag also appended in ocis pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -170,9 +170,9 @@ def unit_test_pipeline(ctx):
     }]
 
 def gui_test_pipeline(ctx):
-    squish_parameters = "--reportgen html,%s --envvar QT_LOGGING_RULES=sync.httplogger=true;gui.socketapi=false  --tags ~@skip --tags ~@skipOnLinux" % dir["guiTestReport"]
     pipelines = []
     for server, params in config["gui-tests"]["servers"].items():
+        squish_parameters = "--reportgen html,%s --envvar QT_LOGGING_RULES=sync.httplogger=true;gui.socketapi=false  --tags ~@skip --tags ~@skipOnLinux" % dir["guiTestReport"]
         if params.get("skip", False):
             continue
         if ctx.build.event == "pull_request" and params.get("skip_in_pr", False) and not "full-ci" in ctx.build.title.lower():


### PR DESCRIPTION
`skipOnOC10` tag was also append to the ocis pipeline which is not right and that skipped the spaces test suite in ocis. This PR fixes the skip tags. And the space suite is running for ocis pipeline