### PR TITLE
[gui-tests][full-ci] Assert the presence of dehydrated file after VFS disabled

### DIFF
--- a/test/gui/shared/scripts/helpers/FilesHelper.py
+++ b/test/gui/shared/scripts/helpers/FilesHelper.py
@@ -1,5 +1,7 @@
 import os
 import re
+import ctypes
+from helpers.ConfigHelper import isWindows
 
 
 def buildConflictedRegex(filename):
@@ -78,3 +80,14 @@ def get_size_in_bytes(size):
                 return size_num * (multiplier**3)
 
     raise Exception("Invalid size: " + size)
+
+
+def get_file_size_on_disk(resource_path):
+    file_size_high = ctypes.c_ulonglong(0)
+    if isWindows():
+        return ctypes.windll.kernel32.GetCompressedFileSizeW(
+            ctypes.c_wchar_p(resource_path), ctypes.pointer(file_size_high)
+        )
+    raise Exception(
+        "'get_file_size_on_disk' function is only supported for Windows OS."
+    )

--- a/test/gui/shared/steps/vfs_context.py
+++ b/test/gui/shared/steps/vfs_context.py
@@ -1,0 +1,22 @@
+from helpers.FilesHelper import get_file_size_on_disk
+
+
+@Then('the placeholder of file "|any|" should exist on the file system')
+def step(context, file_name):
+    resource_path = getResourcePath(file_name)
+    size_on_disk = get_file_size_on_disk(resource_path)
+    test.compare(
+        size_on_disk, 0, f"Size of the placeholder on the disk is: '{size_on_disk}'"
+    )
+
+
+@Then('the file "|any|" should be downloaded')
+def step(context, file_name):
+    resource_path = getResourcePath(file_name)
+    size_on_disk = get_file_size_on_disk(resource_path)
+    file_size = os.stat(resource_path).st_size
+    test.compare(
+        size_on_disk,
+        file_size,
+        f"Original file size '{file_size}' is not equal to its size on disk '{size_on_disk}'",
+    )

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -8,8 +8,23 @@ Feature: Enable/disable virtual file support
 
     Scenario: Disable/Enable VFS
         Given user "Alice" has been created on the server with default attributes and without skeleton files
+        And user "Alice" has uploaded file with content "ownCloud" to "testFile.txt" in the server
+        And user "Alice" has created folder "folder1" in the server
+        And user "Alice" has uploaded file with content "some contents" to "folder1/lorem.txt" in the server
         And user "Alice" has set up a client with default settings
+        Then the placeholder of file "testFile.txt" should exist on the file system
+        And the placeholder of file "folder1/lorem.txt" should exist on the file system
         When the user disables virtual file support
         Then the "Enable virtual file support..." button should be available
+        And the file "testFile.txt" should be downloaded
+        And the file "folder1/lorem.txt" should be downloaded
+        And the file "testFile.txt" should exist on the file system with the following content
+            """
+            ownCloud
+            """
+        And the file "folder1/lorem.txt" should exist on the file system with the following content
+            """
+            some contents
+            """
         When the user enables virtual file support
         Then the "Disable virtual file support..." button should be available


### PR DESCRIPTION
This PR extends the scenario for `Disable/Enable VFS` in windows to verify that the dehydrated file are present after disabling VFS. 

Related Issue: https://github.com/owncloud/client/issues/11346

Added test coverage for https://github.com/owncloud/client/issues/11331