### PR TITLE
[gui-tests][full-ci] Vfs and selective sync

### DIFF
--- a/test/gui/shared/scripts/helpers/FilesHelper.py
+++ b/test/gui/shared/scripts/helpers/FilesHelper.py
@@ -91,3 +91,7 @@ def get_file_size_on_disk(resource_path):
     raise Exception(
         "'get_file_size_on_disk' function is only supported for Windows OS."
     )
+
+
+def get_file_size(resource_path):
+    return os.stat(resource_path).st_size

--- a/test/gui/shared/scripts/pageObjects/SyncConnection.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnection.py
@@ -1,5 +1,6 @@
 import names
 import squish
+import object
 
 from helpers.ConfigHelper import get_config
 
@@ -21,6 +22,12 @@ class SyncConnection:
         "type": "QPushButton",
         "visible": 1,
         "window": names.disable_virtual_file_support_QMessageBox,
+    }
+    SELECTIVE_SYNC_APPLY_BUTTON = {
+        "container": names.settings_stack_QStackedWidget,
+        "name": "selectiveSyncApply",
+        "type": "QPushButton",
+        "visible": 1,
     }
 
     @staticmethod
@@ -62,3 +69,41 @@ class SyncConnection:
     @staticmethod
     def hasMenuItem(item):
         return squish.waitForObjectItem(SyncConnection.MENU, item)
+
+    @staticmethod
+    def menu_item_exists(menuItem):
+        obj = SyncConnection.MENU.copy()
+        obj.update({"type": "QAction", "text": menuItem})
+        return object.exists(obj)
+
+    @staticmethod
+    def choose_what_to_sync():
+        SyncConnection.openMenu()
+        SyncConnection.performAction("Choose what to sync")
+
+    @staticmethod
+    def unselect_folder_in_selective_sync(folder_name):
+        sync_folders = object.children(
+            squish.waitForObject(SyncConnection.FOLDER_SYNC_CONNECTION)
+        )
+        for sync_folder in sync_folders:
+            # TODO: allow selective sync in other sync folders as well
+            if hasattr(sync_folder, "text") and sync_folder.text == "Personal":
+                items = object.children(sync_folder)
+                for item in items:
+                    if hasattr(item, "text") and item.text:
+                        # remove item size suffix
+                        # example: folder1 (13 B) => folder1
+                        item_name = item.text.rsplit(" ", 2)[0]
+                        if item_name == folder_name:
+                            squish.mouseClick(
+                                item,
+                                9,
+                                9,
+                                squish.Qt.NoModifier,
+                                squish.Qt.LeftButton,
+                            )
+                            break
+        squish.clickButton(
+            squish.waitForObject(SyncConnection.SELECTIVE_SYNC_APPLY_BUTTON)
+        )

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -4,7 +4,6 @@ from pageObjects.Toolbar import Toolbar
 from pageObjects.Activity import Activity
 from pageObjects.Settings import Settings
 
-from helpers.SetupClientHelper import getResourcePath
 from helpers.ConfigHelper import get_config, isWindows
 from helpers.SyncHelper import (
     waitForFileOrFolderToSync,
@@ -59,6 +58,16 @@ def step(context):
 def step(context, item):
     SyncConnection.openMenu()
     SyncConnection.hasMenuItem(item)
+
+
+@Then('the "|any|" button should not be available')
+def step(context, item):
+    SyncConnection.openMenu()
+    test.compare(
+        SyncConnection.menu_item_exists(item),
+        False,
+        f'Menu item "{item}" does not exist.',
+    )
 
 
 @When("the user disables virtual file support")
@@ -200,3 +209,9 @@ def step(context, action):
     if isWindows():
         action = action.rstrip("s")
         SyncConnectionWizard.enableOrDisableVfsSupport(action)
+
+
+@When('user unselects a folder "|any|" in selective sync')
+def step(context, folder_name):
+    SyncConnection.choose_what_to_sync()
+    SyncConnection.unselect_folder_in_selective_sync(folder_name)

--- a/test/gui/shared/steps/vfs_context.py
+++ b/test/gui/shared/steps/vfs_context.py
@@ -1,4 +1,4 @@
-from helpers.FilesHelper import get_file_size_on_disk
+from helpers.FilesHelper import get_file_size_on_disk, get_file_size
 
 
 @Then('the placeholder of file "|any|" should exist on the file system')
@@ -14,7 +14,7 @@ def step(context, file_name):
 def step(context, file_name):
     resource_path = getResourcePath(file_name)
     size_on_disk = get_file_size_on_disk(resource_path)
-    file_size = os.stat(resource_path).st_size
+    file_size = get_file_size(resource_path)
     test.compare(
         size_on_disk,
         file_size,

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -11,20 +11,24 @@ Feature: Enable/disable virtual file support
         And user "Alice" has uploaded file with content "ownCloud" to "testFile.txt" in the server
         And user "Alice" has created folder "folder1" in the server
         And user "Alice" has uploaded file with content "some contents" to "folder1/lorem.txt" in the server
+        And user "Alice" has created folder "folder2" in the server
+        And user "Alice" has uploaded file with content "content" to "folder2/lorem.txt" in the server
         And user "Alice" has set up a client with default settings
         Then the placeholder of file "testFile.txt" should exist on the file system
         And the placeholder of file "folder1/lorem.txt" should exist on the file system
+        And the placeholder of file "folder2/lorem.txt" should exist on the file system
+        And the "Choose what to sync" button should not be available
         When the user disables virtual file support
         Then the "Enable virtual file support..." button should be available
         And the file "testFile.txt" should be downloaded
         And the file "folder1/lorem.txt" should be downloaded
-        And the file "testFile.txt" should exist on the file system with the following content
-            """
-            ownCloud
-            """
-        And the file "folder1/lorem.txt" should exist on the file system with the following content
-            """
-            some contents
-            """
+        And the file "folder2/lorem.txt" should be downloaded
+        When user unselects a folder "folder1" in selective sync
+        And the user waits for the files to sync
+        Then the folder "folder1" should not exist on the file system
+        And the file "folder2/lorem.txt" should exist on the file system
         When the user enables virtual file support
         Then the "Disable virtual file support..." button should be available
+        And the placeholder of file "folder1/lorem.txt" should exist on the file system
+        And the file "testFile.txt" should be downloaded
+        And the file "folder2/lorem.txt" should be downloaded


### PR DESCRIPTION
Refactored the test scenario to cover the test cases related to VFS and selective sync in Windows:

1. Verify when VFS is on, user cannot select folders for selective sync
2. Unselect a folder in selective sync and Turn on VFS
3. Turn off VFS

Related Issue: https://github.com/owncloud/client/issues/11346