### PR TITLE
Properly handle ConnectionValidator error

### DIFF
--- a/changelog/unreleased/11467
+++ b/changelog/unreleased/11467
@@ -1,0 +1,6 @@
+Bugfix: Client stuck in `reconnecting`
+
+Properly handle errors during the update of the server settings.
+Due to an unhandled result, the client could get stuck in a `reconnecting` state.
+
+https://github.com/owncloud/client/pull/11467

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -238,13 +238,30 @@ void ConnectionValidator::slotAuthSuccess()
         const auto unsupportedServerError = [this] {
             _errors.append({tr("The configured server for this client is too old."), tr("Please update to the latest server and restart the client.")});
         };
-        connect(fetchSetting, &FetchServerSettingsJob::unknownServerDetected, unsupportedServerError);
-        connect(fetchSetting, &FetchServerSettingsJob::unsupportedServerDetected, [unsupportedServerError, this] {
-            unsupportedServerError();
-            reportResult(ServerVersionMismatch);
-        });
-
-        connect(fetchSetting, &FetchServerSettingsJob::finishedSignal, this, [this] { reportResult(Connected); });
+        connect(
+            fetchSetting, &FetchServerSettingsJob::finishedSignal, this, [fetchSetting, unsupportedServerError, this](FetchServerSettingsJob::Result result) {
+                switch (result) {
+                case FetchServerSettingsJob::Result::UnsupportedServer:
+                    unsupportedServerError();
+                    reportResult(ServerVersionMismatch);
+                    break;
+                case FetchServerSettingsJob::Result::InvalidCredentials:
+                    reportResult(CredentialsWrong);
+                    break;
+                case FetchServerSettingsJob::Result::TimeOut:
+                    reportResult(Timeout);
+                    break;
+                case FetchServerSettingsJob::Result::Success:
+                    if (_account->serverSupportLevel() == Account::ServerSupportLevel::Unknown) {
+                        unsupportedServerError();
+                    }
+                    reportResult(Connected);
+                    break;
+                case FetchServerSettingsJob::Result::Undefined:
+                    reportResult(Undefined);
+                    break;
+                }
+            });
 
         fetchSetting->start();
         return;

--- a/src/gui/fetchserversettings.h
+++ b/src/gui/fetchserversettings.h
@@ -25,31 +25,20 @@ class FetchServerSettingsJob : public QObject
 {
     Q_OBJECT
 public:
+    enum class Result { Success, TimeOut, InvalidCredentials, UnsupportedServer, Undefined };
+    Q_ENUM(Result);
     FetchServerSettingsJob(const AccountPtr &account, QObject *parent);
 
     void start();
 
 Q_SIGNALS:
-    /***
-     * The version of the server is unsupported
-     */
-    void unsupportedServerDetected();
-
-    /***
-     * We failed to detect the server version
-     */
-    void unknownServerDetected();
-
-    void finishedSignal();
+    void finishedSignal(Result);
 
 private:
     void runAsyncUpdates();
 
-    bool checkServerInfo();
-
     // returns whether the started jobs should be excluded from the retry queue
     bool isAuthJob() const;
-
 
     const AccountPtr _account;
 };


### PR DESCRIPTION
Properly handle errors during the update of the server settings. Due to an unhandled result, the client could get stuck in a ` reconnecting` state.