### PR TITLE
Fix badly styled warning/error messages

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -551,22 +551,18 @@ void AccountSettings::slotDisableVfsCurrentFolder()
 
 void AccountSettings::showConnectionLabel(const QString &message, QStringList errors)
 {
-    const QString errStyle = QStringLiteral("color:#ffffff; background-color:#bb4d4d;padding:5px;"
-                                            "border-width: 1px; border-style: solid; border-color: #aaaaaa;"
-                                            "border-radius:5px;");
     if (errors.isEmpty()) {
         ui->connectLabel->setText(message);
         ui->connectLabel->setToolTip(QString());
-        ui->connectLabel->setStyleSheet(QString());
     } else {
         errors.prepend(message);
         const QString msg = errors.join(QLatin1String("\n"));
         qCDebug(lcAccountSettings) << msg;
         ui->connectLabel->setText(msg);
         ui->connectLabel->setToolTip(QString());
-        ui->connectLabel->setStyleSheet(errStyle);
     }
     ui->accountStatus->setVisible(!message.isEmpty());
+    ui->warningLabel->setVisible(!errors.isEmpty());
 }
 
 void AccountSettings::slotEnableCurrentFolder(bool terminate)

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -18,6 +18,43 @@
     <widget class="QWidget" name="accountStatus" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
+       <widget class="QLabel" name="warningLabel">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>64</width>
+          <height>64</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>64</width>
+          <height>64</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::AutoText</enum>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../resources/client.qrc">:/client/resources/light/warning.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="connectLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -315,6 +352,8 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../resources/client.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/gui/folderwizard/folderwizardremotepath.cpp
+++ b/src/gui/folderwizard/folderwizardremotepath.cpp
@@ -40,7 +40,8 @@ FolderWizardRemotePath::FolderWizardRemotePath(FolderWizardPrivate *parent)
 
 {
     _ui->setupUi(this);
-    _ui->warnFrame->hide();
+    _ui->warningIcon->setPixmap(Resources::getCoreIcon(QStringLiteral("warning")).pixmap(_ui->warningIcon->size()));
+    _ui->warningFrame->hide(); // This is `show()`n in `FolderWizardRemotePath::showWarn`
 
     _ui->folderTreeWidget->setSortingEnabled(true);
     _ui->folderTreeWidget->sortByColumn(0, Qt::AscendingOrder);
@@ -361,10 +362,9 @@ void FolderWizardRemotePath::initializePage()
 void FolderWizardRemotePath::showWarn(const QString &msg) const
 {
     if (msg.isEmpty()) {
-        _ui->warnFrame->hide();
-
+        _ui->warningFrame->hide();
     } else {
-        _ui->warnFrame->show();
-        _ui->warnLabel->setText(msg);
+        _ui->warningFrame->show();
+        _ui->warningLabel->setText(QStringLiteral("<b>%1</b>").arg(msg));
     }
 }

--- a/src/gui/folderwizard/folderwizardtargetpage.ui
+++ b/src/gui/folderwizard/folderwizardtargetpage.ui
@@ -79,69 +79,12 @@
     <widget class="QLineEdit" name="folderEntry"/>
    </item>
    <item>
-    <widget class="QFrame" name="warnFrame">
+    <widget class="QFrame" name="warningFrame">
      <property name="palette">
       <palette>
-       <active>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>153</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </active>
-       <inactive>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>153</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </inactive>
-       <disabled>
-        <colorrole role="Base">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>153</blue>
-          </color>
-         </brush>
-        </colorrole>
-        <colorrole role="Window">
-         <brush brushstyle="SolidPattern">
-          <color alpha="255">
-           <red>255</red>
-           <green>255</green>
-           <blue>153</blue>
-          </color>
-         </brush>
-        </colorrole>
-       </disabled>
+       <active/>
+       <inactive/>
+       <disabled/>
       </palette>
      </property>
      <property name="autoFillBackground">
@@ -155,32 +98,72 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QLabel" name="warnLabel">
-        <property name="autoFillBackground">
-         <bool>true</bool>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::RichText</enum>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="margin">
-         <number>3</number>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="warningIcon">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>64</width>
+            <height>64</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>64</width>
+            <height>64</height>
+           </size>
+          </property>
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../../resources/client.qrc">:/client/resources/light/warning.svg</pixmap>
+          </property>
+          <property name="scaledContents">
+           <bool>true</bool>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="warningLabel">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::RichText</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../resources/client.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/gui/logbrowser.cpp
+++ b/src/gui/logbrowser.cpp
@@ -47,7 +47,7 @@ LogBrowser::LogBrowser(QWidget *parent)
 {
     ui->setupUi(this);
 
-    ui->warningLabel->setPixmap(Resources::getCoreIcon(QStringLiteral("warning")).pixmap(ui->warningLabel->size()));
+    ui->warningIcon->setPixmap(Resources::getCoreIcon(QStringLiteral("warning")).pixmap(ui->warningIcon->size()));
     ui->locationLabel->setText(Logger::instance()->temporaryFolderLogDirPath());
 
     ui->enableLoggingButton->setChecked(ConfigFile().automaticLogDir());

--- a/src/gui/logbrowser.ui
+++ b/src/gui/logbrowser.ui
@@ -17,7 +17,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="warningLabel">
+      <widget class="QLabel" name="warningIcon">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -40,7 +40,7 @@
         <string/>
        </property>
        <property name="pixmap">
-        <pixmap resource="../../client.qrc">:/client/resources/light/warning.svg</pixmap>
+        <pixmap resource="../resources/client.qrc">:/client/resources/light/warning.svg</pixmap>
        </property>
        <property name="scaledContents">
         <bool>true</bool>
@@ -50,7 +50,7 @@
      <item>
       <widget class="QLabel" name="label_5">
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;The logs contain sensitive information which you should not make publicly available&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;The logs contain sensitive information which you should not make publicly available&lt;/b&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -192,7 +192,7 @@ Note that using any logging command line options will override the settings.</st
   </layout>
  </widget>
  <resources>
-  <include location="../../client.qrc"/>
+  <include location="../resources/client.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Some error messages were styled in a way that is not compatible with dark mode. These have now been replaced by unstyled labels, but the warning icon is shown to the left of the message.

Fixes: #11412