### PR TITLE
Hide pause-sync-when-metered ceckbox when not supported

### DIFF
--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -192,8 +192,7 @@ void NetworkSettings::loadMeteredSettings()
         }
     }
 
-    _ui->pauseSyncWhenMeteredCheckbox->setEnabled(false);
-    _ui->pauseSyncWhenMeteredCheckbox->setToolTip(tr("Querying metered connection status is not supported on this platform"));
+    _ui->pauseSyncWhenMeteredCheckbox->setVisible(false);
 }
 
 void NetworkSettings::saveProxySettings()


### PR DESCRIPTION
On platforms where metered connection detection is not available, hide the checkbox instead of disabling it.

Fixes: #11471