### PR TITLE
Fix early-use crash in folder watcher on Linux

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -163,8 +163,8 @@ Folder::Folder(const FolderDefinition &definition, const AccountStatePtr &accoun
 
         // Potentially upgrade suffix vfs to windows vfs
         OC_ENFORCE(_vfs);
-        // Initialize the vfs plugin
-        startVfs();
+        // Initialize the vfs plugin. Do this after the UI is running, so we can show a dialog when something goes wrong.
+        QTimer::singleShot(0, this, &Folder::startVfs);
     }
 }
 


### PR DESCRIPTION
In a few error scenarios (out-of-memory or out-of-space), the folder watcher on Linux shows a dialog with an error message. If this occurs during start-up before the GUI is initialised, this will lead to a crash.

This is fixed by delaying the VFS start until after event loop is started, guaranteeing that the GUI is up and running.

Fixes: #11460