### PR TITLE
Move OAuth dialog to HttpCredentialsGui

### DIFF
--- a/changelog/unreleased/11478
+++ b/changelog/unreleased/11478
@@ -1,7 +1,7 @@
-Bugfix: Client stuck in reconnecting after application start
+Bugfix: Client stuck in reconnecting state after application start
 
 We fixed a bug where the client was starting OAuth authentication but
-did not display the required ui.
-This resulted in the client apparently getting stuck in "reconnecting"
+did not prompt the user properly to renew authentication.
+This resulted in the client apparently getting stuck in the "reconnecting" state.
 
 https://github.com/owncloud/client/pull/11478

--- a/changelog/unreleased/11478
+++ b/changelog/unreleased/11478
@@ -1,0 +1,7 @@
+Bugfix: Client stuck in reconnecting after application start
+
+We fixed a bug where the client was starting OAuth authentication but
+did not display the required ui.
+This resulted in the client apparently getting stuck in "reconnecting"
+
+https://github.com/owncloud/client/pull/11478

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -103,9 +103,6 @@ private:
     AccountStatePtr _accountState;
     QAction *_toggleSignInOutAction;
     QAction *_toggleReconnect;
-
-    // needed to make sure we show only one dialog at a time
-    QPointer<LoginRequiredDialog> _askForOAuthLoginDialog = nullptr;
 };
 
 } // namespace OCC

--- a/src/gui/creds/httpcredentialsgui.h
+++ b/src/gui/creds/httpcredentialsgui.h
@@ -16,10 +16,11 @@
 #pragma once
 #include "creds/httpcredentials.h"
 #include "creds/oauth.h"
+
 #include <QPointer>
-#include <QTcpServer>
 
 namespace OCC {
+class LoginRequiredDialog;
 
 /**
  * @brief The HttpCredentialsGui class
@@ -62,16 +63,13 @@ public:
 private slots:
     void asyncAuthResult(OAuth::Result, const QString &accessToken, const QString &refreshToken);
     void showDialog();
-    void askFromUserAsync();
 
 signals:
-    void authorisationLinkChanged();
-
     void oAuthErrorOccurred();
 
 private:
     QScopedPointer<AccountBasedOAuth, QScopedPointerObjectDeleteLater<AccountBasedOAuth>> _asyncAuth;
-    QPointer<QWidget> _loginRequiredDialog;
+    QPointer<LoginRequiredDialog> _loginRequiredDialog;
 };
 
 } // namespace OCC


### PR DESCRIPTION
This fixes a bug where askFromUser did not display a ui and the client got stuck in reconnecting