### PR TITLE
ci: disable changelog pipeline for cron builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -376,6 +376,11 @@ def changelog(ctx):
             "ref": branch_ref + [
                 "refs/pull/**",
             ],
+            "event": {
+                "exclude": [
+                    "cron",
+                ],
+            },
         },
     }]
 


### PR DESCRIPTION
>(and we could disable the changelog generation from the nightly build, it runs on every commit to master)

Changelog pipeline runs on every commit to master so disabling changelog pipeline for nightly builds.