### PR TITLE
[gui-tests][full-ci] Update account cleanup via UI for client 5 and 6

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -210,6 +210,7 @@ def teardown_client():
         # In Windows, removing only config and sync folders won't help
         # so to work around that, remove the account connection
         close_open_dialogs()
+        close_widgets()
         server_host = urlparse(get_config('localBackendUrl')).netloc
         accounts = Toolbar.get_accounts()
         for account in accounts:
@@ -252,4 +253,19 @@ def close_open_dialogs():
         if not closed:
             confirm_dialog = QApplication.activeModalWidget()
             if confirm_dialog.visible:
+                clickButton(waitForObject(AccountSetting.CONFIRMATION_YES_BUTTON))
+
+
+def close_widgets():
+    ch = object.children(squish.waitForObject(AccountSetting.DIALOG_STACK))
+    for obj in ch:
+        if (
+            hasattr(obj, "objectName")
+            and obj.objectName != ''
+            and obj.objectName != "page"
+        ):
+            obj.close()
+            # if the dialog has a confirmation dialog, confirm it
+            confirm_dialog = QApplication.activeModalWidget()
+            if str(confirm_dialog) != "<null>" and confirm_dialog.visible:
                 clickButton(waitForObject(AccountSetting.CONFIRMATION_YES_BUTTON))

--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -205,7 +205,7 @@ def hook(context):
 def teardown_client():
     # Cleanup user accounts from UI for Windows platform
     # It is not needed for Linux so skipping it in order to save CI time
-    if isWindows():
+    if not isWindows():
         # remove account from UI
         # In Windows, removing only config and sync folders won't help
         # so to work around that, remove the account connection

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 import squish, test
 import subprocess
-from os import makedirs, path
+from os import makedirs
 from os.path import exists, join
 from helpers.SpaceHelper import get_space_id
 from helpers.ConfigHelper import get_config, set_config, isWindows

--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -53,6 +53,12 @@ class AccountSetting:
         "type": "QWidget",
         "visible": 0,
     }
+    DIALOG_STACK = {
+        "name": "dialogStack",
+        "type": "QStackedWidget",
+        "visible": 1,
+        "window": names.settings_OCC_SettingsDialog,
+    }
     CONFIRMATION_YES_BUTTON = {"text": "Yes", "type": "QPushButton", "visible": 1}
 
     @staticmethod

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -262,7 +262,7 @@ def step(context):
     waitForInitialSyncToComplete(getResourcePath('/', account_details["user"]))
 
 
-@When('the user cancels the sync connection wizard')
+@Step('the user cancels the sync connection wizard')
 def step(context):
     SyncConnectionWizard.cancelFolderSyncConnectionWizard()
 

--- a/test/gui/shared/steps/sharing_context.py
+++ b/test/gui/shared/steps/sharing_context.py
@@ -285,7 +285,7 @@ def step(context, permissions, receiver, resource):
     SharingDialog.removePermissions(permissions)
 
 
-@When("the user closes the sharing dialog")
+@Step("the user closes the sharing dialog")
 def step(context):
     SharingDialog.closeSharingDialog()
 

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -256,7 +256,7 @@ Feature: Sharing
             | user     | Alice          |
             | password | 1234           |
         And the user removes permissions "edit" for user "Brian Murphy" of resource "textfile.txt" using the client-UI
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
         And the user removes permissions "edit" for user "Brian Murphy" of resource "FOLDER" using the client-UI
         And the user closes the sharing dialog
         And user "Brian" tries to overwrite the file "textfile.txt" with content "overwrite ownCloud test text file"
@@ -444,7 +444,7 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder/child" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
@@ -458,7 +458,7 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
@@ -502,7 +502,7 @@ Feature: Sharing
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | expireDate | %default%    |
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
         Then the expiration date of the last public link of file "textfile.txt" should be "%default%"
         And as user "Alice" the file "textfile.txt" should have a public link in the server
 

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -83,6 +83,7 @@ Feature: Sharing
         And the user opens the sharing dialog of "SharedFolder" using the client-UI
         And the user searches for collaborator "Brian Murphy" using the client-UI
         Then the error "No results for 'Brian Murphy'" should be displayed
+        When the user closes the sharing dialog
 
 
     Scenario: try to self share a file/folder
@@ -96,6 +97,7 @@ Feature: Sharing
         And the user opens the sharing dialog of "OwnFolder" using the client-UI
         And the user selects "Alice Hansen" as collaborator of resource "OwnFolder" using the client-UI
         Then the error "Can't share with yourself" should be displayed
+        When the user closes the sharing dialog
 
 
     Scenario: search for users with minimum autocomplete characters
@@ -109,6 +111,7 @@ Feature: Sharing
             | user      |
             | TestUser1 |
             | TestUser2 |
+        When the user closes the sharing dialog
 
     Scenario: autocomplete offers a list of users followed by a list of groups
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
@@ -119,6 +122,7 @@ Feature: Sharing
             | user          |
             | admin         |
             | admin (group) |
+        When the user closes the sharing dialog
 
     Scenario: collaborators are listed in chronological order
         Given user "Brian" has been created on the server with default attributes and without skeleton files
@@ -141,6 +145,7 @@ Feature: Sharing
             | TestUser1    |
             | TestUser3    |
             | TestUser2    |
+        When the user closes the sharing dialog
 
     @issue-7459
     Scenario: Progress indicator should not be visible after unselecting the password protection checkbox while sharing through public link
@@ -150,6 +155,7 @@ Feature: Sharing
         And the user toggles the password protection using the client-UI
         And the user toggles the password protection using the client-UI
         Then the password progress indicator should not be visible in the client-UI - expected to fail
+        When the user closes the sharing dialog
 
 
     Scenario: Collaborator should not see to whom a file/folder is shared.
@@ -164,6 +170,7 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user opens the sharing dialog of "Folder" using the client-UI
         Then the error text "The item is not shared with any users or groups" should be displayed in the sharing dialog
+        When the user closes the sharing dialog
 
 
     Scenario: share file and folder to a group
@@ -179,6 +186,7 @@ Feature: Sharing
         Then group "grp1" should be listed in the collaborators list for file "simple-folder" with permissions "edit,share" on the client-UI
         And as "Brian" folder "simple-folder" should exist in the server
         And as "Brian" file "textfile0.txt" should exist in the server
+        When the user closes the sharing dialog
 
 
     Scenario: User (non-author) can not share to a group to which the file/folder is already shared
@@ -197,6 +205,7 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user tires to share resource "Folder" with the group "grp1" using the client-UI
         Then the error "Path already shared with this group" should be displayed
+        When the user closes the sharing dialog
 
 
     Scenario: sharee edits content of files shared by sharer
@@ -215,6 +224,7 @@ Feature: Sharing
         And as "Brian" the file "textfile.txt" should have the content "overwrite file in the root" in the server
         And as "Alice" the file "simple-folder/textfile.txt" should have the content "overwrite file inside a folder" in the server
         And as "Alice" the file "textfile.txt" should have the content "overwrite file in the root" in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharee tries to edit content of files shared without write permission
@@ -232,6 +242,7 @@ Feature: Sharing
         And as "Brian" the file "textfile.txt" should have the content "file in the root" in the server
         And as "Alice" the file "Parent/textfile.txt" should have the content "file inside a folder" in the server
         And as "Alice" the file "textfile.txt" should have the content "file in the root" in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharee edits shared files and again try to edit after write permission is revoked
@@ -248,7 +259,7 @@ Feature: Sharing
             | user     | Alice          |
             | password | 1234           |
         And the user removes permissions "edit" for user "Brian Murphy" of resource "textfile.txt" using the client-UI
-        And the user closes the sharing dialog
+        When the user closes the sharing dialog
         And the user removes permissions "edit" for user "Brian Murphy" of resource "FOLDER" using the client-UI
         And user "Brian" tries to overwrite the file "textfile.txt" with content "overwrite ownCloud test text file"
         And user "Brian" tries to overwrite the file "FOLDER/simple.txt" with content "overwrite some content"
@@ -257,6 +268,7 @@ Feature: Sharing
         And as "Brian" the file "FOLDER/simple.txt" should have the content "some content" in the server
         And as "Alice" the file "textfile.txt" should have the content "ownCloud test text file" in the server
         And as "Alice" the file "FOLDER/simple.txt" should have the content "some content" in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharee creates a file and a folder inside a shared folder
@@ -275,6 +287,7 @@ Feature: Sharing
         And as "Brian" folder "Parent/localFolder" should exist in the server
         And as "Alice" file "Parent/localFile.txt" should exist in the server
         And as "Alice" folder "Parent/localFolder" should exist in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharee tries to create a file and a folder inside a shared folder without write permission
@@ -293,6 +306,7 @@ Feature: Sharing
         And as "Brian" folder "Parent/localFolder" should not exist in the server
         And as "Alice" file "Parent/localFile.txt" should not exist in the server
         And as "Alice" folder "Parent/localFolder" should not exist in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharee renames the shared file and folder
@@ -315,6 +329,7 @@ Feature: Sharing
         And as "Alice" file "textfile.txt" should exist in the server
         And as "Alice" folder "PARENT" should not exist in the server
         And as "Alice" file "lorem.txt" should not exist in the server
+        When the user closes the sharing dialog
 
     @issue-9439 @issue-11102 @skip
     Scenario: sharee deletes a file and folder shared by sharer
@@ -331,6 +346,7 @@ Feature: Sharing
         And as "Brian" folder "Folder" on the server should not exist
         And as "Alice" file "textfile.txt" on the server should exist
         And as "Alice" folder "Folder" on the server should exist
+        When the user closes the sharing dialog
 
     @issue-11102 @skip
     Scenario: sharee tries to delete shared file and folder without permissions
@@ -348,6 +364,7 @@ Feature: Sharing
         And as "Brian" folder "Folder" on the server should not exist
         And as "Alice" file "textfile.txt" on the server should exist
         And as "Alice" folder "Folder" on the server should exist
+        When the user closes the sharing dialog
 
 
     Scenario: reshare a file/folder
@@ -364,6 +381,7 @@ Feature: Sharing
         And user "Carol King" should be listed in the collaborators list for file "textfile.txt" with permissions "edit,share" on the client-UI
         And as "Carol" folder "FOLDER" should exist in the server
         And as "Carol" file "textfile.txt" should exist in the server
+        When the user closes the sharing dialog
 
 
     Scenario: try to reshare a file/folder shared without share permission
@@ -378,6 +396,7 @@ Feature: Sharing
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
+        When the user closes the sharing dialog
 
 
     Scenario: unshare a shared file and folder
@@ -394,6 +413,7 @@ Feature: Sharing
         And the user unshares the resource "simple-folder" for collaborator "Brian Murphy" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
         And as "Brian" folder "simple-folder" on the server should not exist
+        When the user closes the sharing dialog
 
 
     Scenario: share a file with many users
@@ -412,6 +432,7 @@ Feature: Sharing
             | Brian Murphy | edit,share  |
             | Carol King   | edit,share  |
             | David Lopez  | edit,share  |
+        When the user closes the sharing dialog
 
     @issue-7423
     Scenario: unshare a reshared file
@@ -423,6 +444,7 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user unshares the resource "textfile.txt" for collaborator "Carol King" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
+        When the user closes the sharing dialog
 
     @smokeTest
     Scenario: simple sharing of file and folder by public link without password
@@ -431,12 +453,13 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder/child" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" without password using the client-UI
-        And the user closes the sharing dialog
+        When the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" without password from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder/child" without password from the last created public link by "Alice" on the server
+        When the user closes the sharing dialog
 
 
     Scenario Outline: simple sharing of file and folder by public link with password
@@ -444,12 +467,13 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for file "textfile0.txt" with password "<password>" using the client-UI
-        And the user closes the sharing dialog
+        When the user closes the sharing dialog
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "<password>" from the last created public link by "Alice" in the server
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder" with password "<password>" from the last created public link by "Alice" on the server
+        When the user closes the sharing dialog
         Examples:
             | password     |
             | password1234 |
@@ -464,6 +488,7 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user deletes the public link for file "textfile0.txt"
         Then as user "Alice" the file "/textfile0.txt" should not have any public link in the server
+        When the user closes the sharing dialog
 
 
     Scenario: sharing of a file by public link with password and changing the password
@@ -477,6 +502,7 @@ Feature: Sharing
         And the user changes the password of public link "Public-link" to "password1234" using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "password1234" from the last created public link by "Alice" on the server
+        When the user closes the sharing dialog
 
 
     Scenario: simple sharing of a file by public link with default expiration date
@@ -485,9 +511,10 @@ Feature: Sharing
         When the user creates a new public link with following settings using the client-UI:
             | path       | textfile.txt |
             | expireDate | %default%    |
-        And the user closes the sharing dialog
+        When the user closes the sharing dialog
         Then the expiration date of the last public link of file "textfile.txt" should be "%default%"
         And as user "Alice" the file "textfile.txt" should have a public link in the server
+        When the user closes the sharing dialog
 
     @issue-9321 @skipOnWindows
     Scenario: simple sharing of file and folder by public link with expiration date
@@ -507,6 +534,7 @@ Feature: Sharing
         Then as user "Alice" the folder "FOLDER" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-12-30 |
+        When the user closes the sharing dialog
 
     @issue-9321 @skipOnWindows
     Scenario: simple sharing of a file by public link with password and expiration date
@@ -520,6 +548,7 @@ Feature: Sharing
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-10-14 |
         And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" in the server
+        When the user closes the sharing dialog
 
     @skip @issue-9321 @skipOnWindows
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
@@ -534,6 +563,7 @@ Feature: Sharing
             | expireDate | 2038-07-21 |
         Then the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2038-07-21 |
+        When the user closes the sharing dialog
 
     @skip @issue-9321 @skipOnWindows
     Scenario: user changes the expiration date of an already existing public link for folder using client-UI
@@ -549,6 +579,7 @@ Feature: Sharing
             | expireDate | 2038-07-21 |
         Then the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2038-07-21 |
+        When the user closes the sharing dialog
 
 
     Scenario Outline: simple sharing of folder by public link with different roles
@@ -563,6 +594,7 @@ Feature: Sharing
             | permissions | <permissions>  |
             | path        | /simple-folder |
             | name        | Public link    |
+        When the user closes the sharing dialog
         Examples:
             | role        | permissions                  |
             | Viewer      | read                         |
@@ -584,6 +616,7 @@ Feature: Sharing
             | path        | /simple-folder |
             | name        | Public link    |
         And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" in the server
+        When the user closes the sharing dialog
 
 
     Scenario Outline: change collaborator permissions of a file & folder
@@ -615,6 +648,7 @@ Feature: Sharing
             | file_target | /Shares/lorem.txt          |
             | item_type   | file                       |
             | permissions | <expected-file-permission> |
+        When the user closes the sharing dialog
         Examples:
             | permissions | expected-folder-permission   | expected-file-permission |
             | edit        | read, share                  | read, share              |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -83,7 +83,7 @@ Feature: Sharing
         And the user opens the sharing dialog of "SharedFolder" using the client-UI
         And the user searches for collaborator "Brian Murphy" using the client-UI
         Then the error "No results for 'Brian Murphy'" should be displayed
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: try to self share a file/folder
@@ -97,7 +97,7 @@ Feature: Sharing
         And the user opens the sharing dialog of "OwnFolder" using the client-UI
         And the user selects "Alice Hansen" as collaborator of resource "OwnFolder" using the client-UI
         Then the error "Can't share with yourself" should be displayed
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: search for users with minimum autocomplete characters
@@ -111,7 +111,7 @@ Feature: Sharing
             | user      |
             | TestUser1 |
             | TestUser2 |
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
     Scenario: autocomplete offers a list of users followed by a list of groups
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
@@ -122,7 +122,7 @@ Feature: Sharing
             | user          |
             | admin         |
             | admin (group) |
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
     Scenario: collaborators are listed in chronological order
         Given user "Brian" has been created on the server with default attributes and without skeleton files
@@ -145,7 +145,7 @@ Feature: Sharing
             | TestUser1    |
             | TestUser3    |
             | TestUser2    |
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
     @issue-7459
     Scenario: Progress indicator should not be visible after unselecting the password protection checkbox while sharing through public link
@@ -155,7 +155,7 @@ Feature: Sharing
         And the user toggles the password protection using the client-UI
         And the user toggles the password protection using the client-UI
         Then the password progress indicator should not be visible in the client-UI - expected to fail
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: Collaborator should not see to whom a file/folder is shared.
@@ -170,7 +170,7 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user opens the sharing dialog of "Folder" using the client-UI
         Then the error text "The item is not shared with any users or groups" should be displayed in the sharing dialog
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: share file and folder to a group
@@ -186,7 +186,6 @@ Feature: Sharing
         Then group "grp1" should be listed in the collaborators list for file "simple-folder" with permissions "edit,share" on the client-UI
         And as "Brian" folder "simple-folder" should exist in the server
         And as "Brian" file "textfile0.txt" should exist in the server
-        When the user closes the sharing dialog
 
 
     Scenario: User (non-author) can not share to a group to which the file/folder is already shared
@@ -205,7 +204,7 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user tires to share resource "Folder" with the group "grp1" using the client-UI
         Then the error "Path already shared with this group" should be displayed
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: sharee edits content of files shared by sharer
@@ -224,7 +223,6 @@ Feature: Sharing
         And as "Brian" the file "textfile.txt" should have the content "overwrite file in the root" in the server
         And as "Alice" the file "simple-folder/textfile.txt" should have the content "overwrite file inside a folder" in the server
         And as "Alice" the file "textfile.txt" should have the content "overwrite file in the root" in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharee tries to edit content of files shared without write permission
@@ -242,7 +240,6 @@ Feature: Sharing
         And as "Brian" the file "textfile.txt" should have the content "file in the root" in the server
         And as "Alice" the file "Parent/textfile.txt" should have the content "file inside a folder" in the server
         And as "Alice" the file "textfile.txt" should have the content "file in the root" in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharee edits shared files and again try to edit after write permission is revoked
@@ -261,6 +258,7 @@ Feature: Sharing
         And the user removes permissions "edit" for user "Brian Murphy" of resource "textfile.txt" using the client-UI
         When the user closes the sharing dialog
         And the user removes permissions "edit" for user "Brian Murphy" of resource "FOLDER" using the client-UI
+        And the user closes the sharing dialog
         And user "Brian" tries to overwrite the file "textfile.txt" with content "overwrite ownCloud test text file"
         And user "Brian" tries to overwrite the file "FOLDER/simple.txt" with content "overwrite some content"
         And user "Brian" waits for file "textfile.txt" to have sync error
@@ -268,7 +266,6 @@ Feature: Sharing
         And as "Brian" the file "FOLDER/simple.txt" should have the content "some content" in the server
         And as "Alice" the file "textfile.txt" should have the content "ownCloud test text file" in the server
         And as "Alice" the file "FOLDER/simple.txt" should have the content "some content" in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharee creates a file and a folder inside a shared folder
@@ -287,7 +284,6 @@ Feature: Sharing
         And as "Brian" folder "Parent/localFolder" should exist in the server
         And as "Alice" file "Parent/localFile.txt" should exist in the server
         And as "Alice" folder "Parent/localFolder" should exist in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharee tries to create a file and a folder inside a shared folder without write permission
@@ -306,7 +302,6 @@ Feature: Sharing
         And as "Brian" folder "Parent/localFolder" should not exist in the server
         And as "Alice" file "Parent/localFile.txt" should not exist in the server
         And as "Alice" folder "Parent/localFolder" should not exist in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharee renames the shared file and folder
@@ -329,7 +324,6 @@ Feature: Sharing
         And as "Alice" file "textfile.txt" should exist in the server
         And as "Alice" folder "PARENT" should not exist in the server
         And as "Alice" file "lorem.txt" should not exist in the server
-        When the user closes the sharing dialog
 
     @issue-9439 @issue-11102 @skip
     Scenario: sharee deletes a file and folder shared by sharer
@@ -346,7 +340,6 @@ Feature: Sharing
         And as "Brian" folder "Folder" on the server should not exist
         And as "Alice" file "textfile.txt" on the server should exist
         And as "Alice" folder "Folder" on the server should exist
-        When the user closes the sharing dialog
 
     @issue-11102 @skip
     Scenario: sharee tries to delete shared file and folder without permissions
@@ -364,7 +357,6 @@ Feature: Sharing
         And as "Brian" folder "Folder" on the server should not exist
         And as "Alice" file "textfile.txt" on the server should exist
         And as "Alice" folder "Folder" on the server should exist
-        When the user closes the sharing dialog
 
 
     Scenario: reshare a file/folder
@@ -381,7 +373,6 @@ Feature: Sharing
         And user "Carol King" should be listed in the collaborators list for file "textfile.txt" with permissions "edit,share" on the client-UI
         And as "Carol" folder "FOLDER" should exist in the server
         And as "Carol" file "textfile.txt" should exist in the server
-        When the user closes the sharing dialog
 
 
     Scenario: try to reshare a file/folder shared without share permission
@@ -394,9 +385,10 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user opens the sharing dialog of "FOLDER" using the client-UI
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
+        And the user closes the sharing dialog
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: unshare a shared file and folder
@@ -412,8 +404,8 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user unshares the resource "simple-folder" for collaborator "Brian Murphy" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
+        And the user closes the sharing dialog
         And as "Brian" folder "simple-folder" on the server should not exist
-        When the user closes the sharing dialog
 
 
     Scenario: share a file with many users
@@ -432,7 +424,6 @@ Feature: Sharing
             | Brian Murphy | edit,share  |
             | Carol King   | edit,share  |
             | David Lopez  | edit,share  |
-        When the user closes the sharing dialog
 
     @issue-7423
     Scenario: unshare a reshared file
@@ -444,7 +435,7 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user unshares the resource "textfile.txt" for collaborator "Carol King" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
     @smokeTest
     Scenario: simple sharing of file and folder by public link without password
@@ -459,7 +450,7 @@ Feature: Sharing
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" without password using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder/child" without password from the last created public link by "Alice" on the server
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario Outline: simple sharing of file and folder by public link with password
@@ -473,7 +464,7 @@ Feature: Sharing
         When the user creates a new public link with permissions "Download / View" for folder "simple-folder" with password "<password>" using the client-UI
         Then as user "Alice" the folder "simple-folder" should have a public link in the server
         And the public should be able to download the folder "simple-folder" with password "<password>" from the last created public link by "Alice" on the server
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
         Examples:
             | password     |
             | password1234 |
@@ -487,8 +478,8 @@ Feature: Sharing
             | name     | Public-link   |
         And user "Alice" has set up a client with default settings
         When the user deletes the public link for file "textfile0.txt"
+        And the user closes the sharing dialog
         Then as user "Alice" the file "/textfile0.txt" should not have any public link in the server
-        When the user closes the sharing dialog
 
 
     Scenario: sharing of a file by public link with password and changing the password
@@ -502,7 +493,7 @@ Feature: Sharing
         And the user changes the password of public link "Public-link" to "password1234" using the client-UI
         Then as user "Alice" the file "textfile0.txt" should have a public link in the server
         And the public should be able to download the file "textfile0.txt" with password "password1234" from the last created public link by "Alice" on the server
-        When the user closes the sharing dialog
+        And the user closes the sharing dialog
 
 
     Scenario: simple sharing of a file by public link with default expiration date
@@ -514,7 +505,6 @@ Feature: Sharing
         When the user closes the sharing dialog
         Then the expiration date of the last public link of file "textfile.txt" should be "%default%"
         And as user "Alice" the file "textfile.txt" should have a public link in the server
-        When the user closes the sharing dialog
 
     @issue-9321 @skipOnWindows
     Scenario: simple sharing of file and folder by public link with expiration date
@@ -531,10 +521,10 @@ Feature: Sharing
         And the user creates a new public link with following settings using the client-UI:
             | path       | FOLDER     |
             | expireDate | 2031-12-30 |
+        And the user closes the sharing dialog
         Then as user "Alice" the folder "FOLDER" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-12-30 |
-        When the user closes the sharing dialog
 
     @issue-9321 @skipOnWindows
     Scenario: simple sharing of a file by public link with password and expiration date
@@ -544,11 +534,11 @@ Feature: Sharing
             | path       | textfile.txt |
             | password   | pass123      |
             | expireDate | 2031-10-14   |
+        And the user closes the sharing dialog
         Then as user "Alice" the file "textfile.txt" should have a public link in the server
         And the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2031-10-14 |
         And the public should be able to download the file "textfile.txt" with password "pass123" from the last created public link by "Alice" in the server
-        When the user closes the sharing dialog
 
     @skip @issue-9321 @skipOnWindows
     Scenario: user changes the expiration date of an already existing public link for file using client-UI
@@ -561,9 +551,9 @@ Feature: Sharing
         When the user opens the public links dialog of "textfile0.txt" using the client-UI
         And the user edits the public link named "Public link" of file "textfile0.txt" changing following
             | expireDate | 2038-07-21 |
+        And the user closes the sharing dialog
         Then the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2038-07-21 |
-        When the user closes the sharing dialog
 
     @skip @issue-9321 @skipOnWindows
     Scenario: user changes the expiration date of an already existing public link for folder using client-UI
@@ -577,9 +567,9 @@ Feature: Sharing
         When the user opens the public links dialog of "simple-folder" using the client-UI
         And the user edits the public link named "Public link" of file "simple-folder" changing following
             | expireDate | 2038-07-21 |
+        And the user closes the sharing dialog
         Then the last public link share response of user "Alice" should include the following fields on the server
             | expireDate | 2038-07-21 |
-        When the user closes the sharing dialog
 
 
     Scenario Outline: simple sharing of folder by public link with different roles
@@ -587,6 +577,7 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for folder "simple-folder" using the client-UI with these details:
             | role | <role> |
+        And the user closes the sharing dialog
         Then user "Alice" on the server should have a share with these details:
             | field       | value          |
             | share_type  | public_link    |
@@ -594,7 +585,6 @@ Feature: Sharing
             | permissions | <permissions>  |
             | path        | /simple-folder |
             | name        | Public link    |
-        When the user closes the sharing dialog
         Examples:
             | role        | permissions                  |
             | Viewer      | read                         |
@@ -608,6 +598,7 @@ Feature: Sharing
         And user "Alice" has set up a client with default settings
         When the user creates a new public link for folder "simple-folder" using the client-UI with these details:
             | role | Contributor |
+        And the user closes the sharing dialog
         Then user "Alice" on the server should have a share with these details:
             | field       | value          |
             | share_type  | public_link    |
@@ -616,7 +607,6 @@ Feature: Sharing
             | path        | /simple-folder |
             | name        | Public link    |
         And the public should not be able to download the file "lorem.txt" from the last created public link by "Alice" in the server
-        When the user closes the sharing dialog
 
 
     Scenario Outline: change collaborator permissions of a file & folder
@@ -632,6 +622,7 @@ Feature: Sharing
         When the user closes the sharing dialog
         And the user removes permissions "<permissions>" for user "Brian Murphy" of resource "lorem.txt" using the client-UI
         Then "<permissions>" permissions should not be displayed for user "Brian Murphy" for resource "lorem.txt" on the client-UI
+        And the user closes the sharing dialog
         And user "Alice" on the server should have a share with these details:
             | field       | value                        |
             | uid_owner   | Alice                        |
@@ -648,7 +639,6 @@ Feature: Sharing
             | file_target | /Shares/lorem.txt          |
             | item_type   | file                       |
             | permissions | <expected-file-permission> |
-        When the user closes the sharing dialog
         Examples:
             | permissions | expected-folder-permission   | expected-file-permission |
             | edit        | read, share                  | read, share              |

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -154,6 +154,7 @@ Feature: Syncing files
             | aFolder   |
             | 123Folder |
             | bFolder   |
+        And the user cancels the sync connection wizard
 
 
     Scenario Outline: Syncing a folder to the server


### PR DESCRIPTION
Updated the account cleanup script to work for client versions ^5 and ^6

Tested in:
- Linux (5 and 6) :heavy_check_mark: 
- Windows (5 and 6) :heavy_check_mark: 
- CI (5) https://drone.owncloud.com/owncloud/client/17650 :heavy_check_mark: 