### PR TITLE
Strip user info from URL in New Connection Wizard

### DIFF
--- a/changelog/unreleased/11497
+++ b/changelog/unreleased/11497
@@ -1,0 +1,8 @@
+Bugfix: strip user information from new-connection URL
+
+Credentials in the URL are not supported for some time. This fix strips
+them from the URL before storage and using it to authenticate the client
+to the server.
+
+https://github.com/owncloud/client/issues/11497
+https://github.com/owncloud/client/pull/11509

--- a/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
+++ b/src/gui/newwizard/states/serverurlsetupwizardstate.cpp
@@ -72,7 +72,7 @@ void ServerUrlSetupWizardState::evaluatePage()
             userProvidedUrl.prepend(defaultUrlSchemeC);
         }
 
-        return QUrl::fromUserInput(userProvidedUrl);
+        return QUrl::fromUserInput(userProvidedUrl).adjusted(QUrl::RemoveUserInfo);
     }();
 
     // (ab)use the account builder as temporary storage for the URL we are about to probe (after sanitation)


### PR DESCRIPTION
Authentication is done through the web browser, so no user information is needed for that URL.

Fixes: #11497