### PR TITLE
[gui-tests][full-ci] wait for sync completion after adding account

### DIFF
--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -18,6 +18,11 @@ def step(context, accountType):
         Toolbar.openNewAccountSetup()
     account_details = getClientDetails(context)
     AccountConnectionWizard.addAccount(account_details)
+    space = ""
+    if get_config("ocis"):
+        space = "Personal"
+    # wait for files to sync
+    waitForInitialSyncToComplete(getResourcePath('/', account_details["user"], space))
 
 
 @When('the user adds the following wrong user credentials:')


### PR DESCRIPTION
Added a wait for sync task completion after an account has been added via UI

### Related issues
- Closes https://github.com/owncloud/client/issues/11503