### PR TITLE
[gui-tests][full-ci remove test for sync related advanced settings

### DIFF
--- a/test/gui/tst_checkAlltabs/test.feature
+++ b/test/gui/tst_checkAlltabs/test.feature
@@ -35,8 +35,6 @@ Feature: Visually check all tabs
             | Sync hidden files                                                    |
             | Edit ignored files                                                   |
             | Log settings                                                         |
-            | Ask for confirmation before synchronizing folders larger than 500 MB |
-            | Ask for confirmation before synchronizing external storages          |
         And the settings tab should have the following options in the network section:
             | Proxy Settings     |
             | Download Bandwidth |


### PR DESCRIPTION
Removed gui tests related advanced settings which were removed in https://github.com/owncloud/client/pull/11517

Closes https://github.com/owncloud/client/issues/11520