### PR TITLE
[tests-only] Move notification to desktop-ci channel of talk.owncloud

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -41,7 +41,7 @@ secrets = {
     "CACHE_BUCKET": "cache_public_s3_bucket",
     "AWS_ACCESS_KEY_ID": "cache_public_s3_access_key",
     "AWS_SECRET_ACCESS_KEY": "cache_public_s3_secret_key",
-    "ROCKETCHAT_WEBHOOK": "rocketchat_chat_webhook",
+    "ROCKETCHAT_WEBHOOK": "rocketchat_talk_webhook",
 }
 
 dir = {
@@ -53,7 +53,7 @@ dir = {
 }
 
 notify_channels = {
-    "desktop-internal": {
+    "desktop-ci": {
         "type": "channel",
     },
 }


### PR DESCRIPTION
Changed notification channel from `desktop-internal` of `chat.owncloud.com` to `desktop-ci` of `talk.owncloud.com`. 
Closes https://github.com/owncloud/client/issues/11536