### PR TITLE
Make 'No' button default in Unknown Certificate dialog

### DIFF
--- a/changelog/unreleased/11531
+++ b/changelog/unreleased/11531
@@ -1,0 +1,7 @@
+Change: Set the 'No' button as default action in the Unknown Certificate dialog
+
+When an unknown certificate is used by the server, the safe action is to
+reject this certificate. So the default action for this dialog should be
+not to accept this unknown certificate.
+
+https://github.com/owncloud/client/issues/11531

--- a/src/gui/tlserrordialog.cpp
+++ b/src/gui/tlserrordialog.cpp
@@ -40,6 +40,11 @@ TlsErrorDialog::TlsErrorDialog(const QList<QSslError> &sslErrors, const QString 
 
     connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, &TlsErrorDialog::accept);
     connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, &TlsErrorDialog::reject);
+
+    // Try to set the No-button (which will also emit the reject signal when cliced) as the default
+    if (QPushButton *noButton = _ui->buttonBox->button(QDialogButtonBox::No)) {
+        noButton->setDefault(true);
+    }
 }
 
 TlsErrorDialog::~TlsErrorDialog()


### PR DESCRIPTION
Fixes: #11531