### PR TITLE
Revert sync folder name back to appName

### DIFF
--- a/changelog/unreleased/enterprise-6390
+++ b/changelog/unreleased/enterprise-6390
@@ -1,0 +1,18 @@
+Change: Revert local folder name back to pre 3.0 behavior
+
+Due to user requests, we reverted the folder name from 
+```
+ownCloud - Albert@owncloud.com
+ownCloud - Katherine@owncloud.org
+ownCloud - Marie@owncloud.com
+```
+
+back to
+
+ ```
+ownCloud
+ownCloud (1)
+ownCloud (2)
+```
+
+https://github.com/owncloud/enterprise/issues/6390

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -966,11 +966,7 @@ Folder *FolderMan::addFolderFromFolderWizardResult(const AccountStatePtr &accoun
 
 QString FolderMan::suggestSyncFolder(const QUrl &server, const QString &displayName, NewFolderType folderType)
 {
-    QString folderName = tr("%1 - %2@%3").arg(Theme::instance()->appName(), displayName, server.host());
-    if (!Theme::instance()->multiAccount()) {
-        folderName = Theme::instance()->appName();
-    }
-    return FolderMan::instance()->findGoodPathForNewSyncFolder(QDir::homePath(), folderName, folderType);
+    return FolderMan::instance()->findGoodPathForNewSyncFolder(QDir::homePath(), Theme::instance()->appName(), folderType);
 }
 
 bool FolderMan::prepareFolder(const QString &folder)


### PR DESCRIPTION
This partly reverts 97192194bd38e1be0824bb5db73842b4387f8f1b and the behavor introduced in 3.0