### PR TITLE
HttpLogger: Log redirects

### DIFF
--- a/changelog/unreleased/11581
+++ b/changelog/unreleased/11581
@@ -1,0 +1,5 @@
+Bugfix: Support logging redirect
+
+We now log when all urls when a request was redirected.
+
+https://github.com/owncloud/client/pull/11581


### PR DESCRIPTION
During a debugging session, I discovered that the client can send the same request multiple times if the redirect is directly handled by Qt.
This wasn't discovered previously as we disallow redirects for most requests.
```
24-04-08 16:59:13:604 [ info sync.httplogger ]:	REQUEST 697f9664-e926-4569-be6c-5c2c228010cf {"request":{"body":{"length":0},"header":{"Accept":"*/*","Accept-Language":"en_DE","Authorization":"Basic [redacted]","Original-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf","User-Agent":"Mozilla/5.0 (Windows) mirall/6.0.0-git (ownCloud, windows-10.0.22631 ClientArchitecture: x86_64 OsArchitecture: x86_64)","X-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf"},"info":{"cached":false,"id":"697f9664-e926-4569-be6c-5c2c228010cf","method":"GET","url":"https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"}}}
24-04-08 16:59:13:746 [ info sync.httplogger ]:	REQUEST 697f9664-e926-4569-be6c-5c2c228010cf {"request":{"body":{"length":0},"header":{"Accept":"*/*","Accept-Language":"en_DE","Authorization":"Basic [redacted]","Original-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf","User-Agent":"Mozilla/5.0 (Windows) mirall/6.0.0-git (ownCloud, windows-10.0.22631 ClientArchitecture: x86_64 OsArchitecture: x86_64)","X-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf"},"info":{"cached":false,"id":"697f9664-e926-4569-be6c-5c2c228010cf","method":"GET","redirects":["https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"],"url":"https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"}}}
24-04-08 16:59:13:864 [ info sync.httplogger ]:	REQUEST 697f9664-e926-4569-be6c-5c2c228010cf {"request":{"body":{"length":0},"header":{"Accept":"*/*","Accept-Language":"en_DE","Authorization":"Basic [redacted]","Original-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf","User-Agent":"Mozilla/5.0 (Windows) mirall/6.0.0-git (ownCloud, windows-10.0.22631 ClientArchitecture: x86_64 OsArchitecture: x86_64)","X-Request-ID":"697f9664-e926-4569-be6c-5c2c228010cf"},"info":{"cached":false,"id":"697f9664-e926-4569-be6c-5c2c228010cf","method":"GET","redirects":["https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi","https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/"],"url":"https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"}}}
24-04-08 16:59:13:897 [ info sync.httplogger ]:	RESPONSE 697f9664-e926-4569-be6c-5c2c228010cf {"response":{"body":{"length":0},"header":{"Authorization":"Basic [redacted]","Content-Type":"text/html; charset=utf-8","Date":"Mon, 08 Apr 2024 14:59:01 GMT","Referrer-Policy":"strict-origin-when-cross-origin","Server":"Caddy","Strict-Transport-Security":"max-age=315360000; preload","Transfer-Encoding":"chunked","X-Content-Type-Options":"nosniff","X-Frame-Options":"SAMEORIGIN","X-Xss-Protection":"0"},"info":{"id":"697f9664-e926-4569-be6c-5c2c228010cf","method":"GET","redirects":["https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi","https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/"],"reply":{"cached":false,"duration":293,"durationString":"duration(0h, 0min, 0s, 293ms)","error":"Error transferring https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/ - server replied: Not Found","status":404,"version":"HTTP 2"},"url":"https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"}}}
```

```json
{
  "request": {
    "body": {
      "length": 0
    },
    "header": {
      "Accept": "*/*",
      "Accept-Language": "en_DE",
      "Authorization": "Basic [redacted]",
      "Original-Request-ID": "697f9664-e926-4569-be6c-5c2c228010cf",
      "User-Agent": "Mozilla/5.0 (Windows) mirall/6.0.0-git (ownCloud, windows-10.0.22631 ClientArchitecture: x86_64 OsArchitecture: x86_64)",
      "X-Request-ID": "697f9664-e926-4569-be6c-5c2c228010cf"
    },
    "info": {
      "cached": false,
      "id": "697f9664-e926-4569-be6c-5c2c228010cf",
      "method": "GET",
      "redirects": [
        "https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi",
        "https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/"
      ],
      "url": "https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"
    }
  }
},
{
  "response": {
    "body": {
      "length": 0
    },
    "header": {
      "Authorization": "Basic [redacted]",
      "Content-Type": "text/html; charset=utf-8",
      "Date": "Mon, 08 Apr 2024 14:59:01 GMT",
      "Referrer-Policy": "strict-origin-when-cross-origin",
      "Server": "Caddy",
      "Strict-Transport-Security": "max-age=315360000; preload",
      "Transfer-Encoding": "chunked",
      "X-Content-Type-Options": "nosniff",
      "X-Frame-Options": "SAMEORIGIN",
      "X-Xss-Protection": "0"
    },
    "info": {
      "id": "697f9664-e926-4569-be6c-5c2c228010cf",
      "method": "GET",
      "redirects": [
        "https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi",
        "https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/"
      ],
      "reply": {
        "cached": false,
        "duration": 293,
        "durationString": "duration(0h, 0min, 0s, 293ms)",
        "error": "Error transferring https://attic.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi/ - server replied: Not Found",
        "status": 404,
        "version": "HTTP 2"
      },
      "url": "https://download.owncloud.com/desktop/ownCloud/daily/6.0/win/ownCloud-6.0.0.12944-daily20231221.x64.msi"
    }
  }
}