### PR TITLE
Remove folderChanged signal

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -77,7 +77,6 @@ AccountSettings::AccountSettings(const AccountStatePtr &accountState, QWidget *p
 
     createAccountToolbox();
     connect(FolderMan::instance(), &FolderMan::folderListChanged, _model, &FolderStatusModel::resetFolders);
-    connect(this, &AccountSettings::folderChanged, _model, &FolderStatusModel::resetFolders);
 
     ui->connectLabel->clear();
 
@@ -279,8 +278,7 @@ void AccountSettings::slotFolderWizardAccepted()
         folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, config.selectiveSyncBlackList);
 
         // The user already accepted the selective sync dialog. everything is in the white list
-        folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, { QLatin1String("/") });
-        Q_EMIT folderChanged();
+        folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, {QLatin1String("/")});
     }
     FolderMan::instance()->setSyncEnabled(true);
     FolderMan::instance()->scheduleAllFolders();
@@ -302,8 +300,6 @@ void AccountSettings::slotRemoveCurrentFolder(Folder *folder)
     connect(messageBox, &QMessageBox::finished, this, [messageBox, yesButton, folder, this] {
         if (messageBox->clickedButton() == yesButton) {
             FolderMan::instance()->removeFolder(folder);
-            // single folder fix to show add-button and hide remove-button
-            Q_EMIT folderChanged();
         }
     });
     messageBox->open();

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -68,7 +68,6 @@ public:
     auto model() { return _sortModel; }
 
 Q_SIGNALS:
-    void folderChanged();
     void showIssuesList();
 
 public Q_SLOTS:

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -451,7 +451,7 @@ void SettingsDialog::accountAdded(AccountStatePtr accountStatePtr)
     _actionForAccount.insert(accountStatePtr->account().data(), accountAction);
     accountAction->trigger();
 
-    connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotFoldersChanged);
+    connect(FolderMan::instance(), &FolderMan::folderListChanged, _gui, &ownCloudGui::slotFoldersChanged);
     connect(accountSettings, &AccountSettings::showIssuesList, this, &SettingsDialog::showIssuesList);
     connect(accountStatePtr->account().data(), &Account::accountChangedAvatar, this, &SettingsDialog::slotAccountAvatarChanged);
     connect(accountStatePtr->account().data(), &Account::accountChangedDisplayName, this, &SettingsDialog::slotAccountDisplayNameChanged);


### PR DESCRIPTION
Since we don't display the selective sync in the folder view we don't need to reset it on tiny changes.