### PR TITLE
Focus settings page for new accounts

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -847,6 +847,8 @@ void ownCloudGui::runNewAccountWizard()
                     auto accountStatePtr = ocApp()->addNewAccount(newAccount);
                     accountStatePtr->setSettingUp(true);
 
+                    _settingsDialog->setCurrentAccount(accountStatePtr->account().data());
+
                     // ensure we are connected and fetch the capabilities
                     auto validator = new ConnectionValidator(accountStatePtr->account(), accountStatePtr->account().data());
 


### PR DESCRIPTION
When a new account has been created, make sure that the settrings page is showing the page for this new account.

Fixes: #11642