### PR TITLE
Rename "Local sync protocol" tab in activity view to "Local Activity"

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -472,7 +472,7 @@ ActivitySettings::ActivitySettings(QWidget *parent)
     connect(_activityWidget, &ActivityWidget::newNotification, this, &ActivitySettings::slotShowActivityTab);
 
     _protocolWidget = new ProtocolWidget(this);
-    _protocolTabId = _tab->addTab(_protocolWidget, Resources::getCoreIcon(QStringLiteral("states/ok")), tr("Sync Protocol"));
+    _protocolTabId = _tab->addTab(_protocolWidget, Resources::getCoreIcon(QStringLiteral("states/ok")), tr("Local Activity"));
 
     _issuesWidget = new IssuesWidget(this);
     _syncIssueTabId = _tab->addTab(_issuesWidget, Resources::getCoreIcon(QStringLiteral("states/error")), QString());

--- a/src/gui/protocolwidget.ui
+++ b/src/gui/protocolwidget.ui
@@ -10,22 +10,9 @@
     <height>515</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="_headerLabel">
-       <property name="text">
-        <string>Local sync protocol</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-      </widget>
-     </item>
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -53,6 +40,9 @@
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
      </property>
+     <property name="accessibleName">
+      <string>Local activity table</string>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
@@ -72,9 +62,6 @@
       <bool>false</bool>
      </attribute>
     </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="_dialogButtonBox"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This makes the purpose more clear to users, and removes the need for the label above the table. In case of oc10, it also makes the difference clear between this tab and the "Server Activity" tab.

The table itself now also has an a11y name.

Fixes: #11637