### PR TITLE
[gui-tests][full-ci] unskip gui tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -113,11 +113,10 @@ def main(ctx):
     unit_tests = unit_test_pipeline(ctx)
     gui_tests = gui_test_pipeline(ctx)
 
-    return gui_tests
-    # return pipelines + \
-    #        unit_tests + \
-    #        gui_tests + \
-    #        pipelinesDependsOn(notification(), unit_tests + gui_tests)
+    return pipelines + \
+           unit_tests + \
+           gui_tests + \
+           pipelinesDependsOn(notification(), unit_tests + gui_tests)
 
 def from_secret(name):
     return {

--- a/.drone.star
+++ b/.drone.star
@@ -88,6 +88,10 @@ config = {
                         "enabled": False,
                         "command": "make dist",
                     },
+                    "activity": {
+                        "enabled": True,
+                        "command": "make dist",
+                    },
                 },
                 "skip_in_pr": True,
                 "skip": False,

--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,7 @@ OC_UBUNTU = "owncloud/ubuntu:20.04"
 # Todo: update or remove the following images
 # https://github.com/owncloud/client/issues/10070
 OC_CI_CLIENT_FEDORA = "owncloudci/client:fedora-39-amd64"
-OC_CI_SQUISH = "owncloudci/squish:fedora-39-7.2.1-qt66x-linux64"
+OC_CI_SQUISH = "sawjan/squish:test"
 
 PLUGINS_GIT_ACTION = "plugins/git-action:1"
 PLUGINS_S3 = "plugins/s3"
@@ -109,10 +109,11 @@ def main(ctx):
     unit_tests = unit_test_pipeline(ctx)
     gui_tests = gui_test_pipeline(ctx)
 
-    return pipelines + \
-           unit_tests + \
-           gui_tests + \
-           pipelinesDependsOn(notification(), unit_tests + gui_tests)
+    return gui_tests
+    # return pipelines + \
+    #        unit_tests + \
+    #        gui_tests + \
+    #        pipelinesDependsOn(notification(), unit_tests + gui_tests)
 
 def from_secret(name):
     return {

--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,7 @@ OC_UBUNTU = "owncloud/ubuntu:20.04"
 # Todo: update or remove the following images
 # https://github.com/owncloud/client/issues/10070
 OC_CI_CLIENT_FEDORA = "owncloudci/client:fedora-39-amd64"
-OC_CI_SQUISH = "sawjan/squish:test"
+OC_CI_SQUISH = "owncloudci/squish:fedora-39-7.2.1-qt66x-linux64"
 
 PLUGINS_GIT_ACTION = "plugins/git-action:1"
 PLUGINS_S3 = "plugins/s3"

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -90,7 +90,7 @@ class Activity:
                 + tabName
                 + " in "
                 + str(tabs)
-                + ". Count: "
+                + ". Tabs count: "
                 + str(tabCount)
             )
 

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -65,16 +65,27 @@ class Activity:
         # Because files count will be appended like "Not Synced (2)"
         # So to overcome this the following approach has been implemented
         tabCount = squish.waitForObjectExists(Activity.SUBTAB_CONTAINER).count
+        tabs = []
         for index in range(tabCount):
             tabText = Activity.getTabText(index)
+            tabs.append(tabText)
 
             if tabName in tabText:
+                # o = squish.waitForObjectExists(Activity.getTabObject(index))
+                # squish.clickTab(o)
                 tabFound = True
                 squish.clickTab(Activity.TAB_CONTAINER, tabText)
                 break
 
         if not tabFound:
-            raise Exception("Tab not found: " + tabName)
+            raise Exception(
+                "Tab not found: "
+                + tabName
+                + " in "
+                + str(tabs)
+                + ". Count: "
+                + str(tabCount)
+            )
 
     @staticmethod
     def checkFileExist(filename):

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -71,10 +71,17 @@ class Activity:
             tabs.append(tabText)
 
             if tabName in tabText:
-                # o = squish.waitForObjectExists(Activity.getTabObject(index))
-                # squish.clickTab(o)
                 tabFound = True
-                squish.clickTab(Activity.TAB_CONTAINER, tabText)
+                # clickTab becomes flaky with "Not Synced" tab
+                # because the tab text changes. e.g. "Not Synced (2)"
+                # squish.clickTab(Activity.TAB_CONTAINER, tabText)
+
+                # NOTE: If only the objectOrName is specified,
+                # the object is clicked in the middle by the Qt::LeftButton button
+                # and with no keyboard modifiers pressed.
+                squish.mouseClick(
+                    squish.waitForObjectExists(Activity.getTabObject(index))
+                )
                 break
 
         if not tabFound:

--- a/test/gui/shared/scripts/pageObjects/PublicLinkDialog.py
+++ b/test/gui/shared/scripts/pageObjects/PublicLinkDialog.py
@@ -120,13 +120,7 @@ class PublicLinkDialog:
 
     @staticmethod
     def openPublicLinkTab():
-        squish.mouseClick(
-            squish.waitForObject(PublicLinkDialog.PUBLIC_LINKS_TAB),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(squish.waitForObject(PublicLinkDialog.PUBLIC_LINKS_TAB))
 
     @staticmethod
     def createPublicLink(password='', permissions='', expireDate='', linkName=''):
@@ -164,13 +158,7 @@ class PublicLinkDialog:
         if not enabled:
             PublicLinkDialog.togglePassword()
 
-        squish.mouseClick(
-            squish.waitForObject(PublicLinkDialog.PASSWORD_INPUT_FIELD),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(squish.waitForObject(PublicLinkDialog.PASSWORD_INPUT_FIELD))
         squish.type(
             squish.waitForObject(PublicLinkDialog.PASSWORD_INPUT_FIELD),
             password,
@@ -192,11 +180,7 @@ class PublicLinkDialog:
             expDate = datetime.strptime(expireDate, '%Y-%m-%d')
             expYear = expDate.year - 2000
             squish.mouseClick(
-                squish.waitForObject(PublicLinkDialog.EXPIRATION_DATE_FIELD),
-                0,
-                0,
-                squish.Qt.NoModifier,
-                squish.Qt.LeftButton,
+                squish.waitForObject(PublicLinkDialog.EXPIRATION_DATE_FIELD)
             )
             # Move the cursor to year (last) field and enter the year
             squish.nativeType("<Ctrl+Right>")
@@ -252,13 +236,7 @@ class PublicLinkDialog:
     # See for more details: https://github.com/owncloud/client/issues/9218
     @staticmethod
     def setExpirationDateWithWorkaround(year, month, day):
-        squish.mouseClick(
-            squish.waitForObject(PublicLinkDialog.EXPIRATION_DATE_FIELD),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(squish.waitForObject(PublicLinkDialog.EXPIRATION_DATE_FIELD))
 
         # date can only be set to future date. But sometimes it can not modify the month field in first attempt.
         # date format is 'm/d/yy', so we have to edit 'month' first

--- a/test/gui/shared/scripts/pageObjects/SharingDialog.py
+++ b/test/gui/shared/scripts/pageObjects/SharingDialog.py
@@ -70,11 +70,7 @@ class SharingDialog:
     @staticmethod
     def searchCollaborator(collaborator):
         squish.mouseClick(
-            squish.waitForObject(SharingDialog.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
+            squish.waitForObject(SharingDialog.SHARE_WITH_COLLABORATOR_INPUT_FIELD)
         )
         squish.type(
             squish.waitForObject(SharingDialog.SHARE_WITH_COLLABORATOR_INPUT_FIELD),
@@ -133,11 +129,7 @@ class SharingDialog:
             squish.waitForObjectItem(
                 SharingDialog.SUGGESTED_COLLABORATOR,
                 escapedReceiverName + postFixInSuggestion,
-            ),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
+            )
         )
 
     @staticmethod

--- a/test/gui/shared/scripts/pageObjects/SyncConnection.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnection.py
@@ -2,8 +2,6 @@ import names
 import squish
 import object
 
-from helpers.ObjectHelper import get_center_coordinates
-
 
 class SyncConnection:
     FOLDER_SYNC_CONNECTION = {
@@ -42,13 +40,7 @@ class SyncConnection:
         menu_button = squish.waitForObject(
             SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON
         )
-        x, y = get_center_coordinates(menu_button)
-        squish.mouseClick(
-            menu_button,
-            x,
-            y,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(menu_button)
 
     @staticmethod
     def performAction(action):
@@ -108,13 +100,7 @@ class SyncConnection:
                         # example: folder1 (13 B) => folder1
                         item_name = item.text.rsplit(" ", 2)[0]
                         if item_name == folder_name:
-                            squish.mouseClick(
-                                item,
-                                9,
-                                9,
-                                squish.Qt.NoModifier,
-                                squish.Qt.LeftButton,
-                            )
+                            squish.mouseClick(item)
                             break
         squish.clickButton(
             squish.waitForObject(SyncConnection.SELECTIVE_SYNC_APPLY_BUTTON)

--- a/test/gui/shared/scripts/pageObjects/SyncConnection.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnection.py
@@ -100,7 +100,15 @@ class SyncConnection:
                         # example: folder1 (13 B) => folder1
                         item_name = item.text.rsplit(" ", 2)[0]
                         if item_name == folder_name:
-                            squish.mouseClick(item)
+                            # NOTE: checkbox does not have separate object
+                            # click on (11,11) which is a checkbox to unselect the folder
+                            squish.mouseClick(
+                                item,
+                                11,
+                                11,
+                                squish.Qt.NoModifier,
+                                squish.Qt.LeftButton,
+                            )
                             break
         squish.clickButton(
             squish.waitForObject(SyncConnection.SELECTIVE_SYNC_APPLY_BUTTON)

--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -110,8 +110,14 @@ class SyncConnectionWizard:
 
     @staticmethod
     def deselectAllRemoteFolders():
+        # NOTE: checkbox does not have separate object
+        # click on (11,11) which is a checkbox
         squish.mouseClick(
-            squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER)
+            squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
+            11,
+            11,
+            squish.Qt.NoModifier,
+            squish.Qt.LeftButton,
         )
 
     @staticmethod
@@ -148,7 +154,15 @@ class SyncConnectionWizard:
                     len(folder_levels) == 1
                     or folder_levels.index(sub_folder) == len(folder_levels) - 1
                 ):
-                    squish.mouseClick(squish.waitForObject(selector))
+                    # NOTE: checkbox does not have separate object
+                    # click on (11,11) which is a checkbox to unselect the folder
+                    squish.mouseClick(
+                        squish.waitForObject(selector),
+                        11,
+                        11,
+                        squish.Qt.NoModifier,
+                        squish.Qt.LeftButton,
+                    )
                 else:
                     squish.doubleClick(squish.waitForObject(selector))
 

--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -104,22 +104,14 @@ class SyncConnectionWizard:
     @staticmethod
     def selectRemoteDestinationFolder(folder):
         squish.mouseClick(
-            squish.waitForObjectItem(SyncConnectionWizard.REMOTE_FOLDER_TREE, folder),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
+            squish.waitForObjectItem(SyncConnectionWizard.REMOTE_FOLDER_TREE, folder)
         )
         SyncConnectionWizard.nextStep()
 
     @staticmethod
     def deselectAllRemoteFolders():
         squish.mouseClick(
-            squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER),
-            11,
-            11,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
+            squish.waitForObject(SyncConnectionWizard.SELECTIVE_SYNC_ROOT_FOLDER)
         )
 
     @staticmethod
@@ -156,21 +148,9 @@ class SyncConnectionWizard:
                     len(folder_levels) == 1
                     or folder_levels.index(sub_folder) == len(folder_levels) - 1
                 ):
-                    squish.mouseClick(
-                        squish.waitForObject(selector),
-                        11,
-                        11,
-                        squish.Qt.NoModifier,
-                        squish.Qt.LeftButton,
-                    )
+                    squish.mouseClick(squish.waitForObject(selector))
                 else:
-                    squish.doubleClick(
-                        squish.waitForObject(selector),
-                        65,
-                        7,
-                        squish.Qt.NoModifier,
-                        squish.Qt.LeftButton,
-                    )
+                    squish.doubleClick(squish.waitForObject(selector))
 
     @staticmethod
     def sortBy(headerText):
@@ -219,13 +199,7 @@ class SyncConnectionWizard:
     def selectSpaceToSync(spaceName):
         selector = SyncConnectionWizard.SPACE_NAME_SELECTOR.copy()
         selector["text"] = spaceName
-        squish.mouseClick(
-            squish.waitForObject(selector),
-            0,
-            0,
-            squish.Qt.NoModifier,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(squish.waitForObject(selector))
 
     @staticmethod
     def setSyncPathInSyncConnectionWizardOcis(sync_path):

--- a/test/gui/shared/scripts/pageObjects/Toolbar.py
+++ b/test/gui/shared/scripts/pageObjects/Toolbar.py
@@ -1,6 +1,5 @@
 import squish, object, names
 from helpers.SetupClientHelper import wait_until_app_killed
-from helpers.ObjectHelper import get_center_coordinates
 from helpers.ConfigHelper import get_config
 
 
@@ -76,30 +75,16 @@ class Toolbar:
 
     @staticmethod
     def openActivity():
-        x, y = get_center_coordinates(squish.waitForObject(Toolbar.ACTIVITY_BUTTON))
-        squish.mouseClick(
-            squish.waitForObject(Toolbar.ACTIVITY_BUTTON), x, y, squish.Qt.LeftButton
-        )
+        squish.mouseClick(squish.waitForObject(Toolbar.ACTIVITY_BUTTON))
 
     @staticmethod
     def openNewAccountSetup():
-        x, y = get_center_coordinates(squish.waitForObject(Toolbar.ADD_ACCOUNT_BUTTON))
-        squish.mouseClick(
-            squish.waitForObject(Toolbar.ADD_ACCOUNT_BUTTON), x, y, squish.Qt.LeftButton
-        )
+        squish.mouseClick(squish.waitForObject(Toolbar.ADD_ACCOUNT_BUTTON))
 
     @staticmethod
     def openAccount(displayname, host):
         account_title = displayname + "\n" + host
-        x, y = get_center_coordinates(
-            squish.waitForObject(Toolbar.getItemSelector(account_title))
-        )
-        squish.mouseClick(
-            squish.waitForObject(Toolbar.getItemSelector(account_title)),
-            x,
-            y,
-            squish.Qt.LeftButton,
-        )
+        squish.mouseClick(squish.waitForObject(Toolbar.getItemSelector(account_title)))
 
     @staticmethod
     def getDisplayedAccountText(displayname, host):
@@ -111,17 +96,11 @@ class Toolbar:
 
     @staticmethod
     def open_settings_tab():
-        x, y = get_center_coordinates(squish.waitForObject(Toolbar.SETTINGS_BUTTON))
-        squish.mouseClick(
-            squish.waitForObject(Toolbar.SETTINGS_BUTTON), x, y, squish.Qt.LeftButton
-        )
+        squish.mouseClick(squish.waitForObject(Toolbar.SETTINGS_BUTTON))
 
     @staticmethod
     def quit_owncloud():
-        x, y = get_center_coordinates(squish.waitForObject(Toolbar.QUIT_BUTTON))
-        squish.mouseClick(
-            squish.waitForObject(Toolbar.QUIT_BUTTON), x, y, squish.Qt.LeftButton
-        )
+        squish.mouseClick(squish.waitForObject(Toolbar.QUIT_BUTTON))
         squish.clickButton(squish.waitForObject(Toolbar.CONFIRM_QUIT_BUTTON))
         for ctx in squish.applicationContextList():
             pid = ctx.pid

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -31,7 +31,7 @@ Feature: Syncing files
         And the folder "simple-folder" should exist on the file system
         And the folder "large-folder" should exist on the file system
 
-    @issue-9733 @skip
+    @issue-9733
     Scenario: Syncing a file from the server and creating a conflict
         Given user "Alice" has uploaded file on the server with content "server content" to "/conflict.txt"
         And user "Alice" has set up a client with default settings
@@ -264,7 +264,7 @@ Feature: Syncing files
         And as "Alice" folder "Folder1/subFolder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist in the server
 
-    @skipOnWindows @skip
+    @skipOnWindows
     Scenario: Filenames that are rejected by the server are reported (Linux only)
         Given user "Alice" has created folder "Folder1" in the server
         And user "Alice" has set up a client with default settings
@@ -372,7 +372,7 @@ Feature: Syncing files
             | filename                                                                                                                                                                                                                     |
             | thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIsAVeryLongFileNameToCheckThatItWorks-thisIs.txt |
 
-    @skipOnOCIS @issue-11104 @skip
+    @skipOnOCIS @issue-11104
     Scenario Outline: File with long name (233 characters) is blacklisted (oC10)
         Given user "Alice" has set up a client with default settings
         When user "Alice" creates a file "<filename>" with the following content inside the sync folder


### PR DESCRIPTION
The test flakiness with oc10 server was mostly due to tab changes during the test execution. the test actions failed due to race-condition.

But unfortunately this PR doesn't fix the keyring issue
Part of https://github.com/owncloud/client/issues/11619