### PR TITLE
Remove event handler from setup wizard

### DIFF
--- a/src/gui/newwizard/setupwizardwindow.cpp
+++ b/src/gui/newwizard/setupwizardwindow.cpp
@@ -75,9 +75,6 @@ SetupWizardWindow::SetupWizardWindow(SettingsDialog *parent)
 
     _ui->transitionProgressIndicator->setFixedSize(32, 32);
     _ui->transitionProgressIndicator->setColor(Theme::instance()->wizardHeaderTitleColor());
-
-    // handle user pressing enter/return key
-    installEventFilter(this);
 }
 
 void SetupWizardWindow::loadStylesheet()
@@ -199,30 +196,6 @@ void SetupWizardWindow::setNavigationEntries(const QList<SetupWizardState> &entr
 void SetupWizardWindow::slotUpdateNextButton()
 {
     _ui->nextButton->setEnabled(_currentPage->validateInput());
-}
-
-bool SetupWizardWindow::eventFilter(QObject *obj, QEvent *event)
-{
-    if (!_transitioning) {
-        if (obj == _currentPage || obj == this) {
-            if (event->type() == QEvent::KeyPress) {
-                auto keyEvent = dynamic_cast<QKeyEvent *>(event);
-
-                switch (keyEvent->key()) {
-                case Qt::Key_Enter:
-                    Q_FALLTHROUGH();
-                case Qt::Key_Return:
-                    slotMoveToNextPage();
-                    return true;
-                default:
-                    // no action required, give other handlers a chance
-                    break;
-                }
-            }
-        }
-    }
-
-    return QDialog::eventFilter(obj, event);
 }
 
 void SetupWizardWindow::disableNextButton()

--- a/src/gui/newwizard/setupwizardwindow.h
+++ b/src/gui/newwizard/setupwizardwindow.h
@@ -61,9 +61,6 @@ public:
 
     void disableNextButton();
 
-protected:
-    bool eventFilter(QObject *obj, QEvent *event) override;
-
 Q_SIGNALS:
     void navigationEntryClicked(SetupWizardState clickedState);
     void nextButtonClicked();


### PR DESCRIPTION
Wizards on all platforms do not react to enter keys when buttons do not have focus.