### PR TITLE
[tests-only] [full-ci] Keep files after deletion of all files

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -29,6 +29,13 @@ class AccountSetting:
         "unnamed": 1,
         "visible": 1,
     }
+    KEEP_FILES = {
+        "text": "Keep files",
+        "type": "QPushButton",
+        "unnamed": 1,
+        "visible": 1,
+        "window": names.remove_All_Files_QMessageBox,
+    }
     ACCOUNT_CONNECTION_LABEL = {
         "container": names.settings_stack_QStackedWidget,
         "name": "connectLabel",
@@ -171,6 +178,10 @@ class AccountSetting:
     @staticmethod
     def confirmRemoveAllFiles():
         squish.clickButton(squish.waitForObject(AccountSetting.REMOVE_ALL_FILES))
+
+    @staticmethod
+    def confirmKeepFiles():
+        squish.clickButton(squish.waitForObject(AccountSetting.KEEP_FILES))
 
     @staticmethod
     def pressKey(key):

--- a/test/gui/shared/steps/file_context.py
+++ b/test/gui/shared/steps/file_context.py
@@ -17,7 +17,6 @@ from helpers.FilesHelper import (
     can_read,
     can_write,
     read_file_content,
-    is_empty_sync_folder,
     get_size_in_bytes,
     prefix_path_namespace,
 )
@@ -256,14 +255,6 @@ def step(context, itemType, resource):
         shutil.rmtree(resourcePath)
     else:
         raise Exception("No such item type for resource")
-
-    # if the sync folder is empty after deleting file,
-    # a dialog will popup asking to confirm "Remove all files"
-    if is_empty_sync_folder(getResourcePath()):
-        try:
-            AccountSetting.confirmRemoveAllFiles()
-        except:
-            pass
 
 
 @When('user "|any|" creates the following files inside the sync folder:')

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -3,6 +3,7 @@ import json
 from helpers.ConfigHelper import get_config
 from helpers.api.Provisioning import setup_app
 from helpers.api.utils import url_join
+from helpers.FilesHelper import is_empty_sync_folder
 import helpers.api.webdav_helper as webdav
 import helpers.api.sharing_helper as sharing_helper
 
@@ -181,3 +182,19 @@ def step(context, user, file_content, file_name):
 @When('user "|any|" deletes the folder "|any|" in the server')
 def step(context, user, folder_name):
     webdav.delete_resource(user, folder_name)
+
+
+@When("the user confirms to keep the files")
+def step(context):
+    AccountSetting.confirmKeepFiles()
+
+
+@When("the user confirms to remove all the files")
+def step(context):
+    # if the sync folder is empty after deleting file,
+    # a dialog will popup asking to confirm "Remove all files"
+    if is_empty_sync_folder(getResourcePath()):
+        try:
+            AccountSetting.confirmRemoveAllFiles()
+        except:
+            pass

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -13,6 +13,7 @@ Feature: deleting files and folders
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "<fileName>" in the server
         And user "Alice" has set up a client with default settings
         When the user deletes the file "<fileName>"
+        And the user confirms to remove all the files
         And the user waits for the files to sync
         Then as "Alice" file "<fileName>" should not exist in the server
         Examples:
@@ -26,6 +27,7 @@ Feature: deleting files and folders
         Given user "Alice" has created folder "<folderName>" in the server
         And user "Alice" has set up a client with default settings
         When the user deletes the folder "<folderName>"
+        And the user confirms to remove all the files
         And the user waits for the files to sync
         Then as "Alice" file "<folderName>" should not exist in the server
         Examples:
@@ -47,3 +49,12 @@ Feature: deleting files and folders
         And as "Alice" folder "test-folder1" should not exist in the server
         And as "Alice" file "textfile2.txt" should exist in the server
         And as "Alice" folder "test-folder2" should exist in the server
+        When the user deletes the file "textfile2.txt"
+        And the user deletes the folder "test-folder2"
+        And the user confirms to keep the files
+        And the user waits for the files to sync
+        Then as "Alice" file "textfile2.txt" should exist in the server
+        And as "Alice" folder "test-folder2" should exist in the server
+        Then the file "textfile2.txt" should exist on the file system
+        Then the folder "test-folder2" should exist on the file system
+

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -23,8 +23,8 @@ Feature:  Logout users
   Scenario: login with incorrect and correct password after log out
     Given user "Alice" has set up a client with default settings
     And user "Alice" has logged out of the client-UI
-    When user "ALice" opens login dialog
-    And user "ALice" enters the password "invalid"
+    When user "Alice" opens login dialog
+    And user "Alice" enters the password "invalid"
     And user "Alice" logs out from the login required dialog
     And user "Alice" logs in to the client-UI
     Then user "Alice" should be connect to the client-UI

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -335,6 +335,7 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
+        And the user confirms to remove all the files
         And the user waits for the files to sync
         Then as "Brian" file "textfile.txt" on the server should not exist
         And as "Brian" folder "Folder" on the server should not exist
@@ -351,6 +352,7 @@ Feature: Sharing
         And user "Brian" has set up a client with default settings
         When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
+        And the user confirms to remove all the files
         And the user waits for the files to sync
         # Sharee can delete (means unshare) the file shared with read permission
         Then as "Brian" file "textfile.txt" on the server should not exist

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -1,7 +1,7 @@
 Feature: Syncing files
 
     As a user
-    I want to be able to sync my local folders to to my owncloud server
+    I want to be able to sync my local folders to my owncloud server
     so that I dont have to upload and download files manually
 
     Background:

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -109,6 +109,7 @@ Feature: Syncing files
         And the file "large-folder/lorem.txt" should not exist on the file system
         And as "Alice" file "simple-folder/localFile.txt" should exist in the server
         When the user deletes the folder "simple-folder"
+        And the user confirms to remove all the files
         And the user waits for the files to sync
         Then as "Alice" folder "simple-folder" should not exist in the server
 


### PR DESCRIPTION
Added test coverage for checking that the files are recreated during sync when `Keep files` is selected in `Remove all files` dialog after deleting all the files.

Related issue: https://github.com/owncloud/client/issues/11653 