### PR TITLE
Update changelog 11552 (typo fix)

### DIFF
--- a/changelog/unreleased/11552
+++ b/changelog/unreleased/11552
@@ -1,4 +1,4 @@
-Bugfix: Ensure folder are scheduled only once
+Bugfix: Ensure folders are scheduled only once
 
 We fixed a bug where a folder could be scheduled multiple times.
 


### PR DESCRIPTION
`folder` --> `folders`

(many thanks to @phil-davis who found this)