### PR TITLE
Add a11y role to the nav bar

### DIFF
--- a/src/gui/qml/AccountBar.qml
+++ b/src/gui/qml/AccountBar.qml
@@ -21,6 +21,7 @@ import org.ownCloud.libsync 1.0
 Pane {
     id: bar
     Accessible.name: qsTr("Navigation bar")
+    Accessible.role: Accessible.PageTabList
 
     RowLayout {
         anchors.fill: parent


### PR DESCRIPTION
This causes it to be a group on macOS for which the accessible name will be used.