### PR TITLE
Fix a11y issues in "Server Activities" tab

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -66,8 +66,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     header->setSectionResizeMode(QHeaderView::Interactive);
     header->setSortIndicator(static_cast<int>(ActivityListModel::ActivityRole::PointInTime), Qt::DescendingOrder);
 
-    _ui->_notifyLabel->hide();
-    _ui->_notifyScroll->hide();
+    _ui->_notifyGroupBox->hide();
 
     // Create a widget container for the notifications. The ui file defines
     // a scroll area that get a widget with a layout as children
@@ -146,19 +145,15 @@ void ActivityWidget::slotRemoveAccount(const AccountStatePtr &ptr)
 
 void ActivityWidget::showLabels()
 {
-    QString t = tr("Server Activities");
-    _ui->_headerLabel->setTextFormat(Qt::RichText);
-    _ui->_headerLabel->setText(t);
+    _ui->_activityGroupBox->setTitle(tr("&Server Activities"));
+    _ui->_notifyGroupBox->setTitle(tr("&Notifications"));
 
-    _ui->_notifyLabel->setText(tr("Notifications"));
-
-    t.clear();
+    QString bottomText;
     QSetIterator<QString> i(_accountsWithoutActivities);
     while (i.hasNext()) {
-        t.append(tr("<br/>%1 does not provide activities.").arg(i.next()));
+        bottomText.append(tr("<br/>%1 does not provide activities.").arg(i.next()));
     }
-    _ui->_bottomLabel->setTextFormat(Qt::RichText);
-    _ui->_bottomLabel->setText(t);
+    _ui->_bottomLabel->setText(bottomText);
 }
 
 void ActivityWidget::slotAccountActivityStatus(AccountStatePtr ast, int statusCode)
@@ -183,11 +178,8 @@ void ActivityWidget::checkActivityTabVisibility()
         _accountsWithoutActivities.count() != accountCount;
     bool hasNotifications = !_widgetForNotifId.isEmpty();
 
-    _ui->_headerLabel->setVisible(hasAccountsWithActivity);
-    _ui->_activityList->setVisible(hasAccountsWithActivity);
-
-    _ui->_notifyLabel->setVisible(hasNotifications);
-    _ui->_notifyScroll->setVisible(hasNotifications);
+    _ui->_activityGroupBox->setVisible(hasAccountsWithActivity);
+    _ui->_notifyGroupBox->setVisible(hasNotifications);
 
     Q_EMIT hideActivityTab(!hasAccountsWithActivity && !hasNotifications);
 }
@@ -420,8 +412,7 @@ void ActivityWidget::slotCheckToCleanWidgets()
 
     // check to see if the whole notification pane should be hidden
     if (_widgetForNotifId.isEmpty()) {
-        _ui->_notifyLabel->setHidden(true);
-        _ui->_notifyScroll->setHidden(true);
+        _ui->_notifyGroupBox->setHidden(true);
     }
 }
 

--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -13,115 +13,101 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QLabel" name="_notifyLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
+    <widget class="QGroupBox" name="_notifyGroupBox">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QScrollArea" name="_notifyScroll">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <widget class="QWidget" name="_scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>637</width>
+           <height>16</height>
+          </rect>
+         </property>
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QScrollArea" name="_notifyScroll">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <widget class="QWidget" name="_scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>673</width>
-        <height>68</height>
-       </rect>
-      </property>
-      <property name="autoFillBackground">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="_headerLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="_filterButton">
-       <property name="text">
-        <string>Filter</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTableView" name="_activityList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="showGrid">
-      <bool>false</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="wordWrap">
-      <bool>false</bool>
-     </property>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
+    <widget class="QGroupBox" name="_activityGroupBox">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="_filterButton">
+          <property name="text">
+           <string>Filter</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTableView" name="_activityList">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="contextMenuPolicy">
+         <enum>Qt::CustomContextMenu</enum>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="showGrid">
+         <bool>false</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -143,6 +129,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>_notifyScroll</tabstop>
+  <tabstop>_filterButton</tabstop>
   <tabstop>_activityList</tabstop>
   <tabstop>_dialogButtonBox</tabstop>
  </tabstops>


### PR DESCRIPTION
The notifications are now shown in a group box named "Notifications", and the server activities are shown in another group box named "Server Activities". The labels have been removed, as the group box titles take their role.

The tab order has also been fixed.