### PR TITLE
[gui-tests][full-ci] wait for tabs to render completely

### DIFF
--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -60,7 +60,7 @@ class Activity:
     def clickTab(tabName):
         tabFound = False
 
-        # NOTE: Some activity tabs are not immediately available
+        # NOTE: Some activity tabs are loaded dynamically
         # and the tab index changes after all the tabs are loaded properly
         # So wait for a second to let the UI render the tabs properly
         # before trying to click the tab

--- a/test/gui/shared/scripts/pageObjects/Activity.py
+++ b/test/gui/shared/scripts/pageObjects/Activity.py
@@ -9,7 +9,6 @@ class Activity:
     TAB_CONTAINER = {
         "container": names.settings_stack_QStackedWidget,
         "type": "QTabWidget",
-        "unnamed": 1,
         "visible": 1,
     }
     SUBTAB_CONTAINER = {
@@ -60,6 +59,12 @@ class Activity:
     @staticmethod
     def clickTab(tabName):
         tabFound = False
+
+        # NOTE: Some activity tabs are not immediately available
+        # and the tab index changes after all the tabs are loaded properly
+        # So wait for a second to let the UI render the tabs properly
+        # before trying to click the tab
+        squish.snooze(get_config("lowestSyncTimeout"))
 
         # Selecting tab by name fails for "Not Synced" when there are no unsynced files
         # Because files count will be appended like "Not Synced (2)"


### PR DESCRIPTION
Added a short wait for all activity tabs to render correctly.

Fixes CI flakineses:
- https://drone.owncloud.com/owncloud/client/18582/2/16
- https://drone.owncloud.com/owncloud/client/18584/2/16