### PR TITLE
[gui-tests][full-ci] add gui test to remove folder sync connection

### DIFF
--- a/test/gui/shared/scripts/names.py
+++ b/test/gui/shared/scripts/names.py
@@ -52,3 +52,4 @@ stack_scrollArea_QScrollArea = {"container": settings_stack_QStackedWidget, "nam
 create_Remote_Folder_QInputDialog = {"type": "QInputDialog", "unnamed": 1, "visible": 1, "windowTitle": "Create Remote Folder"}
 create_Remote_Folder_Enter_the_name_of_the_new_folder_to_be_created_below_QLabel = {"text": "Enter the name of the new folder to be created below '/':", "type": "QLabel", "unnamed": 1, "visible": 1, "window": create_Remote_Folder_QInputDialog}
 groupBox_folderTreeWidget_QTreeWidget = {"container": add_Folder_Sync_Connection_groupBox_QGroupBox, "name": "folderTreeWidget", "type": "QTreeWidget", "visible": 1}
+confirm_Folder_Sync_Connection_Removal_QMessageBox = {"type": "QMessageBox", "unnamed": 1, "visible": 1, "windowTitle": "Confirm Folder Sync Connection Removal"}

--- a/test/gui/shared/scripts/pageObjects/SyncConnection.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnection.py
@@ -29,6 +29,20 @@ class SyncConnection:
         "type": "QPushButton",
         "visible": 1,
     }
+    CANCEL_FOLDER_SYNC_CONNECTION_DIALOG = {
+        "text": "Cancel",
+        "type": "QPushButton",
+        "unnamed": 1,
+        "visible": 1,
+        "window": names.confirm_Folder_Sync_Connection_Removal_QMessageBox,
+    }
+    REMOVE_FOLDER_SYNC_CONNECTION_BUTTON = {
+        "text": "Remove Folder Sync Connection",
+        "type": "QPushButton",
+        "unnamed": 1,
+        "visible": 1,
+        "window": names.confirm_Folder_Sync_Connection_Removal_QMessageBox,
+    }
 
     @staticmethod
     def openMenu():
@@ -110,4 +124,20 @@ class SyncConnection:
                             break
         squish.clickButton(
             squish.waitForObject(SyncConnection.SELECTIVE_SYNC_APPLY_BUTTON)
+        )
+
+    @staticmethod
+    def remove_folder_sync_connection():
+        SyncConnection.performAction("Remove folder sync connection")
+
+    @staticmethod
+    def cancel_folder_sync_connection_removal():
+        squish.clickButton(
+            squish.waitForObject(SyncConnection.CANCEL_FOLDER_SYNC_CONNECTION_DIALOG)
+        )
+
+    @staticmethod
+    def confirm_folder_sync_connection_removal():
+        squish.clickButton(
+            squish.waitForObject(SyncConnection.REMOVE_FOLDER_SYNC_CONNECTION_BUTTON)
         )

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -272,7 +272,7 @@ def step(context):
     SyncConnectionWizard.cancelFolderSyncConnectionWizard()
 
 
-@Then("the sync folder should not be added")
+@Then("the sync folder list should be empty")
 def step(context):
     test.vp("empty_sync_connection")
 

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -271,3 +271,19 @@ def step(context, folder_name, selected):
             SyncConnectionWizard.is_remote_folder_selected(folder_selector),
             "Folder should be selected",
         )
+
+
+@When('the user selects remove folder sync connection option')
+def step(context):
+    SyncConnection.remove_folder_sync_connection()
+
+
+@When('the user cancels the folder sync connection removal dialog')
+def step(context):
+    SyncConnection.cancel_folder_sync_connection_removal()
+
+
+@When('the user removes the folder sync connection')
+def step(context):
+    SyncConnection.remove_folder_sync_connection()
+    SyncConnection.confirm_folder_sync_connection_removal()

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -435,7 +435,7 @@ Feature: Syncing files
         When the user selects manual sync folder option in advanced section
         And the user cancels the sync connection wizard
         Then the account with displayname "Alice Hansen" and host "%local_server_hostname%" should be displayed
-        And the sync folder should not be added
+        And the sync folder list should be empty
 
 
     Scenario: extract a zip file in the sync folder
@@ -486,3 +486,14 @@ Feature: Syncing files
         Then the folder "simple-folder" should not exist on the file system
         And the folder "test-folder/sub-folder2" should exist on the file system
         And the folder "test-folder/sub-folder1" should not exist on the file system
+
+
+    Scenario: remove folder sync connection
+        Given user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has set up a client with default settings
+        When the user selects remove folder sync connection option
+        And the user cancels the folder sync connection removal dialog
+        And the user removes the folder sync connection
+        Then the sync folder list should be empty
+        And the folder "simple-folder" should exist on the file system
+        And as "Alice" folder "simple-folder" should exist in the server


### PR DESCRIPTION
### Description
This PR, adds GUI tests to remove the synced folder connection.

### Related issue
- https://github.com/owncloud/client/issues/11653