### PR TITLE
Fix missing desktop/application icon with Wayland

### DIFF
--- a/owncloud.desktop.in
+++ b/owncloud.desktop.in
@@ -10,6 +10,7 @@ Keywords=@APPLICATION_NAME@;syncing;file;sharing;
 X-GNOME-Autostart-Delay=3
 MimeType=application/vnd.@APPLICATION_EXECUTABLE@;
 Actions=Settings;Quit;
+StartupWMClass=@APPLICATION_NAME@
 
 # Translations
 Comment[oc]=@APPLICATION_NAME@ sincronizacion del client


### PR DESCRIPTION
Fixed by setting the StartupWMClass in the `.desktop` file.

Fixes: #11625