### PR TITLE
[gui-tests][full-ci]update step to only check if the local folder is present in the remote destination wizard

### DIFF
--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -334,7 +334,3 @@ class SyncConnectionWizard:
             except:
                 return False, None
         return True, parent_container
-
-    @staticmethod
-    def is_remote_folder_selected(folder_selector):
-        return squish.waitForObjectExists(folder_selector).selected

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -265,21 +265,13 @@ def step(context):
         SyncConnectionWizard.refresh_remote()
 
 
-@Then(
-    r'the folder "([^"]*)" should be present and (selected|not selected) in the remote destination wizard',
-    regexp=True,
-)
-def step(context, folder_name, selected):
+@Then('the folder "|any|" should be present in the remote destination wizard')
+def step(context, folder_name):
     if not get_config("ocis"):
         has_folder, folder_selector = SyncConnectionWizard.has_remote_folder(
             folder_name
         )
         test.compare(True, has_folder, "Folder should be in the remote list")
-        test.compare(
-            selected == 'selected',
-            SyncConnectionWizard.is_remote_folder_selected(folder_selector),
-            "Folder should be selected",
-        )
 
 
 @When('the user selects remove folder sync connection option')

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -71,9 +71,9 @@ Feature: Syncing files
         And the user navigates back in the sync connection wizard
         And the user sets the temp folder "localSyncFolder" as local sync path in sync connection wizard
         And the user creates a folder "test-folder" in the remote destination wizard
-        Then the folder "test-folder" should be present and selected in the remote destination wizard
+        Then the folder "test-folder" should be present in the remote destination wizard
         When the user refreshes the remote destination in the sync connection wizard
-        Then the folder "test-folder" should be present and not selected in the remote destination wizard
+        Then the folder "test-folder" should be present in the remote destination wizard
         When the user selects "ownCloud" as a remote destination folder
         And the user disables VFS support for Windows
         Then the sync all checkbox should be checked


### PR DESCRIPTION
### Description
This PR updates the step
```feature
Then the folder "test-folder" should be present and selected in the remote destination wizard
```
to
```feature
Then the folder "test-folder" should be present in the remote destination wizard
```
Checking whether the folder is selected or not seemed to be flaky because of the timing issue for folder to be selected, so only checking the presence of the folder in the remote destination wizard.