### PR TITLE
Rename two sets of files from ...Dialog to ...Widget

### DIFF
--- a/src/gui/updater/CMakeLists.txt
+++ b/src/gui/updater/CMakeLists.txt
@@ -10,16 +10,16 @@ endif()
 target_sources(owncloudGui PRIVATE
     ocupdater.cpp
     ocupdater.h
-    newversionavailabledialog.cpp
-    newversionavailabledialog.h
-    newversionavailabledialog.ui
+    newversionavailablewidget.cpp
+    newversionavailablewidget.h
+    newversionavailablewidget.ui
     updateinfo.cpp
     updateinfo.h
     updater.cpp
     updater.h
-    updatedownloadeddialog.cpp
-    updatedownloadeddialog.h
-    updatedownloadeddialog.ui
+    updatedownloadedwidget.cpp
+    updatedownloadedwidget.h
+    updatedownloadedwidget.ui
 )
 
 if(SPARKLE_FOUND)

--- a/src/gui/updater/newversionavailablewidget.cpp
+++ b/src/gui/updater/newversionavailablewidget.cpp
@@ -12,18 +12,18 @@
  * for more details.
  */
 
-#include "newversionavailabledialog.h"
+#include "newversionavailablewidget.h"
 #include "theme.h"
-#include "ui_newversionavailabledialog.h"
+#include "ui_newversionavailablewidget.h"
 
 #include <QDialogButtonBox>
 #include <QPushButton>
 
 namespace OCC {
 
-NewVersionAvailableDialog::NewVersionAvailableDialog(QWidget *parent, const QString &statusMessage)
+NewVersionAvailableWidget::NewVersionAvailableWidget(QWidget *parent, const QString &statusMessage)
     : QWidget(parent)
-    , _ui(new ::Ui::Ui_NewVersionAvailableDialog)
+    , _ui(new ::Ui::Ui_NewVersionAvailableWidget)
 {
     _ui->setupUi(this);
 
@@ -34,29 +34,29 @@ NewVersionAvailableDialog::NewVersionAvailableDialog(QWidget *parent, const QStr
     QPushButton *getUpdateButton = _ui->buttonBox->addButton(tr("Get update"), QDialogButtonBox::AcceptRole);
     QPushButton *rejectButton = _ui->buttonBox->addButton(tr("Skip this time"), QDialogButtonBox::AcceptRole);
 
-    connect(skipButton, &QAbstractButton::clicked, this, &NewVersionAvailableDialog::skipVersion);
-    connect(rejectButton, &QAbstractButton::clicked, this, &NewVersionAvailableDialog::notNow);
-    connect(getUpdateButton, &QAbstractButton::clicked, this, &NewVersionAvailableDialog::getUpdate);
+    connect(skipButton, &QAbstractButton::clicked, this, &NewVersionAvailableWidget::skipVersion);
+    connect(rejectButton, &QAbstractButton::clicked, this, &NewVersionAvailableWidget::notNow);
+    connect(getUpdateButton, &QAbstractButton::clicked, this, &NewVersionAvailableWidget::getUpdate);
 }
 
-NewVersionAvailableDialog::~NewVersionAvailableDialog()
+NewVersionAvailableWidget::~NewVersionAvailableWidget()
 {
     delete _ui;
 }
 
-void NewVersionAvailableDialog::skipVersion()
+void NewVersionAvailableWidget::skipVersion()
 {
     Q_EMIT versionSkipped();
     Q_EMIT finished();
 }
 
-void NewVersionAvailableDialog::notNow()
+void NewVersionAvailableWidget::notNow()
 {
     Q_EMIT noUpdateNow();
     Q_EMIT finished();
 }
 
-void NewVersionAvailableDialog::getUpdate()
+void NewVersionAvailableWidget::getUpdate()
 {
     Q_EMIT updateNow();
     Q_EMIT finished();

--- a/src/gui/updater/newversionavailablewidget.h
+++ b/src/gui/updater/newversionavailablewidget.h
@@ -18,29 +18,32 @@
 #include <QWidget>
 
 namespace Ui {
-class UpdateDownloadedDialog;
+class Ui_NewVersionAvailableWidget;
 }
 
 namespace OCC {
 
-class UpdateDownloadedDialog : public QWidget
+class NewVersionAvailableWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit UpdateDownloadedDialog(QWidget *parent, const QString &statusMessage);
-    ~UpdateDownloadedDialog();
+    explicit NewVersionAvailableWidget(QWidget *parent, const QString &statusMessage);
+    ~NewVersionAvailableWidget();
 
-public Q_SLOTS:
-    void accept();
-    void reject();
+private Q_SLOTS:
+    void skipVersion();
+    void notNow();
+    void getUpdate();
 
 Q_SIGNALS:
-    void accepted();
+    void versionSkipped();
+    void noUpdateNow();
+    void updateNow();
     void finished();
 
 private:
-    ::Ui::UpdateDownloadedDialog *_ui;
+    ::Ui::Ui_NewVersionAvailableWidget *_ui;
 };
 
 }

--- a/src/gui/updater/newversionavailablewidget.ui
+++ b/src/gui/updater/newversionavailablewidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Ui::NewVersionAvailableDialog</class>
- <widget class="QWidget" name="Ui::NewVersionAvailableDialog">
+ <class>Ui::NewVersionAvailableWidget</class>
+ <widget class="QWidget" name="Ui::NewVersionAvailableWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -9,9 +9,6 @@
     <width>400</width>
     <height>300</height>
    </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -21,8 +21,8 @@
 #include "theme.h"
 
 #include "settingsdialog.h"
-#include "updatedownloadeddialog.h"
-#include "updater/newversionavailabledialog.h"
+#include "updatedownloadedwidget.h"
+#include "updater/newversionavailablewidget.h"
 #include "updater/ocupdater.h"
 #include "updater/updater_private.h"
 
@@ -51,12 +51,12 @@ UpdaterScheduler::UpdaterScheduler(Application *app, QObject *parent)
 
         connect(updater, &OCUpdater::updateDownloaded, this, [app, updater, this]() {
             // prevent dialog from being displayed twice (rather unlikely, but it won't hurt)
-            if (_updateDownloadedDialog == nullptr) {
-                _updateDownloadedDialog = new UpdateDownloadedDialog(app->gui()->settingsDialog(), updater->statusString());
-                ocApp()->gui()->settingsDialog()->addModalWidget(_updateDownloadedDialog);
+            if (_updateDownloadedWidget == nullptr) {
+                _updateDownloadedWidget = new UpdateDownloadedWidget(app->gui()->settingsDialog(), updater->statusString());
+                ocApp()->gui()->settingsDialog()->addModalWidget(_updateDownloadedWidget);
 
-                connect(_updateDownloadedDialog, &UpdateDownloadedDialog::accepted, this, []() { RestartManager::requestRestart(); });
-                connect(_updateDownloadedDialog, &UpdateDownloadedDialog::finished, this, [this]() { delete _updateDownloadedDialog.data(); });
+                connect(_updateDownloadedWidget, &UpdateDownloadedWidget::accepted, this, []() { RestartManager::requestRestart(); });
+                connect(_updateDownloadedWidget, &UpdateDownloadedWidget::finished, this, [this]() { delete _updateDownloadedWidget.data(); });
             }
         });
 
@@ -354,7 +354,7 @@ void WindowsUpdater::versionInfoArrived(const UpdateInfo &info)
     } else {
         const QString url = info.downloadUrl();
         if (url.isEmpty()) {
-            showNewVersionAvailableDialog(info);
+            showNewVersionAvailableWidget(info);
         } else {
             _targetFile = ConfigFile::configPath() + url.mid(url.lastIndexOf(QLatin1Char('/')) + 1);
             if (QFile::exists(_targetFile)) {
@@ -374,18 +374,18 @@ void WindowsUpdater::versionInfoArrived(const UpdateInfo &info)
     }
 }
 
-void WindowsUpdater::showNewVersionAvailableDialog(const UpdateInfo &info)
+void WindowsUpdater::showNewVersionAvailableWidget(const UpdateInfo &info)
 {
     // if the version tag is set, there is a newer version.
     QString txt = tr("<p>A new version of the %1 Client is available.</p>"
                      "<p><b>%2</b> is available for download. The installed version is %3.</p>")
                       .arg(Utility::escape(Theme::instance()->appNameGUI()),
                           Utility::escape(info.versionString()), Utility::escape(Version::versionWithBuildNumber().toString()));
-    auto *widget = new NewVersionAvailableDialog(ocApp()->gui()->settingsDialog(), txt);
+    auto *widget = new NewVersionAvailableWidget(ocApp()->gui()->settingsDialog(), txt);
 
-    connect(widget, &NewVersionAvailableDialog::versionSkipped, this, &WindowsUpdater::slotSetPreviouslySkippedVersion);
-    connect(widget, &NewVersionAvailableDialog::updateNow, this, &WindowsUpdater::slotOpenUpdateUrl);
-    connect(widget, &NewVersionAvailableDialog::finished, this, [widget]() { delete widget; });
+    connect(widget, &NewVersionAvailableWidget::versionSkipped, this, &WindowsUpdater::slotSetPreviouslySkippedVersion);
+    connect(widget, &NewVersionAvailableWidget::updateNow, this, &WindowsUpdater::slotOpenUpdateUrl);
+    connect(widget, &NewVersionAvailableWidget::finished, this, [widget]() { delete widget; });
 
     ocApp()->gui()->settingsDialog()->addModalWidget(widget);
 }

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -16,7 +16,7 @@
 #include "gui/owncloudguilib.h"
 
 #include "application.h"
-#include "updater/updatedownloadeddialog.h"
+#include "updater/updatedownloadedwidget.h"
 #include "updater/updateinfo.h"
 #include "updater/updater.h"
 
@@ -92,7 +92,7 @@ private:
     QTimer _updateCheckTimer; /** Timer for the regular update check. */
 
     // make sure we are going to show only one of them at once
-    QPointer<UpdateDownloadedDialog> _updateDownloadedDialog = nullptr;
+    QPointer<UpdateDownloadedWidget> _updateDownloadedWidget = nullptr;
 };
 
 /**
@@ -186,7 +186,7 @@ private Q_SLOTS:
 
 private:
     void wipeUpdateData();
-    void showNewVersionAvailableDialog(const UpdateInfo &info);
+    void showNewVersionAvailableWidget(const UpdateInfo &info);
     void showUpdateErrorDialog(const QString &targetVersion);
     void versionInfoArrived(const UpdateInfo &info) override;
     QScopedPointer<QTemporaryFile> _file;

--- a/src/gui/updater/updatedownloadedwidget.cpp
+++ b/src/gui/updater/updatedownloadedwidget.cpp
@@ -12,18 +12,18 @@
  * for more details.
  */
 
-#include "updatedownloadeddialog.h"
+#include "updatedownloadedwidget.h"
 #include "theme.h"
-#include "ui_updatedownloadeddialog.h"
+#include "ui_updatedownloadedwidget.h"
 
 #include <QDialogButtonBox>
 #include <QPushButton>
 
 namespace OCC {
 
-UpdateDownloadedDialog::UpdateDownloadedDialog(QWidget *parent, const QString &statusMessage)
+UpdateDownloadedWidget::UpdateDownloadedWidget(QWidget *parent, const QString &statusMessage)
     : QWidget(parent)
-    , _ui(new ::Ui::UpdateDownloadedDialog)
+    , _ui(new ::Ui::UpdateDownloadedWidget)
 {
     _ui->setupUi(this);
 
@@ -32,8 +32,8 @@ UpdateDownloadedDialog::UpdateDownloadedDialog(QWidget *parent, const QString &s
 
     _ui->descriptionLabel->setText(statusMessage);
 
-    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, &UpdateDownloadedDialog::reject);
-    connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, &UpdateDownloadedDialog::accept);
+    connect(_ui->buttonBox, &QDialogButtonBox::rejected, this, &UpdateDownloadedWidget::reject);
+    connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, &UpdateDownloadedWidget::accept);
 
     const auto noButton = _ui->buttonBox->button(QDialogButtonBox::No);
     const auto yesButton = _ui->buttonBox->button(QDialogButtonBox::Yes);
@@ -44,18 +44,18 @@ UpdateDownloadedDialog::UpdateDownloadedDialog(QWidget *parent, const QString &s
     yesButton->setDefault(true);
 }
 
-UpdateDownloadedDialog::~UpdateDownloadedDialog()
+UpdateDownloadedWidget::~UpdateDownloadedWidget()
 {
     delete _ui;
 }
 
-void UpdateDownloadedDialog::accept()
+void UpdateDownloadedWidget::accept()
 {
     Q_EMIT accepted();
     Q_EMIT finished();
 }
 
-void UpdateDownloadedDialog::reject()
+void UpdateDownloadedWidget::reject()
 {
     Q_EMIT finished();
 }

--- a/src/gui/updater/updatedownloadedwidget.h
+++ b/src/gui/updater/updatedownloadedwidget.h
@@ -18,32 +18,29 @@
 #include <QWidget>
 
 namespace Ui {
-class Ui_NewVersionAvailableDialog;
+class UpdateDownloadedWidget;
 }
 
 namespace OCC {
 
-class NewVersionAvailableDialog : public QWidget
+class UpdateDownloadedWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit NewVersionAvailableDialog(QWidget *parent, const QString &statusMessage);
-    ~NewVersionAvailableDialog();
+    explicit UpdateDownloadedWidget(QWidget *parent, const QString &statusMessage);
+    ~UpdateDownloadedWidget();
 
-private Q_SLOTS:
-    void skipVersion();
-    void notNow();
-    void getUpdate();
+public Q_SLOTS:
+    void accept();
+    void reject();
 
 Q_SIGNALS:
-    void versionSkipped();
-    void noUpdateNow();
-    void updateNow();
+    void accepted();
     void finished();
 
 private:
-    ::Ui::Ui_NewVersionAvailableDialog *_ui;
+    ::Ui::UpdateDownloadedWidget *_ui;
 };
 
 }

--- a/src/gui/updater/updatedownloadedwidget.ui
+++ b/src/gui/updater/updatedownloadedwidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>UpdateDownloadedDialog</class>
- <widget class="QWidget" name="UpdateDownloadedDialog">
+ <class>UpdateDownloadedWidget</class>
+ <widget class="QWidget" name="UpdateDownloadedWidget">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Both are not based on QDialog anymore, but on QWidget. This rename removes confusion about the nature of the classes.