### PR TITLE
Fix GCC warning about "extra ‘;’"

### DIFF
--- a/src/common/preparedsqlquerymanager.h
+++ b/src/common/preparedsqlquerymanager.h
@@ -111,7 +111,7 @@ public:
 
 private:
     SqlQuery _queries[PreparedQueryCount];
-    Q_DISABLE_COPY(PreparedSqlQueryManager);
+    Q_DISABLE_COPY(PreparedSqlQueryManager)
 };
 
 }


### PR DESCRIPTION
The file is included indirectly in many places, so this one semmicolon produced lots of warnings.