### PR TITLE
[gui-tests][full-ci]add test to check for open connection sync button to be disabled

### DIFF
--- a/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnectionWizard.py
@@ -375,3 +375,9 @@ class SyncConnectionWizard:
     @staticmethod
     def get_warn_label():
         return str(squish.waitForObjectExists(SyncConnectionWizard.WARN_LABEL).text)
+
+    @staticmethod
+    def is_add_sync_folder_button_enabled():
+        return squish.waitForObjectExists(
+            SyncConnectionWizard.ADD_FOLDER_SYNC_BUTTON
+        ).enabled

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -303,3 +303,12 @@ def step(context, space_name):
 @When("the user opens the sync connection wizard")
 def step(context):
     SyncConnectionWizard.open_sync_connection_wizard()
+
+
+@Then('the button to open sync connection wizard should be disabled')
+def step(context):
+    test.compare(
+        False,
+        SyncConnectionWizard.is_add_sync_folder_button_enabled(),
+        'Button to open sync connection wizard should be disabled',
+    )

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -97,7 +97,7 @@ Feature: adding accounts
         Then the default local sync path should contain "%home%/ownCloud (2) (2)" in the sync connection wizard
 
     @skipOnOC10
-    Scenario: Synced spaces should not be available in sync connection wizard (oCIS)
+    Scenario: Button to open sync connection wizard should be disabled when all available spaces are synced (oCIS)
         Given the user has created folder "ownCloud" in the default home path
         And the user has started the client
         And the user has entered the following account information:
@@ -108,5 +108,4 @@ Feature: adding accounts
         And the user opens the advanced configuration
         Then the default local sync path should contain "%home%/ownCloud (2)" in the configuration wizard
         When the user selects download everything option in advanced section
-        And the user opens the sync connection wizard
-        Then the sync folder list should be empty
+        Then the button to open sync connection wizard should be disabled

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -29,7 +29,7 @@ Feature:  Logout users
     And user "Alice" logs in to the client-UI
     Then user "Alice" should be connect to the client-UI
 
-  @skipOnOCIS @skip
+  @skipOnOCIS @skip @issue-11619
   Scenario: login, logout and restart with oauth2 authentication
       Given app "oauth2" has been "enabled" in the server
       And the user has started the client

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -29,7 +29,7 @@ Feature:  Logout users
     And user "Alice" logs in to the client-UI
     Then user "Alice" should be connect to the client-UI
 
-  @skipOnOCIS
+  @skipOnOCIS @skip
   Scenario: login, logout and restart with oauth2 authentication
       Given app "oauth2" has been "enabled" in the server
       And the user has started the client


### PR DESCRIPTION
### Description
This PR checks for the button to open sync connection wizard to be disabled when all the available spaces are already synced.

Test for: https://github.com/owncloud/client/pull/11760

Skipped the scenario: `Scenario: login, logout and restart with oauth2 authentication`
`@skip` tag will be removed after the fix in PR https://github.com/owncloud/client/pull/11761