### PR TITLE
[gui-tests][full-ci]add skip tag on oauth2 authentication related scenario

### DIFF
--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -29,7 +29,7 @@ Feature:  Logout users
     And user "Alice" logs in to the client-UI
     Then user "Alice" should be connect to the client-UI
 
-  @skipOnOCIS @skip
+  @skipOnOCIS @skip @issue-11619
   Scenario: login, logout and restart with oauth2 authentication
       Given app "oauth2" has been "enabled" in the server
       And the user has started the client

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -29,7 +29,7 @@ Feature:  Logout users
     And user "Alice" logs in to the client-UI
     Then user "Alice" should be connect to the client-UI
 
-  @skipOnOCIS
+  @skipOnOCIS @skip
   Scenario: login, logout and restart with oauth2 authentication
       Given app "oauth2" has been "enabled" in the server
       And the user has started the client


### PR DESCRIPTION
### Description
The test scenario `Scenario: login, logout and restart with oauth2 authentication` sometimes fails due to system keyring dialog. Mentioned in issue: https://github.com/owncloud/client/issues/11619

So, skipping this scenario until fixed.
Fixed PR: https://github.com/owncloud/client/pull/11761