### PR TITLE
Automatically add sync connections for new discovered spaces

### DIFF
--- a/changelog/unreleased/11774
+++ b/changelog/unreleased/11774
@@ -1,0 +1,7 @@
+Enhancement: New branding option: automatically sync new spaces
+
+A branding option was added to add new sync connections for newly
+discovered spaces.
+
+https://github.com/owncloud/client/issues/11751
+https://github.com/owncloud/client/pull/11774

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -286,9 +286,10 @@ void AccountSettings::slotRemoveCurrentFolder(Folder *folder)
     messageBox->setAttribute(Qt::WA_DeleteOnClose);
     QPushButton *yesButton = messageBox->addButton(tr("Remove Folder Sync Connection"), QMessageBox::YesRole);
     messageBox->addButton(tr("Cancel"), QMessageBox::NoRole);
-    connect(messageBox, &QMessageBox::finished, this, [messageBox, yesButton, folder] {
+    connect(messageBox, &QMessageBox::finished, this, [messageBox, yesButton, folder, this] {
         if (messageBox->clickedButton() == yesButton) {
             FolderMan::instance()->removeFolder(folder);
+            QTimer::singleShot(0, this, &AccountSettings::slotSpacesUpdated);
         }
     });
     messageBox->open();

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -516,7 +516,7 @@ void AccountSettings::slotSpacesUpdated()
                 const QString folderName =
                     FolderMan::instance()->findGoodPathForNewSyncFolder(localDir, newSpace->displayName(), FolderMan::NewFolderType::SpacesFolder);
 
-                FolderWizard::Result fwr;
+                FolderMan::SyncConnectionDescription fwr;
                 fwr.davUrl = QUrl(newSpace->drive().getRoot().getWebDavUrl());
                 fwr.spaceId = newSpace->drive().getRoot().getId();
                 fwr.localPath = folderName;

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -81,6 +81,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void slotAccountStateChanged();
+    void slotSpacesUpdated();
 
 protected Q_SLOTS:
     void slotAddFolder();

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -956,15 +956,15 @@ Folder *FolderMan::addFolderFromWizard(const AccountStatePtr &accountStatePtr, F
     return newFolder;
 }
 
-Folder *FolderMan::addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const FolderWizard::Result &config)
+Folder *FolderMan::addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const SyncConnectionDescription &description)
 {
-    FolderDefinition definition = FolderDefinition::createNewFolderDefinition(config.davUrl, config.spaceId, config.displayName);
-    definition.setLocalPath(config.localPath);
-    definition.setTargetPath(config.remotePath);
-    auto f = addFolderFromWizard(accountStatePtr, std::move(definition), config.useVirtualFiles);
+    FolderDefinition definition = FolderDefinition::createNewFolderDefinition(description.davUrl, description.spaceId, description.displayName);
+    definition.setLocalPath(description.localPath);
+    definition.setTargetPath(description.remotePath);
+    auto f = addFolderFromWizard(accountStatePtr, std::move(definition), description.useVirtualFiles);
     if (f) {
-        f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, config.selectiveSyncBlackList);
-        f->setPriority(config.priority);
+        f->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, description.selectiveSyncBlackList);
+        f->setPriority(description.priority);
         f->saveToSettings();
     }
     return f;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -18,7 +18,6 @@
 #include "gui/owncloudguilib.h"
 
 #include "folder.h"
-#include "folderwizard/folderwizard.h"
 #include "scheduling/syncscheduler.h"
 
 #include <QList>
@@ -94,6 +93,43 @@ public:
         SpacesFolder,
     };
 
+    struct SyncConnectionDescription
+    {
+        /***
+-         * The webdav url for the sync connection.
+         */
+        QUrl davUrl;
+
+        /***
+         * The id of the space or empty in case of ownCloud 10.
+         */
+        QString spaceId;
+
+        /***
+         * The local folder used for the sync.
+         */
+        QString localPath;
+
+        /***
+         * The relative remote path
+         */
+        QString remotePath;
+
+        /***
+         * The Space name to display in the list of folders or an empty string.
+         */
+        QString displayName;
+
+        /***
+         * Wether to use virtual files.
+         */
+        bool useVirtualFiles;
+
+        uint32_t priority;
+
+        QSet<QString> selectiveSyncBlackList;
+    };
+
     static QString suggestSyncFolder(NewFolderType folderType);
     [[nodiscard]] static bool prepareFolder(const QString &folder);
 
@@ -141,7 +177,7 @@ public:
      * In case Wizard::SyncMode::SelectiveSync is used, nullptr is returned.
      */
     Folder *addFolderFromWizard(const AccountStatePtr &accountStatePtr, FolderDefinition &&definition, bool useVfs);
-    Folder *addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const FolderWizard::Result &config);
+    Folder *addFolderFromFolderWizardResult(const AccountStatePtr &accountStatePtr, const SyncConnectionDescription &config);
 
     /** Removes a folder */
     void removeFolder(Folder *);

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -178,7 +178,7 @@ FolderWizard::~FolderWizard()
 {
 }
 
-FolderWizard::Result FolderWizard::result()
+FolderMan::SyncConnectionDescription FolderWizard::result()
 {
     Q_D(FolderWizard);
 

--- a/src/gui/folderwizard/folderwizard.h
+++ b/src/gui/folderwizard/folderwizard.h
@@ -18,6 +18,7 @@
 #include <QWizard>
 
 #include "accountfwd.h"
+#include "gui/folderman.h"
 
 class QCheckBox;
 class QTreeWidgetItem;
@@ -44,47 +45,10 @@ public:
     };
     Q_ENUM(PageType)
 
-    struct Result
-    {
-        /***
--         * The webdav url for the sync connection.
-         */
-        QUrl davUrl;
-
-        /***
-         * The id of the space or empty in case of ownCloud 10.
-         */
-        QString spaceId;
-
-        /***
-         * The local folder used for the sync.
-         */
-        QString localPath;
-
-        /***
-         * The relative remote path
-         */
-        QString remotePath;
-
-        /***
-         * The Space name to display in the list of folders or an empty string.
-         */
-        QString displayName;
-
-        /***
-         * Wether to use virtual files.
-         */
-        bool useVirtualFiles;
-
-        uint32_t priority;
-
-        QSet<QString> selectiveSyncBlackList;
-    };
-
     explicit FolderWizard(const AccountStatePtr &account, QWidget *parent = nullptr);
     ~FolderWizard() override;
 
-    Result result();
+    FolderMan::SyncConnectionDescription result();
 
     Q_DECLARE_PRIVATE(FolderWizard)
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -525,6 +525,11 @@ bool Theme::enableMoveToTrash() const
     return true;
 }
 
+bool Theme::syncNewlyDiscoveredSpaces() const
+{
+    return false;
+}
+
 bool Theme::enableCernBranding() const
 {
     return false;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -420,6 +420,14 @@ public:
     virtual bool enableMoveToTrash() const;
 
     /**
+     * @brief Automatically add sync connections for newly discovered Spaces.
+     *
+     * Default: false
+     * See #11749
+     */
+    virtual bool syncNewlyDiscoveredSpaces() const;
+
+    /**
      * Whether to enable the special code for cernbox
      * This includes:
      * - spaces migration


### PR DESCRIPTION
For now, this can only be enabled through theming.

Fixes: #11751