### PR TITLE
[gui-tests] install the correct browser

### DIFF
--- a/test/gui/Makefile
+++ b/test/gui/Makefile
@@ -24,7 +24,7 @@ pnpm-install:
 
 .PHONY: pnpm-install-chromium
 pnpm-install-chromium:
-	pnpm dlx playwright install chromium
+	cd webUI && pnpm exec playwright install chromium
 
 .PHONY: pip-install
 pip-install:


### PR DESCRIPTION
Fix the `pnpm-install-chromium` make target to install the correct browser