### PR TITLE
Disable tabKeyNavigation in activity tables

### DIFF
--- a/src/gui/activitywidget.ui
+++ b/src/gui/activitywidget.ui
@@ -36,8 +36,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>637</width>
-           <height>72</height>
+           <width>641</width>
+           <height>83</height>
           </rect>
          </property>
          <property name="autoFillBackground">
@@ -89,6 +89,9 @@
         </property>
         <property name="accessibleName">
          <string>Server activity table</string>
+        </property>
+        <property name="tabKeyNavigation">
+         <bool>false</bool>
         </property>
         <property name="alternatingRowColors">
          <bool>true</bool>

--- a/src/gui/issueswidget.ui
+++ b/src/gui/issueswidget.ui
@@ -39,6 +39,9 @@
      <property name="accessibleName">
       <string>Issues table</string>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>

--- a/src/gui/protocolwidget.ui
+++ b/src/gui/protocolwidget.ui
@@ -43,6 +43,9 @@
      <property name="accessibleName">
       <string>Local activity table</string>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
This allows users to tab out of the table views. Navigation inside the table can still be done with the arrow keys.

Fixes: #11789