### PR TITLE
[a11y] Fix repeated text read by VoiceOver

### DIFF
--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -93,8 +93,7 @@ Pane {
                         id: delegatePane
                         anchors.fill: parent
 
-                        Accessible.description: folderDelegate.accessibleDescription
-                        Accessible.name: Accessible.description
+                        Accessible.name: folderDelegate.accessibleDescription
                         Accessible.role: Accessible.ListItem
 
                         clip: true

--- a/src/gui/spaces/qml/SpacesView.qml
+++ b/src/gui/spaces/qml/SpacesView.qml
@@ -89,8 +89,7 @@ Pane {
 
                     anchors.fill: parent
 
-                    Accessible.description: spaceDelegate.accessibleDescription
-                    Accessible.name: Accessible.description
+                    Accessible.name: spaceDelegate.accessibleDescription
                     Accessible.role: Accessible.ListItem
                     Accessible.selectable: true
                     Accessible.selected: space === spacesBrowser.currentSpace


### PR DESCRIPTION
VoiceOver on macOS will read both the accessible name *and* the accessible description. Setting both to the same value results in having the same text read twice. This is fixed by removing the accessible description.

Fixes: #11775