### PR TITLE
[test-only][full-ci] given step implementation of creating user in the server

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from helpers.StacktraceHelper import getCoredumps, generateStacktrace
 from helpers.SyncHelper import closeSocketConnection, clearWaitedAfterSync
 from helpers.SpaceHelper import delete_project_spaces
-from helpers.api.Provisioning import delete_created_groups
+from helpers.api.Provisioning import delete_created_groups, delete_created_users
 from helpers.SetupClientHelper import wait_until_app_killed
 from helpers.ConfigHelper import (
     init_config,
@@ -149,6 +149,7 @@ def hook(context):
     if get_config("ocis"):
         delete_project_spaces()
     delete_created_groups()
+    delete_created_users()
 
 
 # runs after every scenario

--- a/test/gui/shared/scripts/helpers/UserHelper.py
+++ b/test/gui/shared/scripts/helpers/UserHelper.py
@@ -1,9 +1,41 @@
-import requests
 from base64 import b64encode
-from helpers.ConfigHelper import get_config
-from helpers.api.utils import url_join
 
 createdUsers = {}
+
+test_users = {
+    "admin": {
+        "username": "admin",
+        "password": "admin",
+        "displayname": "adminUsername",
+    },
+    "Alice": {
+        "username": "Alice",
+        "password": "1234",
+        "displayname": "Alice Hansen",
+        "email": "alice@example.org",
+    },
+    "Brian": {
+        "username": "Brian",
+        "password": "AaBb2Cc3Dd4",
+        "displayname": "Brian Murphy",
+        "email": "brian@example.org",
+    },
+    "Carol": {
+        "username": "Carol",
+        "password": "1234",
+        "displayname": "Carol King",
+        "email": "carol@example.org",
+    },
+    "David": {
+        "username": "David",
+        "password": "1234",
+        "displayname": "David Lopez",
+        "email": "david@example.org",
+    },
+    "regularuser": {
+        "password": "1234",
+    },
+}
 
 
 def basic_auth_header(user=None, password=None):
@@ -17,31 +49,11 @@ def basic_auth_header(user=None, password=None):
     return {"Authorization": "Basic " + token}
 
 
-# gets all users information created in a test scenario
-def getCreatedUsersFromMiddleware():
-    createdUsers = {}
-    try:
-        res = requests.get(
-            url_join(get_config('middlewareUrl'), 'state'),
-            headers={"Content-Type": "application/json"},
-        )
-        createdUsers = res.json()['created_users']
-    except ValueError:
-        raise Exception("Could not get created users information from middleware")
-
-    return createdUsers
-
-
 def getUserInfo(username, attribute):
-    # add and update users to the global createdUsers dict if not already there
-    # so that we don't have to request for user information in every scenario
-    # but instead get user information from the global dict
-    global createdUsers
-    if username in createdUsers:
-        return createdUsers[username][attribute]
+    if username in test_users:
+        return test_users[username][attribute]
     else:
-        createdUsers = {**createdUsers, **getCreatedUsersFromMiddleware()}
-        return createdUsers[username][attribute]
+        return test_users["regularuser"][attribute]
 
 
 def getDisplaynameForUser(username):

--- a/test/gui/shared/scripts/helpers/api/Provisioning.py
+++ b/test/gui/shared/scripts/helpers/api/Provisioning.py
@@ -3,6 +3,7 @@ import helpers.api.oc10 as oc
 import helpers.api.ocis as ocis
 from helpers.api.utils import url_join
 from helpers.ConfigHelper import get_config
+import helpers.UserHelper as UserHelper
 
 created_groups = {}
 
@@ -58,3 +59,35 @@ def add_user_to_group(user, group_name):
         ocis.add_user_to_group(user, group_name)
     else:
         oc.add_user_to_group(user, group_name)
+
+
+def create_user(username):
+    user = {}
+    if username in UserHelper.test_users:
+        user = UserHelper.test_users[username]
+    else:
+        user = {
+            "username": username,
+            "displayname": username,
+            "email": f'{username}@mail.com',
+            "password": UserHelper.test_users["regularuser"]["password"],
+        }
+
+    if get_config('ocis'):
+        user_info = ocis.create_user(
+            user['username'], user['password'], user['displayname'], user['email']
+        )
+    else:
+        user_info = oc.create_user(
+            user['username'], user['password'], user['displayname'], user['email']
+        )
+    UserHelper.createdUsers[username] = user_info
+
+
+def delete_created_users():
+    for username, user_info in list(UserHelper.createdUsers.items()):
+        if get_config('ocis'):
+            ocis.delete_user(user_info["id"])
+        else:
+            oc.delete_user(user_info["username"])
+        del UserHelper.createdUsers[username]

--- a/test/gui/shared/scripts/helpers/api/oc10.py
+++ b/test/gui/shared/scripts/helpers/api/oc10.py
@@ -39,3 +39,34 @@ def add_user_to_group(user, group_name):
     body = {"groupid": group_name}
     response = request.post(url, body)
     request.assertHttpStatus(response, 200)
+
+
+def create_user(username, password, displayname, email):
+    url = url_join(get_ocs_url(), "users")
+    body = {
+        "userid": username,
+        "password": password,
+        "displayname": displayname,
+        "email": email,
+    }
+    response = request.post(url, body)
+    request.assertHttpStatus(response, 200)
+    # oc10 does not set display name while creating user,
+    # so we need update the user info
+    user_url = url_join(get_ocs_url(), "users", username)
+    display_name_body = {"key": "displayname", "value": displayname}
+    display_name_response = request.put(user_url, display_name_body)
+    request.assertHttpStatus(display_name_response, 200)
+    return {
+        "id": username,
+        "username": username,
+        "password": password,
+        "displayname": displayname,
+        "email": email,
+    }
+
+
+def delete_user(userid):
+    url = url_join(get_ocs_url(), 'users', userid)
+    response = request.delete(url)
+    request.assertHttpStatus(response, 200)

--- a/test/gui/shared/scripts/helpers/api/ocis.py
+++ b/test/gui/shared/scripts/helpers/api/ocis.py
@@ -51,3 +51,31 @@ def add_user_to_group(user, group_name):
     body = json.dumps({"@odata.id": data})
     response = request.post(url, body)
     request.assertHttpStatus(response, 204)
+
+
+def create_user(username, password, displayname, email):
+    url = url_join(get_graph_url(), "users")
+    body = json.dumps(
+        {
+            "onPremisesSamAccountName": username,
+            "passwordProfile": {"password": password},
+            "displayname": displayname,
+            "mail": email,
+        }
+    )
+    response = request.post(url, body)
+    request.assertHttpStatus(response, 201)
+    resp_object = response.json()
+    return {
+        "id": resp_object['id'],
+        "username": username,
+        "password": password,
+        "displayname": resp_object['displayName'],
+        "email": resp_object['mail'],
+    }
+
+
+def delete_user(id):
+    url = url_join(get_graph_url(), 'users', id)
+    response = request.delete(url)
+    request.assertHttpStatus(response, 204)

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -192,3 +192,8 @@ def step(context, group_name):
 @Given('user "|any|" has been added to group "|any|" in the server')
 def step(context, user, group_name):
     Provisioning.add_user_to_group(user, group_name)
+
+
+@Given('user "|any|" has been created in the server with default attributes')
+def step(context, user):
+    Provisioning.create_user(user)

--- a/test/gui/tst_activity/test.feature
+++ b/test/gui/tst_activity/test.feature
@@ -5,9 +5,9 @@ Feature: filter activity for user
 
 
     Scenario: filter synced activities
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
-        And user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has created folder "simple-folder" on the server
+        Given user "Alice" has been created in the server with default attributes
+        And user "Brian" has been created in the server with default attributes
+        And user "Alice" has created folder "simple-folder" in the server
         And the user has set up the following accounts with default settings:
             | Alice |
             | Brian |
@@ -20,7 +20,7 @@ Feature: filter activity for user
 
 
     Scenario: filter not synced activities
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has created a folder "Folder1" inside the sync folder
         And user "Alice" has set up a client with default settings
         When user "Alice" creates the following files inside the sync folder:

--- a/test/gui/tst_addAccount/test.feature
+++ b/test/gui/tst_addAccount/test.feature
@@ -4,7 +4,7 @@ Feature: adding accounts
     So that I can sync data with various organisations
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
 
 
     Scenario: Check default options in advanced configuration
@@ -29,7 +29,7 @@ Feature: adding accounts
 
 
     Scenario: Adding multiple accounts
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
         When the user opens the add-account dialog
         And the user adds the following account:

--- a/test/gui/tst_checkAlltabs/test.feature
+++ b/test/gui/tst_checkAlltabs/test.feature
@@ -5,7 +5,7 @@ Feature: Visually check all tabs
 
 
     Scenario: Tabs in toolbar looks correct
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
         Then the toolbar should have the following tabs:
             | Add Account |
@@ -15,7 +15,7 @@ Feature: Visually check all tabs
 
 
     Scenario: Verify various setting options in Settings tab
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
         When the user clicks on the settings tab
         Then the settings tab should have the following options in the general section:

--- a/test/gui/tst_deletFilesFolders/test.feature
+++ b/test/gui/tst_deletFilesFolders/test.feature
@@ -4,7 +4,7 @@ Feature: deleting files and folders
   	So that I can keep my filing system clean and tidy
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
 
     @issue-9439
     Scenario Outline: Delete a file

--- a/test/gui/tst_editFiles/test.feature
+++ b/test/gui/tst_editFiles/test.feature
@@ -4,7 +4,7 @@ Feature: edit files
     So that I can modify and change file data
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
 
 
     Scenario: Modify orignal content of a file with special character

--- a/test/gui/tst_loginLogout/test.feature
+++ b/test/gui/tst_loginLogout/test.feature
@@ -4,7 +4,7 @@ Feature:  Logout users
   So that I can protect my work and identity and be assured of privacy
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
 
 
     Scenario: logging out

--- a/test/gui/tst_moveFilesFolders/test.feature
+++ b/test/gui/tst_moveFilesFolders/test.feature
@@ -4,7 +4,7 @@ Feature: move file and folder
     So that I can organize my files and folders
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has created folder "folder1" in the server
         And user "Alice" has created folder "folder1/folder2" in the server
         And user "Alice" has created folder "folder1/folder2/folder3" in the server

--- a/test/gui/tst_removeAccountConnection/test.feature
+++ b/test/gui/tst_removeAccountConnection/test.feature
@@ -5,8 +5,8 @@ Feature: remove account connection
 
 
     Scenario: remove an account connection
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
+        And user "Brian" has been created in the server with default attributes
         And the user has set up the following accounts with default settings:
             | Alice |
             | Brian |
@@ -16,7 +16,7 @@ Feature: remove account connection
 
 
     Scenario: remove the only account connection
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
         When the user removes the connection for user "Alice" and host %local_server_hostname%
         Then connection wizard should be visible

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -5,12 +5,12 @@ Feature: Sharing
     So that those users can access the files and folders
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And the setting "shareapi_auto_accept_share" on the server of app "core" has been set to "yes"
 
     @smokeTest
     Scenario: simple sharing with user
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has set up a client with default settings
@@ -23,7 +23,7 @@ Feature: Sharing
 
 
     Scenario: sharing file and folder with user who has some other shares
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "shared" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
@@ -42,7 +42,7 @@ Feature: Sharing
 
 
     Scenario: sharing file/folder with a user that has special characters as username
-        Given user "Speci@l_Name-.+" has been created on the server with default attributes and without skeleton files
+        Given user "Speci@l_Name-.+" has been created in the server with default attributes
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has set up a client with default settings
@@ -56,7 +56,7 @@ Feature: Sharing
 
 
     Scenario: Share files/folders with special characters in their name
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "SampleFolder,With,$pecial#Characters" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/$ample1#.txt" in the server
         And user "Alice" has set up a client with default settings
@@ -69,7 +69,7 @@ Feature: Sharing
 
 
     Scenario: try to share a file/folder with a user to whom the file has already been shared
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "SharedFolder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
         And user "Alice" has shared folder "SharedFolder" on the server with user "Brian" with "all" permissions
@@ -100,8 +100,8 @@ Feature: Sharing
 
 
     Scenario: search for users with minimum autocomplete characters
-        Given user "TestUser1" has been created on the server with default attributes and without skeleton files
-        And user "TestUser2" has been created on the server with default attributes and without skeleton files
+        Given user "TestUser1" has been created in the server with default attributes
+        And user "TestUser2" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
@@ -126,11 +126,11 @@ Feature: Sharing
 
 
     Scenario: collaborators are listed in chronological order
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Carol" has been created on the server with default attributes and without skeleton files
-        And user "TestUser1" has been created on the server with default attributes and without skeleton files
-        And user "TestUser2" has been created on the server with default attributes and without skeleton files
-        And user "TestUser3" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
+        And user "Carol" has been created in the server with default attributes
+        And user "TestUser1" has been created in the server with default attributes
+        And user "TestUser2" has been created in the server with default attributes
+        And user "TestUser3" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "textfile.txt" on the server with user "Carol" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
@@ -160,7 +160,7 @@ Feature: Sharing
 
 
     Scenario: Collaborator should not see to whom a file/folder is shared.
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share" permission
@@ -176,7 +176,7 @@ Feature: Sharing
 
     Scenario: share file and folder to a group
         Given group "grp1" has been created in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Brian" has been added to group "grp1" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
@@ -190,7 +190,7 @@ Feature: Sharing
 
 
     Scenario: User (non-author) can not share to a group to which the file/folder is already shared
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And group "grp1" has been created in the server
         And user "Brian" on the server has been added to group "grp1"
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
@@ -212,7 +212,7 @@ Feature: Sharing
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "file inside a folder" to "simple-folder/textfile.txt" in the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -230,7 +230,7 @@ Feature: Sharing
         Given user "Alice" has created folder "Parent" in the server
         And user "Alice" has uploaded file with content "file inside a folder" to "Parent/textfile.txt" in the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
@@ -247,7 +247,7 @@ Feature: Sharing
         Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "some content" to "FOLDER/simple.txt" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared folder "FOLDER" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -271,7 +271,7 @@ Feature: Sharing
 
     Scenario: sharee creates a file and a folder inside a shared folder
         Given user "Alice" has created folder "Parent" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
@@ -289,7 +289,7 @@ Feature: Sharing
 
     Scenario: sharee tries to create a file and a folder inside a shared folder without write permission
         Given user "Alice" has created folder "Parent" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
         When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
@@ -308,7 +308,7 @@ Feature: Sharing
     Scenario: sharee renames the shared file and folder
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "FOLDER" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -330,7 +330,7 @@ Feature: Sharing
     Scenario: sharee deletes a file and folder shared by sharer
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
@@ -346,7 +346,7 @@ Feature: Sharing
     Scenario: sharee tries to delete shared file and folder without permissions
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
         And user "Alice" has shared file "Folder" on the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
@@ -361,8 +361,8 @@ Feature: Sharing
 
 
     Scenario: reshare a file/folder
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Carol" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
+        And user "Carol" has been created in the server with default attributes
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
@@ -377,8 +377,8 @@ Feature: Sharing
 
 
     Scenario: try to reshare a file/folder shared without share permission
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Carol" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
+        And user "Carol" has been created in the server with default attributes
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "read" permissions
@@ -393,7 +393,7 @@ Feature: Sharing
 
 
     Scenario: unshare a shared file and folder
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has shared file "textfile0.txt" on the server with user "Brian" with "all" permissions
@@ -410,9 +410,9 @@ Feature: Sharing
 
 
     Scenario: share a file with many users
-        Given user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Carol" has been created on the server with default attributes and without skeleton files
-        And user "David" has been created on the server with default attributes and without skeleton files
+        Given user "Brian" has been created in the server with default attributes
+        And user "Carol" has been created in the server with default attributes
+        And user "David" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has set up a client with default settings
         When the user adds following collaborators of resource "textfile0.txt" using the client-UI
@@ -429,10 +429,10 @@ Feature: Sharing
     @issue-7423
     Scenario: unshare a reshared file
         Given user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
-        And user "Carol" has been created on the server with default attributes and without skeleton files
-        And user "Alice" has shared folder "textfile.txt" on the server with user "Brian"
-        And user "Brian" has shared folder "textfile.txt" on the server with user "Carol"
+        And user "Brian" has been created in the server with default attributes
+        And user "Carol" has been created in the server with default attributes
+        And user "Alice" has shared file "textfile.txt" on the server with user "Brian"
+        And user "Brian" has shared file "textfile.txt" on the server with user "Carol"
         And user "Brian" has set up a client with default settings
         When the user unshares the resource "textfile.txt" for collaborator "Carol King" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
@@ -614,7 +614,7 @@ Feature: Sharing
         Given the administrator on the server has set the default folder for received shares to "Shares"
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created file "lorem.txt" on the server
-        And user "Brian" has been created on the server with default attributes and without skeleton files
+        And user "Brian" has been created in the server with default attributes
         And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
         And user "Alice" has shared file "lorem.txt" on the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -5,7 +5,7 @@ Feature: Project spaces
     So that I can do view and manage the space
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And the administrator has created a space "Project101"
 
 

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -4,7 +4,7 @@ Feature: Syncing files
     so that I dont have to upload and download files manually
 
     Background:
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
 
     @smokeTest @issue-9281
     Scenario: Syncing a file to the server

--- a/test/gui/tst_vfs/test.feature
+++ b/test/gui/tst_vfs/test.feature
@@ -6,7 +6,7 @@ Feature: Enable/disable virtual file support
 
 
     Scenario: Disable/Enable VFS
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud" to "testFile.txt" in the server
         And user "Alice" has created folder "folder1" in the server
         And user "Alice" has uploaded file with content "some contents" to "folder1/lorem.txt" in the server
@@ -34,7 +34,7 @@ Feature: Enable/disable virtual file support
 
 
     Scenario: Copy and paste virtual file
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "sample file" to "sampleFile.txt" in the server
         And user "Alice" has uploaded file with content "lorem file" to "lorem.txt" in the server
         And user "Alice" has uploaded file with content "test file" to "testFile.txt" in the server
@@ -60,7 +60,7 @@ Feature: Enable/disable virtual file support
 
 
     Scenario: Move virtual file
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "lorem file" to "lorem.txt" in the server
         And user "Alice" has uploaded file with content "some contents" to "sampleFile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
@@ -75,7 +75,7 @@ Feature: Enable/disable virtual file support
 
 
     Scenario: Disable/Enable VFS quickly
-        Given user "Alice" has been created on the server with default attributes and without skeleton files
+        Given user "Alice" has been created in the server with default attributes
         And user "Alice" has set up a client with default settings
         When user "Alice" creates a file "newfile.txt" with size "100MB" inside the sync folder
         And the user waits for file "newfile.txt" to be synced


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
This `Given` step implementation creates user in the server with default attributes and without skeleton files.

Renamed step:

```diff
-Given user <user> has been created on the server with default attributes and without skeleton files
+Given user <user> has been created in the server with default attributes and without skeleton files
```
Part of https://github.com/owncloud/client/issues/10432