### PR TITLE
[a11y] Move server URL from status label to Account button

### DIFF
--- a/changelog/unreleased/11810
+++ b/changelog/unreleased/11810
@@ -1,0 +1,11 @@
+Bugfix: Make open account in browser accessible for keyboard navigation
+
+On the account settings page, the status label contained the URL of the
+server. This URL was not accessible with keyboard navigation or when a
+screen-reader was used. Now there is an "Open in Web Browser" action in
+the pop-up menu of the "Manage Account" button (which is next to the
+status label), and the URL has been removed from the status label.
+
+https://github.com/owncloud/client/issues/11772
+https://github.com/owncloud/client/issues/11800
+https://github.com/owncloud/client/pull/11810

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -44,7 +44,7 @@
          <string/>
         </property>
         <property name="textFormat">
-         <enum>Qt::TextFormat::AutoText</enum>
+         <enum>Qt::PlainText</enum>
         </property>
         <property name="pixmap">
          <pixmap resource="../resources/client.qrc">:/client/resources/light/warning.svg</pixmap>
@@ -55,7 +55,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="connectLabel">
+       <widget class="QLabel" name="connectionStatusLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -63,24 +63,18 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Connected with &lt;server&gt; as &lt;user&gt;</string>
+         <string notr="true">Connection Status</string>
         </property>
         <property name="textFormat">
-         <enum>Qt::TextFormat::RichText</enum>
+         <enum>Qt::PlainText</enum>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
         </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::TextBrowserInteraction</set>
-        </property>
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="accountToolButton">
+       <widget class="QToolButton" name="manageAccountButton">
         <property name="text">
          <string>Manage Account</string>
         </property>
@@ -104,9 +98,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -120,9 +111,6 @@
          <property name="text">
           <string>Preparing the account</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignCenter</set>
-         </property>
         </widget>
        </item>
        <item>
@@ -134,9 +122,6 @@
        </item>
        <item>
         <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>


### PR DESCRIPTION
The URL in the status label of the account settings page was not always accessible by keyboard. The label will now only show the connection status, and the "Manage Account" button has a new entry for "Open in Web Browser".