### PR TITLE
When sync connections for new Spaces are automatically added, then...

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -138,7 +138,11 @@ void AccountSettings::slotCustomContextMenuRequested(Folder *folder)
     connect(folder, &OCC::Folder::destroyed, menu, &QMenu::close);
     // Only allow removal if the item isn't in "ready" state.
     if (!folder->isReady() && !isDeployed) {
-        addRemoveFolderAction(menu);
+        if (Theme::instance()->syncNewlyDiscoveredSpaces()) {
+            menu->addAction(tr("Folder is not ready yet"))->setEnabled(false);
+        } else {
+            addRemoveFolderAction(menu);
+        }
         menu->popup(QCursor::pos());
         // accassebility
         menu->setFocus();
@@ -190,7 +194,9 @@ void AccountSettings::slotCustomContextMenuRequested(Folder *folder)
         connect(ac, &QAction::triggered, this, [folder, this] { slotEnableCurrentFolder(folder, true); });
 
         if (!isDeployed) {
-            addRemoveFolderAction(menu);
+            if (!Theme::instance()->syncNewlyDiscoveredSpaces()) {
+                addRemoveFolderAction(menu);
+            }
 
             if (Theme::instance()->showVirtualFilesOption()) {
                 if (folder->virtualFilesEnabled()) {

--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -239,7 +239,7 @@ Pane {
                 enabled: (accountSettings.accountState.state === AccountState.Connected) && (accountSettings.unsyncedSpaces || !accountSettings.accountState.supportsSpaces)
 
                 // with Spaces Theme.singleSyncFolder hast no effect
-                visible: accountSettings.accountState.supportsSpaces || listView.count === 0 || !Theme.singleSyncFolder
+                visible: accountSettings.accountState.supportsSpaces ? !Theme.syncNewlyDiscoveredSpaces : (listView.count === 0 || !Theme.singleSyncFolder)
 
                 Keys.onBacktabPressed: {
                     listView.currentItem.forceActiveFocus(Qt.TabFocusReason);

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -61,6 +61,7 @@ class OWNCLOUDSYNC_EXPORT Theme : public QObject
     Q_PROPERTY(bool multiAccount READ multiAccount FINAL CONSTANT)
     Q_PROPERTY(bool singleSyncFolder READ singleSyncFolder FINAL CONSTANT)
     Q_PROPERTY(QList<QmlUrlButton> urlButtons READ qmlUrlButtons FINAL CONSTANT)
+    Q_PROPERTY(bool syncNewlyDiscoveredSpaces READ syncNewlyDiscoveredSpaces FINAL CONSTANT)
     QML_SINGLETON
     QML_ELEMENT
 public:


### PR DESCRIPTION
- Disable space removal (otherwise the removed space is immediately added)
- Hide add space button (there is no space to add manually)
