### PR TITLE
docs: add missing pull link to changelog

### DIFF
--- a/changelog/unreleased/11567
+++ b/changelog/unreleased/11567
@@ -4,3 +4,5 @@ An encrypted connection to a captive portal will use an unknown certificate, whi
 This is now changed: when a captive portal is detected by the OS, the client now shows in the account status that it cannot connect to the server because of a captive portal.
 
 Supported OSses: Windows, Linux (with some network managers)
+
+https://github.com/owncloud/client/pull/11567

--- a/changelog/unreleased/11567
+++ b/changelog/unreleased/11567
@@ -5,4 +5,5 @@ This is now changed: when a captive portal is detected by the OS, the client now
 
 Supported OSses: Windows, Linux (with some network managers)
 
+https://github.com/owncloud/client/issues/11533
 https://github.com/owncloud/client/pull/11567


### PR DESCRIPTION
Pull link was missing in the changelog entry and the CI was complaining about it: https://drone.owncloud.com/owncloud/client/19078/4/2

Added the necessary pull link to the changelog entry