### PR TITLE
Include server in avatar gradient computation

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -165,7 +165,7 @@ QString Account::initials() const
 
 QGradient::Preset Account::avatarGradient() const
 {
-    return static_cast<QGradient::Preset>(qHash(initials()) % QGradient::NumPresets + 1);
+    return static_cast<QGradient::Preset>(qHash(displayNameWithHost()) % QGradient::NumPresets + 1);
 }
 
 QString Account::davDisplayName() const


### PR DESCRIPTION
If you have the same display name on multiple servers, you will now get different avatars.