### PR TITLE
Fix warning

### DIFF
--- a/src/gui/qml/AccountBar.qml
+++ b/src/gui/qml/AccountBar.qml
@@ -150,7 +150,7 @@ Pane {
             model: Theme.urlButtons
 
             delegate: AccountButton {
-                property UrlButtonData urlButton: modelData
+                property urlbuttondata urlButton: modelData
 
                 Layout.fillHeight: true
                 Layout.maximumWidth: widthHint

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -37,7 +37,7 @@ class QmlUrlButton
     Q_PROPERTY(QString icon MEMBER icon CONSTANT)
     Q_PROPERTY(QString name MEMBER name CONSTANT)
     Q_PROPERTY(QUrl url MEMBER url CONSTANT)
-    QML_VALUE_TYPE(UrlButtonData)
+    QML_VALUE_TYPE(urlbuttondata)
 
 public:
     QmlUrlButton();


### PR DESCRIPTION
```
Invalid QML element name "UrlButtonData"; value type names should begin with a lowercase letter E:\_\4a671fd5\qtdeclarative-everywhere-src-6.7.2\src\qml\qml\qqmlmetatype.cpp: 397