### PR TITLE
Properly use opacity instead of enabled icons

### DIFF
--- a/src/gui/qml/AccountBar.qml
+++ b/src/gui/qml/AccountBar.qml
@@ -22,6 +22,8 @@ import org.ownCloud.resources 1.0
 Pane {
     id: bar
     readonly property SettingsDialog settingsDialog: ocContext
+    readonly property OCQuickWidget widget: ocQuickWidget
+
     Accessible.name: qsTr("Navigation bar")
 
     Connections {
@@ -42,6 +44,9 @@ Pane {
 
     RowLayout {
         anchors.fill: parent
+
+        // don't modify the enabled state directly as it messes with the palette in Qt 6.7.2
+        opacity: widget.enabled ? 1.0 : 0.5
 
         Repeater {
             id: accountButtons

--- a/src/gui/qml/AccountButton.qml
+++ b/src/gui/qml/AccountButton.qml
@@ -67,6 +67,7 @@ ToolButton {
 
     contentItem: ColumnLayout {
         spacing: control.spacing
+        opacity: enabled ? 1.0 : 0.5
 
         Loader {
             id: loader
@@ -83,7 +84,6 @@ ToolButton {
             elide: Text.ElideRight
             font: control.font
             horizontalAlignment: Text.AlignHCenter
-            opacity: enabled ? 1.0 : 0.3
             text: control.text
             verticalAlignment: Text.AlignTop
         }

--- a/src/gui/qmlutils.cpp
+++ b/src/gui/qmlutils.cpp
@@ -21,6 +21,7 @@
 #include <QQmlContext>
 #include <QQuickItem>
 #include <QQuickWidget>
+#include <QTimer>
 
 void OCC::QmlUtils::OCQuickWidget::setOCContext(const QUrl &src, QWidget *parentWidget, QObject *ocContext, QJSEngine::ObjectOwnership ownership)
 {
@@ -34,6 +35,7 @@ void OCC::QmlUtils::OCQuickWidget::setOCContext(const QUrl &src, QWidget *parent
     }
 
     rootContext()->setContextProperty(QStringLiteral("ocParentWidget"), parentWidget);
+    rootContext()->setContextProperty(QStringLiteral("ocQuickWidget"), this);
     rootContext()->setContextProperty(QStringLiteral("ocContext"), ocContext);
     engine()->setObjectOwnership(ocContext, ownership);
     engine()->addImageProvider(QStringLiteral("ownCloud"), new OCC::Resources::CoreImageProvider());
@@ -73,7 +75,7 @@ void OCC::QmlUtils::OCQuickWidget::focusInEvent(QFocusEvent *event)
 bool OCC::QmlUtils::OCQuickWidget::event(QEvent *event)
 {
     if (event->type() == QEvent::EnabledChange) {
-        rootObject()->setEnabled(isEnabled());
+        QTimer::singleShot(0, this, &OCQuickWidget::enabledChanged);
     }
 
     return QQuickWidget::event(event);

--- a/src/gui/qmlutils.h
+++ b/src/gui/qmlutils.h
@@ -39,6 +39,10 @@ namespace OCC::QmlUtils {
 class OCQuickWidget : public QQuickWidget
 {
     Q_OBJECT
+    // override of the enabled property of QWidget, but with a notifier
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged FINAL)
+    QML_ELEMENT
+    QML_UNCREATABLE("C++")
 public:
     using QQuickWidget::QQuickWidget;
     void setOCContext(const QUrl &src, QWidget *parentWidget, QObject *ocContext, QJSEngine::ObjectOwnership ownership);
@@ -47,6 +51,8 @@ public:
 Q_SIGNALS:
     void focusFirst();
     void focusLast();
+
+    void enabledChanged();
 
 protected:
     void focusInEvent(QFocusEvent *event) override;


### PR DESCRIPTION
This also fixes the display of disabled avatars


![image](https://github.com/user-attachments/assets/67bfa4ec-3877-4ee9-af3c-483e9704313c)

