### PR TITLE
Fix tab order in settings page

### DIFF
--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -176,7 +176,11 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="NetworkSettings" name="widget" native="true"/>
+           <widget class="NetworkSettings" name="widget" native="true">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -269,6 +273,7 @@
   <tabstop>moveToTrashCheckBox</tabstop>
   <tabstop>ignoredFilesButton</tabstop>
   <tabstop>logSettingsButton</tabstop>
+  <tabstop>widget</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>about_pushButton</tabstop>
  </tabstops>

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -44,6 +44,8 @@ NetworkSettings::NetworkSettings(QWidget *parent)
 {
     _ui->setupUi(this);
 
+    setFocusProxy(_ui->pauseSyncWhenMeteredCheckbox);
+
     _ui->hostLineEdit->setPlaceholderText(tr("Hostname of proxy server"));
     _ui->hostLineEdit->setAccessibleName(tr("Hostname of proxy server"));
     _ui->userLineEdit->setPlaceholderText(tr("Username for proxy server"));


### PR DESCRIPTION
The network settings are now tab-selected before the about button.

Fixes: #11782