### PR TITLE
Disable bounce behaviour in list views

### DIFF
--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -60,6 +60,7 @@ Pane {
                 id: listView
                 anchors.fill: parent
                 focus: true
+                boundsBehavior: Flickable.StopAtBounds
 
                 model: accountSettings.model
                 spacing: 20

--- a/src/gui/spaces/qml/SpacesView.qml
+++ b/src/gui/spaces/qml/SpacesView.qml
@@ -53,6 +53,7 @@ Pane {
             anchors.fill: parent
             spacing: 20
             focus: true
+            boundsBehavior: Flickable.StopAtBounds
 
             model: spacesBrowser.model
 


### PR DESCRIPTION
On the desktop, list views do not bounce when reaching the top/bottom.