### PR TITLE
[gui-tests] abort testcase execution on first failure

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -209,6 +209,9 @@ def gui_test_pipeline(ctx):
             "--tags ~@skipOnLinux",
         ]
 
+        if not "full-ci" in ctx.build.title.lower() and ctx.build.event == "pull_request":
+            squish_parameters.append("--abortOnFail")
+
         if params.get("skip", False):
             continue
         if ctx.build.event == "pull_request" and params.get("skip_in_pr", False) and not "full-ci" in ctx.build.title.lower():


### PR DESCRIPTION
- Allow abort on failure for Squish tests in PRs (using `--abortOnFail` arg) - skips the next testcases if current fails
- With `full-ci` in the PR title, the above behavior is disabled

The `--abortOnFail` option is available only when using `--testsuite` option but does not work with `--testcase`.

>[--abortOnFail](https://doc.qt.io/squish/cli-squishrunner.html#playback-option-op-op-op-op-abortonfail)
>If the --abortOnFail option is specified, squishrunner will terminate the suite execution as soon as a failed test case is detected.

This means that if we have test cases 1, 2, 3 and 4, and test case no.2 failed then test cases 3 and 4 will not run. Also if the fail was in the first scenario of test case no.2, other scenarios of test case no.2 still continue to run.

Fixes: https://github.com/owncloud/client/issues/10315