### PR TITLE
Fix (back-)tabbing into ListViews

### DIFF
--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -32,14 +32,14 @@ Pane {
         target: accountSettings
 
         function onFocusFirst() {
-            listView.currentIndex = 0;
+            listView.forceActiveFocus(Qt.TabFocusReason);
         }
 
         function onFocusLast() {
             if (addSyncButton.enabled) {
                 addSyncButton.forceActiveFocus(Qt.TabFocusReason);
             } else {
-                listView.currentIndex = listView.count - 1;
+                addSyncButton.nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason);
             }
         }
     }

--- a/src/gui/spaces/qml/SpacesView.qml
+++ b/src/gui/spaces/qml/SpacesView.qml
@@ -40,11 +40,11 @@ Pane {
             target: spacesBrowser
 
             function onFocusFirst() {
-                listView.currentIndex = 0;
+                listView.forceActiveFocus(Qt.TabFocusReason);
             }
 
             function onFocusLast() {
-                listView.currentIndex = listView.count - 1;
+                listView.forceActiveFocus(Qt.TabFocusReason);
             }
         }
 


### PR DESCRIPTION
When entering a ListView through tab navigation (both forward and backward), the selection should stay the same. The selection itself can be changed with the arrow keys.