### PR TITLE
[test-only][full-ci] Given step implementation of sharing file or folder in the server

### DIFF
--- a/test/gui/.pylintrc
+++ b/test/gui/.pylintrc
@@ -24,7 +24,7 @@ load-plugins=
     pylint.extensions.overlapping_exceptions,
     pylint.extensions.typing,
     pylint.extensions.redefined_variable_type,
-py-version=3.8
+py-version=3.10
 unsafe-load-any-extension=no
 
 [BASIC]

--- a/test/gui/shared/scripts/helpers/api/sharing_helper.py
+++ b/test/gui/shared/scripts/helpers/api/sharing_helper.py
@@ -11,6 +11,23 @@ share_types = MappingProxyType(
     {"user": 0, "group": 1, "public_link": 3, "federated_cloud_share": 6}
 )
 
+PERMISSIONS = {"read": 1, "update": 2, "create": 4, "delete": 8, "share": 16}
+
+
+def get_permission_value(permissions):
+    permission_list = [perm.strip() for perm in permissions.split(",")]
+    combinedPermission = 0
+    if "all" in permission_list:
+        return sum(PERMISSIONS.values())
+
+    for permission in permission_list:
+        permission_value = PERMISSIONS.get(permission)
+        if permission_value is None:
+            raise ValueError(f"Permission '{permission}' is not valid.")
+        combinedPermission += permission_value
+
+    return combinedPermission
+
 
 def get_share_url():
     return oc.format_json(
@@ -77,3 +94,18 @@ def download_last_public_link_resource(user, resource, public_link_password=None
         return False
     else:
         raise Exception(f"Server returned status code: {response.status_code}")
+
+
+def share_resource(user, resource, receiver, permissions):
+    permissions = get_permission_value(permissions)
+    url = get_share_url()
+    body = {
+        "path": f"/{resource}",
+        "shareType": 0,
+        "shareWith": receiver,
+        "permissions": permissions,
+    }
+    response = request.post(url, body, user=user)
+    request.assertHttpStatus(
+        response, 200, f"Failed to share resource '{resource}' to user '{user}'"
+    )

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -198,3 +198,12 @@ def step(context, user, group_name):
 @Given('user "|any|" has been created in the server with default attributes')
 def step(context, user):
     Provisioning.create_user(user)
+
+
+@Given(
+    # pylint: disable=line-too-long
+    r'user "([^"].*)" has shared (?:file|folder) "([^"].*)" in the server with user "([^"].*)" with "([^"].*)" permission(?:s)?',
+    regexp=True,
+)
+def step(context, user, resource, receiver, permissions):
+    sharing_helper.share_resource(user, resource, receiver, permissions)

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -28,8 +28,8 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
         And user "Alice" has uploaded file with content "shared file" to "sharedfile.txt" in the server
-        And user "Alice" has shared folder "shared" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "sharedfile.txt" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "shared" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "sharedfile.txt" in the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user adds "Brian Murphy" as collaborator of resource "textfile.txt" with permissions "edit,share" using the client-UI
         And the user adds "Brian Murphy" as collaborator of resource "simple-folder" with permissions "edit,share" using the client-UI
@@ -72,8 +72,8 @@ Feature: Sharing
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has created folder "SharedFolder" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "/textfile.txt" in the server
-        And user "Alice" has shared folder "SharedFolder" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "SharedFolder" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         And the user searches for collaborator "Brian Murphy" using the client-UI
@@ -132,11 +132,11 @@ Feature: Sharing
         And user "TestUser2" has been created in the server with default attributes
         And user "TestUser3" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
-        And user "Alice" has shared file "textfile.txt" on the server with user "Carol" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "TestUser1" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "TestUser3" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "TestUser2" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Carol" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "TestUser1" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "TestUser3" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "TestUser2" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
         Then the collaborators should be listed in the following order:
@@ -163,8 +163,8 @@ Feature: Sharing
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "Folder" in the server
-        And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share" permission
-        And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share" permission
+        And user "Alice" has shared file "/textfile0.txt" in the server with user "Brian" with "read, share" permission
+        And user "Alice" has shared folder "Folder" in the server with user "Brian" with "read, share" permission
         And user "Brian" has set up a client with default settings
         When the user opens the sharing dialog of "textfile0.txt" using the client-UI
         Then the error text "The item is not shared with any users or groups" should be displayed in the sharing dialog
@@ -195,8 +195,8 @@ Feature: Sharing
         And user "Brian" on the server has been added to group "grp1"
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt" in the server
         And user "Alice" has created folder "Folder" in the server
-        And user "Alice" has shared file "/textfile0.txt" on the server with user "Brian" with "read, share, update" permission
-        And user "Alice" has shared folder "Folder" on the server with user "Brian" with "read, share, update" permission
+        And user "Alice" has shared file "/textfile0.txt" in the server with user "Brian" with "read, share, update" permission
+        And user "Alice" has shared folder "Folder" in the server with user "Brian" with "read, share, update" permission
         And user "Alice" has shared file "/textfile0.txt" on the server with group "grp1" with "read, share, update" permission
         And user "Alice" has shared folder "Folder" on the server with group "grp1" with "read, share, update" permission
         And user "Brian" has set up a client with default settings
@@ -213,8 +213,8 @@ Feature: Sharing
         And user "Alice" has uploaded file with content "file inside a folder" to "simple-folder/textfile.txt" in the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "simple-folder" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user overwrites the file "textfile.txt" with content "overwrite file in the root"
         And the user waits for file "textfile.txt" to be synced
@@ -231,8 +231,8 @@ Feature: Sharing
         And user "Alice" has uploaded file with content "file inside a folder" to "Parent/textfile.txt" in the server
         And user "Alice" has uploaded file with content "file in the root" to "textfile.txt" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
+        And user "Alice" has shared folder "Parent" in the server with user "Brian" with "read" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
         When the user tries to overwrite the file "Parent/textfile.txt" with content "overwrite file inside a folder"
         And the user tries to overwrite the file "textfile.txt" with content "overwrite file in the root"
@@ -248,8 +248,8 @@ Feature: Sharing
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "some content" to "FOLDER/simple.txt" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared folder "FOLDER" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "FOLDER" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user opens the add-account dialog
         And the user adds the following account:
@@ -272,7 +272,7 @@ Feature: Sharing
     Scenario: sharee creates a file and a folder inside a shared folder
         Given user "Alice" has created folder "Parent" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared folder "Parent" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "Parent" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
             """
@@ -290,7 +290,7 @@ Feature: Sharing
     Scenario: sharee tries to create a file and a folder inside a shared folder without write permission
         Given user "Alice" has created folder "Parent" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared folder "Parent" on the server with user "Brian" with "read" permissions
+        And user "Alice" has shared folder "Parent" in the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
         When user "Brian" creates a file "Parent/localFile.txt" with the following content inside the sync folder
             """
@@ -309,8 +309,8 @@ Feature: Sharing
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "FOLDER" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "FOLDER" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user renames a file "textfile.txt" to "lorem.txt"
         And the user renames a folder "FOLDER" to "PARENT"
@@ -331,8 +331,8 @@ Feature: Sharing
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "Folder" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "Folder" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
@@ -347,8 +347,8 @@ Feature: Sharing
         Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile.txt" in the server
         And user "Alice" has created folder "Folder" in the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
-        And user "Alice" has shared file "Folder" on the server with user "Brian" with "read" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "read" permissions
+        And user "Alice" has shared file "Folder" in the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
         When the user deletes the file "textfile.txt"
         And the user deletes the folder "Folder"
@@ -365,8 +365,8 @@ Feature: Sharing
         And user "Carol" has been created in the server with default attributes
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
-        And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "FOLDER" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "all" permissions
         And user "Brian" has set up a client with default settings
         When the user adds "Carol King" as collaborator of resource "FOLDER" with permissions "edit,share" using the client-UI
         And the user adds "Carol King" as collaborator of resource "textfile.txt" with permissions "edit,share" using the client-UI
@@ -381,8 +381,8 @@ Feature: Sharing
         And user "Carol" has been created in the server with default attributes
         And user "Alice" has created folder "FOLDER" in the server
         And user "Alice" has uploaded file with content "ownCloud test text file" to "textfile.txt" in the server
-        And user "Alice" has shared file "FOLDER" on the server with user "Brian" with "read" permissions
-        And user "Alice" has shared file "textfile.txt" on the server with user "Brian" with "read" permissions
+        And user "Alice" has shared file "FOLDER" in the server with user "Brian" with "read" permissions
+        And user "Alice" has shared file "textfile.txt" in the server with user "Brian" with "read" permissions
         And user "Brian" has set up a client with default settings
         When the user opens the sharing dialog of "FOLDER" using the client-UI
         Then the error text "The file can not be shared because it was shared without sharing permission." should be displayed in the sharing dialog
@@ -396,8 +396,8 @@ Feature: Sharing
         Given user "Brian" has been created in the server with default attributes
         And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" in the server
         And user "Alice" has created folder "simple-folder" in the server
-        And user "Alice" has shared file "textfile0.txt" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "textfile0.txt" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "simple-folder" in the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user unshares the resource "textfile0.txt" for collaborator "Brian Murphy" using the client-UI
         Then the text "The item is not shared with any users or groups" should be displayed in the sharing dialog
@@ -615,8 +615,8 @@ Feature: Sharing
         And user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has created file "lorem.txt" on the server
         And user "Brian" has been created in the server with default attributes
-        And user "Alice" has shared folder "simple-folder" on the server with user "Brian" with "all" permissions
-        And user "Alice" has shared file "lorem.txt" on the server with user "Brian" with "all" permissions
+        And user "Alice" has shared folder "simple-folder" in the server with user "Brian" with "all" permissions
+        And user "Alice" has shared file "lorem.txt" in the server with user "Brian" with "all" permissions
         And user "Alice" has set up a client with default settings
         When the user removes permissions "<permissions>" for user "Brian Murphy" of resource "simple-folder" using the client-UI
         Then "<permissions>" permissions should not be displayed for user "Brian Murphy" for resource "simple-folder" on the client-UI


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
This `Given` step implementation shares file or folder in the server.

Renamed step:

```diff
-Given user "<user>" has shared file|folder <file|folder> on the server with user "<user>" with "<permission>" permission(s)
+Given user "<user>" has shared file|folder <file|folder> in the server with user "<user>" with "<permission>" permission(s)
```
Part of https://github.com/owncloud/client/issues/10432