### PR TITLE
Fix QML warnings on application exit

### DIFF
--- a/src/gui/qmlutils.cpp
+++ b/src/gui/qmlutils.cpp
@@ -24,6 +24,15 @@
 
 void OCC::QmlUtils::OCQuickWidget::setOCContext(const QUrl &src, QWidget *parentWidget, QObject *ocContext, QJSEngine::ObjectOwnership ownership)
 {
+    if (ownership == QJSEngine::CppOwnership) {
+        // Destroying the `ocContext` will result in property changed signals, causing the re-evaluation
+        // of the bindings in the QML file, which in turn results in warnings about accessing a property
+        // of a `null` object.
+        // To prevent this, reset the source to an empty URL.
+        connect(
+            ocContext, &QObject::destroyed, this, [this] { setSource(QUrl()); }, Qt::DirectConnection);
+    }
+
     rootContext()->setContextProperty(QStringLiteral("ocParentWidget"), parentWidget);
     rootContext()->setContextProperty(QStringLiteral("ocContext"), ocContext);
     engine()->setObjectOwnership(ocContext, ownership);


### PR DESCRIPTION
The `ocContext` in referenced from the QML side is deleted before the QML items (and their binding), resulting in access to a `null` context:

```
TypeError: Cannot read property 'currentPage' of null
```

Fixes: #11805