### PR TITLE
[test-only][full-ci] Given step implementation of sharing resource with group in the server

### DIFF
--- a/test/gui/shared/scripts/helpers/api/sharing_helper.py
+++ b/test/gui/shared/scripts/helpers/api/sharing_helper.py
@@ -96,18 +96,20 @@ def download_last_public_link_resource(user, resource, public_link_password=None
     raise AssertionError(f'Server returned status code: {response.status_code}')
 
 
-def share_resource(user, resource, receiver, permissions):
+def share_resource(user, resource, receiver, permissions, receiver_type):
     permissions = get_permission_value(permissions)
     url = get_share_url()
     body = {
         'path': resource,
-        'shareType': share_types['user'],
+        'shareType': share_types[receiver_type],
         'shareWith': receiver,
         'permissions': permissions,
     }
     response = request.post(url, body, user=user)
     request.assertHttpStatus(
-        response, 200, f"Failed to share resource '{resource}' to user '{user}'"
+        response,
+        200,
+        f"Failed to share resource '{resource}' to {receiver_type} '{receiver}'",
     )
     checkSuccessOcsStatus(response)
 

--- a/test/gui/shared/steps/server_context.py
+++ b/test/gui/shared/steps/server_context.py
@@ -202,11 +202,11 @@ def step(context, user):
 
 @Given(
     # pylint: disable=line-too-long
-    r'user "([^"].*)" has shared (?:file|folder) "([^"].*)" in the server with user "([^"].*)" with "([^"].*)" permission(?:s)?',
+    r'user "([^"].*)" has shared (?:file|folder) "([^"].*)" in the server with (user|group) "([^"].*)" with "([^"].*)" permission(?:s)?',
     regexp=True,
 )
-def step(context, user, resource, receiver, permissions):
-    sharing_helper.share_resource(user, resource, receiver, permissions)
+def step(context, user, resource, receiver_type, receiver, permissions):
+    sharing_helper.share_resource(user, resource, receiver, permissions, receiver_type)
 
 
 @Given('user "|any|" has created the following public link share in the server')

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -197,8 +197,8 @@ Feature: Sharing
         And user "Alice" has created folder "Folder" in the server
         And user "Alice" has shared file "/textfile0.txt" in the server with user "Brian" with "read, share, update" permission
         And user "Alice" has shared folder "Folder" in the server with user "Brian" with "read, share, update" permission
-        And user "Alice" has shared file "/textfile0.txt" on the server with group "grp1" with "read, share, update" permission
-        And user "Alice" has shared folder "Folder" on the server with group "grp1" with "read, share, update" permission
+        And user "Alice" has shared file "/textfile0.txt" in the server with group "grp1" with "read, share, update" permission
+        And user "Alice" has shared folder "Folder" in the server with group "grp1" with "read, share, update" permission
         And user "Brian" has set up a client with default settings
         When the user tires to share resource "textfile0.txt" with the group "grp1" using the client-UI
         Then the error "Path already shared with this group" should be displayed in the sharing dialog


### PR DESCRIPTION
## Description
Implemented `on the server` steps in the local test directory.
This `Given` step implementation shares file or folder with group in the server.

Renamed step:

```diff
-Given user "<user>" has shared file|folder <file|folder> on the server with group "<group>" with "<permission>" permission(s)
+Given user "<user>" has shared file|folder <file|folder> in the server with group "<group>" with "<permission>" permission(s)
```
Part of https://github.com/owncloud/client/issues/10432