### PR TITLE
Fix count of synced spaces

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -488,6 +488,10 @@ void AccountSettings::slotAccountStateChanged()
             icon = StatusIcon::Warning;
         }
         showConnectionLabel(tr("Connected"), icon, errors);
+        if (accountsState()->supportsSpaces()) {
+            connect(accountsState()->account()->spacesManager(), &GraphApi::SpacesManager::updated, this, &AccountSettings::slotSpacesUpdated);
+            slotSpacesUpdated();
+        }
         break;
     }
     case AccountState::ServiceUnavailable:

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -77,9 +77,6 @@ AccountSettings::AccountSettings(const AccountStatePtr &accountState, QWidget *p
     ui->quickWidget->setOCContext(QUrl(QStringLiteral("qrc:/qt/qml/org/ownCloud/gui/qml/FolderDelegate.qml")), this);
 
     connect(FolderMan::instance(), &FolderMan::folderListChanged, _model, &FolderStatusModel::resetFolders);
-    if (accountsState()->supportsSpaces()) {
-        connect(accountsState()->account()->spacesManager(), &GraphApi::SpacesManager::updated, this, &AccountSettings::slotSpacesUpdated);
-    }
 
     ui->connectionStatusLabel->clear();
 
@@ -489,7 +486,8 @@ void AccountSettings::slotAccountStateChanged()
         }
         showConnectionLabel(tr("Connected"), icon, errors);
         if (accountsState()->supportsSpaces()) {
-            connect(accountsState()->account()->spacesManager(), &GraphApi::SpacesManager::updated, this, &AccountSettings::slotSpacesUpdated);
+            connect(accountsState()->account()->spacesManager(), &GraphApi::SpacesManager::updated, this, &AccountSettings::slotSpacesUpdated,
+                Qt::UniqueConnection);
             slotSpacesUpdated();
         }
         break;


### PR DESCRIPTION
When a new account is added, the settings page for the account is created with the account in the disconnected state. At that point, it is not yet known if the server supports spaces, so there is no space manager yet, and the update signal is not connected. Moving the signal connect to `slotAccountStateChanged` for the `Connected` state fixes the issue.

Fixes: #11889