### PR TITLE
Fix button alignment in oauth screen

### DIFF
--- a/src/gui/qml/credentials/OAuthCredentials.qml
+++ b/src/gui/qml/credentials/OAuthCredentials.qml
@@ -59,7 +59,7 @@ Credentials {
 
             Button {
                 id: copyToClipboardButton
-                Layout.preferredWidth: openBrowserButton.width
+                Layout.preferredWidth: openBrowserButton.implicitWidth
                 visible: credentials.isValid
 
                 text: qsTr("Copy url")
@@ -82,7 +82,7 @@ Credentials {
             }
 
             Loader {
-                Layout.preferredWidth: openBrowserButton.width
+                Layout.preferredWidth: openBrowserButton.implicitWidth
                 Layout.alignment: Qt.AlignHCenter
                 sourceComponent: logOutButton
             }


### PR DESCRIPTION
When an item is in a layout, the width property is ignored, and the implicitWidth is used. So the copy-to-clipboard button's preferredWidth should be bound the implicitWidth property of the open-browser button.

Fixes: #11915