### PR TITLE
chore: drop broken linux build from GitHub - releases on linux for br…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,6 @@ jobs:
               os: macos-latest
               fetch-depth: 1
               container:
-            - name: linux-gcc-x86_64
-              target: linux-64-gcc
-              os: ubuntu-latest
-              container: owncloudci/appimage-build:centos7-devtoolset11-amd64
-              fetch-depth: 1
 
     name: ${{ matrix.name }}
 


### PR DESCRIPTION
…anch 5 via jenkins are still possible