### PR TITLE
Use native tooltips for Navigation bar

### DIFF
--- a/src/gui/qml/AccountBar.qml
+++ b/src/gui/qml/AccountBar.qml
@@ -26,6 +26,12 @@ Pane {
 
     Accessible.name: qsTr("Navigation bar")
 
+    Component.onCompleted: {
+        if ('popupType' in ToolTip.toolTip) {
+            ToolTip.toolTip.popupType = Popup.Native;
+        }
+    }
+
     Connections {
         target: widget
 


### PR DESCRIPTION
This fixes the issue where a (non-native) tooltip could be shown where the mouse cursor is positioned, which would block any clicks to go through to the button underneath.

Fixes: #11951