### PR TITLE
chore: pin craft-blueprints-kde to fdca754081357bce51abf038f53facc02d…

### DIFF
--- a/.craft.shelf
+++ b/.craft.shelf
@@ -7,7 +7,7 @@ version = 2023-12-12
 
 [craft/craft-blueprints-kde]
 version = master
-revision = ec61c47d
+revision = fdca754081357bce51abf038f53facc02d230b4d
 
 [craft/craft-blueprints-owncloud]
 version = master


### PR DESCRIPTION
…230b4d

Brings in https://invent.kde.org/packaging/craft-blueprints-kde/-/commit/fdca754081357bce51abf038f53facc02d230b4d which fixes an issue in pkg2appimage with fixes a client crash on wayland based desktops (e.g. Debian Testing right now)

refs: https://github.com/AppImageCommunity/pkg2appimage/pull/559#issuecomment-2460063077

 