### PR TITLE
Fix crash when checking the sync file status

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -408,7 +408,7 @@ bool Folder::syncPaused() const
 
 bool Folder::canSync() const
 {
-    return !syncPaused() && accountState()->readyForSync() && isReady() && _accountState->account()->hasCapabilities() && _folderWatcher;
+    return _engine && !syncPaused() && accountState()->readyForSync() && isReady() && _accountState->account()->hasCapabilities() && _folderWatcher;
 }
 
 bool Folder::isReady() const


### PR DESCRIPTION
Sometimes a `Folder` is created for a local path that we cannot sync (e.g. it's not writable). This folder will not have a sync engine. If the engine of this `Folder` is accessed, this will lead to a crash.

The fix is to check for the existance of a sync engine in the `Folder::canSync()` method.

Fixes: #11981