### PR TITLE
Log percent-encoded URL/filename

### DIFF
--- a/src/libsync/httplogger.cpp
+++ b/src/libsync/httplogger.cpp
@@ -43,7 +43,7 @@ bool isTextBody(const QString &s)
 struct HttpContext
 {
     HttpContext(const QNetworkRequest &request)
-        : originalUrl(request.url().toString())
+        : originalUrl(QString::fromUtf8(request.url().toEncoded())) // Encoded URL as it is passed "over the wire"
         , lastUrl(request.url())
         , id(QString::fromUtf8(request.rawHeader(QByteArrayLiteral("X-Request-ID"))))
     {


### PR DESCRIPTION
This can be used to debug Unicode normalization/encoding issues.