### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with regular multiplication

### DIFF
--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -89,12 +89,12 @@ bool Utility::hasDarkSystray()
 
 void Utility::UnixTimeToFiletime(time_t t, FILETIME *filetime)
 {
-    LONGLONG ll = Int32x32To64(t, 10000000) + 116444736000000000;
+    LONGLONG ll = (t * 10000000LL) + 116444736000000000LL;
     filetime->dwLowDateTime = (DWORD) ll;
     filetime->dwHighDateTime = ll >>32;
 }
 
-void Utility::FiletimeToLargeIntegerFiletime(FILETIME *filetime, LARGE_INTEGER *hundredNSecs)
+void Utility::FiletimeToLargeIntegerFiletime(const FILETIME *filetime, LARGE_INTEGER *hundredNSecs)
 {
     hundredNSecs->LowPart = filetime->dwLowDateTime;
     hundredNSecs->HighPart = filetime->dwHighDateTime;
@@ -102,9 +102,7 @@ void Utility::FiletimeToLargeIntegerFiletime(FILETIME *filetime, LARGE_INTEGER *
 
 void Utility::UnixTimeToLargeIntegerFiletime(time_t t, LARGE_INTEGER *hundredNSecs)
 {
-    LONGLONG ll = Int32x32To64(t, 10000000) + 116444736000000000;
-    hundredNSecs->LowPart = (DWORD) ll;
-    hundredNSecs->HighPart = ll >>32;
+    hundredNSecs->QuadPart = (t * 10000000LL) + 116444736000000000LL;
 }
 
 

--- a/src/common/utility_win.h
+++ b/src/common/utility_win.h
@@ -68,7 +68,7 @@ namespace Utility {
 
     // Possibly refactor to share code with UnixTimevalToFileTime in c_time.c
     OCSYNC_EXPORT void UnixTimeToFiletime(time_t t, FILETIME *filetime);
-    OCSYNC_EXPORT void FiletimeToLargeIntegerFiletime(FILETIME *filetime, LARGE_INTEGER *hundredNSecs);
+    OCSYNC_EXPORT void FiletimeToLargeIntegerFiletime(const FILETIME *filetime, LARGE_INTEGER *hundredNSecs);
     OCSYNC_EXPORT void UnixTimeToLargeIntegerFiletime(time_t t, LARGE_INTEGER *hundredNSecs);
 
     OCSYNC_EXPORT QString formatWinError(long error);

--- a/src/csync/std/c_time.cpp
+++ b/src/csync/std/c_time.cpp
@@ -48,8 +48,7 @@ Q_LOGGING_CATEGORY(lcCSyncCtime, "sync.csync.c_time", QtInfoMsg)
 //after Microsoft KB167296
 static void UnixTimevalToFileTime(struct timeval t, LPFILETIME pft)
 {
-    LONGLONG ll;
-    ll = Int32x32To64(t.tv_sec, CSYNC_USEC_IN_SEC*10) + t.tv_usec*10 + CSYNC_SECONDS_SINCE_1601*CSYNC_USEC_IN_SEC*10;
+    LONGLONG ll = t.tv_sec * CSYNC_USEC_IN_SEC*10 + t.tv_usec*10 + CSYNC_SECONDS_SINCE_1601*CSYNC_USEC_IN_SEC*10;
     pft->dwLowDateTime = (DWORD)ll;
     pft->dwHighDateTime = ll >> 32;
 }


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>

Note: I don't know if `src/csync/std/c_time.cpp` should be edited as part of this repository, or another upstream source. At the moment I included the necessary changes in this PR, but if this part of the PR needs to be directed elsewhere I'm happy to do so instead.