### PR TITLE
fix: bypass Qt's QFile::encodeName() in csync

### DIFF
--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -49,6 +49,16 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcFileSystem, "sync.filesystem", QtInfoMsg)
 
+QByteArray FileSystem::encodeFileName(const QString &fileName)
+{
+    return fileName.toLocal8Bit();
+}
+
+QString FileSystem::decodeFileName(const char *localFileName)
+{
+    return QString::fromLocal8Bit(localFileName);
+}
+
 QString FileSystem::longWinPath(const QString &inpath)
 {
 #ifndef Q_OS_WIN

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -209,28 +209,15 @@ bool FileSystem::uncheckedRenameReplace(const QString &originFileName,
     QString *errorString)
 {
     Q_ASSERT(errorString);
+
 #ifndef Q_OS_WIN
-    bool success;
-    QFile orig(originFileName);
-    // We want a rename that also overwrites.  QFile::rename does not overwrite.
-    // Qt 5.1 has QSaveFile::renameOverwrite we could use.
-    // ### FIXME
-    success = true;
-    bool destExists = fileExists(destinationFileName);
-    if (destExists && !QFile::remove(destinationFileName)) {
-        *errorString = orig.errorString();
-        qCWarning(lcFileSystem) << "Target file could not be removed.";
-        success = false;
-    }
-    if (success) {
-        success = orig.rename(destinationFileName);
-    }
-    if (!success) {
-        *errorString = orig.errorString();
+    std::error_code err;
+    std::filesystem::rename(originFileName.toStdString(), destinationFileName.toStdString(), err);
+    if (err) {
+        *errorString = QString::fromStdString(err.message());
         qCWarning(lcFileSystem) << "Renaming temp file to final failed: " << *errorString;
         return false;
     }
-
 #else //Q_OS_WIN
     // You can not overwrite a read-only file on windows.
 

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -361,7 +361,7 @@ bool FileSystem::mkpath(const QString &parent, const QString &newDir)
         fullPath += u'/';
     }
     fullPath += newDir;
-    std::filesystem::create_directories(newDir.toStdString(), err);
+    std::filesystem::create_directories(fullPath.toStdString(), err);
     return err.value() == 0;
 #endif
 }

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -26,6 +26,8 @@
 #include <QSettings>
 #include <QStorageInfo>
 
+#include <filesystem>
+
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -359,6 +361,22 @@ bool FileSystem::fileExists(const QString &filename, const QFileInfo &fileInfo)
         re = QFileInfo::exists(filename);
     }
     return re;
+}
+
+bool FileSystem::mkpath(const QString &parent, const QString &newDir)
+{
+#ifdef Q_OS_WIN
+    return QDir(parent).mkpath(newDir);
+#else // POSIX
+    std::error_code err;
+    QString fullPath = parent;
+    if (!fullPath.endsWith(u'/')) {
+        fullPath += u'/';
+    }
+    fullPath += newDir;
+    std::filesystem::create_directories(newDir.toStdString(), err);
+    return err.value() == 0;
+#endif
 }
 
 QString FileSystem::fileSystemForPath(const QString &path)

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -108,6 +108,8 @@ namespace FileSystem {
      */
     bool OCSYNC_EXPORT fileExists(const QString &filename, const QFileInfo & = QFileInfo());
 
+    bool OCSYNC_EXPORT mkpath(const QString &parent, const QString &newDir);
+
     /**
      * @brief Rename the file \a originFileName to \a destinationFileName.
      *

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -47,6 +47,9 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcFileSystem)
 namespace FileSystem {
     OCSYNC_EXPORT Q_NAMESPACE;
 
+    QByteArray OCSYNC_EXPORT encodeFileName(const QString &fileName);
+    QString OCSYNC_EXPORT decodeFileName(const char *localFileName);
+
     /**
      * List of characters not allowd in filenames on Windows
      */

--- a/src/csync/std/c_time.cpp
+++ b/src/csync/std/c_time.cpp
@@ -23,11 +23,9 @@
 
 #include "common/filesystembase.h"
 
-#include <QFile>
-
 #ifdef HAVE_UTIMES
 int c_utimes(const QString &uri, const struct timeval *times) {
-    int ret = utimes(QFile::encodeName(uri).constData(), times);
+    int ret = utimes(uri.toLocal8Bit().constData(), times);
     return ret;
 }
 #else // HAVE_UTIMES

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -235,9 +235,7 @@ void SocketApi::slotReadSocket()
     static auto invalidListener = QSharedPointer<SocketListener>::create(nullptr);
     const auto listener = _listeners.value(socket, invalidListener);
     while (socket->canReadLine()) {
-        // Make sure to normalize the input from the socket to
-        // make sure that the path will match, especially on OS X.
-        QString line = QString::fromUtf8(socket->readLine()).normalized(QString::NormalizationForm_C);
+        QString line = QString::fromUtf8(socket->readLine());
         // Note: do NOT use QString::trimmed() here! That will also remove any trailing spaces (which _are_ part of the filename)!
         line.chop(1); // remove the '\n'
 

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -178,8 +178,8 @@ void PropagateLocalMkdir::start()
         done(SyncFileItem::NormalError, tr("Can not create local folder %1 because of a local file name clash with %2").arg(newDirStr, QDir::toNativeSeparators(clash.get())));
         return;
     }
-    QDir localDir(propagator()->localPath());
-    if (!localDir.mkpath(_item->_file)) {
+
+    if (!FileSystem::mkpath(propagator()->localPath(), _item->_file)) {
         done(SyncFileItem::NormalError, tr("could not create folder %1").arg(newDirStr));
         return;
     }

--- a/test/testfilesystem.cpp
+++ b/test/testfilesystem.cpp
@@ -137,6 +137,37 @@ private Q_SLOTS:
 
         QVERIFY(tmp.remove());
     }
+
+    void testMkdir_data()
+    {
+        QTest::addColumn<QString>("name");
+
+        const unsigned char a_umlaut_composed_bytes[] = {0xc3, 0xa4, 0x00};
+        const QString a_umlaut_composed = QString::fromUtf8(reinterpret_cast<const char *>(a_umlaut_composed_bytes));
+        const QString a_umlaut_decomposed = a_umlaut_composed.normalized(QString::NormalizationForm_D);
+
+        QTest::newRow("a-umlaut composed") << a_umlaut_composed;
+        QTest::newRow("a-umlaut decomposed") << a_umlaut_decomposed;
+    }
+
+    // This is not a full test, it is meant to verify that no nomalization changes are done.
+    // The implementation of `OCC::FileSystem::mkpath` relies on either Qt (Windows) or
+    // `std::filesystem` (POSIX), which should be covered by tests of their own.
+    void testMkdir()
+    {
+        QFETCH(QString, name);
+
+        auto tmp = OCC::TestUtils::createTempDir();
+        QVERIFY(OCC::FileSystem::mkpath(tmp.path(), name));
+        csync_file_stat_t buf;
+        auto dh = csync_vio_local_opendir(tmp.path());
+        QVERIFY(dh);
+        while (auto fs = csync_vio_local_readdir(dh, nullptr)) {
+            QCOMPARE(fs->path, name);
+            QCOMPARE(fs->type, ItemTypeDirectory);
+        }
+        csync_vio_local_closedir(dh);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestFileSystem)

--- a/test/testfilesystem.cpp
+++ b/test/testfilesystem.cpp
@@ -168,6 +168,43 @@ private Q_SLOTS:
         }
         csync_vio_local_closedir(dh);
     }
+
+    void testRename_data()
+    {
+        QTest::addColumn<QString>("name");
+
+        const unsigned char a_umlaut_composed_bytes[] = {0xc3, 0xa4, 0x00};
+        const QString a_umlaut_composed = QString::fromUtf8(reinterpret_cast<const char *>(a_umlaut_composed_bytes));
+        const QString a_umlaut_decomposed = a_umlaut_composed.normalized(QString::NormalizationForm_D);
+
+        QTest::newRow("a-umlaut composed") << a_umlaut_composed;
+        QTest::newRow("a-umlaut decomposed") << a_umlaut_decomposed;
+    }
+
+    // This is not a full test, it is meant to verify that no nomalization changes are done.
+    void testRename()
+    {
+        QFETCH(QString, name);
+
+        auto tmp = OCC::TestUtils::createTempDir();
+        QFile f(tmp.path() + u"/abc");
+        QVERIFY(f.open(QFile::WriteOnly));
+        QByteArray data("abc");
+        QCOMPARE(f.write(data), data.size());
+        f.close();
+
+        QString err;
+        QVERIFY(OCC::FileSystem::uncheckedRenameReplace(f.fileName(), tmp.path() + u'/' + name, &err));
+
+        csync_file_stat_t buf;
+        auto dh = csync_vio_local_opendir(tmp.path());
+        QVERIFY(dh);
+        while (auto fs = csync_vio_local_readdir(dh, nullptr)) {
+            QCOMPARE(fs->path, name);
+            QCOMPARE(fs->type, ItemTypeFile);
+        }
+        csync_vio_local_closedir(dh);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestFileSystem)

--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -15,6 +15,7 @@
 #include "libsync/syncresult.h"
 
 #include <thread>
+#include <vio/csync_vio_local.h>
 
 using namespace std::chrono_literals;
 using namespace std::chrono;
@@ -1099,34 +1100,41 @@ void FakeFolder::toDisk(QDir &dir, const FileInfo &templateFi)
 
 void FakeFolder::fromDisk(QDir &dir, FileInfo &templateFi)
 {
-    const auto infoList = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot);
-    for (const auto &diskChild : infoList) {
-        if (diskChild.isHidden() || diskChild.fileName().startsWith(QStringLiteral(".sync_"))) {
-            // Skip system files, sqlite db files, sync log, etc.
+    auto dh = csync_vio_local_opendir(dir.absolutePath());
+    if (!dh) {
+        return;
+    }
+    while (true) {
+        auto dirent = csync_vio_local_readdir(dh, nullptr);
+        if (!dirent)
+            break;
+        if (dirent->type == ItemTypeSkip)
             continue;
-        }
+        if (dirent->is_hidden || dirent->path.startsWith(QStringLiteral(".sync_")))
+            continue;
 
-        if (diskChild.isDir()) {
+        QString absolutePathItem = dir.absolutePath() + QDir::separator() + dirent->path;
+        if (dirent->type == ItemTypeDirectory) {
             QDir subDir = dir;
-            subDir.cd(diskChild.fileName());
-            FileInfo &subFi = templateFi.children[diskChild.fileName()] = FileInfo { diskChild.fileName() };
-            subFi.setLastModified(diskChild.lastModified());
+            subDir.cd(dirent->path);
+            FileInfo &subFi = templateFi.children[dirent->path] = FileInfo{dirent->path};
+            subFi.setLastModified(QDateTime::fromSecsSinceEpoch(dirent->modtime, QTimeZone::utc()));
             fromDisk(subDir, subFi);
         } else {
-            FileInfo fi(diskChild.fileName());
+            FileInfo fi(dirent->path);
             fi.isDir = false;
-            fi.fileSize = diskChild.size();
-            fi.isDehydratedPlaceholder = isDehydratedPlaceholder(diskChild.absoluteFilePath());
-            fi.setLastModified(diskChild.lastModified());
+            fi.fileSize = dirent->size;
+            fi.isDehydratedPlaceholder = isDehydratedPlaceholder(absolutePathItem);
+            fi.setLastModified(QDateTime::fromSecsSinceEpoch(dirent->modtime, QTimeZone::utc()));
             if (fi.isDehydratedPlaceholder) {
                 fi.contentChar = '\0';
                 fi.contentSize = 0;
             } else {
-                QFile f { diskChild.filePath() };
+                QFile f{absolutePathItem};
                 OC_ENFORCE(f.open(QFile::ReadOnly));
                 auto content = f.read(1);
                 if (content.size() == 0) {
-                    qWarning() << "Empty file at:" << diskChild.filePath();
+                    qWarning() << "Empty file at:" << dirent->path;
                     fi.contentChar = FileInfo::DefaultContentChar;
                 } else {
                     fi.contentChar = content.at(0);
@@ -1137,6 +1145,7 @@ void FakeFolder::fromDisk(QDir &dir, FileInfo &templateFi)
             templateFi.children.insert(fi.name, fi);
         }
     }
+    csync_vio_local_closedir(dh);
 }
 
 FileInfo &findOrCreateDirs(FileInfo &base, const PathComponents &components)

--- a/test/testutils/syncenginetestutils.h
+++ b/test/testutils/syncenginetestutils.h
@@ -710,6 +710,11 @@ inline char *printDbData(const FileInfo &fi)
     return QTest::toString(QStringLiteral("FileInfo with %1 files(%2)").arg(files.size()).arg(files.join(QStringLiteral(", "))));
 }
 
+/**
+ * @brief Utility class that count the number of GET/PUT/MOVE/DELETE operations during a sync.
+ *
+ * This can be used for subsequent syncs, but the counters need to be reset.
+ */
 struct OperationCounter
 {
     int nGET = 0;
@@ -717,7 +722,7 @@ struct OperationCounter
     int nMOVE = 0;
     int nDELETE = 0;
 
-    OperationCounter() {};
+    OperationCounter() { }
     OperationCounter(const OperationCounter &) = delete;
     OperationCounter(OperationCounter &&) = delete;
     void operator=(OperationCounter const &) = delete;


### PR DESCRIPTION
## ToDo
- [x] extract commits as individual reasonable PRs
- [x] fix failing windows test @erikjv 
- [x] implement test case for nfd/nfc encoded mkpath
- [x] implement test case for nfd/nfc encoded rename
