### PR TITLE
Rename `LongPathTest` to `FileSystemTest`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,7 +53,7 @@ if( UNIX AND NOT APPLE )
 endif(UNIX AND NOT APPLE)
 
 
-owncloud_add_test(LongPath)
+owncloud_add_test(FileSystem)
 
 owncloud_add_test(FolderMan)
 

--- a/test/testfilesystem.cpp
+++ b/test/testfilesystem.cpp
@@ -26,7 +26,7 @@
 #include <QTest>
 
 
-class TestLongWindowsPath : public QObject
+class TestFileSystem : public QObject
 {
     Q_OBJECT
 
@@ -139,5 +139,5 @@ private Q_SLOTS:
     }
 };
 
-QTEST_GUILESS_MAIN(TestLongWindowsPath)
-#include "testlongpath.moc"
+QTEST_GUILESS_MAIN(TestFileSystem)
+#include "testfilesystem.moc"


### PR DESCRIPTION
In preparation for adding more tests for `OCC::FileSystem`.