### PR TITLE
Fix possible crash if the client encountered an error during folder s…

### DIFF
--- a/changelog/unreleased/11664
+++ b/changelog/unreleased/11664
@@ -1,0 +1,5 @@
+Bugfix: Fix crash for folders that could not be initialized
+
+We fixed a bug where interacting with a folder in the file browser could lead to a crash if the folder was not properly initialized.
+
+https://github.com/owncloud/client/pull/11664

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -952,8 +952,9 @@ SyncFileStatus SocketApi::FileData::syncFileStatus() const
 SyncJournalFileRecord SocketApi::FileData::journalRecord() const
 {
     SyncJournalFileRecord record;
-    if (!folder)
+    if (!folder || !folder->canSync()) {
         return record;
+    }
     folder->journalDb()->getFileRecord(folderRelativePath, &record);
     return record;
 }


### PR DESCRIPTION
…etup

In that case the engne would return a nullptr.

(cherry picked from commit 1d689e1a70cee3672bfb19eab858b16bb51ca1da)