### PR TITLE
Fixed the Folder/Space error message when in collapsed state

### DIFF
--- a/src/gui/qml/FolderError.qml
+++ b/src/gui/qml/FolderError.qml
@@ -69,7 +69,7 @@ ColumnLayout {
             Layout.fillWidth: true
             ErrorItem {
                 Layout.fillWidth: true
-                text: errorMessages
+                text: errorMessages[0]
                 maximumLineCount: 1
             }
             Label {

--- a/src/gui/spaces/qml/SpacesView.qml
+++ b/src/gui/spaces/qml/SpacesView.qml
@@ -22,7 +22,7 @@ import org.ownCloud.libsync 1.0
 Pane {
     id: spacesView
     // TODO: not cool
-    readonly property real normalSize: 70
+    readonly property real normalSize: 170
 
     readonly property SpacesBrowser spacesBrowser: ocContext
     readonly property OCQuickWidget widget: ocQuickWidget

--- a/src/gui/spaces/qml/SpacesView.qml
+++ b/src/gui/spaces/qml/SpacesView.qml
@@ -22,7 +22,7 @@ import org.ownCloud.libsync 1.0
 Pane {
     id: spacesView
     // TODO: not cool
-    readonly property real normalSize: 170
+    readonly property real normalSize: 70
 
     readonly property SpacesBrowser spacesBrowser: ocContext
     readonly property OCQuickWidget widget: ocQuickWidget


### PR DESCRIPTION
This was the least destructive approach I could find.

also fixed the error message when it's "show less"

finally reverted the size change since we don't know if it fits, but kept the fix for collapsed error messages