### PR TITLE
Update MacOS --> macOS where necessary, especially for the translation

### DIFF
--- a/changelog/unreleased/12044.md
+++ b/changelog/unreleased/12044.md
@@ -1,4 +1,4 @@
-Change: Only support APFS on MacOS
+Change: Only support APFS on macOS
 
 Apple File System in contrary to HFS+ is Unicode normalization preserving.
 To support this properly the upcoming version 6 of desktop client will support

--- a/src/csync/INSTALL
+++ b/src/csync/INSTALL
@@ -28,7 +28,7 @@ build and run csync successfully with an older version, please let us know.
 First, you need to configure the compilation, using CMake. Go inside the
 `build` dir. Create it if it doesn't exist.
 
-GNU/Linux and MacOS X:
+GNU/Linux and macOS X:
 
     cmake -DCMAKE_BUILD_TYPE=Debug ..
     make
@@ -38,7 +38,7 @@ Here is a list of the most interesting options provided out of the box by CMake.
 
 - CMAKE_BUILD_TYPE: The type of build (can be Debug Release MinSizeRel RelWithDebInfo)
 - CMAKE_INSTALL_PREFIX: The prefix to use when running make install (Default to
-  /usr/local on GNU/Linux and MacOS X)
+  /usr/local on GNU/Linux and macOS X)
 - CMAKE_C_COMPILER: The path to the C compiler
 - CMAKE_CXX_COMPILER: The path to the C++ compiler
 
@@ -59,7 +59,7 @@ CMake options using `cmakesetup` (Windows) or `ccmake` (GNU/Linux and MacOS X).
 
 - Go to the build dir
 - On Windows: run `cmakesetup`
-- On GNU/Linux and MacOS X: run `ccmake ..`
+- On GNU/Linux and macOS X: run `ccmake ..`
 
 ## Installing
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -311,7 +311,7 @@ bool FolderMan::ensureFilesystemSupported(const FolderDefinition &folderDefiniti
 
     QString filesystemType = FileSystem::fileSystemForPath(folderDefinition.localPath());
     if (filesystemType != QStringLiteral("apfs")) {
-        QMessageBox::warning(nullptr, tr("Unsupported filesystem"), tr("On MacOS only Apple File System is supported."), QMessageBox::Ok);
+        QMessageBox::warning(nullptr, tr("Unsupported filesystem"), tr("On macOS, only the Apple File System is supported."), QMessageBox::Ok);
 
         return false;
     }

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -45,9 +45,9 @@ namespace OCC {
  * complex class design was set up:
  *
  * For Windows and Linux, the updaters are inherited from OCUpdater, while
- * the MacOSX SparkleUpdater directly uses the class Updater. On windows,
+ * the macOSX SparkleUpdater directly uses the class Updater. On windows,
  * NSISUpdater starts the update if a new version of the client is available.
- * On MacOSX, the sparkle framework handles the installation of the new
+ * On macOSX, the sparkle framework handles the installation of the new
  * version. On Linux, the update capabilities of the underlying linux distro
  * are relied on, and thus the PassiveUpdateNotifier just shows a notification
  * if there is a new version once at every start of the application.


### PR DESCRIPTION
Fixes: #12090 (Translation source string has a wrong capitalisation)

This PR updates some relevant occurrences where the string `macOS` has the wrong capitalsiation.

There are many more occurrences but these are mainly:
* changelog entries for releases already published
* parts of the code where directories are accesses.
This would need dir naming changes too which is not worth it (except one decides to)  