### PR TITLE
Update the sync exclude list with two extensions relevant for Infinite Scale

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -38,4 +38,8 @@
 *.unison
 .nfs*
 
+# Relevant for Infinite Scale
+].space
+*.psec
+
 My Saved Places.


### PR DESCRIPTION
Fixes: #12086 (Add .psec to the exclude sync extensions)

There are two extensions that need to be added to the sync exclude list, relevant for Infinite Scale:

* `.psec` which is an extension used for password protected folders.
See the referenced issue for more details
* `.space` this is a directory that is used locally when syncing Spaces.
If you do not exclude it, you get entries for not synced items

Note that `*` and `]` are intentionally based on the definition of excluded items, see the GUI for details.

@kobergj @LukasHirt 

Note that it is a bit courious finding an "exclude" item named `My Saved Places.`, imho this could be removed as no use, but possibly another story...