### PR TITLE
fix(test framework): a finished signal could be emitted twice

### DIFF
--- a/test/testutils/syncenginetestutils.cpp
+++ b/test/testutils/syncenginetestutils.cpp
@@ -661,6 +661,7 @@ void FakeGetReply::respond()
             // It can happen that this job is cancelled before the full data is read, and the job is aborted. This being the test framework, processing happens
             // synchronously, so between the signals above and here, the job can get aborted, which emits the finished signal. So do NOT emit it again if
             // this is the case.
+            setFinished(true);
             Q_EMIT finished();
         }
     }


### PR DESCRIPTION
fixes #12096 