### PR TITLE
Fix translatable source strings

### DIFF
--- a/src/gui/qml/FolderDelegate.qml
+++ b/src/gui/qml/FolderDelegate.qml
@@ -256,7 +256,7 @@ Pane {
                 Layout.fillWidth: true
             }
             Label {
-                text: (Theme.spacesAreCalledFolders ? qsTr("You are synchronizing %1 out of %n folder(s)", "", accountSettings.syncedSpaces + accountSettings.unsyncedSpaces) : qsTr("You are synchronizing %1 out of %n space(s)", "", accountSettings.syncedSpaces + accountSettings.unsyncedSpaces)).arg(accountSettings.syncedSpaces)
+                text: (Theme.spacesAreCalledFolders ? qsTr("Synchronizing %1 out of %n folder(s)", "", accountSettings.syncedSpaces + accountSettings.unsyncedSpaces) : qsTr("Synchronizing %1 out of %n Space(s)", "", accountSettings.syncedSpaces + accountSettings.unsyncedSpaces)).arg(accountSettings.syncedSpaces)
                 visible: accountSettings.accountState.supportsSpaces && accountSettings.accountState.state === AccountState.Connected
             }
         }


### PR DESCRIPTION
References: #12105 (Work/numeral translations en us)

While looking in the refernced PR and also open strings for the client in TX, I identified two issues:

1. Avoid the use of personal pronouns like `you`. This makes text harder to translate
2. `Space` (or Spaces) is a proper noun and therefore written with a capital S

This PR fixes these two issues.