### PR TITLE
fix: test undefined APPLICATION_UPDATE_URL

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -243,7 +243,11 @@ void Theme::setSystrayUseMonoIcons(bool mono)
 
 QUrl Theme::updateCheckUrl() const
 {
+#ifndef APPLICATION_UPDATE_URL
+    return QUrl(QString());
+#else
     return QUrl(QStringLiteral(APPLICATION_UPDATE_URL));
+#endif
 }
 
 bool Theme::wizardSkipAdvancedPage() const


### PR DESCRIPTION
In case the cmake variable APPLICATION_UPDATE_URL is undefined the code shall still compile ;-)

Before:
```
***\src\libsync\theme.cpp(246): error C2146: syntax error: missing ')' before identifier 'APPLICATION_UPDATE_URL'
***\src\libsync\theme.cpp(246): error C2059: syntax error: ')'
***\src\libsync\theme.cpp(246): error C2059: syntax error: ')'
