### PR TITLE
General common sense cleanup related to accounts

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -266,20 +266,20 @@ void AccountManager::saveAccount(Account *account, bool saveCredentials)
 
 QStringList AccountManager::accountNames() const
 {
-    QStringList accounts;
-    accounts.reserve(AccountManager::instance()->accounts().size());
-    for (const auto &a : AccountManager::instance()->accounts()) {
-        accounts << a->account()->displayNameWithHost();
+    QStringList accountNames;
+    accountNames.reserve(_accounts.count());
+    for (const auto &a : _accounts) {
+        accountNames << a->account()->displayNameWithHost();
     }
-    std::sort(accounts.begin(), accounts.end());
-    return accounts;
+    accountNames.sort();
+    return accountNames;
 }
 
 QList<AccountState *> AccountManager::accountsRaw() const
 {
     QList<AccountState *> out;
     out.reserve(_accounts.size());
-    for (auto &x : _accounts.values()) {
+    for (auto &x : _accounts) {
         out.append(x);
     }
     return out;

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -121,6 +121,10 @@ public Q_SLOTS:
 Q_SIGNALS:
     void accountAdded(AccountStatePtr account);
     void accountRemoved(AccountStatePtr account);
+
+    // this signal is not formally connected anywhere, but it's used on the Q_PROPERTY declared for "accounts" above
+    // the accountManager::accounts prop is used as a model in AccountsBar.qml so the accounts are reevaluated in that gui
+    // any time the accountsChanged signal is emitted.
     void accountsChanged();
 
 private:

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -18,7 +18,6 @@
 #include "application.h"
 #include "configfile.h"
 #include "fetchserversettings.h"
-#include "guiutility.h"
 
 #include "libsync/creds/abstractcredentials.h"
 #include "libsync/creds/httpcredentials.h"
@@ -29,7 +28,6 @@
 #include "gui/spacemigration.h"
 #include "gui/tlserrordialog.h"
 
-#include "logger.h"
 #include "socketapi/socketapi.h"
 #include "theme.h"
 
@@ -288,9 +286,8 @@ void AccountState::setState(State state)
             _fetchCapabilitiesJob->start();
         });
     }
-    // don't anounce a state change from connected to connected
-    // https://github.com/owncloud/client/commit/2c6c21d7532f0cbba4b768fde47810f6673ed931
-    if (oldState != state || state != Connected) {
+
+    if (oldState != _state) {
         Q_EMIT stateChanged(_state);
     }
 }

--- a/src/gui/creds/qmlcredentials.h
+++ b/src/gui/creds/qmlcredentials.h
@@ -78,6 +78,7 @@ Q_SIGNALS:
 
 
 private:
+    // Refactor todo: this could be dangerous per Erik's review
     QPointer<OAuth> _oauth = nullptr;
     bool _ready = false;
 };

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -1,8 +1,6 @@
 #include "setupwizardcontroller.h"
 
-#include "determineauthtypejobfactory.h"
 #include "gui/application.h"
-#include "gui/folderman.h"
 #include "pages/accountconfiguredwizardpage.h"
 #include "states/abstractsetupwizardstate.h"
 #include "states/accountconfiguredsetupwizardstate.h"
@@ -201,11 +199,17 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState, ChangeReas
             return;
         }
         case SetupWizardState::AccountConfiguredState: {
+            // Lisa todo: is that page guaranteed to be alive at this point? more: why on earth are we pulling data from the page?!
+            // that info should be transferred to the state or some other data model or dm owner
+            // using a polymorphic impl for the states/pages is in theory good, but if you have to start casting to specific
+            // impls that is a big code smell that indicates your abstraction is faulty
             const auto *pagePtr = qobject_cast<AccountConfiguredWizardPage *>(_currentState->page());
-
+            Q_ASSERT(pagePtr);
             auto account = _context->accountBuilder().build();
             Q_ASSERT(account != nullptr);
-            Q_EMIT finished(account, pagePtr->syncMode(), _context->accountBuilder().dynamicRegistrationData());
+            if (pagePtr && account) {
+                Q_EMIT finished(account, pagePtr->syncMode(), _context->accountBuilder().dynamicRegistrationData());
+            }
             return;
         }
         default:

--- a/src/gui/newwizard/setupwizardwidget.cpp
+++ b/src/gui/newwizard/setupwizardwidget.cpp
@@ -130,7 +130,7 @@ void SetupWizardWidget::displayPage(AbstractSetupWizardPage *page, SetupWizardSt
 
     connect(_currentPage, &AbstractSetupWizardPage::contentChanged, this, &SetupWizardWidget::slotUpdateNextButton);
 
-    QTimer::singleShot(0, [this]() {
+    QTimer::singleShot(0, this, [this]() {
         // this can optionally be overwritten by the page
         Q_EMIT _currentPage->pageDisplayed();
     });

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -29,7 +29,6 @@
 #include "guiutility.h"
 #include "libsync/theme.h"
 #include "logbrowser.h"
-#include "logger.h"
 #include "openfilemanager.h"
 #include "progressdispatcher.h"
 #include "settingsdialog.h"
@@ -594,12 +593,14 @@ void ownCloudGui::updateContextMenu()
     for (const auto &a : accountList) {
         if (a->isConnected()) {
             atLeastOneConnected = true;
+            break;
         }
     }
 
     for (auto *f : FolderMan::instance()->folders()) {
         if (f->syncPaused()) {
             atLeastOnePaused = true;
+            break;
         }
     }
 


### PR DESCRIPTION
Most important fix in AccountState::setState ensures we only notify AccountState::stateChanged when the state has *actually* changed