### PR TITLE
fix crash when adding an accountState to the AccountManager

### DIFF
--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -77,9 +77,9 @@ public:
     Q_DECL_DEPRECATED_X("Please use the uuid to specify the account") AccountStatePtr account(const QString &name);
 
     /**
-     * Return the account state pointer for an account identified by its display name
+     * Return the accountState state pointer for an accountState identified by its display name
      */
-    AccountStatePtr account(const QUuid uuid);
+    AccountStatePtr accountState(const QUuid uuid);
 
     /**
      * Delete the AccountState

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -493,7 +493,7 @@ void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status sta
         if (status == ConnectionValidator::Connected) {
             Q_ASSERT(_account->hasCapabilities());
             if (_account->capabilities().migration().space_migration.enabled) {
-                auto statePtr = AccountManager::instance()->account(_account->uuid());
+                auto statePtr = AccountManager::instance()->accountState(_account->uuid());
                 auto migration = new SpaceMigration(statePtr, _account->capabilities().migration().space_migration.endpoint, this);
                 connect(migration, &SpaceMigration::finished, this, [migration, this] {
                     migration->deleteLater();

--- a/src/gui/models/activitylistmodel.cpp
+++ b/src/gui/models/activitylistmodel.cpp
@@ -50,7 +50,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     }
 
     const auto &a = _finalList.at(index.row());
-    const AccountStatePtr accountState = AccountManager::instance()->account(a.accountUuid());
+    const AccountStatePtr accountState = AccountManager::instance()->accountState(a.accountUuid());
     if (!accountState) {
         return {};
     }

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -72,7 +72,7 @@ public:
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
     {
         const auto qmlIcon = OCC::Resources::QMLResources::parseIcon(id);
-        const auto accountState = OCC::AccountManager::instance()->account(QUuid::fromString(qmlIcon.iconName));
+        const auto accountState = OCC::AccountManager::instance()->accountState(QUuid::fromString(qmlIcon.iconName));
         return OCC::Resources::pixmap(requestedSize, accountState->account()->avatar(), qmlIcon.enabled ? QIcon::Normal : QIcon::Disabled, size);
     }
 };


### PR DESCRIPTION
slot to saveAccount was connected before AccountState was effectively added. saveAccount uses the AccountStatePtr so it was null in some cases and crashed.

I added checks for null on the account state in these areas and also re-ordered the behavior in AccountManager::addAccountState

also renamed AccountManager::account to accountState as that's actually what you get from it.