### PR TITLE
Remove invalid assert in the HTTP logger

### DIFF
--- a/src/libsync/httplogger.cpp
+++ b/src/libsync/httplogger.cpp
@@ -110,7 +110,6 @@ void logHttp(const QByteArray &verb, HttpContext *ctx, QJsonObject &&header, QIO
         }
         if (isTextBody(contentType)) {
             if (!device->isOpen()) {
-                Q_ASSERT(dynamic_cast<QBuffer *>(device));
                 // should we close it again?
                 device->open(QIODevice::ReadOnly);
             }


### PR DESCRIPTION
The assumption that the content "device" is a `QBuffer` when it is closed, is wrong: it can very well be a `QNetworkReply`, plus that shouldn't matter just for logging.

Fixes: #12098