### PR TITLE
Deprecate bandwidth limits

### DIFF
--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -101,6 +101,14 @@ NetworkSettings::NetworkSettings(QWidget *parent)
     checkAccountLocalhost();
 
     connect(_ui->pauseSyncWhenMeteredCheckbox, &QAbstractButton::clicked, this, &NetworkSettings::saveMeteredSettings);
+
+    ConfigFile config;
+    if (config.useUploadLimit() == 0 && config.useDownloadLimit() == 0) {
+        _ui->warningIcon->setVisible(false);
+        _ui->warningLabel->setVisible(false);
+        _ui->uploadBox->setVisible(false);
+        _ui->downloadBox->setVisible(false);
+    }
 }
 
 NetworkSettings::~NetworkSettings()

--- a/src/gui/networksettings.ui
+++ b/src/gui/networksettings.ui
@@ -227,6 +227,53 @@
     </widget>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <widget class="QLabel" name="warningIcon">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../resources/client.qrc">:/client/resources/core/states/warning.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="warningLabel">
+       <property name="font">
+        <font>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Bandwith limits are deprecated and will be removed in a future release!</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QGroupBox" name="downloadBox">
@@ -419,7 +466,9 @@
   <tabstop>uploadLimitRadioButton</tabstop>
   <tabstop>uploadSpinBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../resources/client.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>downloadLimitRadioButton</sender>

--- a/test/gui/tst_checkAlltabs/test.feature
+++ b/test/gui/tst_checkAlltabs/test.feature
@@ -29,7 +29,5 @@ Feature: Visually check all tabs
             | Log settings                                                         |
         And the settings tab should have the following options in the network section:
             | Proxy Settings     |
-            | Download Bandwidth |
-            | Upload Bandwidth   |
         When the user opens the about dialog
         Then the about dialog should be opened


### PR DESCRIPTION
Implement deprecation of bandwidth limits:
- when none are set, hide the UI
- when a limit is set, show the UI, including a warning icon and a text label warning about the deprecation