### PR TITLE
Mark string as non-translatable

### DIFF
--- a/src/gui/accountmodalwidget.ui
+++ b/src/gui/accountmodalwidget.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>GroupBox</string>
+      <string notr="true">placeholder</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2"/>
     </widget>


### PR DESCRIPTION
This string is replaced at runtime by the correct string. It is only in the UI file as a placeholder, showing that another string will be put in.