### PR TITLE
eliminate crash in EtagWatcher after removing an account.

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -629,10 +629,11 @@ void FolderMan::removeFolder(Folder *f)
     f->removeFromSettings();
 
     unloadFolder(f);
-    f->deleteLater();
 
     Q_EMIT folderRemoved(f);
     Q_EMIT folderListChanged();
+
+    f->deleteLater();
 }
 
 QString FolderMan::getBackupName(QString fullPathName) const

--- a/src/gui/scheduling/syncscheduler.cpp
+++ b/src/gui/scheduling/syncscheduler.cpp
@@ -103,6 +103,10 @@ private:
     std::unordered_map<Folder *, SyncScheduler::Priority> _scheduledFolders;
 };
 
+// Refactoring todo: I do not see where/how the syncs and etag watcher get updated when eg an account is removed.
+// the main dep here is on the FolderMan which means we rely on the folder list being updated and/or folders deleted
+// to disconnect this stuff, but afaik the accountStatePtr is ACTUALLY the first thing to go when an account is removed.
+// this scheduler/watcher combo needs deep investigation as it might be the source of "mysterious" crashes.
 SyncScheduler::SyncScheduler(FolderMan *parent)
     : QObject(parent)
     , _pauseSyncWhenMetered(ConfigFile().pauseSyncWhenMetered())


### PR DESCRIPTION
needs more refactoring but hopefully adding checks for null AccountState prevents crashes.

fixes #7187