### PR TITLE
[test-only][full-ci] Refactor tests to use normal account setup flow

### DIFF
--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -29,7 +29,7 @@ def substitute_inline_codes(value):
     return value
 
 
-def get_client_details(context):
+def get_client_details(details):
     client_details = {
         'server': '',
         'user': '',
@@ -37,7 +37,7 @@ def get_client_details(context):
         'sync_folder': '',
         'oauth': False,
     }
-    for row in context.table[0:]:
+    for row in details:
         row[1] = substitute_inline_codes(row[1])
         if row[0] == 'server':
             client_details.update({'server': row[1]})

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -37,6 +37,8 @@ def get_client_details(details):
         'sync_folder': '',
         'oauth': False,
     }
+    print(".......................................................")
+    print(details)
     for row in details:
         row[1] = substitute_inline_codes(row[1])
         if row[0] == 'server':

--- a/test/gui/shared/scripts/helpers/SetupClientHelper.py
+++ b/test/gui/shared/scripts/helpers/SetupClientHelper.py
@@ -37,8 +37,6 @@ def get_client_details(details):
         'sync_folder': '',
         'oauth': False,
     }
-    print(".......................................................")
-    print(details)
     for row in details:
         row[1] = substitute_inline_codes(row[1])
         if row[0] == 'server':

--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -60,7 +60,6 @@ SYNC_PATTERNS = {
             SYNC_STATUS['REGISTER'],
             SYNC_STATUS['UPDATE'],
             SYNC_STATUS['UPDATE'],
-            SYNC_STATUS['UPDATE'],
         ],
         # when syncing empty account (hidden files are ignored)
         [SYNC_STATUS['UPDATE'], SYNC_STATUS['OK']],

--- a/test/gui/shared/scripts/pageObjects/SyncConnection.py
+++ b/test/gui/shared/scripts/pageObjects/SyncConnection.py
@@ -2,6 +2,8 @@ import names
 import squish
 import object  # pylint: disable=redefined-builtin
 
+from helpers.ConfigHelper import get_config
+
 
 class SyncConnection:
     FOLDER_SYNC_CONNECTION_LIST = {
@@ -14,6 +16,12 @@ class SyncConnection:
         "name": "_folderList",
         "type": "QListView",
         "visible": 1,
+    }
+    FOLDER_SYNC_CONNECTION_LABEL = {
+        "container": names.quickWidget_scrollView_ScrollView,
+        "type": "Label",
+        "unnamed": 1,
+        "visible": True,
     }
     FOLDER_SYNC_CONNECTION_MENU_BUTTON = {
         "checkable": False,
@@ -55,15 +63,30 @@ class SyncConnection:
     }
 
     @staticmethod
-    def open_menu():
-        menu_button = squish.waitForObject(
-            SyncConnection.FOLDER_SYNC_CONNECTION_MENU_BUTTON
-        )
+    def open_menu(sync_folder=""):
+        if get_config("ocis") and not sync_folder:
+            sync_folder = "Personal"
+        elif not sync_folder:
+            sync_folder = "ownCloud"
+        selector = SyncConnection.FOLDER_SYNC_CONNECTION_LABEL.copy()
+        selector.update({"text": sync_folder})
+
+        menu_button = None
+
+        # get the parent of the sync folder label
+        parent = object.parent(
+            squish.waitForObject(selector)
+        ).parent.parent.parent.parent.parent
+        children = object.children(squish.waitForObject(parent))
+        for obj in children:
+            # get sync folder menu button
+            if obj.id == "moreButton":
+                menu_button = squish.waitForObject(obj)
         squish.mouseClick(menu_button)
 
     @staticmethod
-    def perform_action(action):
-        SyncConnection.open_menu()
+    def perform_action(action, sync_folder=""):
+        SyncConnection.open_menu(sync_folder)
         squish.activateItem(squish.waitForObjectItem(SyncConnection.MENU, action))
 
     @staticmethod
@@ -138,8 +161,8 @@ class SyncConnection:
         return squish.waitForObject(SyncConnection.FOLDER_SYNC_CONNECTION_LIST).count
 
     @staticmethod
-    def remove_folder_sync_connection():
-        SyncConnection.perform_action("Remove folder sync connection")
+    def remove_folder_sync_connection(sync_folder=""):
+        SyncConnection.perform_action("Remove folder sync connection", sync_folder)
 
     @staticmethod
     def cancel_folder_sync_connection_removal():

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -48,7 +48,9 @@ def step(context, displayname, host):
 @Given('user "|any|" has set up a client with default settings')
 def step(context, username):
     password = get_password_for_user(username)
-    account_details = get_client_details([['server', '%local_server%'], ['user', username], ['password', password]])
+    account_details = get_client_details(
+        [['server', '%local_server%'], ['user', username], ['password', password]]
+    )
     start_client()
     AccountConnectionWizard.add_account(account_details)
     # wait for files to sync
@@ -62,12 +64,16 @@ def step(context):
     for idx, row in enumerate(context.table):
         username = row[0]
         password = get_password_for_user(username)
-        account_details = get_client_details([['server', '%local_server%'], ['user', username], ['password', password]])
+        account_details = get_client_details(
+            [['server', '%local_server%'], ['user', username], ['password', password]]
+        )
         if idx > 0:
             Toolbar.open_new_account_setup()
         AccountConnectionWizard.add_account(account_details)
         # wait for files to sync
-        wait_for_initial_sync_to_complete(get_resource_path('/', account_details['user']))
+        wait_for_initial_sync_to_complete(
+            get_resource_path('/', account_details['user'])
+        )
 
 
 @Given('the user has started the client')

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -13,6 +13,7 @@ from helpers.SetupClientHelper import (
 from helpers.UserHelper import get_displayname_for_user, get_password_for_user
 from helpers.SyncHelper import (
     wait_for_initial_sync_to_complete,
+    listen_sync_status_for_item,
 )
 from helpers.ConfigHelper import get_config, is_windows, is_linux
 
@@ -84,6 +85,12 @@ def step(context):
 @When('the user starts the client')
 def step(context):
     start_client()
+
+
+@When('user "|any|" starts the client')
+def step(context, user):
+    start_client()
+    listen_sync_status_for_item(get_resource_path('/', user))
 
 
 @When('the user opens the add-account dialog')

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -51,8 +51,6 @@ def step(context, username):
     account_details = get_client_details(
         [['server', '%local_server%'], ['user', username], ['password', password]]
     )
-    print("....................")
-    print(account_details)
     start_client()
     AccountConnectionWizard.add_account(account_details)
     # wait for files to sync

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -109,7 +109,6 @@ def step(context):
 @Given('the user has entered the following account information:')
 def step(context):
     account_details = get_client_details(context.table)
-    print(account_details)
     AccountConnectionWizard.add_account_information(account_details)
 
 

--- a/test/gui/shared/steps/account_context.py
+++ b/test/gui/shared/steps/account_context.py
@@ -19,7 +19,7 @@ from helpers.ConfigHelper import get_config, is_windows, is_linux
 
 @When('the user adds the following user credentials:')
 def step(context):
-    account_details = get_client_details(context)
+    account_details = get_client_details(context.table)
     AccountConnectionWizard.add_user_credentials(
         account_details['user'], account_details['password']
     )
@@ -51,6 +51,8 @@ def step(context, username):
     account_details = get_client_details(
         [['server', '%local_server%'], ['user', username], ['password', password]]
     )
+    print("....................")
+    print(account_details)
     start_client()
     AccountConnectionWizard.add_account(account_details)
     # wait for files to sync
@@ -93,7 +95,7 @@ def step(context):
 
 @When('the user adds the following account:')
 def step(context):
-    account_details = get_client_details(context)
+    account_details = get_client_details(context.table)
     AccountConnectionWizard.add_account(account_details)
     # wait for files to sync
     wait_for_initial_sync_to_complete(get_resource_path('/', account_details['user']))
@@ -101,7 +103,8 @@ def step(context):
 
 @Given('the user has entered the following account information:')
 def step(context):
-    account_details = get_client_details(context)
+    account_details = get_client_details(context.table)
+    print(account_details)
     AccountConnectionWizard.add_account_information(account_details)
 
 
@@ -268,7 +271,7 @@ def step(context):
 
 @When('the user adds the following oauth2 account:')
 def step(context):
-    account_details = get_client_details(context)
+    account_details = get_client_details(context.table)
     account_details.update({'oauth': True})
     AccountConnectionWizard.add_account(account_details)
     # wait for files to sync

--- a/test/gui/shared/steps/spaces_context.py
+++ b/test/gui/shared/steps/spaces_context.py
@@ -1,8 +1,3 @@
-from pageObjects.EnterPassword import EnterPassword
-
-from helpers.UserHelper import get_password_for_user
-from helpers.SetupClientHelper import setup_client, get_resource_path
-from helpers.SyncHelper import wait_for_initial_sync_to_complete
 from helpers.SpaceHelper import (
     create_space,
     create_space_folder,
@@ -11,7 +6,6 @@ from helpers.SpaceHelper import (
     get_file_content,
     resource_exists,
 )
-from helpers.ConfigHelper import get_config
 
 
 @Given('the administrator has created a space "|any|"')
@@ -34,18 +28,6 @@ def step(context, file_name, content, space_name):
 @Given('the administrator has added user "|any|" to space "|any|" with role "|any|"')
 def step(context, user, space_name, role):
     add_user_to_space(user, space_name, role)
-
-
-@Given('user "|any|" has set up a client with space "|any|"')
-def step(context, user, space_name):
-    password = get_password_for_user(user)
-    setup_client(user, space_name)
-    enter_password = EnterPassword()
-    if get_config('ocis'):
-        enter_password.accept_certificate()
-    enter_password.login_after_setup(user, password)
-    # wait for files to sync
-    wait_for_initial_sync_to_complete(get_resource_path('/', user, space_name))
 
 
 @Then(

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -19,6 +19,11 @@ from helpers.SetupClientHelper import (
 )
 
 
+@When('using sync connection folder "|any|"')
+def step(context, sync_folder):
+    set_config('syncConnectionName', sync_folder)
+
+
 @Given('the user has paused the file sync')
 def step(context):
     SyncConnection.pause_sync()

--- a/test/gui/shared/steps/sync_context.py
+++ b/test/gui/shared/steps/sync_context.py
@@ -299,9 +299,9 @@ def step(context):
     SyncConnection.cancel_folder_sync_connection_removal()
 
 
-@When('the user removes the folder sync connection')
-def step(context):
-    SyncConnection.remove_folder_sync_connection()
+@When('the user removes the "|any|" folder sync connection')
+def step(context, sync_folder):
+    SyncConnection.remove_folder_sync_connection(sync_folder)
     SyncConnection.confirm_folder_sync_connection_removal()
 
 

--- a/test/gui/tst_activity/test.feature
+++ b/test/gui/tst_activity/test.feature
@@ -21,8 +21,8 @@ Feature: filter activity for user
 
     Scenario: filter not synced activities
         Given user "Alice" has been created in the server with default attributes
-        And user "Alice" has created a folder "Folder1" inside the sync folder
         And user "Alice" has set up a client with default settings
+        And user "Alice" has created a folder "Folder1" inside the sync folder
         When user "Alice" creates the following files inside the sync folder:
             | files             |
             | /.htaccess        |

--- a/test/gui/tst_sharing/test.feature
+++ b/test/gui/tst_sharing/test.feature
@@ -89,12 +89,12 @@ Feature: Sharing
         And user "Alice" has created folder "OwnFolder" in the server
         And user "Alice" has set up a client with default settings
         When the user opens the sharing dialog of "textfile.txt" using the client-UI
-        And the user selects "Alice Hansen" as collaborator of resource "textfile.txt" using the client-UI
-        Then the error "Can't share with yourself" should be displayed in the sharing dialog
+        And the user searches for collaborator with autocomplete characters "Alice Hansen" using the client-UI
+        Then the error "No results for 'Alice Hansen'" should be displayed in the sharing dialog
         When the user closes the sharing dialog
         And the user opens the sharing dialog of "OwnFolder" using the client-UI
-        And the user selects "Alice Hansen" as collaborator of resource "OwnFolder" using the client-UI
-        Then the error "Can't share with yourself" should be displayed in the sharing dialog
+        And the user searches for collaborator with autocomplete characters "Alice Hansen" using the client-UI
+        Then the error "No results for 'Alice Hansen'" should be displayed in the sharing dialog
         And the user closes the sharing dialog
 
 

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -13,7 +13,7 @@ Feature: Project spaces
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
-        And user "Alice" has set up a client with space "Project101"
+        And user "Alice" has set up a client with default settings
         Then user "Alice" should be able to open the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" should have content "some content" on the file system
 
@@ -22,7 +22,7 @@ Feature: Project spaces
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
-        And user "Alice" has set up a client with space "Project101"
+        And user "Alice" has set up a client with default settings
         Then user "Alice" should not be able to edit the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content" in the server
 
@@ -31,7 +31,7 @@ Feature: Project spaces
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
-        And user "Alice" has set up a client with space "Project101"
+        And user "Alice" has set up a client with default settings
         When the user overwrites the file "testfile.txt" with content "overwrite some content"
         And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
@@ -43,7 +43,7 @@ Feature: Project spaces
         Given the administrator has created a folder "planning" in space "Project101"
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "editor"
-        And user "Alice" has set up a client with space "Project101"
+        And user "Alice" has set up a client with default settings
         When the user overwrites the file "testfile.txt" with content "some content edited"
         And the user waits for file "testfile.txt" to be synced
         Then as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content edited" in the server
@@ -51,7 +51,7 @@ Feature: Project spaces
 
     Scenario: User with Manager role can add files and folders
         Given the administrator has added user "Alice" to space "Project101" with role "manager"
-        And user "Alice" has set up a client with space "Project101"
+        And user "Alice" has set up a client with default settings
         When user "Alice" creates a file "localFile.txt" with the following content inside the sync folder
             """
             test content

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -7,7 +7,6 @@ Feature: Project spaces
     Background:
         Given user "Alice" has been created in the server with default attributes
         And the administrator has created a space "Project101"
-        When using sync connection folder "Project101"
 
 
     Scenario: User with Viewer role can open the file
@@ -15,6 +14,7 @@ Feature: Project spaces
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with default settings
+        When using sync connection folder "Project101"
         Then user "Alice" should be able to open the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" should have content "some content" on the file system
 
@@ -24,6 +24,7 @@ Feature: Project spaces
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with default settings
+        When using sync connection folder "Project101"
         Then user "Alice" should not be able to edit the file "testfile.txt" on the file system
         And as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content" in the server
 
@@ -33,7 +34,8 @@ Feature: Project spaces
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "viewer"
         And user "Alice" has set up a client with default settings
-        When the user overwrites the file "testfile.txt" with content "overwrite some content"
+        When using sync connection folder "Project101"
+        And the user overwrites the file "testfile.txt" with content "overwrite some content"
         And the user clicks on the activity tab
         And the user selects "Not Synced" tab in the activity
         Then the file "testfile.txt" should be blacklisted
@@ -45,7 +47,8 @@ Feature: Project spaces
         And the administrator has uploaded a file "testfile.txt" with content "some content" inside space "Project101"
         And the administrator has added user "Alice" to space "Project101" with role "editor"
         And user "Alice" has set up a client with default settings
-        When the user overwrites the file "testfile.txt" with content "some content edited"
+        When using sync connection folder "Project101"
+        And the user overwrites the file "testfile.txt" with content "some content edited"
         And the user waits for file "testfile.txt" to be synced
         Then as "Alice" the file "testfile.txt" in the space "Project101" should have content "some content edited" in the server
 
@@ -53,7 +56,8 @@ Feature: Project spaces
     Scenario: User with Manager role can add files and folders
         Given the administrator has added user "Alice" to space "Project101" with role "manager"
         And user "Alice" has set up a client with default settings
-        When user "Alice" creates a file "localFile.txt" with the following content inside the sync folder
+        When using sync connection folder "Project101"
+        And user "Alice" creates a file "localFile.txt" with the following content inside the sync folder
             """
             test content
             """

--- a/test/gui/tst_spaces/test.feature
+++ b/test/gui/tst_spaces/test.feature
@@ -7,6 +7,7 @@ Feature: Project spaces
     Background:
         Given user "Alice" has been created in the server with default attributes
         And the administrator has created a space "Project101"
+        When using sync connection folder "Project101"
 
 
     Scenario: User with Viewer role can open the file

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -269,8 +269,8 @@ Feature: Syncing files
         Given user "Alice" has created a folder "Folder1" inside the sync folder
         And user "Alice" has created a folder "Folder1/subFolder1" inside the sync folder
         And user "Alice" has created a folder "Folder1/subFolder1/subFolder2" inside the sync folder
-        When the user starts the client
-        And the user waits for folder "Folder1/subFolder1/subFolder2" to be synced
+        When user "Alice" starts the client
+        And the user waits for the files to sync
         Then as "Alice" folder "Folder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist in the server

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -452,6 +452,7 @@ Feature: Syncing files
             | file2.txt | file   | Test file2 |
         And user "Alice" has set up a client with default settings
         When user "Alice" moves file "archive.zip" from the temp folder into the sync folder
+        And the user waits for the files to sync
         And user "Alice" unzips the zip file "archive.zip" inside the sync root
         And the user waits for the files to sync
         Then as "Alice" folder "folder1" should exist in the server

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -264,10 +264,13 @@ Feature: Syncing files
 
 
     Scenario: Verify pre existing folders in local (Desktop client) are copied over to the server
+        Given user "Alice" has set up a client with default settings
+        When the user quits the client
         Given user "Alice" has created a folder "Folder1" inside the sync folder
         And user "Alice" has created a folder "Folder1/subFolder1" inside the sync folder
         And user "Alice" has created a folder "Folder1/subFolder1/subFolder2" inside the sync folder
-        And user "Alice" has set up a client with default settings
+        When the user starts the client
+        And the user waits for folder "Folder1/subFolder1/subFolder2" to be synced
         Then as "Alice" folder "Folder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1" should exist in the server
         And as "Alice" folder "Folder1/subFolder1/subFolder2" should exist in the server

--- a/test/gui/tst_syncing/test.feature
+++ b/test/gui/tst_syncing/test.feature
@@ -492,13 +492,25 @@ Feature: Syncing files
         And the folder "test-folder/sub-folder2" should exist on the file system
         And the folder "test-folder/sub-folder1" should not exist on the file system
 
-    @issue-11814
-    Scenario: remove folder sync connection
+    @issue-11814 @skipOnOC10
+    Scenario: remove folder sync connection (oCIS)
         Given user "Alice" has created folder "simple-folder" in the server
         And user "Alice" has set up a client with default settings
         When the user selects remove folder sync connection option
         And the user cancels the folder sync connection removal dialog
-        And the user removes the folder sync connection
+        And the user removes the "Shares" folder sync connection
+        And the user removes the "Personal" folder sync connection
+        Then the sync folder list should be empty
+        And the folder "simple-folder" should exist on the file system
+        And as "Alice" folder "simple-folder" should exist in the server
+
+    @issue-11814 @skipOnOCIS
+    Scenario: remove folder sync connection (oC10)
+        Given user "Alice" has created folder "simple-folder" in the server
+        And user "Alice" has set up a client with default settings
+        When the user selects remove folder sync connection option
+        And the user cancels the folder sync connection removal dialog
+        And the user removes the "ownCloud" folder sync connection
         Then the sync folder list should be empty
         And the folder "simple-folder" should exist on the file system
         And as "Alice" folder "simple-folder" should exist in the server


### PR DESCRIPTION
This PR uses the full account setup in all the test scenarios and removes the use of incomplete config file when setting up account.

Fixes https://github.com/owncloud/client/issues/12136