### PR TITLE
Skip the selective sync page when VFS is forced

### DIFF
--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -23,6 +23,7 @@
 
 #include "account.h"
 #include "common/asserts.h"
+#include "common/vfs.h"
 #include "gui/application.h"
 #include "gui/settingsdialog.h"
 #include "theme.h"
@@ -74,21 +75,26 @@ FolderWizardPrivate::FolderWizardPrivate(FolderWizard *q, const AccountStatePtr 
     : q_ptr(q)
     , _account(account)
     , _folderWizardSourcePage(new FolderWizardLocalPath(this))
-    , _folderWizardSelectiveSyncPage(new FolderWizardSelectiveSync(this))
+    , _folderWizardSelectiveSyncPage(nullptr)
 {
     if (account->supportsSpaces()) {
         _spacesPage = new SpacesPage(account->account(), q);
         q->setPage(FolderWizard::Page_Space, _spacesPage);
     }
+
     q->setPage(FolderWizard::Page_Source, _folderWizardSourcePage);
 
-    // for now spaces are meant to be synced as a whole
     if (!_account->supportsSpaces() && !Theme::instance()->singleSyncFolder()) {
         _folderWizardTargetPage = new FolderWizardRemotePath(this);
         q->setPage(FolderWizard::Page_Target, _folderWizardTargetPage);
     }
 
-    q->setPage(FolderWizard::Page_SelectiveSync, _folderWizardSelectiveSyncPage);
+    // When VFS is available (currently only with Windows' CFApi), and it is forced on, Spaces are meant to be synced as a whole.
+    const bool showPage = VfsPluginManager::instance().bestAvailableVfsMode() != Vfs::WindowsCfApi || !Theme::instance()->forceVirtualFilesOption();
+    if (showPage) {
+        _folderWizardSelectiveSyncPage = new FolderWizardSelectiveSync(this);
+        q->setPage(FolderWizard::Page_SelectiveSync, _folderWizardSelectiveSyncPage);
+    }
 }
 
 QString FolderWizardPrivate::initialLocalPath() const
@@ -152,7 +158,7 @@ const AccountStatePtr &FolderWizardPrivate::accountState()
 bool FolderWizardPrivate::useVirtualFiles() const
 {
     const auto mode = VfsPluginManager::instance().bestAvailableVfsMode();
-    const bool useVirtualFiles = (Theme::instance()->forceVirtualFilesOption() && mode == Vfs::WindowsCfApi) || (_folderWizardSelectiveSyncPage->useVirtualFiles());
+    const bool useVirtualFiles = (Theme::instance()->forceVirtualFilesOption() && mode == Vfs::WindowsCfApi) || (_folderWizardSelectiveSyncPage && _folderWizardSelectiveSyncPage->useVirtualFiles());
     if (useVirtualFiles) {
         const auto availability = Vfs::checkAvailability(initialLocalPath(), mode);
         if (!availability) {
@@ -193,16 +199,18 @@ FolderMan::SyncConnectionDescription FolderWizard::result()
         }
     }
 
+    // clang-format off
     return {
-        d->davUrl(), //
-        d->spaceId(), //
-        localPath, //
-        d->remotePath(), //
-        d->displayName(), //
-        d->useVirtualFiles(), //
-        d->priority(), //
-        d->_folderWizardSelectiveSyncPage ? d->_folderWizardSelectiveSyncPage->selectiveSyncBlackList() : QSet<QString>{} //
+        d->davUrl(),
+        d->spaceId(),
+        localPath,
+        d->remotePath(),
+        d->displayName(),
+        d->useVirtualFiles(),
+        d->priority(),
+        d->_folderWizardSelectiveSyncPage ? d->_folderWizardSelectiveSyncPage->selectiveSyncBlackList() : QSet<QString>{}
     };
+    // clang-format on
 }
 
 } // end namespace


### PR DESCRIPTION
When VFS is forced on, all elements on this page are disabled: the checkbox to turn VFS off is disabled, and the selective sync chooser is also disabled. This can be very confusing to the user, so completely skip this page.

This also prevents a bug in this page from showing: if VFS is forced, the checkbox for disabling VFS is not shown. And when this checkbox is not shown, the selective sync widget is not disabled, allowing to do selective sync with VFS (forced) on.

Fixes: #12135
(cherry picked from commit 02544983b88ff27828bab30398928ee473e97dce)