### PR TITLE
[DC-10] fix: block creation of duplicate new account

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -279,6 +279,19 @@ QStringList AccountManager::accountNames() const
     return accountNames;
 }
 
+bool AccountManager::accountForLoginExists(const QUrl &url, const QString &davUser) const
+{
+    for (const auto &state : _accounts) {
+        if (state) {
+            AccountPtr account = state->account();
+            if (account && account->url() == url && account->davUser() == davUser) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 QList<AccountState *> AccountManager::accountsRaw() const
 {
     QList<AccountState *> out;

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -69,7 +69,7 @@ public:
     /**
      * Return a list of all accounts.
      */
-    const QList<AccountStatePtr> accounts() { return _accounts.values(); }
+    const QList<AccountStatePtr> accounts() const { return _accounts.values(); }
 
     /**
      * Return the account state pointer for an account identified by its display name
@@ -97,6 +97,8 @@ public:
      * Returns a sorted list of displayNames
      */
     QStringList accountNames() const;
+
+    bool accountForLoginExists(const QUrl &url, const QString &davUser) const;
 
 private:
     // expose raw pointers to qml

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -1,5 +1,6 @@
 #include "setupwizardcontroller.h"
 
+#include "gui/accountmanager.h"
 #include "gui/application.h"
 #include "pages/accountconfiguredwizardpage.h"
 #include "states/abstractsetupwizardstate.h"
@@ -184,9 +185,15 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState, ChangeReas
             connect(fetchUserInfoJob, &CoreJob::finished, this, [this, fetchUserInfoJob] {
                 if (fetchUserInfoJob->success()) {
                     auto result = fetchUserInfoJob->result().value<FetchUserInfoResult>();
-                    _context->accountBuilder().setDisplayName(result.displayName());
-                    _context->accountBuilder().authenticationStrategy()->setDavUser(result.userName());
-                    changeStateTo(SetupWizardState::AccountConfiguredState);
+
+                    if (AccountManager::instance()->accountForLoginExists(_context->accountBuilder().serverUrl(), result.userName())) {
+                        _context->window()->showErrorMessage(tr("You are already connected to an account with these credentials"));
+                        changeStateTo(_currentState->state());
+                    } else {
+                        _context->accountBuilder().setDisplayName(result.displayName());
+                        _context->accountBuilder().authenticationStrategy()->setDavUser(result.userName());
+                        changeStateTo(SetupWizardState::AccountConfiguredState);
+                    }
                 } else if (fetchUserInfoJob->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
                     _context->window()->showErrorMessage(tr("Invalid credentials"));
                     changeStateTo(_currentState->state());
@@ -205,6 +212,7 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState, ChangeReas
             // impls that is a big code smell that indicates your abstraction is faulty
             const auto *pagePtr = qobject_cast<AccountConfiguredWizardPage *>(_currentState->page());
             Q_ASSERT(pagePtr);
+
             auto account = _context->accountBuilder().build();
             Q_ASSERT(account != nullptr);
             if (pagePtr && account) {

--- a/src/gui/newwizard/setupwizardcontroller.cpp
+++ b/src/gui/newwizard/setupwizardcontroller.cpp
@@ -187,7 +187,7 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState, ChangeReas
                     auto result = fetchUserInfoJob->result().value<FetchUserInfoResult>();
 
                     if (AccountManager::instance()->accountForLoginExists(_context->accountBuilder().serverUrl(), result.userName())) {
-                        _context->window()->showErrorMessage(tr("You are already connected to an account with these credentials"));
+                        _context->window()->showErrorMessage(tr("You are already connected to an account with these credentials."));
                         changeStateTo(_currentState->state());
                     } else {
                         _context->accountBuilder().setDisplayName(result.displayName());
@@ -195,10 +195,10 @@ void SetupWizardController::changeStateTo(SetupWizardState nextState, ChangeReas
                         changeStateTo(SetupWizardState::AccountConfiguredState);
                     }
                 } else if (fetchUserInfoJob->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 401) {
-                    _context->window()->showErrorMessage(tr("Invalid credentials"));
+                    _context->window()->showErrorMessage(tr("Invalid credentials."));
                     changeStateTo(_currentState->state());
                 } else {
-                    _context->window()->showErrorMessage(tr("Failed to retrieve user information from server"));
+                    _context->window()->showErrorMessage(tr("Failed to retrieve user information from server."));
                     changeStateTo(_currentState->state());
                 }
             });


### PR DESCRIPTION
block creation of account if an account with the same url and davUser already exists in the account manager