### PR TITLE
[DC-37] chore: remove qa safety net for fake configs

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -24,8 +24,6 @@
 #include <QObject>
 #include <QQueue>
 
-class TestFolderMigration;
-
 namespace OCC {
 
 class FolderMan;
@@ -411,9 +409,6 @@ private:
     // tests folder def for minimum reqs
     bool validateFolderDefinition(const FolderDefinition &folderDefinition);
 
-    /// \returns true of the FolderDefinition was migrated, false if it was unchanged
-    bool migrateFolderDefinition(FolderDefinition &folderDef, AccountStatePtr account);
-
     /** Connects a folder instance, provided it has no setup errors
      */
     void connectFolder(Folder *folder);
@@ -471,7 +466,6 @@ private:
 
     static FolderMan *_instance;
     friend class OCC::Application;
-    friend class ::TestFolderMigration;
 };
 
 } // namespace OCC

--- a/src/libsync/determineauthtypejobfactory.cpp
+++ b/src/libsync/determineauthtypejobfactory.cpp
@@ -65,7 +65,7 @@ CoreJob *DetermineAuthTypeJobFactory::startJob(const QUrl &url, QObject *parent)
                 if (authChallenge.isEmpty()) {
                     qCWarning(lcDetermineAuthTypeJob) << "Did not receive WWW-Authenticate reply to auth-test PROPFIND";
                 }
-
+                // todo: #18 - if not OAuth this should most likely be Unknown
                 return AuthType::Basic;
             }
         }();


### PR DESCRIPTION
remove folder migration which only supported incomplete/faked config used by squish tests in the past

also added a future todo to determineauthtypejobfactory.cpp