### PR TITLE
[tests-only][full-ci] fix remove account connection for windows

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -189,9 +189,10 @@ def teardown_client():
         # so to work around that, remove the account connection
         close_dialogs()
         close_widgets()
-        accounts, _ = Toolbar.get_accounts()
-        for account in accounts:
-            Toolbar.open_account(account["displayname"])
+        accounts, selectors = Toolbar.get_accounts()
+        for display_name in selectors.values():
+            _, account_objects = Toolbar.get_accounts()
+            squish.mouseClick(squish.waitForObject(account_objects[display_name]))
             AccountSetting.remove_account_connection()
         if accounts:
             squish.waitForObject(AccountConnectionWizard.SERVER_ADDRESS_BOX)

--- a/test/gui/shared/scripts/pageObjects/Toolbar.py
+++ b/test/gui/shared/scripts/pageObjects/Toolbar.py
@@ -130,7 +130,7 @@ class Toolbar:
                 account_locator.update({"text": account_info["hostname"]})
 
                 accounts[account_info["displayname"]] = account_info
-                selectors[account_info["displayname"]] = account_locator
+                selectors[account_info["displayname"]] = obj
                 account_idx += 1
         return accounts, selectors
 
@@ -150,7 +150,7 @@ class Toolbar:
     @staticmethod
     def account_has_focus(display_name):
         account, selector = Toolbar.get_account(display_name)
-        return account["current"] and squish.waitForObjectExists(selector).checked
+        return account["current"] and squish.waitForObject(selector).checked
 
     @staticmethod
     def account_exists(display_name):
@@ -161,4 +161,4 @@ class Toolbar:
             and account["displayname"] != display_name
         ):
             raise LookupError(f'Account "{display_name}" does not exist')
-        squish.waitForObjectExists(selector)
+        squish.waitForObject(selector)


### PR DESCRIPTION
### Desctiption
The accounts tab in the desktop client does not contain the display name. In windows during clean up of users, account connection need to be removed, and the selector used the display name which resulted in failure to remove the users. This PR fixes this problem in windows.