### PR TITLE
[tests-only][full-ci] fix cleanup user account in windows

### DIFF
--- a/test/gui/shared/scripts/bdd_hooks.py
+++ b/test/gui/shared/scripts/bdd_hooks.py
@@ -190,7 +190,7 @@ def teardown_client():
         close_dialogs()
         close_widgets()
         accounts, selectors = Toolbar.get_accounts()
-        for display_name in selectors.values():
+        for display_name in selectors:
             _, account_objects = Toolbar.get_accounts()
             squish.mouseClick(squish.waitForObject(account_objects[display_name]))
             AccountSetting.remove_account_connection()


### PR DESCRIPTION
### Description
Fixes the selector while selecting the account from toolbar during user account cleanup in windows.

Follow up of PR: https://github.com/owncloud/client/pull/12160
