### PR TITLE
[tests-only][full-ci] add missing cache envs - fix notification

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -411,6 +411,8 @@ def notification():
             "name": "notify-matrix",
             "image": OC_CI_ALPINE,
             "environment": {
+                "CACHE_ENDPOINT": S3_PUBLIC_CACHE_SERVER,
+                "CACHE_BUCKET": S3_PUBLIC_CACHE_BUCKET,
                 "MATRIX_TOKEN": {
                     "from_secret": "matrix_token",
                 },


### PR DESCRIPTION
### Description
This PR https://github.com/owncloud/client/pull/12173, missed the environment releated to cache due to which the notification missed the failed logs in the message notification. This PR adds the missing envs.