### PR TITLE
Unpin icoutils

### DIFF
--- a/.craft.shelf
+++ b/.craft.shelf
@@ -26,9 +26,6 @@ version = latest
 [dev-utils/cmake-base]
 version = 3.30.0
 
-[dev-utils/icoutils]
-version = 0.32.3
-
 [dev-utils/jom]
 version = 1_1_3
 


### PR DESCRIPTION
This package is only used on Windows, and therefore only ends up in the cache for Windows. However, it was also pulled in for release builds on Linux (uncached), because of being in the shelf file.