### PR TITLE
ci: no hard coded branch names in transifex workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
           submodules: recursive
-          ref: "6"
 
       - name: install-deps
         run: sudo apt install -y qt6-l10n-tools


### PR DESCRIPTION
both git actions need to work on the same branch - to allow choosing the branch no branch names shall be hard coded 