### PR TITLE
[DC-82] Fix: delete account-specific caches when an account is removed

### DIFF
--- a/changelog/unreleased/12224.md
+++ b/changelog/unreleased/12224.md
@@ -1,0 +1,5 @@
+Bugfix: Delete account-specific caches when an account is removed
+
+This includes the cache for space images, as well as certain cached network jobs.
+
+https://github.com/owncloud/client/pull/12224

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -410,9 +410,6 @@ void AccountManager::deleteAccount(AccountStatePtr account)
 
     _accounts.remove(account->account()->uuid());
 
-    // Abort any pending jobs: the account credentials are invalidated.
-    account->account()->jobQueue()->clear();
-
     if (account->account()->hasDefaultSyncRoot()) {
         Utility::unmarkDirectoryAsSyncRoot(account->account()->defaultSyncRoot());
     }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -410,7 +410,8 @@ void AccountManager::deleteAccount(AccountStatePtr account)
 
     _accounts.remove(account->account()->uuid());
 
-    account->account()->cleanupForRemoval();
+    // Abort any pending jobs: the account credentials are invalidated.
+    account->account()->jobQueue()->clear();
 
     if (account->account()->hasDefaultSyncRoot()) {
         Utility::unmarkDirectoryAsSyncRoot(account->account()->defaultSyncRoot());
@@ -427,6 +428,8 @@ void AccountManager::deleteAccount(AccountStatePtr account)
     // better than having these calls at the start.
     Q_EMIT accountRemoved(account);
     Q_EMIT accountsChanged();
+
+    account->account()->cleanupForRemoval();
 
     account->deleteLater();
 }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -410,6 +410,8 @@ void AccountManager::deleteAccount(AccountStatePtr account)
 
     _accounts.remove(account->account()->uuid());
 
+    account->account()->cleanupForRemoval();
+
     if (account->account()->hasDefaultSyncRoot()) {
         Utility::unmarkDirectoryAsSyncRoot(account->account()->defaultSyncRoot());
     }

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -94,7 +94,10 @@ Account::~Account()
 
 void Account::cleanupForRemoval()
 {
-    // Stop the spaces manager, because it might have resource jobs running that use the resource cache.
+    // Abort any pending jobs: the account credentials are invalidated.
+    jobQueue()->clear();
+
+    // Stop the spaces manager, because it might start a new `Drives` job before the account is deleted.
     if (_spacesManager) {
         delete _spacesManager;
         _spacesManager = nullptr;

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -94,15 +94,19 @@ Account::~Account()
 
 void Account::cleanupForRemoval()
 {
-    // First stop the resource cache (including any pending jobs), because this uses the cache directory
+    // Stop the spaces manager, because it might have resource jobs running that use the resource cache.
+    if (_spacesManager) {
+        delete _spacesManager;
+        _spacesManager = nullptr;
+    }
+
+    // Stop the resource cache (including any pending jobs), because this uses the cache directory.
     delete _resourcesCache;
+    _resourcesCache = nullptr;
 
     if (!QDir(_cacheDirectory).removeRecursively()) {
         qCWarning(lcAccount) << "Cache directory" << _cacheDirectory << "was not fully removed";
     }
-
-    // Abort any pending jobs: the account credentials are about to be invalidated.
-    _jobQueue.clear();
 }
 
 QString Account::davPath() const

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -92,6 +92,19 @@ Account::~Account()
 {
 }
 
+void Account::cleanupForRemoval()
+{
+    // First stop the resource cache (including any pending jobs), because this uses the cache directory
+    delete _resourcesCache;
+
+    if (!QDir(_cacheDirectory).removeRecursively()) {
+        qCWarning(lcAccount) << "Cache directory" << _cacheDirectory << "was not fully removed";
+    }
+
+    // Abort any pending jobs: the account credentials are about to be invalidated.
+    _jobQueue.clear();
+}
+
 QString Account::davPath() const
 {
     return QLatin1String("/remote.php/dav/files/") + davUser() + QLatin1Char('/');

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -92,6 +92,8 @@ public:
     static AccountPtr create(const QUuid &uuid);
     ~Account() override;
 
+    void cleanupForRemoval();
+
     AccountPtr sharedFromThis();
 
     /**

--- a/src/libsync/graphapi/space.cpp
+++ b/src/libsync/graphapi/space.cpp
@@ -156,10 +156,7 @@ void SpaceImage::update()
 
         _etag = newEtag;
         _url = QUrl(img->getWebDavUrl());
-        // issue 12057: I am leaving the space as the parent of the job just to avoid having confusion about "new" destructor crashes. At least
-        // we'll get any future crashes on the space still. I don't think that changing the parent is going to eliminate the associate crash - save
-        // this for a future refactoring
-        auto job = _space->_spaceManager->account()->resourcesCache()->makeGetJob(_url, {}, _space);
+        auto job = _space->_spaceManager->account()->resourcesCache()->makeGetJob(_url);
 
         // TODO: next problem = this routine is correctly run when the icon has changed on the server, but the icon in the gui does not get refreshed!
         // The icon IS in the app cache, so it seems to have been brought back from the server correctly, but it is not shown until restart

--- a/src/libsync/graphapi/space.cpp
+++ b/src/libsync/graphapi/space.cpp
@@ -156,7 +156,7 @@ void SpaceImage::update()
 
         _etag = newEtag;
         _url = QUrl(img->getWebDavUrl());
-        auto job = _space->_spaceManager->account()->resourcesCache()->makeGetJob(_url);
+        auto job = _space->_spaceManager->account()->resourcesCache()->makeGetJob(_url, this);
 
         // TODO: next problem = this routine is correctly run when the icon has changed on the server, but the icon in the gui does not get refreshed!
         // The icon IS in the app cache, so it seems to have been brought back from the server correctly, but it is not shown until restart
@@ -165,6 +165,7 @@ void SpaceImage::update()
         QObject::connect(job, &SimpleNetworkJob::finishedSignal, _space, [job, this] {
             if (job->httpStatusCode() == 200) {
                 _image = job->asIcon();
+                job->deleteLater();
                 Q_EMIT imageChanged();
             }
         });

--- a/src/libsync/networkjobs/resources.cpp
+++ b/src/libsync/networkjobs/resources.cpp
@@ -81,8 +81,8 @@ QIcon ResourceJob::asIcon() const
     return QIcon(_cache->path(_cacheKey));
 }
 
-ResourceJob::ResourceJob(const ResourcesCache *cache, const QUrl &rootUrl, const QString &path, QObject *parent)
-    : SimpleNetworkJob(cache->account()->sharedFromThis(), rootUrl, path, "GET", {}, {}, parent)
+ResourceJob::ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path)
+    : SimpleNetworkJob(cache->account()->sharedFromThis(), rootUrl, path, "GET", {}, {}, cache)
     , _cache(cache)
 {
     setStoreInCache(true);
@@ -96,14 +96,9 @@ ResourcesCache::ResourcesCache(const QString &cacheDirectory, Account *account)
     Q_ASSERT(_cacheDirectory.isValid());
 }
 
-ResourceJob *ResourcesCache::makeGetJob(const QUrl &rootUrl, const QString &path, QObject *parent) const
+ResourceJob *ResourcesCache::makeGetJob(const QUrl &rootUrl)
 {
-    return new ResourceJob(this, rootUrl, path, parent);
-}
-
-ResourceJob *ResourcesCache::makeGetJob(const QString &path, QObject *parent) const
-{
-    return makeGetJob(_account->url(), path, parent);
+    return new ResourceJob(this, rootUrl, {});
 }
 
 Account *ResourcesCache::account() const

--- a/src/libsync/networkjobs/resources.cpp
+++ b/src/libsync/networkjobs/resources.cpp
@@ -81,8 +81,8 @@ QIcon ResourceJob::asIcon() const
     return QIcon(_cache->path(_cacheKey));
 }
 
-ResourceJob::ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path)
-    : SimpleNetworkJob(cache->account()->sharedFromThis(), rootUrl, path, "GET", {}, {}, cache)
+ResourceJob::ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path, QObject *parent)
+    : SimpleNetworkJob(cache->account()->sharedFromThis(), rootUrl, path, "GET", {}, {}, parent)
     , _cache(cache)
 {
     setStoreInCache(true);
@@ -96,9 +96,9 @@ ResourcesCache::ResourcesCache(const QString &cacheDirectory, Account *account)
     Q_ASSERT(_cacheDirectory.isValid());
 }
 
-ResourceJob *ResourcesCache::makeGetJob(const QUrl &rootUrl)
+ResourceJob *ResourcesCache::makeGetJob(const QUrl &rootUrl, QObject *parent)
 {
-    return new ResourceJob(this, rootUrl, {});
+    return new ResourceJob(this, rootUrl, {}, parent);
 }
 
 Account *ResourcesCache::account() const

--- a/src/libsync/networkjobs/resources.h
+++ b/src/libsync/networkjobs/resources.h
@@ -23,7 +23,7 @@ public:
     QIcon asIcon() const;
 
 protected:
-    explicit ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path);
+    explicit ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path, QObject *parent);
 
 private:
     const ResourcesCache *_cache;
@@ -48,9 +48,9 @@ public:
     /**
      * Create a simple get job, but store the result in the cache.
      *
-     * Note: because this job uses the cache, it's parent is the cache.
+     * Note: the caller is responsible for deleting the job.
      */
-    ResourceJob *makeGetJob(const QUrl &url);
+    ResourceJob *makeGetJob(const QUrl &url, QObject *parent);
 
     Account *account() const;
 

--- a/src/libsync/networkjobs/resources.h
+++ b/src/libsync/networkjobs/resources.h
@@ -23,7 +23,7 @@ public:
     QIcon asIcon() const;
 
 protected:
-    explicit ResourceJob(const ResourcesCache *cache, const QUrl &rootUrl, const QString &path, QObject *parent);
+    explicit ResourceJob(ResourcesCache *cache, const QUrl &rootUrl, const QString &path);
 
 private:
     const ResourcesCache *_cache;
@@ -45,9 +45,12 @@ public:
      */
     explicit ResourcesCache(const QString &cacheDirectory, Account *account);
 
-    ResourceJob *makeGetJob(const QUrl &rootUrl, const QString &path, QObject *parent) const;
-
-    ResourceJob *makeGetJob(const QString &path, QObject *parent) const;
+    /**
+     * Create a simple get job, but store the result in the cache.
+     *
+     * Note: because this job uses the cache, it's parent is the cache.
+     */
+    ResourceJob *makeGetJob(const QUrl &url);
 
     Account *account() const;
 


### PR DESCRIPTION
This includes the cache for space images, as well as certain cached network jobs.