### PR TITLE
Cleanup the cookie jar

### DIFF
--- a/src/libsync/cookiejar.cpp
+++ b/src/libsync/cookiejar.cpp
@@ -17,6 +17,7 @@
 // todo: #31
 
 #include <QLoggingCategory>
+#include <QNetworkCookie>
 
 namespace OCC {
 
@@ -29,6 +30,13 @@ CookieJar::CookieJar(QObject *parent)
 
 CookieJar::~CookieJar()
 {
+}
+
+CookieJar *CookieJar::clone(QObject *parent)
+{
+    auto newJar = new CookieJar(parent);
+    newJar->setAllCookies(allCookies());
+    return newJar;
 }
 
 } // namespace OCC

--- a/src/libsync/cookiejar.h
+++ b/src/libsync/cookiejar.h
@@ -22,7 +22,7 @@
 namespace OCC {
 
 /**
- * @brief The CookieJar class
+ * @brief A clonable cookie jar. This can be used when we don't want to spoil the original cookie jar.
  * @ingroup libsync
  */
 class OWNCLOUDSYNC_EXPORT CookieJar : public QNetworkCookieJar
@@ -32,8 +32,10 @@ public:
     explicit CookieJar(QObject *parent = nullptr);
     ~CookieJar() override;
 
-    using QNetworkCookieJar::setAllCookies;
-    using QNetworkCookieJar::allCookies;
+    /**
+     * Return a clone of this cookie jar, with a copy of all cookies.
+     */
+    CookieJar *clone(QObject *parent = nullptr);
 };
 
 } // namespace OCC

--- a/src/libsync/networkjobs/checkserverjobfactory.cpp
+++ b/src/libsync/networkjobs/checkserverjobfactory.cpp
@@ -76,8 +76,8 @@ CheckServerJobFactory CheckServerJobFactory::createFromAccount(const AccountPtr 
     nam->setParent(parent);
     // do we start with the old cookies or new
     if (!(clearCookies && Theme::instance()->connectionValidatorClearCookies())) {
-        const auto accountCookies = account->accessManager()->ownCloudCookieJar()->allCookies();
-        nam->ownCloudCookieJar()->setAllCookies(accountCookies);
+        const auto newJar = account->accessManager()->ownCloudCookieJar()->clone();
+        nam->setCookieJar(newJar);
     }
     return CheckServerJobFactory(nam);
 }


### PR DESCRIPTION
And make it clear why this class exists: so we can clone it for cases where we don't want to spoil the original jar.