### PR TITLE
Remove `AccountStatePtr`

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -285,7 +285,7 @@ void AccountManager::saveAccount(Account *account, bool saveCredentials)
     settings->endGroup();
 
     // save the account state but only if it actually exists!!!
-    AccountStatePtr state = accountState(account->uuid());
+    AccountState *state = accountState(account->uuid());
     if (state) {
         state->writeToSettings(*settings);
     }
@@ -319,7 +319,7 @@ bool AccountManager::accountForLoginExists(const QUrl &url, const QString &davUs
     return false;
 }
 
-QList<AccountState *> AccountManager::accountsRaw() const
+const QList<AccountState *> AccountManager::accounts() const
 {
     return _accounts.values();
 }
@@ -363,22 +363,22 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     return acc;
 }
 
-AccountStatePtr AccountManager::account(const QString &name)
+AccountState *AccountManager::account(const QString &name)
 {
     for (const auto &acc : std::as_const(_accounts)) {
         if (acc->account()->displayNameWithHost() == name) {
             return acc;
         }
     }
-    return AccountStatePtr();
+    return nullptr;
 }
 
-AccountStatePtr AccountManager::accountState(const QUuid uuid)
+AccountState *AccountManager::accountState(const QUuid uuid)
 {
     return _accounts.value(uuid);
 }
 
-AccountStatePtr AccountManager::addAccount(const AccountPtr &newAccount)
+AccountState *AccountManager::addAccount(const AccountPtr &newAccount)
 {
     auto id = newAccount->id();
     if (id.isEmpty() || !isAccountIdAvailable(id)) {
@@ -389,7 +389,7 @@ AccountStatePtr AccountManager::addAccount(const AccountPtr &newAccount)
     return addAccountState(AccountState::fromNewAccount(newAccount));
 }
 
-void AccountManager::deleteAccount(AccountStatePtr account)
+void AccountManager::deleteAccount(AccountState *account)
 {
     // do these notifications asap so anyone trying to use the account stops doing that
     // unfortunately, if we call these early, the "button" for the account is never removed, and if it's the last
@@ -448,16 +448,6 @@ void AccountManager::shutdown()
     }
 }
 
-const QList<AccountStatePtr> AccountManager::accounts() const
-{
-    QList<AccountStatePtr> ptrs;
-    ptrs.reserve(_accounts.size());
-    for (AccountState *acc : _accounts) {
-        ptrs.append(acc);
-    }
-    return ptrs;
-}
-
 bool AccountManager::isAccountIdAvailable(const QString &id) const
 {
     for (const auto &acc : _accounts) {
@@ -482,9 +472,9 @@ QString AccountManager::generateFreeAccountId() const
     }
 }
 
-AccountStatePtr AccountManager::addAccountState(std::unique_ptr<AccountState> &&accountState)
+AccountState *AccountManager::addAccountState(std::unique_ptr<AccountState> &&accountState)
 {
-    AccountStatePtr statePtr = accountState.release();
+    AccountState *statePtr = accountState.release();
     if (!statePtr) // just bail. I have no idea why this is happening but fine. it's null and not usable
         return statePtr;
 

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -34,7 +34,7 @@ namespace OCC {
 class OWNCLOUDGUI_EXPORT AccountManager : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QList<AccountState *> accounts READ accountsRaw() NOTIFY accountsChanged)
+    Q_PROPERTY(QList<AccountState *> accounts READ accounts() NOTIFY accountsChanged)
     QML_SINGLETON
     QML_ELEMENT
 public:
@@ -68,7 +68,7 @@ public:
      * Typically called from the wizard
      */
     // todo: #28 - this should not be public and should not be called directly by any third party
-    AccountStatePtr addAccount(const AccountPtr &newAccount);
+    AccountState *addAccount(const AccountPtr &newAccount);
 
     /**
      * remove all accounts
@@ -78,22 +78,22 @@ public:
     /**
      * Return a list of all accounts.
      */
-    const QList<AccountStatePtr> accounts() const;
+    const QList<AccountState *> accounts() const;
 
     /**
      * Return the account state pointer for an account identified by its display name
      */
-    Q_DECL_DEPRECATED_X("Please use the uuid to specify the account") AccountStatePtr account(const QString &name);
+    Q_DECL_DEPRECATED_X("Please use the uuid to specify the account") AccountState *account(const QString &name);
 
     /**
      * Return the accountState state pointer for an accountState identified by its display name
      */
-    AccountStatePtr accountState(const QUuid uuid);
+    AccountState *accountState(const QUuid uuid);
 
     /**
      * Delete the AccountState
      */
-    void deleteAccount(AccountStatePtr account);
+    void deleteAccount(AccountState *account);
 
 
     /**
@@ -113,9 +113,6 @@ public:
     bool accountForLoginExists(const QUrl &url, const QString &davUser) const;
 
 private:
-    // expose raw pointers to qml
-    QList<AccountState *> accountsRaw() const;
-
     // saving and loading Account to settings
     void saveAccountHelper(Account *account, QSettings &settings, bool saveCredentials = true);
     AccountPtr loadAccountHelper(QSettings &settings);
@@ -126,15 +123,15 @@ private:
     QString generateFreeAccountId() const;
 
     // Adds an account to the tracked list, emitting accountAdded()
-    AccountStatePtr addAccountState(std::unique_ptr<AccountState> &&accountState);
+    AccountState *addAccountState(std::unique_ptr<AccountState> &&accountState);
 
 public Q_SLOTS:
     /// Saves account data, not including the credentials
     void saveAccount(Account *account, bool saveCredentials);
 
 Q_SIGNALS:
-    void accountAdded(AccountStatePtr account);
-    void accountRemoved(AccountStatePtr account);
+    void accountAdded(AccountState *account);
+    void accountRemoved(AccountState *account);
     void lastAccountRemoved();
 
     // this signal is not formally connected anywhere, but it's used on the Q_PROPERTY declared for "accounts" above

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -60,7 +60,7 @@ Q_LOGGING_CATEGORY(lcAccountSettings, "gui.account.settings", QtInfoMsg)
 // also ditch the lambdas which should actually be functions (private if necessary)
 // Also refactoring todo: split the controller behavior out into a controller. A widget should NOT contain
 // business or controller logic!
-AccountSettings::AccountSettings(const AccountStatePtr &accountState, QWidget *parent)
+AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::AccountSettings)
     , _wasDisabledBefore(false)

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -61,7 +61,7 @@ public:
     enum class ModalWidgetSizePolicy { Minimum = QSizePolicy::Minimum, Expanding = QSizePolicy::Expanding };
     Q_ENUM(ModalWidgetSizePolicy)
 
-    explicit AccountSettings(const AccountStatePtr &accountState, QWidget *parent = nullptr);
+    explicit AccountSettings(AccountState *accountState, QWidget *parent = nullptr);
     ~AccountSettings() override;
 
     void addModalLegacyDialog(QWidget *widget, ModalWidgetSizePolicy sizePolicy);
@@ -113,7 +113,7 @@ private:
     FolderStatusModel *_model;
     QSortFilterProxyModel *_sortModel;
     bool _wasDisabledBefore;
-    AccountStatePtr _accountState;
+    QPointer<AccountState> _accountState;
     // are we already in the destructor
     bool _goingDown = false;
     uint _syncedSpaces = 0;

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -234,4 +234,3 @@ private:
 }
 
 Q_DECLARE_METATYPE(OCC::AccountState *)
-Q_DECLARE_METATYPE(OCC::AccountStatePtr)

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -81,7 +81,7 @@ ActivityWidget::ActivityWidget(QWidget *parent)
     connect(_model, &ActivityListModel::activityJobStatusCode,
         this, &ActivityWidget::slotAccountActivityStatus);
 
-    connect(AccountManager::instance(), &AccountManager::accountRemoved, this, [this](AccountStatePtr ast) {
+    connect(AccountManager::instance(), &AccountManager::accountRemoved, this, [this](AccountState *ast) {
         if (_accountsWithoutActivities.remove(ast->account()->displayNameWithHost())) {
             showLabels();
         }
@@ -117,12 +117,12 @@ ActivityWidget::~ActivityWidget()
     delete _ui;
 }
 
-void ActivityWidget::slotRefreshActivities(const AccountStatePtr &ptr)
+void ActivityWidget::slotRefreshActivities(AccountState *ptr)
 {
     _model->slotRefreshActivity(ptr);
 }
 
-void ActivityWidget::slotRefreshNotifications(const AccountStatePtr &ptr)
+void ActivityWidget::slotRefreshNotifications(AccountState *ptr)
 {
     // start a server notification handler if no notification requests
     // are running
@@ -137,7 +137,7 @@ void ActivityWidget::slotRefreshNotifications(const AccountStatePtr &ptr)
     }
 }
 
-void ActivityWidget::slotRemoveAccount(const AccountStatePtr &ptr)
+void ActivityWidget::slotRemoveAccount(AccountState *ptr)
 {
     _model->slotRemoveAccount(ptr);
 }
@@ -155,7 +155,7 @@ void ActivityWidget::showLabels()
     _ui->_bottomLabel->setText(bottomText);
 }
 
-void ActivityWidget::slotAccountActivityStatus(AccountStatePtr ast, int statusCode)
+void ActivityWidget::slotAccountActivityStatus(AccountState *ast, int statusCode)
 {
     if (!(ast && ast->account())) {
         return;
@@ -485,7 +485,7 @@ ActivitySettings::ActivitySettings(QWidget *parent)
     _tab->setCurrentIndex(1);
 
     connect(AccountManager::instance(), &AccountManager::accountRemoved, this,
-        [this](const AccountStatePtr &accountStatePtr) { _timeSinceLastCheck.take(accountStatePtr); });
+        [this](AccountState *accountStatePtr) { _timeSinceLastCheck.take(accountStatePtr); });
 }
 
 void ActivitySettings::setNotificationRefreshInterval(std::chrono::milliseconds interval)
@@ -534,12 +534,12 @@ void ActivitySettings::slotShowIssuesTab()
     _tab->setCurrentIndex(_syncIssueTabId);
 }
 
-void ActivitySettings::slotRemoveAccount(const AccountStatePtr &ptr)
+void ActivitySettings::slotRemoveAccount(AccountState *ptr)
 {
     _activityWidget->slotRemoveAccount(ptr);
 }
 
-void ActivitySettings::slotRefresh(AccountStatePtr ptr)
+void ActivitySettings::slotRefresh(AccountState *ptr)
 {
     // QElapsedTimer isn't actually constructed as invalid.
     if (!_timeSinceLastCheck.contains(ptr)) {

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -73,10 +73,10 @@ public:
     void checkActivityTabVisibility();
 
 public Q_SLOTS:
-    void slotRefreshActivities(const AccountStatePtr &ptr);
-    void slotRefreshNotifications(const AccountStatePtr &ptr);
-    void slotRemoveAccount(const AccountStatePtr &ptr);
-    void slotAccountActivityStatus(AccountStatePtr ast, int statusCode);
+    void slotRefreshActivities(AccountState *ptr);
+    void slotRefreshNotifications(AccountState *ptr);
+    void slotRemoveAccount(AccountState *ptr);
+    void slotAccountActivityStatus(AccountState *ast, int statusCode);
     void slotRequestCleanupAndBlacklist(const Activity &blacklistActivity);
 
 Q_SIGNALS:
@@ -133,8 +133,8 @@ public:
     ~ActivitySettings() override;
 
 public Q_SLOTS:
-    void slotRefresh(AccountStatePtr ptr);
-    void slotRemoveAccount(const AccountStatePtr &ptr);
+    void slotRefresh(AccountState *ptr);
+    void slotRemoveAccount(AccountState *ptr);
 
     void setNotificationRefreshInterval(std::chrono::milliseconds interval);
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -130,18 +130,15 @@ void Application::lastAccountStateRemoved() const
     }
 }
 
-void Application::slotAccountStateAdded(AccountStatePtr accountState) const
+void Application::slotAccountStateAdded(AccountState *accountState) const
 {
     // Hook up the GUI slots to the account state's Q_SIGNALS:
-    connect(accountState.data(), &AccountState::stateChanged,
-        _gui.data(), &ownCloudGui::slotAccountStateChanged);
-    connect(accountState->account().data(), &Account::serverVersionChanged,
-        _gui.data(), [account = accountState->account().data(), this] {
-            _gui->slotTrayMessageIfServerUnsupported(account);
-        });
+    connect(accountState, &AccountState::stateChanged, _gui.data(), &ownCloudGui::slotAccountStateChanged);
+    connect(accountState->account().data(), &Account::serverVersionChanged, _gui.data(),
+        [account = accountState->account().data(), this] { _gui->slotTrayMessageIfServerUnsupported(account); });
 
     // Hook up the folder manager slots to the account state's Q_SIGNALS:
-    connect(accountState.data(), &AccountState::isConnectedChanged, FolderMan::instance(), &FolderMan::slotIsConnectedChanged);
+    connect(accountState, &AccountState::isConnectedChanged, FolderMan::instance(), &FolderMan::slotIsConnectedChanged);
     connect(accountState->account().data(), &Account::serverVersionChanged, FolderMan::instance(),
         [account = accountState->account().data()] { FolderMan::instance()->slotServerVersionChanged(account); });
 }

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -69,7 +69,7 @@ public:
 protected Q_SLOTS:
     void slotUseMonoIconsChanged(bool);
     void slotCleanup();
-    void slotAccountStateAdded(AccountStatePtr accountState) const;
+    void slotAccountStateAdded(AccountState *accountState) const;
     void lastAccountStateRemoved() const;
 
 private:

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -102,7 +102,7 @@ using namespace FileSystem::SizeLiterals;
 
 Q_LOGGING_CATEGORY(lcFolder, "gui.folder", QtInfoMsg)
 
-Folder::Folder(const FolderDefinition &definition, const AccountStatePtr &accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent)
+Folder::Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent)
     : QObject(parent)
     , _accountState(accountState)
     , _definition(definition)

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -189,13 +189,13 @@ public:
 
     /** Create a new Folder
      */
-    Folder(const FolderDefinition &definition, const AccountStatePtr &accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent = nullptr);
+    Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent = nullptr);
 
     ~Folder() override;
     /**
      * The account the folder is configured on.
      */
-    AccountStatePtr accountState() const { return _accountState; }
+    AccountState *accountState() const { return _accountState; }
 
     const FolderDefinition &definition() const { return _definition; }
 
@@ -503,7 +503,7 @@ private:
 
     void changeVfsMode(Vfs::Mode newMode);
 
-    AccountStatePtr _accountState;
+    QPointer<AccountState> _accountState;
     FolderDefinition _definition;
     QString _canonicalLocalPath; // As returned with QFileInfo:canonicalFilePath.  Always ends with "/"
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -161,13 +161,13 @@ public:
      *  Refactoring todo: this should not be public! it is currently "required" for some tests which is not really cool, as it does not represent
      *  a complete/standalone impl.
      */
-    Folder *addFolder(const AccountStatePtr &accountState, const FolderDefinition &folderDefinition);
+    Folder *addFolder(AccountState *accountState, const FolderDefinition &folderDefinition);
 
 
     /**
      *  sets up sync folders/spaces after adding a new account via the gui
      */
-    void setUpInitialSyncFolders(AccountStatePtr accountStatePtr, bool useVfs);
+    void setUpInitialSyncFolders(AccountState *accountState, bool useVfs);
 
     // Refactoring todo: this function actually just returns the internal vector of folders. I do not see any evidence of
     // what is docced here, at least related to this specific function.
@@ -313,7 +313,7 @@ public:
      */
     // todo: #1
     // todo: #2
-    void addFolderFromGui(const AccountStatePtr &accountStatePtr, const SyncConnectionDescription &config);
+    void addFolderFromGui(AccountState *accountState, const SyncConnectionDescription &config);
 
     // todo: #3
     void removeFolderSettings(Folder *folder);
@@ -360,7 +360,7 @@ private Q_SLOTS:
     void slotFolderSyncStarted();
     void slotFolderSyncFinished(const SyncResult &);
 
-    void slotRemoveFoldersForAccount(const AccountStatePtr &accountState);
+    void slotRemoveFoldersForAccount(AccountState *accountState);
 
     void slotServerVersionChanged(Account *account);
 
@@ -386,14 +386,14 @@ private:
      * from some dynamic operation (eg folders from new account or via the gui add folder sync operations).
      * In case Wizard::SyncMode::SelectiveSync is used, nullptr is returned.
      */
-    Folder *addFolderFromScratch(const AccountStatePtr &accountStatePtr, FolderDefinition &&definition, bool useVfs);
+    Folder *addFolderFromScratch(AccountState *accountState, FolderDefinition &&definition, bool useVfs);
 
     /**
      *  private handler connected to spacesManager::ready signal
      *  this is a bit weird as you have to ask the manager if it's ready then wait for the signal before actually loading
      *  the spaces. this function loads all the spaces into the FolderMan and saves them in an efficient manner
      */
-    void loadSpacesWhenReady(AccountStatePtr accountState, bool useVfs);
+    void loadSpacesWhenReady(AccountState *accountState, bool useVfs);
 
     /**
      *  reads the folder defs from the config for a single account.
@@ -404,7 +404,7 @@ private:
      *
      *  returns false when a downgrade of the database is detected, true otherwise.
      */
-    bool addFoldersFromConfigByAccount(QSettings &settings, AccountStatePtr account);
+    bool addFoldersFromConfigByAccount(QSettings &settings, AccountState *account);
 
     // tests folder def for minimum reqs
     bool validateFolderDefinition(const FolderDefinition &folderDefinition);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -184,7 +184,7 @@ FolderStatusModel::FolderStatusModel(QObject *parent)
 
 FolderStatusModel::~FolderStatusModel() { }
 
-void FolderStatusModel::setAccountState(const AccountStatePtr &accountState)
+void FolderStatusModel::setAccountState(AccountState *accountState)
 {
     // Refactoring todo: what is the logic here? I especially don't understand why we are expecting current _accountState to
     // be nullptr (via assert) when this is called.

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -62,7 +62,7 @@ public:
 
     FolderStatusModel(QObject *parent = nullptr);
     ~FolderStatusModel() override;
-    void setAccountState(const AccountStatePtr &accountState);
+    void setAccountState(AccountState *accountState);
 
     Folder *folder(const QModelIndex &index) const;
 
@@ -81,7 +81,7 @@ private Q_SLOTS:
 private:
     int indexOf(Folder *f) const;
 
-    AccountStatePtr _accountState;
+    QPointer<AccountState> _accountState;
     std::vector<std::unique_ptr<SubFolderInfo>> _folders;
 };
 

--- a/src/gui/folderwizard/folderwizard.cpp
+++ b/src/gui/folderwizard/folderwizard.cpp
@@ -71,7 +71,7 @@ QString FolderWizardPrivate::defaultSyncRoot() const
     }
 }
 
-FolderWizardPrivate::FolderWizardPrivate(FolderWizard *q, const AccountStatePtr &account)
+FolderWizardPrivate::FolderWizardPrivate(FolderWizard *q, AccountState *account)
     : q_ptr(q)
     , _account(account)
     , _folderWizardSourcePage(new FolderWizardLocalPath(this))
@@ -151,7 +151,7 @@ QString FolderWizardPrivate::displayName() const
     return QString();
 }
 
-const AccountStatePtr &FolderWizardPrivate::accountState()
+AccountState *FolderWizardPrivate::accountState()
 {
     return _account;
 }
@@ -172,7 +172,7 @@ bool FolderWizardPrivate::useVirtualFiles() const
     return useVirtualFiles;
 }
 
-FolderWizard::FolderWizard(const AccountStatePtr &account, QWidget *parent)
+FolderWizard::FolderWizard(AccountState *account, QWidget *parent)
     : QWizard(parent)
     , d_ptr(new FolderWizardPrivate(this, account))
 {

--- a/src/gui/folderwizard/folderwizard.h
+++ b/src/gui/folderwizard/folderwizard.h
@@ -45,7 +45,7 @@ public:
     };
     Q_ENUM(PageType)
 
-    explicit FolderWizard(const AccountStatePtr &account, QWidget *parent = nullptr);
+    explicit FolderWizard(AccountState *account, QWidget *parent = nullptr);
     ~FolderWizard() override;
 
     FolderMan::SyncConnectionDescription result();

--- a/src/gui/folderwizard/folderwizard_p.h
+++ b/src/gui/folderwizard/folderwizard_p.h
@@ -32,7 +32,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcFolderWizard);
 class FolderWizardPrivate
 {
 public:
-    FolderWizardPrivate(FolderWizard *q, const AccountStatePtr &account);
+    FolderWizardPrivate(FolderWizard *q, AccountState *account);
     static QString formatWarnings(const QStringList &warnings, bool isError = false);
 
     QString initialLocalPath() const;
@@ -48,13 +48,13 @@ public:
     bool useVirtualFiles() const;
     QString displayName() const;
 
-    const AccountStatePtr &accountState();
+    AccountState *accountState();
 
 private:
     Q_DECLARE_PUBLIC(FolderWizard)
     FolderWizard *q_ptr;
 
-    AccountStatePtr _account;
+    QPointer<AccountState> _account;
     class SpacesPage *_spacesPage;
     class FolderWizardLocalPath *_folderWizardSourcePage = nullptr;
     class FolderWizardRemotePath *_folderWizardTargetPage = nullptr;

--- a/src/gui/models/activitylistmodel.h
+++ b/src/gui/models/activitylistmodel.h
@@ -63,15 +63,15 @@ public:
 
 
 public Q_SLOTS:
-    void slotRefreshActivity(const AccountStatePtr &ast);
-    void slotRemoveAccount(AccountStatePtr ast);
+    void slotRefreshActivity(AccountState *ast);
+    void slotRemoveAccount(AccountState *ast);
 
 Q_SIGNALS:
-    void activityJobStatusCode(AccountStatePtr ast, int statusCode);
+    void activityJobStatusCode(AccountState *ast, int statusCode);
 
 private:
     void setActivityList(const ActivityList &&resultList);
-    void startFetchJob(AccountStatePtr s);
+    void startFetchJob(AccountState *ast);
     void combineActivityLists();
 
     QMap<AccountState *, ActivityList> _activityLists;

--- a/src/gui/newaccountwizard/newaccountbuilder.cpp
+++ b/src/gui/newaccountwizard/newaccountbuilder.cpp
@@ -32,7 +32,7 @@ void NewAccountBuilder::buildAccount()
     // the account manager triggers the first checkConnection in the state when it's added - there should be no need to call it again explicitly
     // either in the application or the folderman, as was the case previously
     _accountState = AccountManager::instance()->addAccount(_account);
-    connect(_accountState.get(), &AccountState::stateChanged, this, &NewAccountBuilder::onAccountStateChanged);
+    connect(_accountState, &AccountState::stateChanged, this, &NewAccountBuilder::onAccountStateChanged);
     _accountState->setSettingUp(true);
 }
 

--- a/src/gui/newaccountwizard/newaccountbuilder.h
+++ b/src/gui/newaccountwizard/newaccountbuilder.h
@@ -32,7 +32,7 @@ public:
     void buildAccount();
 
 Q_SIGNALS:
-    void requestSetUpSyncFoldersForAccount(AccountStatePtr, bool useVfs);
+    void requestSetUpSyncFoldersForAccount(AccountState *, bool useVfs);
     void requestFolderWizard(OCC::AccountPtr account);
     void unableToCompleteAccountCreation(const QString &error);
 
@@ -41,7 +41,7 @@ private:
     void completeAccountSetup();
 
     AccountPtr _account = nullptr;
-    AccountStatePtr _accountState = nullptr;
+    AccountState *_accountState = nullptr;
     NewAccount::SyncType _syncType = NewAccount::SyncType::NONE;
 };
 }

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -191,7 +191,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     bool allSignedOut = true;
     bool allPaused = true;
     bool allDisconnected = true;
-    QVector<AccountStatePtr> problemAccounts;
+    QVector<AccountState *> problemAccounts;
     auto setStatusText = [&](const QString &text) {
         // Don't overwrite the status if we're currently syncing
         if (FolderMan::instance()->isAnySyncRunning())
@@ -311,7 +311,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     }
 }
 
-void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *menu)
+void ownCloudGui::addAccountContextMenu(AccountState *accountState, QMenu *menu)
 {
     menu->addAction(CommonStrings::showInWebBrowser(), this, [accountState] { QDesktopServices::openUrl(accountState->account()->url()); });
 
@@ -319,7 +319,7 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
     const auto &map = folderMan->folders();
     bool onePaused = false;
     for (auto *folder : map) {
-        if (folder->accountState() != accountState.data()) {
+        if (folder->accountState() != accountState) {
             continue;
         }
 
@@ -810,7 +810,7 @@ void ownCloudGui::handleAccountSetupError(const QString &error)
         tr("The account could not be created due to an error:\n%1\nPlease check the server's availability then run the wizard again.").arg(error));
 }
 
-void ownCloudGui::setPauseOnAllFoldersHelper(const QList<AccountStatePtr> &accounts, bool pause)
+void ownCloudGui::setPauseOnAllFoldersHelper(const QList<AccountState *> &accounts, bool pause)
 {
     for (auto *f : FolderMan::instance()->folders()) {
         if (accounts.contains(f->accountState())) {

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -74,7 +74,7 @@ public:
     void runNewestAccountWizard();
 
 Q_SIGNALS:
-    void requestSetUpSyncFoldersForAccount(AccountStatePtr account, bool useVfs);
+    void requestSetUpSyncFoldersForAccount(AccountState *account, bool useVfs);
 
 public Q_SLOTS:
     void setupContextMenu();
@@ -113,9 +113,9 @@ public Q_SLOTS:
     void handleAccountSetupError(const QString &error);
 
 private:
-    void setPauseOnAllFoldersHelper(const QList<AccountStatePtr> &accounts, bool pause);
+    void setPauseOnAllFoldersHelper(const QList<AccountState *> &accounts, bool pause);
     void setupActions();
-    void addAccountContextMenu(AccountStatePtr accountState, QMenu *menu);
+    void addAccountContextMenu(AccountState *accountState, QMenu *menu);
 
     Systray *_tray;
     SettingsDialog *_settingsDialog;

--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -30,7 +30,7 @@ ServerNotificationHandler::ServerNotificationHandler(QObject *parent)
 {
 }
 
-void ServerNotificationHandler::slotFetchNotifications(AccountStatePtr ptr)
+void ServerNotificationHandler::slotFetchNotifications(AccountState *ptr)
 {
     // check connectivity and credentials
     if (!(ptr && ptr->isConnected() && ptr->account() && ptr->account()->credentials() && ptr->account()->credentials()->ready())) {
@@ -61,7 +61,7 @@ void ServerNotificationHandler::slotFetchNotifications(AccountStatePtr ptr)
     job->start();
 }
 
-void ServerNotificationHandler::slotNotificationsReceived(JsonApiJob *job, const AccountStatePtr &accountState)
+void ServerNotificationHandler::slotNotificationsReceived(JsonApiJob *job, AccountState *accountState)
 {
     if (job->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() != 200) {
         qCWarning(lcServerNotification) << "Notifications failed with status code " << job->ocsStatus();

--- a/src/gui/servernotificationhandler.h
+++ b/src/gui/servernotificationhandler.h
@@ -33,10 +33,10 @@ Q_SIGNALS:
     void newNotificationList(ActivityList);
 
 public Q_SLOTS:
-    void slotFetchNotifications(AccountStatePtr ptr);
+    void slotFetchNotifications(AccountState *ptr);
 
 private:
-    void slotNotificationsReceived(JsonApiJob *job, const AccountStatePtr &accountState);
+    void slotNotificationsReceived(JsonApiJob *job, AccountState *accountState);
 };
 }
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -162,7 +162,7 @@ SettingsDialog::~SettingsDialog()
     delete _ui;
 }
 
-void SettingsDialog::onAccountAdded(AccountStatePtr state)
+void SettingsDialog::onAccountAdded(AccountState *state)
 {
     if (!state)
         return;
@@ -172,7 +172,7 @@ void SettingsDialog::onAccountAdded(AccountStatePtr state)
     setCurrentAccount(state->account().get());
 }
 
-void SettingsDialog::onAccountRemoved(AccountStatePtr state)
+void SettingsDialog::onAccountRemoved(AccountState *state)
 {
     if (!state)
         return;

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -79,8 +79,8 @@ Q_SIGNALS:
     void currentAccountChanged();
 
 protected Q_SLOTS:
-    void onAccountAdded(AccountStatePtr state);
-    void onAccountRemoved(AccountStatePtr state);
+    void onAccountAdded(AccountState *state);
+    void onAccountRemoved(AccountState *state);
 
 protected:
     void setVisible(bool visible) override;

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -38,13 +38,8 @@ namespace OCC {
 
 static const int thumbnailSize = 40;
 
-ShareDialog::ShareDialog(AccountStatePtr accountState,
-    const QUrl &baseUrl,
-    const QString &sharePath,
-    const QString &localPath,
-    SharePermissions maxSharingPermissions,
-    ShareDialogStartPage startPage,
-    QWidget *parent)
+ShareDialog::ShareDialog(AccountState *accountState, const QUrl &baseUrl, const QString &sharePath, const QString &localPath,
+    SharePermissions maxSharingPermissions, ShareDialogStartPage startPage, QWidget *parent)
     : QDialog(parent)
     , _ui(new Ui::ShareDialog)
     , _accountState(accountState)

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -45,13 +45,8 @@ class ShareDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ShareDialog(AccountStatePtr accountState,
-        const QUrl &baseUrl,
-        const QString &sharePath,
-        const QString &localPath,
-        SharePermissions maxSharingPermissions,
-        ShareDialogStartPage startPage,
-        QWidget *parent);
+    explicit ShareDialog(AccountState *accountState, const QUrl &baseUrl, const QString &sharePath, const QString &localPath,
+        SharePermissions maxSharingPermissions, ShareDialogStartPage startPage, QWidget *parent);
     ~ShareDialog() override;
 
     QString localPath() const { return _localPath; }
@@ -65,7 +60,7 @@ private:
     void showSharingUi();
 
     Ui::ShareDialog *_ui;
-    AccountStatePtr _accountState;
+    QPointer<AccountState> _accountState;
     QString _sharePath;
     QString _localPath;
     SharePermissions _maxSharingPermissions;

--- a/src/libsync/accountfwd.h
+++ b/src/libsync/accountfwd.h
@@ -15,7 +15,6 @@
 #ifndef SERVERFWD_H
 #define SERVERFWD_H
 
-#include <QPointer>
 #include <QSharedPointer>
 
 namespace OCC {
@@ -24,7 +23,6 @@ class Account;
 class AccountState;
 
 using AccountPtr = QSharedPointer<Account>;
-using AccountStatePtr = QPointer<AccountState>;
 
 
 } // namespace OCC

--- a/test/testutils/testutils.cpp
+++ b/test/testutils/testutils.cpp
@@ -20,7 +20,7 @@ namespace TestUtils {
         acc->setUrl(QUrl(QStringLiteral("http://localhost/owncloud")));
         acc->setDavDisplayName(QStringLiteral("fakename") + acc->uuid().toString(QUuid::WithoutBraces));
         acc->setCapabilities({acc->url(), OCC::TestUtils::testCapabilities()});
-        return {OCC::AccountManager::instance()->addAccount(acc).get(), &TestUtilsPrivate::accountStateDeleter};
+        return {OCC::AccountManager::instance()->addAccount(acc), &TestUtilsPrivate::accountStateDeleter};
     }
 
     // We have more than one of these?


### PR DESCRIPTION
This typedef was a left-over from long ago. If a class stores the `AccountState` as a member field, it is responsible for wrapping it in a `QPointer`.