### PR TITLE
[tests-only][full-ci] wait for action menu to load

### DIFF
--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -50,6 +50,8 @@ class AccountSetting:
     @staticmethod
     def account_action(action):
         squish.clickButton(squish.waitForObject(AccountSetting.MANAGE_ACCOUNT_BUTTON))
+        # wait 500ms for action menu to load
+        squish.snooze(1 / 2)
         squish.activateItem(
             squish.waitForObjectItem(AccountSetting.ACCOUNT_MENU, action)
         )


### PR DESCRIPTION
## Description
Wait for 500ms for the action menu to open properly after clicking `Manage Account` button. 

Fixes the failures in following builds:
- https://drone.owncloud.com/owncloud/client/21808
- https://drone.owncloud.com/owncloud/client/21809