### PR TITLE
[DC-111] Actively delete version keys

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -235,7 +235,7 @@ const QList<AccountState *> AccountManager::accounts() const
 
 AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 {
-    if (!settings.value("version").isNull()) {
+    if (settings.contains("version")) {
         // Migration from pre-7.0:
         settings.remove("version");
     }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -97,7 +97,7 @@ bool AccountManager::restore()
         return false;
     }
 
-    if (!settings->contains("version")) {
+    if (settings->contains("version")) {
         // Migration from pre-7.0:
         settings->remove("version");
     }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -97,6 +97,11 @@ bool AccountManager::restore()
         return false;
     }
 
+    if (!settings->value("version").isNull()) {
+        // Migration from pre-7.0:
+        settings->remove("version");
+    }
+
     // If there are no accounts, check the old format.
     const auto &childGroups = settings->childGroups();
     for (const auto &accountId : childGroups) {
@@ -230,6 +235,11 @@ const QList<AccountState *> AccountManager::accounts() const
 
 AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 {
+    if (!settings.value("version").isNull()) {
+        // Migration from pre-7.0:
+        settings.remove("version");
+    }
+
     auto urlConfig = settings.value(urlC());
     if (!urlConfig.isValid()) {
         // No URL probably means a corrupted entry in the account settings

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -97,7 +97,7 @@ bool AccountManager::restore()
         return false;
     }
 
-    if (!settings->value("version").isNull()) {
+    if (!settings->contains("version")) {
         // Migration from pre-7.0:
         settings->remove("version");
     }

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1211,6 +1211,11 @@ FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &i
         def._virtualFilesMode = Vfs::modeFromString(vfsModeString);
     }
 
+    if (!settings.value("version").isNull()) {
+        // Migration from pre-7.0:
+        settings.remove("version");
+    }
+
     const QVariant ignoreHiddenFiles = settings.value(QStringLiteral("ignoreHiddenFiles"));
     if (!ignoreHiddenFiles.isNull()) {
         // Migration from pre-7.0:

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1178,19 +1178,19 @@ uint32_t FolderDefinition::priority() const
 
 void FolderDefinition::save(QSettings &settings, const FolderDefinition &def)
 {
-    settings.setValue(QStringLiteral("localPath"), def.localPath());
-    settings.setValue(QStringLiteral("journalPath"), def.journalPath());
-    settings.setValue(QStringLiteral("targetPath"), def.targetPath());
+    settings.setValue("localPath", def.localPath());
+    settings.setValue("journalPath", def.journalPath());
+    settings.setValue("targetPath", def.targetPath());
     if (!def.spaceId().isEmpty()) {
         settings.setValue(spaceIdC(), def.spaceId());
     }
     settings.setValue(davUrlC(), def.webDavUrl());
     settings.setValue(displayNameC(), def.displayName());
-    settings.setValue(QStringLiteral("paused"), def.paused());
+    settings.setValue("paused", def.paused());
     settings.setValue(deployedC(), def.isDeployed());
     settings.setValue(priorityC(), def.priority());
 
-    settings.setValue(QStringLiteral("virtualFilesMode"), Utility::enumToString(def.virtualFilesMode()));
+    settings.setValue("virtualFilesMode", Utility::enumToString(def.virtualFilesMode()));
 }
 
 FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &id)
@@ -1198,10 +1198,10 @@ FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &i
     Q_ASSERT(!id.isEmpty());
 
     FolderDefinition def{id, settings.value(davUrlC()).toUrl(), settings.value(spaceIdC()).toString(), settings.value(displayNameC()).toString()};
-    def.setLocalPath(settings.value(QStringLiteral("localPath")).toString());
-    def.setTargetPath(settings.value(QStringLiteral("targetPath")).toString());
-    def._journalPath = settings.value(QStringLiteral("journalPath")).toString();
-    def._paused = settings.value(QStringLiteral("paused")).toBool();
+    def.setLocalPath(settings.value("localPath").toString());
+    def.setTargetPath(settings.value("targetPath").toString());
+    def._journalPath = settings.value("journalPath").toString();
+    def._paused = settings.value("paused").toBool();
     def._deployed = settings.value(deployedC(), false).toBool();
     def._priority = settings.value(priorityC(), 0).toUInt();
 
@@ -1211,15 +1211,15 @@ FolderDefinition FolderDefinition::load(QSettings &settings, const QByteArray &i
         def._virtualFilesMode = Vfs::modeFromString(vfsModeString);
     }
 
-    if (!settings.value("version").isNull()) {
+    if (settings.contains("version")) {
         // Migration from pre-7.0:
         settings.remove("version");
     }
 
-    const QVariant ignoreHiddenFiles = settings.value(QStringLiteral("ignoreHiddenFiles"));
+    const QVariant ignoreHiddenFiles = settings.value("ignoreHiddenFiles");
     if (!ignoreHiddenFiles.isNull()) {
         // Migration from pre-7.0:
-        settings.remove(QStringLiteral("ignoreHiddenFiles"));
+        settings.remove("ignoreHiddenFiles");
         FolderMan::instance()->setIgnoreHiddenFiles(ignoreHiddenFiles.toBool());
     }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -92,7 +92,7 @@ using namespace FileSystem::SizeLiterals;
 
 Q_LOGGING_CATEGORY(lcFolder, "gui.folder", QtInfoMsg)
 
-Folder::Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent)
+Folder::Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, bool ignoreHiddenFiles, QObject *parent)
     : QObject(parent)
     , _accountState(accountState)
     , _definition(definition)
@@ -117,7 +117,7 @@ Folder::Folder(const FolderDefinition &definition, AccountState *accountState, s
         // current impl can result in an invalid engine which is just a mess given the folder is useless without it
         _engine.reset(new SyncEngine(_accountState->account(), webDavUrl(), path(), remotePath(), &_journal));
         // pass the setting if hidden files are to be ignored, will be read in csync_update
-        _engine->setIgnoreHiddenFiles(ConfigFile().ignoreHiddenFiles());
+        _engine->setIgnoreHiddenFiles(ignoreHiddenFiles);
 
         if (!_engine->loadDefaultExcludes()) {
             qCWarning(lcFolder, "Could not read system exclude file");

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -183,7 +183,7 @@ public:
 
     /** Create a new Folder
      */
-    Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, QObject *parent = nullptr);
+    Folder(const FolderDefinition &definition, AccountState *accountState, std::unique_ptr<Vfs> &&vfs, bool ignoreHiddenFiles, QObject *parent = nullptr);
 
     ~Folder() override;
     /**

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -54,7 +54,7 @@ qsizetype numberOfSyncJournals(const QString &path)
 namespace OCC {
 Q_LOGGING_CATEGORY(lcFolderMan, "gui.folder.manager", QtInfoMsg)
 
-static std::string_view IgnoreHiddenFilesKey = "ignoreHiddenFiles";
+inline static const QString IgnoreHiddenFilesKey = "ignoreHiddenFiles";
 
 void TrayOverallStatusResult::addResult(Folder *f)
 {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -54,8 +54,6 @@ qsizetype numberOfSyncJournals(const QString &path)
 namespace OCC {
 Q_LOGGING_CATEGORY(lcFolderMan, "gui.folder.manager", QtInfoMsg)
 
-inline static const QString IgnoreHiddenFilesKey = "ignoreHiddenFiles";
-
 void TrayOverallStatusResult::addResult(Folder *f)
 {
     _overallStatus._numNewConflictItems += f->syncResult()._numNewConflictItems;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -457,6 +457,8 @@ private:
 
     static FolderMan *_instance;
     friend class OCC::Application;
+
+    inline static const QString IgnoreHiddenFilesKey = "ignoreHiddenFiles";
 };
 
 } // namespace OCC

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -458,7 +458,8 @@ private:
     static FolderMan *_instance;
     friend class OCC::Application;
 
-    inline static const QString IgnoreHiddenFilesKey = "ignoreHiddenFiles";
+    // the literal is needed to get the tests to build
+    inline static const QString IgnoreHiddenFilesKey = QStringLiteral("ignoreHiddenFiles");
 };
 
 } // namespace OCC

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -183,10 +183,13 @@ void ConfigFile::setOptionalDesktopNotifications(bool show)
     settings.sync();
 }
 
-bool ConfigFile::ignoreHiddenFiles() const
+std::optional<bool> ConfigFile::ignoreHiddenFiles() const
 {
     auto settings = makeQSettings();
-    return settings.value(ignoreHiddenFilesC(), true).toBool();
+    auto value = settings.value(ignoreHiddenFilesC());
+    if (value.isNull())
+        return {};
+    return value.toBool();
 }
 
 void ConfigFile::setIgnoreHiddenFiles(bool ignore)

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -59,10 +59,6 @@ const QString optionalDesktopNotificationsC()
 {
     return QStringLiteral("optionalDesktopNotifications");
 }
-const QString ignoreHiddenFilesC()
-{
-    return QStringLiteral("ignoreHiddenFiles");
-}
 const QString skipUpdateCheckC() { return QStringLiteral("skipUpdateCheck"); }
 const QString updateCheckIntervalC() { return QStringLiteral("updateCheckInterval"); }
 const QString updateChannelC() { return QStringLiteral("updateChannel"); }
@@ -180,22 +176,6 @@ void ConfigFile::setOptionalDesktopNotifications(bool show)
 {
     auto settings = makeQSettings();
     settings.setValue(optionalDesktopNotificationsC(), show);
-    settings.sync();
-}
-
-std::optional<bool> ConfigFile::ignoreHiddenFiles() const
-{
-    auto settings = makeQSettings();
-    auto value = settings.value(ignoreHiddenFilesC());
-    if (value.isNull())
-        return {};
-    return value.toBool();
-}
-
-void ConfigFile::setIgnoreHiddenFiles(bool ignore)
-{
-    auto settings = makeQSettings();
-    settings.setValue(ignoreHiddenFilesC(), ignore);
     settings.sync();
 }
 

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -148,7 +148,7 @@ public:
     bool optionalDesktopNotifications() const;
     void setOptionalDesktopNotifications(bool show);
 
-    bool ignoreHiddenFiles() const;
+    std::optional<bool> ignoreHiddenFiles() const;
     void setIgnoreHiddenFiles(bool ignore);
 
     std::optional<QStringList> issuesWidgetFilter() const;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -148,9 +148,6 @@ public:
     bool optionalDesktopNotifications() const;
     void setOptionalDesktopNotifications(bool show);
 
-    std::optional<bool> ignoreHiddenFiles() const;
-    void setIgnoreHiddenFiles(bool ignore);
-
     std::optional<QStringList> issuesWidgetFilter() const;
     void setIssuesWidgetFilter(const QStringList &checked);
 


### PR DESCRIPTION
These keys were not written out anymore, but would still stay in the configuration file if no configuration change was made. Now they are removed when detected.