### PR TITLE
[DC-165] fix: reauth request when access token expired but refresh token is still valid

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -16,6 +16,7 @@
 #include "application.h"
 #include "configfile.h"
 
+#include "credentials.h"
 #include "fetchserversettings.h"
 
 #include "libsync/creds/abstractcredentials.h"
@@ -536,15 +537,15 @@ void AccountState::slotInvalidCredentials()
         if (account()->credentials()->ready()) {
             account()->credentials()->invalidateToken();
         }
-        // todo: DC-112 evaluate if this is even needed (it seems to be working fine casting to HttpCredentials which would have failed to cast -> ie it's a
-        // noop), and if it is, fix the abstraction todo: NO! if you have to cast it something is wrong with the abstraction
-        /* if (auto creds = qobject_cast<HttpCredentials *>(account()->credentials())) {
-             qCInfo(lcAccountState) << "refreshing oauth";
-             if (creds->refreshAccessToken()) {
-                 return;
-             }
-             qCInfo(lcAccountState) << "refreshing oauth failed";
-         }*/
+        // todo: evaluate if this is even needed (it seems to be working fine casting to HttpCredentials which would have failed to cast -> ie it's a
+        // noop), and if it is, fix the abstraction todo: needs update in AbstractCredentials
+        if (auto creds = qobject_cast<Credentials *>(account()->credentials())) {
+            qCInfo(lcAccountState) << "refreshing oauth";
+            if (creds->refreshAccessToken()) {
+                return;
+            }
+            qCInfo(lcAccountState) << "refreshing oauth failed";
+        }
         qCInfo(lcAccountState) << "asking user";
         account()->credentials()->askFromUser();
         setState(AskingCredentials);


### PR DESCRIPTION
see https://kiteworks.atlassian.net/browse/DC-165

fixes #12308 