### PR TITLE
[tests-only][full-ci] update url to raw.githubusercontent.com while downloading syncstate.py

### DIFF
--- a/test/gui/shared/scripts/helpers/SyncHelper.py
+++ b/test/gui/shared/scripts/helpers/SyncHelper.py
@@ -20,7 +20,10 @@ else:
 
     if not os.path.exists(syncstate_lib_file):
         response = request.get(
-            'https://raw.github.com/owncloud/client-desktop-shell-integration-nautilus/master/src/syncstate.py',
+            (
+                'https://raw.githubusercontent.com/'
+                'owncloud/client-desktop-shell-integration-nautilus/master/src/syncstate.py'
+            )
         )
         assert response.status_code == 200, 'Failed to get content of syncstate file'
         with open(syncstate_lib_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Description
Update url and use `raw.githubusercontent.com` instead of `raw.github.com` to download syncstate.py.

Follow up of: https://github.com/owncloud/client/pull/12322

Part of: https://github.com/owncloud/client/issues/12316