### PR TITLE
Deprecate oc10 specific themable sharing options as of 7.0 (#12321)

### DIFF
--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -281,8 +281,8 @@ public:
      *
      * Allow link sharing and or user/group sharing
      */
-    virtual bool linkSharing() const;
-    virtual bool userGroupSharing() const;
+    [[deprecated("themable link sharing has been removed as of client 7.0")]] virtual bool linkSharing() const;
+    [[deprecated("oc10 user group sharing has been removed as of client 7.0")]] virtual bool userGroupSharing() const;
 
     /**
      * If this returns true, the user cannot configure the proxy in the network settings.


### PR DESCRIPTION
(cherry picked from commit f2105f3b7d0504e1c3e9093df7b937801dcd3aba)