### PR TITLE
[DC-146, DC-166] Fix VFS checkbox in folder wizard (#12305)

### DIFF
--- a/changelog/unreleased/12305.md
+++ b/changelog/unreleased/12305.md
@@ -1,0 +1,8 @@
+Bugfix: Fix VFS checkbox in folder wizard
+
+On the last page of the folder wizard, there is a checkbox to
+select/deselect VFS. By default this is checked. The bug was that
+after unchecking this checkbox, it could not be checked again.
+This has now been fixed.
+
+https://github.com/owncloud/client/pull/12305

--- a/src/gui/folderwizard/folderwizardselectivesync.cpp
+++ b/src/gui/folderwizard/folderwizardselectivesync.cpp
@@ -27,7 +27,6 @@
 #include "libsync/theme.h"
 
 #include "common/vfs.h"
-#include "gui/settingsdialog.h"
 
 #include <QCheckBox>
 #include <QVBoxLayout>
@@ -42,15 +41,12 @@ FolderWizardSelectiveSync::FolderWizardSelectiveSync(FolderWizardPrivate *parent
     _selectiveSync = new SelectiveSyncWidget(folderWizardPrivate()->accountState()->account(), this);
     layout->addWidget(_selectiveSync);
 
-    if (!Theme::instance()->forceVirtualFilesOption() && Theme::instance()->showVirtualFilesOption()
-        && VfsPluginManager::instance().bestAvailableVfsMode() == Vfs::WindowsCfApi) {
+    if (Theme::instance()->showVirtualFilesOption() && VfsPluginManager::instance().bestAvailableVfsMode() == Vfs::WindowsCfApi) {
         _virtualFilesCheckBox = new QCheckBox(tr("Use virtual files instead of downloading content immediately"));
-        connect(_virtualFilesCheckBox, &QCheckBox::clicked, this, &FolderWizardSelectiveSync::virtualFilesCheckboxClicked);
-        connect(_virtualFilesCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
-            _selectiveSync->setEnabled(state == Qt::Unchecked);
-        });
+        connect(_virtualFilesCheckBox, &QCheckBox::checkStateChanged, this, &FolderWizardSelectiveSync::slotVfsStateChanged);
         _virtualFilesCheckBox->setChecked(true);
         layout->addWidget(_virtualFilesCheckBox);
+        _virtualFilesCheckBox->setDisabled(Theme::instance()->forceVirtualFilesOption());
     }
 }
 
@@ -83,18 +79,13 @@ bool FolderWizardSelectiveSync::useVirtualFiles() const
     return _virtualFilesCheckBox && _virtualFilesCheckBox->isChecked();
 }
 
-void FolderWizardSelectiveSync::virtualFilesCheckboxClicked()
-{
-    // The click has already had an effect on the box, so if it's
-    // checked it was newly activated.
-    if (_virtualFilesCheckBox->isChecked()) {
-        if (OC_ENSURE(VfsPluginManager::instance().bestAvailableVfsMode() == Vfs::WindowsCfApi)) {
-            _virtualFilesCheckBox->setChecked(false);
-        }
-    }
-}
-
 const QSet<QString> &FolderWizardSelectiveSync::selectiveSyncBlackList() const
 {
     return _selectiveSyncBlackList;
+}
+
+void FolderWizardSelectiveSync::slotVfsStateChanged(Qt::CheckState state)
+{
+    // Enable the selective sync widget when VFS is *not* used, disable it if VFS *is* used.
+    _selectiveSync->setEnabled(state == Qt::Unchecked);
 }

--- a/src/gui/folderwizard/folderwizardselectivesync.h
+++ b/src/gui/folderwizard/folderwizardselectivesync.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "gui/folderwizard/folderwizard_p.h"
-#include "libsync/accountfwd.h"
 
 namespace OCC {
 
@@ -44,8 +43,8 @@ public:
 
     const QSet<QString> &selectiveSyncBlackList() const;
 
-private Q_SLOTS:
-    void virtualFilesCheckboxClicked();
+private slots:
+    void slotVfsStateChanged(Qt::CheckState state);
 
 private:
     SelectiveSyncWidget *_selectiveSync;


### PR DESCRIPTION
* [DC-146] Fix VFS checkbox in folder wizard

On the last page of the folder wizard, there is a checkbox to select/deselect VFS. By default this is checked. The bug was that after unchecking this checkbox, it could not be checked again. This has now been fixed.

* Move checkbox handling to a slot

* [DC-166] Disable selective-sync when VFS is forced

Previously the checkbox to deselect VFS was not shown when VFS was forced. This also caused the selective sync widget to be enabled. This is now fixed: the checkbox is shown (and checked) when VFS is availabled, but disabled when VFS is forced. This leaves it in the checked state, but the user cannot deselect it.

---------


(cherry picked from commit 73493d0087fc1280004bd9d46e760637179498df)