### PR TITLE
[DC-188] fix: use QPushButton for the [Manage Account] button - this …

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -523,31 +523,7 @@ void AccountSettings::buildManageAccountMenu()
     menu->addAction(CommonStrings::showInWebBrowser(), this, &AccountSettings::slotOpenAccountInBrowser);
     menu->addAction(tr("Remove"), this, &AccountSettings::slotDeleteAccount);
 
-    if (Utility::isMac()) {
-        // VoiceOver will read the button as a "menu button", clearly indicating that this is not a normal
-        // button, and that a menu will appear. Using the Windows/Linux work-around results in the button
-        // being read as "button" (no indication of the menu), and the setActiveAction doesn't help either.
-        //
-        // Bug in Qt: the menu somehow is not added to the a11y chain, VoiceOver doesn't "see" it, even
-        // when navigating around inside it with the arrow keys.
-        ui->manageAccountButton->setMenu(menu);
-        ui->manageAccountButton->setPopupMode(QToolButton::InstantPopup);
-    } else {
-        // Windows: when using a button-with-a-menu, Narrator will not notice the menu. Manually showing
-        // and placing it, and then setting the first item as active, will have Narrator read this as
-        // "Account options menu, window, Log in, menu item".
-        //
-        // Linux with Gnome: place the menu BELOW the button. If this is omitted, the click event that
-        // opened the menu will be forwarded to the menu, resulting in selecting the first action (!!!),
-        // and immediately close the menu. The work-around is to manually call "popup", which seems
-        // to work in ~60% of the cases. If it doesn't work, select e.g settings, switch back, and try
-        // again.
-        connect(ui->manageAccountButton, &QPushButton::clicked, this, [menu, logInOutAction, button = ui->manageAccountButton] {
-            auto pos = button->mapToGlobal(QPoint(0, button->height()));
-            menu->popup(pos);
-            menu->setActiveAction(logInOutAction);
-        });
-    }
+    ui->manageAccountButton->setMenu(menu);
 }
 
 // Refactoring todo: the signal sends the new account state, refactor this to use that param

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -68,7 +68,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QToolButton" name="manageAccountButton">
+       <widget class="QPushButton" name="manageAccountButton">
         <property name="text">
          <string>Manage Account</string>
         </property>

--- a/test/gui/shared/scripts/pageObjects/AccountSetting.py
+++ b/test/gui/shared/scripts/pageObjects/AccountSetting.py
@@ -6,7 +6,7 @@ class AccountSetting:
     MANAGE_ACCOUNT_BUTTON = {
         "container": names.settings_dialogStack_QStackedWidget,
         "name": "manageAccountButton",
-        "type": "QToolButton",
+        "type": "QPushButton",
         "visible": 1,
     }
     ACCOUNT_MENU = {


### PR DESCRIPTION
…… (#12360)

* [DC-188] fix: use QPushButton for the [Manage Account] button - this way we get consistent behaviour across all platforms and no platform specific logic needs to be applied

* fix: gui tests