### PR TITLE
fix: sync issue on mac when file name is locally NFD, remote NFC (#12…

### DIFF
--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -183,15 +183,22 @@ bool FileSystem::rename(const QString &originFileName,
         if (!success) {
             error = Utility::formatWinError(GetLastError());
         }
-    } else
-#endif
-    {
+    } else {
         QFile orig(originFileName);
         success = orig.rename(destinationFileName);
         if (!success) {
             error = orig.errorString();
         }
     }
+#else
+    std::error_code err;
+    std::filesystem::rename(originFileName.toStdString(), destinationFileName.toStdString(), err);
+    if (err) {
+        error = QString::fromStdString(err.message());
+    } else {
+        success = true;
+    }
+#endif
 
     if (!success) {
         qCWarning(lcFileSystem) << "Error renaming file" << originFileName

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -542,8 +542,8 @@ bool SyncJournalDb::checkConnect()
 
     QByteArray sql("SELECT lastTryEtag, lastTryModtime, retrycount, errorstring, lastTryTime, ignoreDuration, renameTarget, errorCategory, requestId "
                    "FROM blacklist WHERE path=?1");
-    if (Utility::fsCasePreserving()) {
-        // if the file system is case preserving we have to check the blacklist
+    if (Utility::fsCasePreservingButCaseInsensitive()) {
+        // if the file system is case insensitive we have to check the blacklist
         // case insensitively
         sql += " COLLATE NOCASE";
     }

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -170,7 +170,7 @@ OCSYNC_EXPORT bool fsCasePreserving_override = []() -> bool {
     return Utility::isWindows() || Utility::isMac();
 }();
 
-bool Utility::fsCasePreserving()
+bool Utility::fsCasePreservingButCaseInsensitive()
 {
     return fsCasePreserving_override;
 }
@@ -184,7 +184,7 @@ bool Utility::fileNamesEqual(const QString &fn1, const QString &fn2)
     // ONLY use this function with existing pathes.
     const QString a = fd1.canonicalPath();
     const QString b = fd2.canonicalPath();
-    bool re = !a.isEmpty() && QString::compare(a, b, fsCasePreserving() ? Qt::CaseInsensitive : Qt::CaseSensitive) == 0;
+    bool re = !a.isEmpty() && QString::compare(a, b, fsCaseSensitivity()) == 0;
     return re;
 }
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -140,10 +140,10 @@ OCSYNC_EXPORT Q_DECLARE_LOGGING_CATEGORY(lcUtility)
     // if this function returns true, the file system is case preserving,
     // that means "test" means the same as "TEST" for filenames.
     // if false, the two cases are two different files.
-    OCSYNC_EXPORT bool fsCasePreserving();
+    OCSYNC_EXPORT bool fsCasePreservingButCaseInsensitive();
     inline auto fsCaseSensitivity()
     {
-        return fsCasePreserving() ? Qt::CaseInsensitive : Qt::CaseSensitive;
+        return fsCasePreservingButCaseInsensitive() ? Qt::CaseInsensitive : Qt::CaseSensitive;
     }
 
     // Check if two pathes that MUST exist are equal. This function

--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -737,7 +737,7 @@ void ExcludedFiles::prepare()
             .arg(fullFileDirKeep, fullDirKeep, bnameFileDirKeep, bnameDirKeep, fullFileDirRemove, fullDirRemove, bnameFileDirRemove, bnameDirRemove));
 
     QRegularExpression::PatternOptions patternOptions = QRegularExpression::NoPatternOption;
-    if (OCC::Utility::fsCasePreserving())
+    if (OCC::Utility::fsCasePreservingButCaseInsensitive())
         patternOptions |= QRegularExpression::CaseInsensitiveOption;
     _bnameTraversalRegexFile.setPatternOptions(patternOptions);
     _bnameTraversalRegexFile.optimize();

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -594,6 +594,67 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
     processFileAnalyzeLocalInfo(item, path, localEntry, serverEntry, dbEntry, _queryServer);
 }
 
+bool ProcessDirectoryJob::isMove(
+    const SyncFileItemPtr &item, const PathTuple &path, const LocalInfo &localEntry, const SyncJournalFileRecord &base, const QString &originalPath) const
+{
+    // Go from "cheap" to check up to "expensive" to check
+
+    if (!base.isValid()) {
+        qCInfo(lcDisco) << "Not a move, no item in db with inode" << localEntry.inode;
+        return false;
+    }
+
+    // Type changes (file->dir or vice-versa) are not moves
+    if (base.isDirectory() != item->isDirectory()) {
+        qCInfo(lcDisco) << "Not a move, types don't match" << base._type << item->_type << localEntry.type;
+        return false;
+    }
+
+    // Directories and virtual files don't need size/mtime equality
+    if (!localEntry.isDirectory && !base.isVirtualFile() && (base._modtime != localEntry.modtime || base._fileSize != localEntry.size)) {
+        qCInfo(lcDisco) << "Not a move, mtime or size differs, "
+                        << "modtime:" << base._modtime << localEntry.modtime << ", "
+                        << "size:" << base._fileSize << localEntry.size;
+        return false;
+    }
+
+    if (_discoveryData->isRenamed(originalPath)) {
+        qCInfo(lcDisco) << "Not a move, base path already renamed";
+        return false;
+    }
+
+    // If the old file still exists, it is not a move
+    if (QFile::exists(_discoveryData->_localDir + originalPath)) {
+        // However...:
+        if (
+            // Exception 1: If the rename only changes case (like "foo" -> "Foo"), the
+            // old filename might still point to the same file on a case-insensitive filesystem
+            !(Utility::fsCasePreservingButCaseInsensitive() && originalPath.compare(path._local, Qt::CaseInsensitive) == 0 && originalPath != path._local)
+            // Exception 2: normalization change
+            && !(
+                originalPath != path._local && originalPath.normalized(QString::NormalizationForm_C) == path._local.normalized(QString::NormalizationForm_C))) {
+            qCInfo(lcDisco) << "Not a move, base file still exists at" << originalPath;
+            return false;
+        }
+    }
+
+    // Verify the checksum where possible
+    if (!base._checksumHeader.isEmpty() && item->_type == ItemTypeFile && base._type == ItemTypeFile) {
+        if (computeLocalChecksum(base._checksumHeader, _discoveryData->_localDir + path._original, item)) {
+            qCInfo(lcDisco) << "checking checksum of potential rename " << path._original << item->_checksumHeader << base._checksumHeader;
+            if (item->_checksumHeader != base._checksumHeader) {
+                qCInfo(lcDisco) << "Not a move, checksums differ";
+                return false;
+            }
+        } else {
+            // We cannot calculate the checksum, so we cannot assume the contents of the old file and the new file are the same.
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     const SyncFileItemPtr &item, const PathTuple &path, const LocalInfo &localEntry,
     const RemoteInfo &serverEntry, const SyncJournalFileRecord &dbEntry, QueryMode recurseQueryServer)
@@ -778,65 +839,38 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     };
 
     // Check if it is a move
-    OCC::SyncJournalFileRecord base;
+    SyncJournalFileRecord base;
     if (!_discoveryData->_statedb->getFileRecordByInode(localEntry.inode, &base)) {
         dbError();
         return;
     }
     const auto originalPath = QString::fromUtf8(base._path);
 
-    // Function to gradually check conditions for accepting a move-candidate
-    auto moveCheck = [&]() {
-        if (!base.isValid()) {
-            qCInfo(lcDisco) << "Not a move, no item in db with inode" << localEntry.inode;
-            return false;
-        }
-        if (base.isDirectory() != item->isDirectory()) {
-            qCInfo(lcDisco) << "Not a move, types don't match" << base._type << item->_type << localEntry.type;
-            return false;
-        }
-        // Directories and virtual files don't need size/mtime equality
-        if (!localEntry.isDirectory && !base.isVirtualFile()
-            && (base._modtime != localEntry.modtime || base._fileSize != localEntry.size)) {
-            qCInfo(lcDisco) << "Not a move, mtime or size differs, "
-                            << "modtime:" << base._modtime << localEntry.modtime << ", "
-                            << "size:" << base._fileSize << localEntry.size;
-            return false;
-        }
-
-        // The old file must have been deleted.
-        if (QFile::exists(_discoveryData->_localDir + originalPath)
-            // Exception: If the rename changes case only (like "foo" -> "Foo") the
-            // old filename might still point to the same file.
-            && !(Utility::fsCasePreserving()
-                 && originalPath.compare(path._local, Qt::CaseInsensitive) == 0
-                 && originalPath != path._local)) {
-            qCInfo(lcDisco) << "Not a move, base file still exists at" << originalPath;
-            return false;
-        }
-
-        // Verify the checksum where possible
-        if (!base._checksumHeader.isEmpty() && item->_type == ItemTypeFile && base._type == ItemTypeFile) {
-            if (computeLocalChecksum(base._checksumHeader, _discoveryData->_localDir + path._original, item)) {
-                qCInfo(lcDisco) << "checking checksum of potential rename " << path._original << item->_checksumHeader << base._checksumHeader;
-                if (item->_checksumHeader != base._checksumHeader) {
-                    qCInfo(lcDisco) << "Not a move, checksums differ";
-                    return false;
-                }
-            }
-        }
-
-        if (_discoveryData->isRenamed(originalPath)) {
-            qCInfo(lcDisco) << "Not a move, base path already renamed";
-            return false;
-        }
-
-        return true;
-    };
-
     // If it's not a move it's just a local-NEW
-    if (!moveCheck()) {
+    if (!isMove(item, path, localEntry, base, originalPath)) {
         postProcessLocalNew(path);
+        finalize(path, recurseQueryServer);
+        return;
+    }
+
+    // File size, mod time, checksum the same, but the name is different. Now check if the move is
+    // *only* a normalization change, not a capitalization change.
+    if (originalPath.normalized(QString::NormalizationForm_C) == path._local.normalized(QString::NormalizationForm_C)) {
+        // Issue a local rename: this is a technical encoding change, and not visible to end-users
+        QString adjustedOriginalPath = _discoveryData->adjustRenamedPath(originalPath, SyncFileItem::Down);
+        _discoveryData->_renamedItemsLocal.insert(originalPath, path._local);
+        item->_modtime = base._modtime;
+        item->_inode = base._inode;
+        item->_etag = base._etag;
+        item->_checksumHeader = base._checksumHeader;
+        item->_fileId = base._fileId;
+        item->_remotePerm = base._remotePerm;
+        item->setInstruction(CSYNC_INSTRUCTION_RENAME);
+        item->_direction = SyncFileItem::Down;
+        item->_renameTarget = adjustedOriginalPath;
+        item->_file = path._local;
+        item->_originalFile = originalPath;
+        qCInfo(lcDisco) << "Rename detected (down) " << item->_file << " -> " << item->_renameTarget;
         finalize(path, recurseQueryServer);
         return;
     }

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -154,6 +154,10 @@ private:
     /// processFile helper for when remote information is available, typically flows into AnalyzeLocalInfo when done
     void processFileAnalyzeRemoteInfo(const SyncFileItemPtr &item, PathTuple, const LocalInfo &, const RemoteInfo &, const SyncJournalFileRecord &);
 
+    /// Function to gradually check conditions for accepting a move-candidate
+    bool isMove(
+        const SyncFileItemPtr &item, const PathTuple &path, const LocalInfo &localEntry, const SyncJournalFileRecord &base, const QString &originalPath) const;
+
     /// processFile helper for reconciling local changes
     void processFileAnalyzeLocalInfo(const SyncFileItemPtr &item, const PathTuple &, const LocalInfo &, const RemoteInfo &, const SyncJournalFileRecord &, QueryMode recurseQueryServer);
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -564,7 +564,7 @@ const SyncOptions &OwncloudPropagator::syncOptions() const
 Result<QString, bool> OwncloudPropagator::localFileNameClash(const QString &relFile)
 {
     OC_ASSERT(!relFile.isEmpty());
-    if (!relFile.isEmpty() && Utility::fsCasePreserving()) {
+    if (!relFile.isEmpty() && Utility::fsCasePreservingButCaseInsensitive()) {
         const QFileInfo fileInfo(_localDir + relFile);
 #ifdef Q_OS_MAC
         // APFS is case preserving but case ignoring. It is also normalization preserving and normalization ignoring.

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -224,10 +224,10 @@ void PropagateLocalRename::start()
         propagator()->reportProgress(*_item, 0);
         qCDebug(lcPropagateLocalRename) << "MOVE " << existingFile << " => " << targetFile;
 
-        if (QString::compare(_item->_file, _item->_renameTarget, Qt::CaseInsensitive) != 0
-            && propagator()->localFileNameClash(_item->_renameTarget)) {
-            // Only use localFileNameClash for the destination if we know that the source was not
-            // the one conflicting  (renaming  A.txt -> a.txt is OK)
+        if (_item->_file.normalized(QString::NormalizationForm_C)
+                != _item->_renameTarget.normalized(QString::NormalizationForm_C) // Normalization-only changes are okay
+            && QString::compare(_item->_file, _item->_renameTarget, Qt::CaseInsensitive) != 0 // Case-only changes are ok
+            && propagator()->localFileNameClash(_item->_renameTarget)) { // Anything else: check for a name-clash
 
             // Fixme: the file that is the reason for the clash could be named here,
             // it would have to come out the localFileNameClash function

--- a/src/libsync/syncoptions.cpp
+++ b/src/libsync/syncoptions.cpp
@@ -48,6 +48,7 @@ void SyncOptions::setFilePattern(const QString &pattern)
 
 void SyncOptions::setPathPattern(const QString &pattern)
 {
-    _fileRegex.setPatternOptions(Utility::fsCasePreserving() ? QRegularExpression::CaseInsensitiveOption : QRegularExpression::NoPatternOption);
+    _fileRegex.setPatternOptions(
+        Utility::fsCasePreservingButCaseInsensitive() ? QRegularExpression::CaseInsensitiveOption : QRegularExpression::NoPatternOption);
     _fileRegex.setPattern(pattern);
 }

--- a/test/testlocaldiscovery.cpp
+++ b/test/testlocaldiscovery.cpp
@@ -315,6 +315,49 @@ private Q_SLOTS:
         QVERIFY(remoteState.find(QStringLiteral("P/B") + incorrect + QStringLiteral("/b"))
             == nullptr); // there should NOT be a directory with another normalization
     }
+
+    void testLocalNameNormalizationChange()
+    {
+        QFETCH_GLOBAL(Vfs::Mode, vfsMode);
+        QFETCH_GLOBAL(bool, filesAreDehydrated);
+
+        // Create an empty remote folder
+        FakeFolder fakeFolder({FileInfo{}}, vfsMode, filesAreDehydrated);
+        OperationCounter counter(fakeFolder);
+
+        const unsigned char a_umlaut_composed_bytes[] = {0xc3, 0xa4, 0x00};
+        const QString a_umlaut_composed = QString::fromUtf8(reinterpret_cast<const char *>(a_umlaut_composed_bytes));
+        const QString a_umlaut_decomposed = a_umlaut_composed.normalized(QString::NormalizationForm_D);
+
+        // OC10 stores names in composed form only, oCIS might have a mix, but NFC is common.
+        fakeFolder.remoteModifier().insert(a_umlaut_composed);
+
+        // Download the file
+        QVERIFY(fakeFolder.applyLocalModificationsAndSync());
+
+        // With client version 5 on mac, the file name would be decomposed by Qt. Simulate that:
+        QString err;
+        bool result = FileSystem::uncheckedRenameReplace(fakeFolder.localPath() + a_umlaut_composed, fakeFolder.localPath() + a_umlaut_decomposed, &err);
+        QVERIFY(result);
+        QVERIFY(err.isEmpty());
+
+        // Now nothing should happen...
+        counter.reset();
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(counter.nGET, 0);
+        QCOMPARE(counter.nDELETE, 0);
+        QCOMPARE(counter.nMOVE, 0);
+        QCOMPARE(counter.nPUT, 0);
+
+        // Check that nothing changed on the server:
+        QVERIFY(fakeFolder.currentRemoteState().find(a_umlaut_composed) != nullptr);
+        QVERIFY(fakeFolder.currentRemoteState().find(a_umlaut_decomposed) == nullptr);
+
+        // Check that locally the file is renamed back to the same composition as on the server
+        QVERIFY(fakeFolder.currentLocalState().find(a_umlaut_composed) != nullptr);
+        QVERIFY(fakeFolder.currentLocalState().find(a_umlaut_decomposed) == nullptr);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestLocalDiscovery)

--- a/test/testsyncfilestatustracker.cpp
+++ b/test/testsyncfilestatustracker.cpp
@@ -295,11 +295,11 @@ private Q_SLOTS:
 
         // Should still get the status for different casing on macOS and Windows.
         QCOMPARE(fakeFolder.syncEngine().syncFileStatusTracker().fileStatus(QStringLiteral("a")),
-            SyncFileStatus(Utility::fsCasePreserving() ? SyncFileStatus::StatusWarning : SyncFileStatus::StatusNone));
+            SyncFileStatus(Utility::fsCasePreservingButCaseInsensitive() ? SyncFileStatus::StatusWarning : SyncFileStatus::StatusNone));
         QCOMPARE(fakeFolder.syncEngine().syncFileStatusTracker().fileStatus(QStringLiteral("A/A1")),
-            SyncFileStatus(Utility::fsCasePreserving() ? SyncFileStatus::StatusError : SyncFileStatus::StatusNone));
+            SyncFileStatus(Utility::fsCasePreservingButCaseInsensitive() ? SyncFileStatus::StatusError : SyncFileStatus::StatusNone));
         QCOMPARE(fakeFolder.syncEngine().syncFileStatusTracker().fileStatus(QStringLiteral("b")),
-            SyncFileStatus(Utility::fsCasePreserving() ? SyncFileStatus::StatusExcluded : SyncFileStatus::StatusNone));
+            SyncFileStatus(Utility::fsCasePreservingButCaseInsensitive() ? SyncFileStatus::StatusExcluded : SyncFileStatus::StatusNone));
     }
 
     void parentsGetWarningStatusForError() {

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -592,7 +592,7 @@ private Q_SLOTS:
         remote.appendByte(QStringLiteral("A2/a2m"));
         local.rename(QStringLiteral("A2"), QStringLiteral("A3"));
         local.setContents(QStringLiteral("B2/b2m"), FileModifier::DefaultFileSize, 'D');
-        local.appendByte(QStringLiteral("B2/b2m"));
+        local.appendByte(QStringLiteral("B2/b2m"), 'D');
         remote.rename(QStringLiteral("B2"), QStringLiteral("B3"));
         QVERIFY(fakeFolder.applyLocalModificationsAndSync());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
@@ -607,16 +607,16 @@ private Q_SLOTS:
 
         // Folder rename with contents touched on both ends
         remote.setContents(QStringLiteral("A3/a2m"), FileModifier::DefaultFileSize, 'R');
-        remote.appendByte(QStringLiteral("A3/a2m"));
+        remote.appendByte(QStringLiteral("A3/a2m"), 'R');
         local.setContents(QStringLiteral("A3/a2m"), FileModifier::DefaultFileSize, 'L');
-        local.appendByte(QStringLiteral("A3/a2m"));
-        local.appendByte(QStringLiteral("A3/a2m"));
+        local.appendByte(QStringLiteral("A3/a2m"), 'L');
+        local.appendByte(QStringLiteral("A3/a2m"), 'L');
         local.rename(QStringLiteral("A3"), QStringLiteral("A4"));
         remote.setContents(QStringLiteral("B3/b2m"), FileModifier::DefaultFileSize, 'R');
-        remote.appendByte(QStringLiteral("B3/b2m"));
+        remote.appendByte(QStringLiteral("B3/b2m"), 'R');
         local.setContents(QStringLiteral("B3/b2m"), FileModifier::DefaultFileSize, 'L');
-        local.appendByte(QStringLiteral("B3/b2m"));
-        local.appendByte(QStringLiteral("B3/b2m"));
+        local.appendByte(QStringLiteral("B3/b2m"), 'L');
+        local.appendByte(QStringLiteral("B3/b2m"), 'L');
         remote.rename(QStringLiteral("B3"), QStringLiteral("B4"));
         QThread::sleep(1); // This test is timing-sensitive. No idea why, it's probably the modtime on the client side.
         QVERIFY(fakeFolder.applyLocalModificationsAndSync());
@@ -629,6 +629,7 @@ private Q_SLOTS:
         auto conflicts = findConflicts(currentLocal.children[QStringLiteral("A4")]);
         QCOMPARE(conflicts.size(), 1);
         for (const auto &c : std::as_const(conflicts)) {
+            qDebug() << c;
             QCOMPARE(currentLocal.find(c)->contentChar, 'L');
             local.remove(c);
         }

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -155,12 +155,12 @@ private Q_SLOTS:
 
     void testFsCasePreserving()
     {
-        QVERIFY(isMac() || isWindows() ? fsCasePreserving() : ! fsCasePreserving());
+        QVERIFY(isMac() || isWindows() ? fsCasePreservingButCaseInsensitive() : !fsCasePreservingButCaseInsensitive());
         QScopedValueRollback<bool> scope(OCC::fsCasePreserving_override);
         OCC::fsCasePreserving_override = 1;
-        QVERIFY(fsCasePreserving());
+        QVERIFY(fsCasePreservingButCaseInsensitive());
         OCC::fsCasePreserving_override = 0;
-        QVERIFY(! fsCasePreserving());
+        QVERIFY(!fsCasePreservingButCaseInsensitive());
     }
 
     void testFileNamesEqual()
@@ -169,7 +169,7 @@ private Q_SLOTS:
         QVERIFY(dir.isValid());
         QDir dir2(dir.path());
         QVERIFY(dir2.mkpath(QStringLiteral("1")));
-        if( !fsCasePreserving() ) {
+        if (!fsCasePreservingButCaseInsensitive()) {
             QVERIFY(dir2.mkpath(QStringLiteral("TEST")));
         }
         QVERIFY(dir2.mkpath(QStringLiteral("test/TESTI")));


### PR DESCRIPTION
…336)

* Fix sync issue on mac when file name is locally NFD, remote NFC

This happens after a migration from 6 to 7. A previous sync will have created file names locally in NFD (decomposed form), while the server might have them in NFC (composed form). This would result in a DELETE and a PUT (file locally removed, but a new one was created), instead of a MOVE (rename). Subsequent changes will make this remote MOVE a local rename.

* Renamed fsCasePreserving

Renamed to fsCasePreservingButCaseInsensitive, because it is the case-insensitive bit that is actually checked for.

* Move lambda into its own method

Also assume not-a-move when we cannot calculate the checksum of a file, as the contents might have changed, which we cannot detect.

* Fix tests

* Use `std::filesystem::rename` in `FileSystem::rename`

So Qt on macOS won't mess with the normalization of the file name.

* Check for normalization-only change in PropagateLocalRename

Normalization-only changes for a rename are not a collision, just like case-only changes.

* Detect local normalization-only rename, and name it back

When a local rename is detected, but only the normalization has changed, do not propagate this to the server. For users these normalization changes are not visible, so "rename" the local file back to the original name.

(cherry picked from commit 21a529f6ff0bd375c4c64ec5db0b3c4fcab1c0a1)