### PR TITLE
[test-only][full-ci] Fix commit_author handling for scheduled workflow runs

### DIFF
--- a/.github/workflows/gui-tests.yml
+++ b/.github/workflows/gui-tests.yml
@@ -175,4 +175,5 @@ jobs:
           CACHE_BUCKET: ${{ env.S3_PUBLIC_CACHE_BUCKET }}
           MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
           GITHUB_BUILD_STATUS: ${{ needs.gui-tests.result }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: bash test/gui/ci/notification_template.sh .

--- a/test/gui/ci/notification_template.sh
+++ b/test/gui/ci/notification_template.sh
@@ -11,13 +11,6 @@ TEST_LOGS=""
 BRANCH_NAME="${GITHUB_REF_NAME}"
 ROOMID="!rnWsCVUmDHDJbiSPMM:matrix.org"
 
-
-if [ "${GITHUB_EVENT_NAME}" == "schedule" ]; then
-    COMMIT_AUTHOR="Scheduled Run ($(git log -1 --pretty=format:'%an' 2>/dev/null))"
-else
-    COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an' 2>/dev/null)
-fi
-
 if [ "${GITHUB_BUILD_STATUS}" == "failure" ]; then
     BUILD_STATUS="❌️ Failure"
 fi
@@ -75,7 +68,10 @@ log_success() {
 
 GITHUB_BUILD_LINK="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-message_html='<b>'$BUILD_STATUS'</b> <a href="'${GITHUB_BUILD_LINK}'">'${GITHUB_REPOSITORY}'#'$COMMIT_SHA_SHORT'</a> ('${BRANCH_NAME}') by <b>'${COMMIT_AUTHOR}'</b> <br> <b>'"${TEST_LOGS}"'</b>'
+AUTHOR_NAME=""
+[ "$GITHUB_EVENT_NAME" != "schedule" ] && AUTHOR_NAME=" by <b>$COMMIT_AUTHOR</b>"
+
+message_html='<b>'$BUILD_STATUS'</b> <a href="'${GITHUB_BUILD_LINK}'">'${GITHUB_REPOSITORY}'#'$COMMIT_SHA_SHORT'</a> ('${BRANCH_NAME}')'${AUTHOR_NAME}' <br> <b>'"${TEST_LOGS}"'</b>'
 message_html=$(echo "$message_html" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
 
 log_info "Sending report to the element chat..."


### PR DESCRIPTION
Scheduled GitHub Actions runs do not have a real commit author. This PR removes the `COMMIT_AUTHOR` from schedule workflow. Push and pull request workflows continue to display the commit author as before.