### PR TITLE
fix: compatibility with extra-cmake-modules-6.19.0 (#12374)

### DIFF
--- a/changelog/unreleased/12374.md
+++ b/changelog/unreleased/12374.md
@@ -1,0 +1,5 @@
+Bugfix: Fix compatibility with extra-cmake-modules-6.19.0
+
+Fix runtime crash at startup with ECM 6.19.
+
+https://github.com/owncloud/client/pull/12374

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -119,6 +119,7 @@ ecm_add_qml_module(owncloudGui
         URI org.ownCloud.gui
         VERSION 1.0
         NAMESPACE OCC
+        GENERATE_PLUGIN_SOURCE
         QML_FILES
             qml/AccountBar.qml
             qml/AccountButton.qml

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -100,6 +100,7 @@ ecm_add_qml_module(libsync
         URI org.ownCloud.libsync
         VERSION 1.0
         NAMESPACE OCC
+        GENERATE_PLUGIN_SOURCE
 )
 
 ecm_finalize_qml_module(libsync DESTINATION ${KDE_INSTALL_QMLDIR})

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -45,6 +45,7 @@ ecm_add_qml_module(owncloudResources
         URI org.ownCloud.resources
         VERSION 1.0
         NAMESPACE OCC
+        GENERATE_PLUGIN_SOURCE
 )
 
 ecm_finalize_qml_module(owncloudResources DESTINATION ${KDE_INSTALL_QMLDIR})


### PR DESCRIPTION
Fix compatibility with extra-cmake-modules-6.19.0

owncloud is not using a custom QQmlExtensionPlugin subclass, so we need to pass GENERATE_PLUGIN_SOURCE so that a default implementation is generated.

This fixes compatibility with ECM 6.19 since that (correctly) considers plugins that don't use GENERATE_PLUGIN_SOURCE to be not optional [0]. That causes the QML engine to try and load the (invalid) plugin:

```
QList(qrc:/qt/qml/org/ownCloud/gui/qml/AccountBar.qml:18:1: Failed to extract plugin
  meta data from '/usr/lib64/qt6/qml/org/ownCloud/gui/libowncloudGuiplugin.so':
    '/usr/lib64/qt6/qml/org/ownCloud/gui/libowncloudGuiplugin.so' is not a Qt plugin (metadata not found)
    import org.ownCloud.gui 1.0
    ^)
```

Pass GENERATE_PLUGIN_SOURCE to fix the startup problem.

[0] commit 4e9b73da40792ece7885924007441880ecc06d8d

Bug: https://bugs.gentoo.org/964420



(cherry picked from commit 77b6f1609595582e0511f0f27ab6cd3c0f907555)