### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -19,14 +19,10 @@
 #include "utility_win.h"
 #include "utility.h"
 
-#include "asserts.h"
-#include "filesystembase.h"
-
 #include <comdef.h>
 #include <qt_windows.h>
 #include <shlguid.h>
 #include <shlobj.h>
-#include <string>
 
 #include <QCoreApplication>
 #include <QDir>
@@ -110,18 +106,6 @@ QString Utility::formatWinError(long errorCode)
 {
     return QStringLiteral("WindowsError: %1: %2").arg(QString::number(errorCode, 16), QString::fromWCharArray(_com_error(errorCode).ErrorMessage()));
 }
-
-
-Utility::NtfsPermissionLookupRAII::NtfsPermissionLookupRAII()
-{
-    qt_ntfs_permission_lookup++;
-}
-
-Utility::NtfsPermissionLookupRAII::~NtfsPermissionLookupRAII()
-{
-    qt_ntfs_permission_lookup--;
-}
-
 
 Utility::Handle::Handle(HANDLE h, std::function<void(HANDLE)> &&close)
     : _handle(h)

--- a/src/common/utility_win.h
+++ b/src/common/utility_win.h
@@ -72,20 +72,5 @@ namespace Utility {
     OCSYNC_EXPORT void UnixTimeToLargeIntegerFiletime(time_t t, LARGE_INTEGER *hundredNSecs);
 
     OCSYNC_EXPORT QString formatWinError(long error);
-
-    class OCSYNC_EXPORT NtfsPermissionLookupRAII
-    {
-    public:
-        /**
-         * NTFS permissions lookup is disabled by default for performance reasons
-         * Enable it and disable it again once we leave the scope
-         * https://doc.qt.io/Qt-5/qfileinfo.html#ntfs-permissions
-         */
-        NtfsPermissionLookupRAII();
-        ~NtfsPermissionLookupRAII();
-
-    private:
-        Q_DISABLE_COPY(NtfsPermissionLookupRAII);
-    };
 }
 }

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -193,7 +193,7 @@ GraphApi::Space *Folder::space() const
 bool Folder::checkLocalPath()
 {
 #ifdef Q_OS_WIN
-    Utility::NtfsPermissionLookupRAII ntfs_perm;
+    QNtfsPermissionCheckGuard ntfs_perm;
 #endif
     const QFileInfo fi(_definition.localPath());
     _canonicalLocalPath = fi.canonicalFilePath();

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -950,7 +950,7 @@ QString FolderMan::checkPathValidityRecursive(const QString &path, FolderMan::Ne
     }
 
 #ifdef Q_OS_WIN
-    Utility::NtfsPermissionLookupRAII ntfs_perm;
+    QNtfsPermissionCheckGuard ntfs_perm;
 #endif
 
     auto pathLengthCheck = Folder::checkPathLength(path);

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1009,5 +1009,3 @@ void SocketApiJobV2::setWarning(const QString &warning)
 }
 
 } // namespace OCC
-
-#include "socketapi.moc"

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -248,7 +248,7 @@ QString ConfigFile::configPath()
 QString ConfigFile::excludeFile(Scope scope) const
 {
 #ifdef Q_OS_WIN
-    Utility::NtfsPermissionLookupRAII ntfs_perm;
+    QNtfsPermissionCheckGuard ntfs_perm;
 #endif
     // prefer sync-exclude.lst, but if it does not exist, check for
     // exclude.lst for compatibility reasons in the user writeable

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -34,7 +34,7 @@ private Q_SLOTS:
     void testCheckPathValidityForNewFolder()
     {
 #ifdef Q_OS_WIN
-        Utility::NtfsPermissionLookupRAII ntfs_perm;
+        QNtfsPermissionCheckGuard ntfs_perm;
 #endif
         auto dir = TestUtils::createTempDir();
         QVERIFY(dir.isValid());


### PR DESCRIPTION
- Use `QNtfsPermissionCheckGuard` instead of deprecated API
- Remove unused includes
- remove include of `socketapi.moc`, nothing needs to be moc-ed anymore