### PR TITLE
[tests-only][full-ci] backport remove c compiler env on client build stage

### DIFF
--- a/.github/workflows/gui-tests.yml
+++ b/.github/workflows/gui-tests.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -G"Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DBUILD_TESTING=OFF -S ..
+          cmake -G"Ninja" -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=OFF -S ..
           ninja
 
       - name: Install Python Modules


### PR DESCRIPTION
## Description
Backport of PR: https://github.com/owncloud/client/pull/12457