### PR TITLE
ci: open PR for translation updates instead of pushing directly

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -10,8 +10,7 @@ permissions: {}
 jobs:
   update-translations:
     permissions:
-      # for git push
-      contents: write
+      contents: read
     strategy:
       matrix:
         # current transifex plan only allows 1 additional branch
@@ -25,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ssh-key: ${{ secrets.DEPLOYMENT_SSH_KEY }}
           submodules: recursive
           fetch-depth: 0
           ref: ${{ matrix.branch }}
+          persist-credentials: false
 
       - name: install-deps
         run: sudo apt install -y qt6-l10n-tools
@@ -72,14 +71,21 @@ jobs:
           token: ${{ secrets.TX_TOKEN }}
           args: pull --force --all --silent
 
-      - name: Push
-        run: |
-          git config user.name "ownClouders"
-          git config user.email "devops@owncloud.com"
-          git add translations
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          git commit -m "[tx] updated translations from transifex"
-          git push origin ${{ matrix.branch }}
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+        with:
+          app-id: ${{ secrets.TRANSLATION_APP_ID }}
+          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
+
+      - name: Create or update translations PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/translations-update-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          commit-message: "chore: update translations from transifex"
+          title: "chore: update translations from transifex"
+          body: "Automated translation update from Transifex. This pull request is updated on each sync run — merging it will close it and a fresh one will be opened on the next change."
+          delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
## Summary
- Replaces direct `git push` to `master`/`6` branches with `peter-evans/create-pull-request`
- Translations are now proposed via a PR (`chore/translations-update-<branch>`) that can be reviewed before merging
- Uses a GitHub App token (`TRANSLATION_APP_ID` / `TRANSLATION_APP_PRIVATE_KEY`) for PR creation — same approach as [`translation-sync.yml`](https://github.com/owncloud/reusable-workflows/blob/main/.github/workflows/translation-sync.yml) in reusable-workflows
- Removed `ssh-key` from checkout and downgraded `contents` permission to `read` since we no longer push directly
- Each matrix branch gets its own PR branch (`chore/translations-update-master`, `chore/translations-update-6`) targeting the correct base branch

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify two PRs are opened (one per matrix branch)
- [ ] Verify no direct commits land on `master` or `6`
- [ ] Confirm `TRANSLATION_APP_ID` and `TRANSLATION_APP_PRIVATE_KEY` secrets are available in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)