### PR TITLE
feat: request review from desktop-developers on translation PRs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -89,3 +89,4 @@ jobs:
           body: "Automated translation update from Transifex. This pull request is updated on each sync run — merging it will close it and a fresh one will be opened on the next change."
           delete-branch: true
           sign-commits: true
+          team-reviewers: owncloud/desktop-developers


### PR DESCRIPTION
## Summary

- Adds `team-reviewers: owncloud/desktop-developers` to the `create-pull-request` step in `translate.yml`
- The `desktop-developers` team will automatically be requested for review on every translation sync PR

## Test plan
- [ ] Trigger `translate.yml` via `workflow_dispatch` and verify the created/updated translation PR shows `desktop-developers` as a requested reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)