### PR TITLE
ci: add PR title linting workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - synchronize
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/lint-pr-title.yml` to enforce semantic PR titles via `amannn/action-semantic-pull-request`
- Mirrors the workflow already used in many other repos e.g. [owncloud/impersonate](https://github.com/owncloud/impersonate/blob/master/.github/workflows/lint-pr-title.yml)

## Test plan
- [ ] Open a PR with a non-semantic title and verify the check fails
- [ ] Open a PR with a semantic title (e.g. `fix: ...`) and verify the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)