### PR TITLE
fix: [DC-291] Complaints about location of Manage Account menu indicator

### DIFF
--- a/src/gui/accountview.ui
+++ b/src/gui/accountview.ui
@@ -69,8 +69,22 @@
       </item>
       <item>
        <widget class="QPushButton" name="manageAccountButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="focusPolicy">
          <enum>Qt::FocusPolicy::StrongFocus</enum>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton::menu-indicator 
+{
+	subcontrol-origin: padding;
+    subcontrol-position: right center;
+	left: -2;	
+}</string>
         </property>
         <property name="text">
          <string>Manage Account</string>


### PR DESCRIPTION
in essence the indicator look and position is what the windows style "wants" and changing it may break the mac look

if this change messes up mac look/feel it's dead in the water. 