### PR TITLE
ci: use reusable calens workflow from reusable-workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,43 +10,7 @@ permissions: {}
 
 jobs:
   changelog:
-    runs-on: ubuntu-latest
-    permissions: {}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Generate changelog
-        uses: actionhippie/calens@244f3e5c328b842a740113859b87bbebf697f63b # v1.13.1
-        with:
-          target: CHANGELOG.md
-
-      - name: Show diff
-        run: git diff
-
-      - name: Output
-        run: cat CHANGELOG.md
-
-      - name: Generate GitHub App token
-        id: app-token
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
-        with:
-          app-id: ${{ secrets.TRANSLATION_APP_ID }}
-          private-key: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
-
-      - name: Create or update changelog pull request
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          branch: chore/changelog-update
-          commit-message: "chore: update changelog"
-          title: "chore: update changelog"
-          body: "Automated changelog update. This pull request is updated on each push to master — merging it will close it and a fresh one will be opened on the next change."
-          delete-branch: true
-          sign-commits: true
+    uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
+    secrets:
+      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
+      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Replaces the inline changelog job with a call to `owncloud/reusable-workflows/.github/workflows/calens.yml@main`
- Trigger (`pull_request`, `push` to master/tags) is unchanged
- On pull requests and tags the reusable workflow runs calens and shows the diff but skips PR creation (guarded by `github.ref == refs/heads/master`)

## Test plan

- [ ] Merge owncloud/reusable-workflows#39 first
- [ ] Open a PR in this repo — confirm the changelog job runs but does not create a changelog PR
- [ ] Push to master — confirm a `chore/changelog-update` PR is created/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)