### PR TITLE
ci: rename calens GitHub App secrets to CALENS_APP_ID/KEY

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,5 +12,5 @@ jobs:
   changelog:
     uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
     secrets:
-      CALENS_APP_ID: ${{ secrets.CALENS_APP_ID }}
-      CALENS_APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}
+      APP_ID: ${{ secrets.CALENS_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,5 +12,5 @@ jobs:
   changelog:
     uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
     secrets:
-      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
-      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}
+      CALENS_APP_ID: ${{ secrets.CALENS_APP_ID }}
+      CALENS_APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Standardize changelog workflow to use \`CALENS_APP_ID\` / \`CALENS_APP_PRIVATE_KEY\` instead of the overloaded \`TRANSLATION_APP_*\` secrets.

Org-level secrets are already provisioned. Merge this before merging the corresponding \`reusable-workflows\` PR.