### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,9 @@
-## Submitting Desktop Client issues
+# Contributing
 
-If you have questions about how to use the ownCloud Desktop Client, please
-join our [forum][forum].
-We are also available on [IRC][irc].
+Thank you for your interest in contributing to this project!
 
-### Bug Reporting Guidelines
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
 
-- **Important**: When reporting an issue provide as much requested information as possible, we :heart: log files.
-- **SECURITY**: Report any potential security bug to security@owncloud.com following our [security policy](https://owncloud.com/security/) instead of filing an issue in our bug tracker
-- This repository is _only_ for issues within the ownCloud desktop client.
-  Issues in other components should be reported in their own repositories:
-  - [ownCloud server](https://github.com/owncloud/core/issues)
-  - [ownCloud apps](https://github.com/owncloud/apps/issues) (e.g. Calendar,
-    Contacts...)
-  - [Android client](https://github.com/owncloud/android/issues)
-  - [iOS client](https://github.com/owncloud/ios-issues/issues)
-- Search the existing issues first, it's likely that your issue was already
-  reported.
-
-If your issue appears to be a bug, and hasn't been reported, open a new issue.
-
-Help us to maximize the effort we can spend fixing issues and adding new
-features, by not reporting duplicate issues.
-
-[forum]: https://central.owncloud.org/
-[irc]: https://web.libera.chat/?channels=#owncloud
-
-## Contributing to Source Code
-
-Thanks for wanting to contribute source code to ownCloud. That's great!
-
-Before we're able to merge your code to ownCloud Desktop Client, you need to sign
-our [Contributor Agreement][agreement].
-
-Please read the [Desktop Client Manual][desktopman] to get useful info about the client.
-
-[agreement]: https://owncloud.com/contribute/join-the-development/contributor-agreement/
-[desktopman]: https://doc.owncloud.com/desktop
-
-## Translations
-
-Please submit translations via [Transifex][transifex].
-
-[transifex]: https://www.transifex.com/projects/p/owncloud/
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,112 @@
 # ownCloud Desktop Client
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/client/status.svg)](https://drone.owncloud.com/owncloud/client) [![Build Status](https://github.com/owncloud/client/workflows/ownCloud%20CI/badge.svg)](https://github.com/owncloud/client/actions)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-## Introduction
+[![License](https://img.shields.io/badge/License-GPL--2.0-blue.svg)](COPYING) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
-The ownCloud Desktop Client is a tool to synchronize files from ownCloud Server
-with your computer.
+The ownCloud Desktop Client synchronizes files between an ownCloud server and your local computer. It runs on Windows, macOS, and Linux, providing automatic background synchronization, selective sync, conflict resolution, and virtual file support. The client integrates with the native file manager through shell extensions for overlay icons and context menu actions.
 
-## Download
+## Part of Desktop Client
 
-### Binary packages
+This is the core repository for the [ownCloud Desktop Client](https://github.com/owncloud/client). It connects to both [ownCloud Infinite Scale (oCIS)](https://github.com/owncloud/ocis) and [ownCloud Server (Classic)](https://github.com/owncloud/core). Download the latest release from [owncloud.com/desktop-app](https://owncloud.com/desktop-app/).
 
-- Refer to the download page https://owncloud.com/desktop-app/
+## Getting Started
 
-### Source code
+Follow the steps below to install or build the desktop client.
 
-The ownCloud Desktop Client is developed in Git. Since Git makes it easy to
-fork and improve the source code and to adapt it to your need, many copies
-can be found on the Internet, in particular on GitHub. However, the
-authoritative repository maintained by the developers is located at
-https://github.com/owncloud/client.
+### Binary Packages
 
-### Building from source
+Download from https://owncloud.com/desktop-app/
 
-This project uses CMake as build system. Please refer to the cmake documentation
-for general instructions on how to use CMake: https://cmake.org/documentation/.
+### Building from Source
 
-Further more as meta build system KDE Craft is used. Please refer to the KDE Craft
-documentation for instructions on how to use Craft: https://community.kde.org/Craft.
+This project uses CMake as its build system and KDE Craft as a meta build system.
 
-For easy to use instructions on how to build the ownCloud Desktop Client please have 
-a look at https://github.com/owncloud/ownbuild.
+- [CMake documentation](https://cmake.org/documentation/)
+- [KDE Craft documentation](https://community.kde.org/Craft)
+- [Build instructions](https://github.com/owncloud/ownbuild)
 
-## Reporting issues and contributing
+## Documentation
 
-If you find any bugs or have any suggestion for improvement, please
-file an issue at https://github.com/owncloud/client/issues. Do not
-contact the authors directly by mail, as this increases the chance
-of your report being lost.
+- [CHANGELOG.md](https://github.com/owncloud/client/blob/master/CHANGELOG.md) - Release history
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
+- [PACKAGING.md](https://github.com/owncloud/client/blob/master/PACKAGING.md) - Packaging instructions
+- [ownCloud documentation](https://doc.owncloud.com)
 
-If you created a patch, please submit a [Pull
-Request](https://github.com/owncloud/client/pulls). For non-trivial
-patches, we need you to sign the [Contributor
-Agreement](https://owncloud.com/contribute/join-the-development/contributor-agreement/) before
-we can accept your patch.
+## Community & Support
 
+**[Star](https://github.com/owncloud/client)** this repo and **Watch** for release notifications!
 
-## Maintainers and Contributors
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-ownCloud Desktop Client is developed by the ownCloud community and [receives
-patches from a variety of authors](https://github.com/owncloud/client/graphs/contributors).
+## Contributing
 
-Past maintainers:
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-- Markus Goetz <guruz@owncloud.com>
-- Olivier Goffart <ogoffart@owncloud.com>
-- Christian Kamm <mail@ckamm.de>
-- Thomas Müller <thomas.mueller@owncloud.com>
-- Klaas Freitag <freitag@owncloud.com>
-- Daniel Molkentin <daniel@molkentin.de>
-- Andreas Schneider <asn@cryptomilk.org>
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
 
 ## License
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+This project is licensed under the [GPL-2.0](COPYING).
 
-    This program is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-    for more details.
+## About the ownCloud OSPO
 
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-2.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: GPL-2.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,80 @@
+# AI Agent Guidelines for ownCloud Desktop Client
+
+This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) working in this repository.
+
+## Repository Overview
+- **Product family:** Desktop Client
+- **Primary language(s):** C++
+- **Build system:** CMake
+- **Test framework:** Qt Test, CTest
+- **CI system:** GitHub Actions
+
+## Architecture & Key Paths
+- `src/` - Main source code (GUI, sync engine, networking)
+- `test/` - Test suites
+- `shell_integration/` - File manager shell integration modules
+- `cmake/` - CMake modules and helpers
+- `admin/` - Administrative scripts and packaging
+- `translations/` - Translation files
+- `CMakeLists.txt` - Root CMake configuration
+- `VERSION.cmake` - Version definition
+- `OWNCLOUD.cmake` - ownCloud-specific CMake variables
+- `THEME.cmake` - Theming configuration
+- `CONTRIBUTING.md` - Contribution guidelines
+- `CHANGELOG.md` - Release history
+- `sync-exclude.lst` - Default sync exclusion patterns
+
+## Development Conventions
+- **Branching:** master
+- **Commit messages:** DCO sign-off required (`git commit -s`)
+- **Code style:** EditorConfig (.editorconfig)
+- **PR process:** Open a PR against master. All CI checks must pass.
+
+## Build & Test Commands
+```bash
+# Build (using CMake)
+mkdir build && cd build
+cmake ..
+cmake --build .
+
+# Test
+cd build && ctest
+
+# Meta build system (recommended)
+# See https://community.kde.org/Craft for KDE Craft instructions
+```
+
+## Important Constraints
+- All code contributions must be compatible with the **GPL-2.0** license
+- Do not introduce new **copyleft-licensed dependencies** (GPL, AGPL, LGPL, MPL) without explicit discussion in an issue first. This is especially important for repos migrating to Apache 2.0.
+- Do not introduce new dependencies without discussion in an issue first
+- C++17 standard is required (CMAKE_CXX_STANDARD 17)
+- KDE heritage code exists - be aware of KDE-era copyrights
+- Documentation is separately licensed under COPYING.documentation
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), or verified on the GitHub Marketplace.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it.
+
+## Context for AI Agents
+- Match existing code style
+- Do not refactor unrelated code in the same PR
+- Write tests for new functionality
+- Keep PRs focused and atomic
+- Follow Qt/C++ conventions used in the existing codebase
+- Shell integrations (Dolphin, Nautilus) are in separate repositories


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  - License-specific OSPO section (Desktop Client is GPL-2.0 — migration prerequisites listed per [Apache legal policy](https://www.apache.org/legal/resolved.html) Category X)
  - Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  - Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  - Security section pointing to security.owncloud.com + YesWeHack bug bounty
  - Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** _(new)_: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** _(new)_: Redirect to https://owncloud.com/contribute/code-of-conduct/
- **CONTRIBUTING.md**: Replaced with canonical redirect to https://owncloud.com/contribute/
- **SECURITY.md** _(new)_: Redirect to https://security.owncloud.com + YesWeHack
- **SUPPORT.md** _(new)_: Redirect to https://owncloud.com/contact-us/ and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] GPL-2.0 migration prerequisites are correctly listed
- [ ] Transifex link points to correct owncloud project

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: https://kiteworks.com/opensource