### PR TITLE
feat: add GET_PRIVATE_LINK socket command for Wayland clipboard support

### DIFF
--- a/src/gui/guiutility.h
+++ b/src/gui/guiutility.h
@@ -50,7 +50,7 @@ namespace Utility {
 
     void startShellIntegration();
 
-    QString socketApiSocketPath();
+    OWNCLOUDGUI_EXPORT QString socketApiSocketPath();
 
     OWNCLOUDGUI_EXPORT void markDirectoryAsSyncRoot(const QString &path, const QUuid &accountUuid);
     std::pair<QString, QUuid> getDirectorySyncRootMarkings(const QString &path);

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -493,6 +493,13 @@ void SocketApi::command_COPY_PRIVATE_LINK(const QString &localFile, SocketListen
     fetchPrivateLinkUrlHelper(localFile, &SocketApi::copyUrlToClipboard);
 }
 
+void SocketApi::command_GET_PRIVATE_LINK(const QString &localFile, SocketListener *listener)
+{
+    fetchPrivateLinkUrlHelper(localFile, [listener](const QUrl &url) {
+        listener->sendMessage(QStringLiteral("PRIVATE_LINK:") + url.toString());
+    });
+}
+
 void SocketApi::command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *)
 {
     fetchPrivateLinkUrlHelper(localFile, &SocketApi::emailPrivateLink);

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -116,6 +116,7 @@ private:
     // The context menu actions
     Q_INVOKABLE void command_SHARE(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_COPY_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_GET_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_OPEN_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_OPEN_PRIVATE_LINK_VERSIONS(const QString &localFile, SocketListener *listener);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ if( UNIX AND NOT APPLE )
 endif(UNIX AND NOT APPLE)
 
 owncloud_add_test(FileSystem)
+owncloud_add_test(SocketApi)
 
 owncloud_add_test(FolderMan)
 

--- a/test/testsocketapi.cpp
+++ b/test/testsocketapi.cpp
@@ -15,7 +15,6 @@
 #include <QtTest>
 #include <QLocalSocket>
 #include <QSignalSpy>
-#include <QStandardPaths>
 #include <QTemporaryDir>
 
 #include <chrono>
@@ -24,6 +23,7 @@ using namespace std::chrono_literals;
 #include "socketapi/socketapi.h"
 #include "folderman.h"
 #include "accountmanager.h"
+#include "guiutility.h"
 
 #include "testutils/syncenginetestutils.h"
 #include "testutils/testutils.h"
@@ -77,14 +77,9 @@ class TestSocketApi : public QObject
     // Path of the folder registered during a test (reset by cleanup()).
     QString _registeredFolderPath;
 
-    // Compute the socket path the same way guiutility_unix.cpp does.
-    // Utility::socketApiSocketPath() provides the same logic, but it lives in the
-    // GUI library and is not exposed as a public method of SocketApi, so the
-    // computation is duplicated here rather than introducing an extra dependency.
     static QString socketApiPath()
     {
-        return QStringLiteral("%1/ownCloud/socket")
-            .arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
+        return Utility::socketApiSocketPath();
     }
 
     // Connect to the SocketApi's server and wait for the connection to be accepted

--- a/test/testsocketapi.cpp
+++ b/test/testsocketapi.cpp
@@ -13,42 +13,38 @@
  */
 
 #include <QtTest>
-#include <QLocalSocket>
-#include <QSignalSpy>
+#include <QBuffer>
 #include <QTemporaryDir>
 
 #include <chrono>
 using namespace std::chrono_literals;
 
 #include "socketapi/socketapi.h"
+#include "socketapi/socketapi_p.h"
 #include "folderman.h"
 #include "accountmanager.h"
-#include "guiutility.h"
 
 #include "testutils/syncenginetestutils.h"
 #include "testutils/testutils.h"
 
 using namespace OCC;
 
-// A minimal fake reply that emits a Depth:0 PROPFIND multistatus response
-// with status 207 and the correct content-type, suitable for private link lookups.
+// Minimal 207 multistatus reply for intercepting PROPFIND requests in tests.
 class FakeMultistatReply : public FakeReply
 {
     Q_OBJECT
 public:
     QByteArray _body;
-
-    FakeMultistatReply(QNetworkAccessManager::Operation op, const QNetworkRequest &request,
+    FakeMultistatReply(QNetworkAccessManager::Operation op, const QNetworkRequest &req,
                        const QByteArray &body, QObject *parent)
         : FakeReply(parent), _body(body)
     {
-        setRequest(request);
-        setUrl(request.url());
+        setRequest(req);
+        setUrl(req.url());
         setOperation(op);
         open(QIODevice::ReadOnly);
         QTimer::singleShot(10ms, this, &FakeMultistatReply::respond);
     }
-
     void respond()
     {
         setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 207);
@@ -58,15 +54,13 @@ public:
         Q_EMIT readyRead();
         checkedFinished();
     }
-
     qint64 readData(char *buf, qint64 max) override
     {
         max = qMin<qint64>(max, _body.size());
-        std::copy(_body.cbegin(), _body.cbegin() + max, buf);
+        memcpy(buf, _body.constData(), static_cast<size_t>(max));
         _body.remove(0, static_cast<int>(max));
         return max;
     }
-
     qint64 bytesAvailable() const override { return _body.size(); }
 };
 
@@ -74,43 +68,16 @@ class TestSocketApi : public QObject
 {
     Q_OBJECT
 
-    // Path of the folder registered during a test (reset by cleanup()).
     QString _registeredFolderPath;
-
-    static QString socketApiPath()
-    {
-        return Utility::socketApiSocketPath();
-    }
-
-    // Connect to the SocketApi's server and wait for the connection to be accepted
-    // (slotNewConnection fired). Returns the connected socket or nullptr on failure.
-    static QLocalSocket *connectAndWaitForListener()
-    {
-        const QString path = socketApiPath();
-        auto *sock = new QLocalSocket;
-        sock->connectToServer(path);
-        if (!sock->waitForConnected(3000)) {
-            qWarning() << "Failed to connect to socket" << path
-                       << "error:" << sock->errorString();
-            delete sock;
-            return nullptr;
-        }
-        // Give the server side a chance to run slotNewConnection and
-        // insert the listener into _listeners.
-        QCoreApplication::processEvents();
-        return sock;
-    }
 
 private Q_SLOTS:
     void initTestCase()
     {
-        // Ensure FolderMan singleton exists before any test
         TestUtils::folderMan();
     }
 
     void cleanup()
     {
-        // Remove any folder registered during the test to avoid polluting later tests.
         if (!_registeredFolderPath.isEmpty()) {
             Folder *folder = TestUtils::folderMan()->folderForPath(_registeredFolderPath);
             if (folder) {
@@ -122,25 +89,17 @@ private Q_SLOTS:
 
     void testGetPrivateLinkSendsUrlOverSocket()
     {
-        // ----- Set up a paused sync folder so no sync fires -----
-
-        // Create a real directory on disk as the local sync root
         const QTemporaryDir tempDir = TestUtils::createTempDir();
         QVERIFY(tempDir.isValid());
-        // Ensure trailing slash (FolderDefinition normalises it, but be explicit)
         const QString localPath = QDir::cleanPath(tempDir.path()) + QLatin1Char('/');
 
-        // createDummyAccount creates an account with a FakeAM (empty FileInfo)
         auto accountState = createDummyAccount();
         Account *account = accountState->account();
 
-        // Enable private links capability
         auto cap = TestUtils::testCapabilities();
         cap[QStringLiteral("files")] = QVariantMap{{QStringLiteral("privateLinks"), true}};
         account->setCapabilities({account->url(), cap});
 
-        // Set a server override: intercept the Depth:0 PROPFIND that fetchPrivateLinkUrl issues
-        // and reply with a 207 multistatus containing the private link URL.
         const QString expectedUrl = QStringLiteral("https://example.com/f/abc123");
         auto *fakeAm = dynamic_cast<FakeAM *>(account->accessManager());
         QVERIFY(fakeAm);
@@ -149,8 +108,7 @@ private Q_SLOTS:
                                           QIODevice *) -> QNetworkReply * {
             if (op != QNetworkAccessManager::CustomOperation)
                 return nullptr;
-            if (req.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray()
-                != QByteArrayLiteral("PROPFIND"))
+            if (req.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray() != QByteArrayLiteral("PROPFIND"))
                 return nullptr;
             if (req.rawHeader(QByteArrayLiteral("Depth")) != QByteArrayLiteral("0"))
                 return nullptr;
@@ -165,86 +123,47 @@ private Q_SLOTS:
                 + QByteArrayLiteral("</oc:privatelink>"
                                     "</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>"
                                     "</d:response></d:multistatus>");
+
             return new FakeMultistatReply(op, req, body, nullptr);
         });
 
-        // Register the directory with FolderMan (paused so no sync fires)
         auto def = TestUtils::createDummyFolderDefinition(account, localPath);
         def.setPaused(true);
         Folder *folder = TestUtils::folderMan()->addFolder(accountState.get(), def);
         QVERIFY(folder);
-        // Track the path so cleanup() can remove it after the test.
         _registeredFolderPath = localPath;
 
-        // ----- Start SocketApi server -----
+        // Use a QBuffer as the socket so SocketListener::sendMessage has somewhere to write.
+        QBuffer capture;
+        capture.open(QIODevice::ReadWrite);
+        SocketListener listener(&capture);
+
         SocketApi api;
-        api.startShellIntegration();
+        QMetaObject::invokeMethod(&api, "command_GET_PRIVATE_LINK",
+            Q_ARG(QString, localPath), Q_ARG(OCC::SocketListener *, &listener));
 
-        // Connect a client socket (triggers slotNewConnection → listener registered)
-        std::unique_ptr<QLocalSocket> clientSocket(connectAndWaitForListener());
-        QVERIFY(clientSocket);
-
-        // Drain any broadcast messages sent on connect (e.g. REGISTER_PATH)
-        QCoreApplication::processEvents();
-        clientSocket->readAll();
-
-        // ----- Send the GET_PRIVATE_LINK command -----
-        // Use the sync-folder root as the localFile argument.
-        // isSyncFolder() is true for the root path, so the journal record
-        // check is bypassed.
-        const QString command =
-            QStringLiteral("GET_PRIVATE_LINK:") + localPath + QLatin1Char('\n');
-        clientSocket->write(command.toUtf8());
-        QVERIFY(clientSocket->flush());
-
-        // ----- Wait for the PRIVATE_LINK response -----
-        QSignalSpy readySpy(clientSocket.get(), &QLocalSocket::readyRead);
-        QVERIFY(readySpy.wait(5000));
-
-        // Collect all data (may arrive in chunks)
-        QByteArray received;
-        for (int retries = 5; retries > 0; --retries) {
-            received += clientSocket->readAll();
-            if (received.contains("PRIVATE_LINK:"))
-                break;
-            if (!readySpy.wait(1000))
-                break;
-        }
-
-        const QByteArray expectedResponse =
+        const QByteArray expected =
             QByteArrayLiteral("PRIVATE_LINK:") + expectedUrl.toUtf8() + '\n';
-        QVERIFY2(received.contains(expectedResponse),
-            qPrintable(QStringLiteral("Expected '%1' in received data '%2'")
-                .arg(QString::fromUtf8(expectedResponse), QString::fromUtf8(received))));
+        QTRY_VERIFY2(capture.data().contains(expected),
+            qPrintable(QStringLiteral("Expected '%1' in buffer '%2'")
+                .arg(QString::fromUtf8(expected), QString::fromUtf8(capture.data()))));
     }
 
     void testGetPrivateLinkNoResponseWhenFileNotSynced()
     {
-        // The path /tmp/not_a_synced_file_testsocketapi.txt is not under any registered
-        // sync root → command_GET_PRIVATE_LINK should return early with no reply.
+        QBuffer capture;
+        capture.open(QIODevice::ReadWrite);
+        SocketListener listener(&capture);
 
         SocketApi api;
-        api.startShellIntegration();
+        QMetaObject::invokeMethod(&api, "command_GET_PRIVATE_LINK",
+            Q_ARG(QString, QStringLiteral("/tmp/not_a_synced_file_testsocketapi.txt")),
+            Q_ARG(OCC::SocketListener *, &listener));
 
-        std::unique_ptr<QLocalSocket> clientSocket(connectAndWaitForListener());
-        QVERIFY(clientSocket);
-
-        // Drain broadcast messages
-        QCoreApplication::processEvents();
-        clientSocket->readAll();
-
-        const QString command =
-            QStringLiteral("GET_PRIVATE_LINK:/tmp/not_a_synced_file_testsocketapi.txt\n");
-        clientSocket->write(command.toUtf8());
-        QVERIFY(clientSocket->flush());
-
-        // Wait briefly — there should be no PRIVATE_LINK message.
-        // Using QTest::qWait (unconditional) rather than QSignalSpy::wait so the
-        // assertion is always evaluated and cannot pass vacuously when no data arrives.
         QTest::qWait(500);
-        const QByteArray received = clientSocket->readAll();
-        QVERIFY2(!received.contains("PRIVATE_LINK:"),
-            qPrintable(QStringLiteral("Expected no PRIVATE_LINK response for unsynced file, got: ") + received));
+        QVERIFY2(!capture.data().contains("PRIVATE_LINK:"),
+            qPrintable(QStringLiteral("Expected no PRIVATE_LINK response for unsynced file, got: ")
+                + QString::fromUtf8(capture.data())));
     }
 };
 

--- a/test/testsocketapi.cpp
+++ b/test/testsocketapi.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) by Thomas Müller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include <QtTest>
+#include <QLocalSocket>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <chrono>
+using namespace std::chrono_literals;
+
+#include "socketapi/socketapi.h"
+#include "folderman.h"
+#include "accountmanager.h"
+
+#include "testutils/syncenginetestutils.h"
+#include "testutils/testutils.h"
+
+using namespace OCC;
+
+// A minimal fake reply that emits a Depth:0 PROPFIND multistatus response
+// with status 207 and the correct content-type, suitable for private link lookups.
+class FakeMultistatReply : public FakeReply
+{
+    Q_OBJECT
+public:
+    QByteArray _body;
+
+    FakeMultistatReply(QNetworkAccessManager::Operation op, const QNetworkRequest &request,
+                       const QByteArray &body, QObject *parent)
+        : FakeReply(parent), _body(body)
+    {
+        setRequest(request);
+        setUrl(request.url());
+        setOperation(op);
+        open(QIODevice::ReadOnly);
+        QTimer::singleShot(10ms, this, &FakeMultistatReply::respond);
+    }
+
+    void respond()
+    {
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, 207);
+        setHeader(QNetworkRequest::ContentTypeHeader, QByteArrayLiteral("application/xml; charset=utf-8"));
+        setHeader(QNetworkRequest::ContentLengthHeader, _body.size());
+        Q_EMIT metaDataChanged();
+        Q_EMIT readyRead();
+        checkedFinished();
+    }
+
+    qint64 readData(char *buf, qint64 max) override
+    {
+        max = qMin<qint64>(max, _body.size());
+        std::copy(_body.cbegin(), _body.cbegin() + max, buf);
+        _body.remove(0, static_cast<int>(max));
+        return max;
+    }
+
+    qint64 bytesAvailable() const override { return _body.size(); }
+};
+
+class TestSocketApi : public QObject
+{
+    Q_OBJECT
+
+    // Path of the folder registered during a test (reset by cleanup()).
+    QString _registeredFolderPath;
+
+    // Compute the socket path the same way guiutility_unix.cpp does.
+    // Utility::socketApiSocketPath() provides the same logic, but it lives in the
+    // GUI library and is not exposed as a public method of SocketApi, so the
+    // computation is duplicated here rather than introducing an extra dependency.
+    static QString socketApiPath()
+    {
+        return QStringLiteral("%1/ownCloud/socket")
+            .arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
+    }
+
+    // Connect to the SocketApi's server and wait for the connection to be accepted
+    // (slotNewConnection fired). Returns the connected socket or nullptr on failure.
+    static QLocalSocket *connectAndWaitForListener()
+    {
+        const QString path = socketApiPath();
+        auto *sock = new QLocalSocket;
+        sock->connectToServer(path);
+        if (!sock->waitForConnected(3000)) {
+            qWarning() << "Failed to connect to socket" << path
+                       << "error:" << sock->errorString();
+            delete sock;
+            return nullptr;
+        }
+        // Give the server side a chance to run slotNewConnection and
+        // insert the listener into _listeners.
+        QCoreApplication::processEvents();
+        return sock;
+    }
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        // Ensure FolderMan singleton exists before any test
+        TestUtils::folderMan();
+    }
+
+    void cleanup()
+    {
+        // Remove any folder registered during the test to avoid polluting later tests.
+        if (!_registeredFolderPath.isEmpty()) {
+            Folder *folder = TestUtils::folderMan()->folderForPath(_registeredFolderPath);
+            if (folder) {
+                TestUtils::folderMan()->removeFolderFromGui(folder);
+            }
+            _registeredFolderPath.clear();
+        }
+    }
+
+    void testGetPrivateLinkSendsUrlOverSocket()
+    {
+        // ----- Set up a paused sync folder so no sync fires -----
+
+        // Create a real directory on disk as the local sync root
+        const QTemporaryDir tempDir = TestUtils::createTempDir();
+        QVERIFY(tempDir.isValid());
+        // Ensure trailing slash (FolderDefinition normalises it, but be explicit)
+        const QString localPath = QDir::cleanPath(tempDir.path()) + QLatin1Char('/');
+
+        // createDummyAccount creates an account with a FakeAM (empty FileInfo)
+        auto accountState = createDummyAccount();
+        Account *account = accountState->account();
+
+        // Enable private links capability
+        auto cap = TestUtils::testCapabilities();
+        cap[QStringLiteral("files")] = QVariantMap{{QStringLiteral("privateLinks"), true}};
+        account->setCapabilities({account->url(), cap});
+
+        // Set a server override: intercept the Depth:0 PROPFIND that fetchPrivateLinkUrl issues
+        // and reply with a 207 multistatus containing the private link URL.
+        const QString expectedUrl = QStringLiteral("https://example.com/f/abc123");
+        auto *fakeAm = dynamic_cast<FakeAM *>(account->accessManager());
+        QVERIFY(fakeAm);
+        fakeAm->setOverride([expectedUrl](QNetworkAccessManager::Operation op,
+                                          const QNetworkRequest &req,
+                                          QIODevice *) -> QNetworkReply * {
+            if (op != QNetworkAccessManager::CustomOperation)
+                return nullptr;
+            if (req.attribute(QNetworkRequest::CustomVerbAttribute).toByteArray()
+                != QByteArrayLiteral("PROPFIND"))
+                return nullptr;
+            if (req.rawHeader(QByteArrayLiteral("Depth")) != QByteArrayLiteral("0"))
+                return nullptr;
+
+            const QString path = req.url().path();
+            const QByteArray body =
+                QByteArrayLiteral("<?xml version=\"1.0\"?>"
+                                  "<d:multistatus xmlns:d=\"DAV:\" xmlns:oc=\"http://owncloud.org/ns\">"
+                                  "<d:response><d:href>") + path.toUtf8()
+                + QByteArrayLiteral("</d:href><d:propstat><d:prop>"
+                                    "<oc:privatelink>") + expectedUrl.toUtf8()
+                + QByteArrayLiteral("</oc:privatelink>"
+                                    "</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>"
+                                    "</d:response></d:multistatus>");
+            return new FakeMultistatReply(op, req, body, nullptr);
+        });
+
+        // Register the directory with FolderMan (paused so no sync fires)
+        auto def = TestUtils::createDummyFolderDefinition(account, localPath);
+        def.setPaused(true);
+        Folder *folder = TestUtils::folderMan()->addFolder(accountState.get(), def);
+        QVERIFY(folder);
+        // Track the path so cleanup() can remove it after the test.
+        _registeredFolderPath = localPath;
+
+        // ----- Start SocketApi server -----
+        SocketApi api;
+        api.startShellIntegration();
+
+        // Connect a client socket (triggers slotNewConnection → listener registered)
+        std::unique_ptr<QLocalSocket> clientSocket(connectAndWaitForListener());
+        QVERIFY(clientSocket);
+
+        // Drain any broadcast messages sent on connect (e.g. REGISTER_PATH)
+        QCoreApplication::processEvents();
+        clientSocket->readAll();
+
+        // ----- Send the GET_PRIVATE_LINK command -----
+        // Use the sync-folder root as the localFile argument.
+        // isSyncFolder() is true for the root path, so the journal record
+        // check is bypassed.
+        const QString command =
+            QStringLiteral("GET_PRIVATE_LINK:") + localPath + QLatin1Char('\n');
+        clientSocket->write(command.toUtf8());
+        QVERIFY(clientSocket->flush());
+
+        // ----- Wait for the PRIVATE_LINK response -----
+        QSignalSpy readySpy(clientSocket.get(), &QLocalSocket::readyRead);
+        QVERIFY(readySpy.wait(5000));
+
+        // Collect all data (may arrive in chunks)
+        QByteArray received;
+        for (int retries = 5; retries > 0; --retries) {
+            received += clientSocket->readAll();
+            if (received.contains("PRIVATE_LINK:"))
+                break;
+            if (!readySpy.wait(1000))
+                break;
+        }
+
+        const QByteArray expectedResponse =
+            QByteArrayLiteral("PRIVATE_LINK:") + expectedUrl.toUtf8() + '\n';
+        QVERIFY2(received.contains(expectedResponse),
+            qPrintable(QStringLiteral("Expected '%1' in received data '%2'")
+                .arg(QString::fromUtf8(expectedResponse), QString::fromUtf8(received))));
+    }
+
+    void testGetPrivateLinkNoResponseWhenFileNotSynced()
+    {
+        // The path /tmp/not_a_synced_file_testsocketapi.txt is not under any registered
+        // sync root → command_GET_PRIVATE_LINK should return early with no reply.
+
+        SocketApi api;
+        api.startShellIntegration();
+
+        std::unique_ptr<QLocalSocket> clientSocket(connectAndWaitForListener());
+        QVERIFY(clientSocket);
+
+        // Drain broadcast messages
+        QCoreApplication::processEvents();
+        clientSocket->readAll();
+
+        const QString command =
+            QStringLiteral("GET_PRIVATE_LINK:/tmp/not_a_synced_file_testsocketapi.txt\n");
+        clientSocket->write(command.toUtf8());
+        QVERIFY(clientSocket->flush());
+
+        // Wait briefly — there should be no PRIVATE_LINK message.
+        // Using QTest::qWait (unconditional) rather than QSignalSpy::wait so the
+        // assertion is always evaluated and cannot pass vacuously when no data arrives.
+        QTest::qWait(500);
+        const QByteArray received = clientSocket->readAll();
+        QVERIFY2(!received.contains("PRIVATE_LINK:"),
+            qPrintable(QStringLiteral("Expected no PRIVATE_LINK response for unsynced file, got: ") + received));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestSocketApi)
+#include "testsocketapi.moc"


### PR DESCRIPTION
## Problem

On native Wayland sessions the ownCloud daemon has no compositor surface.
`QApplication::clipboard()->setText()` requires a valid Wayland `wl_data_device` serial
from a recent input event, but a tray-only app (system tray via `StatusNotifierItem`)
never receives seat events and so never has one. The compositor silently drops the
clipboard write. **Copy private link to clipboard** is broken for all users on Wayland.

Qt 6.9+ added `zwlr-data-control` support as a partial fix (`QT_WAYLAND_USE_DATA_CONTROL=1`),
but it requires an environment variable and only works on KDE/wlroots compositors — not on
GNOME/Mutter, which is the primary affected environment.

## Solution

Add `GET_PRIVATE_LINK:<file>` → `PRIVATE_LINK:<url>` to the socket protocol. File manager
extensions that run inside processes with a real Wayland surface (Nautilus, Dolphin) can
request the URL and write to the clipboard themselves.

The command reuses `fetchPrivateLinkUrlHelper()` — ~7 lines of new production code.
`COPY_PRIVATE_LINK` is unchanged for X11 and for extensions that do not yet use the new
command.

## Related

- https://github.com/owncloud/client-desktop-shell-integration-nautilus/pull/11 (closed — this PR is the correct server-side fix)
- Nautilus extension fix: https://github.com/owncloud/client-desktop-shell-integration-nautilus/pull/12
- Dolphin plugin fix: https://github.com/owncloud/client-desktop-shell-integration-dolphin/pull/5

## Backward compatibility

| Scenario | Behaviour |
|---|---|
| New client + new Nautilus/Dolphin, Wayland | ✅ Fixed |
| New client + new Nautilus/Dolphin, X11 | ✅ Unchanged |
| Old client + new Nautilus, Wayland | Graceful: `GET_PRIVATE_LINK` times out (3 s), falls through to `COPY_PRIVATE_LINK` |
| New client + old Nautilus/Dolphin, Wayland | Unchanged (old extension still sends `COPY_PRIVATE_LINK`) |