### PR TITLE
fix(ci): set changelog workflow permissions to contents: read

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,8 @@ on:
     branches: [ master ]
     tags: [ "*" ]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   changelog:


### PR DESCRIPTION
## Summary

- Changes `permissions: {}` to `permissions:\n  contents: read` in `.github/workflows/changelog.yml`

## Why

Explicitly scoping permissions to `contents: read` makes the intent clear and satisfies the minimum required permissions for a changelog workflow that reads repository contents, following least-privilege CI hygiene.