### PR TITLE
chore: Bump OpenSSL version to 3.4.5 (#12538)

### DIFF
--- a/.craft.ini
+++ b/.craft.ini
@@ -1,6 +1,8 @@
 [General]
 Branch = master
 ShallowClone = False
+# Cloned repo which contains blueprints for openssl 3.4.4 and 3.4.5
+CraftUrl=https://github.com/owncloud/craft.git
 
 # Variables defined here override the default value
 # The variable names are case-sensitive
@@ -75,7 +77,7 @@ qt-libs/qtkeychain.buildWithQt6 = True
 
 # pinning versions to fix security issues
 libs/libcurl.version = 7.84.0
-libs/openssl.version = 3.4.3
+libs/openssl.version = 3.4.5
 libs/libpng.version = 1.6.45
 libs/freetype.version = 2.14.1
 

--- a/.craft.shelf
+++ b/.craft.shelf
@@ -15,7 +15,7 @@ revision = d28bcaf
 
 [craft/craft-core]
 version = master
-revision = 949d36244
+revision = 6cf4d10fb3024c9038bbda0cd26a220ffefab3ff
 
 [dev-utils/7zip-base]
 version = 25.01
@@ -120,7 +120,7 @@ version = 20.1.7
 version = 3.12.0
 
 [libs/openssl]
-version = 3.4.3
+version = 3.4.5
 
 [libs/pcre2]
 version = 10.44


### PR DESCRIPTION
This uses a cloned craft repository, because the OpenSSL blueprint is
part of craft itself.
