### PR TITLE
fix: use actions/upload-artifact for GUI test result

### DIFF
--- a/.github/workflows/branded-client.yml
+++ b/.github/workflows/branded-client.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   NPM_GHERLINT: "@gherlint/gherlint@1.1.0"
-  S3_PUBLIC_CACHE_SERVER: "https://cache.owncloud.com"
-  S3_PUBLIC_CACHE_BUCKET: "public"
 
 jobs:
   gui-tests:
@@ -76,15 +74,9 @@ jobs:
 
       - name: Upload GUI test result
         if: ${{ failure() && steps.run_gui_test.outcome == 'failure' }}
-        run: |
-          curl -L https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-          chmod +x /tmp/mc
-          /tmp/mc alias set cache ${{ env.S3_PUBLIC_CACHE_SERVER }} ${{ secrets.CACHE_PUBLIC_S3_ACCESS_KEY }} ${{ secrets.CACHE_PUBLIC_S3_SECRET_KEY }}
-          /tmp/mc cp --recursive test/gui/guiReportUpload cache/${{ env.S3_PUBLIC_CACHE_BUCKET }}/${{ github.repository }}/${{ github.run_number }}/ocis
-
-      - name: Log GUI reports
-        if: ${{ failure() && steps.run_gui_test.outcome == 'failure' }}
-        env:
-          REPORT_DIR: /__w/client/client/test/gui/guiReportUpload
-          SERVER_TYPE: ocis
-        run: bash test/gui/ci/log_reports.sh ${REPORT_DIR} ${GITHUB_REPO} ${GITHUB_RUN_NUMBER} ${SERVER_TYPE}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: gui-report-branded-client-${{ github.run_number }}
+          path: test/gui/guiReportUpload
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/gui-tests.yml
+++ b/.github/workflows/gui-tests.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   NPM_GHERLINT: "@gherlint/gherlint@1.1.0"
-  S3_PUBLIC_CACHE_SERVER: "https://cache.owncloud.com"
-  S3_PUBLIC_CACHE_BUCKET: "public"
 
 jobs:
   lint-gui-test:
@@ -146,15 +144,9 @@ jobs:
 
       - name: Upload GUI test result
         if: ${{ failure() && steps.run_gui_test.outcome == 'failure' }}
-        run: |
-          curl -L https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-          chmod +x /tmp/mc
-          /tmp/mc alias set cache ${{ env.S3_PUBLIC_CACHE_SERVER }} ${{ secrets.CACHE_PUBLIC_S3_ACCESS_KEY }} ${{ secrets.CACHE_PUBLIC_S3_SECRET_KEY }}
-          /tmp/mc cp --recursive test/gui/guiReportUpload cache/${{ env.S3_PUBLIC_CACHE_BUCKET }}/${{ github.repository }}/${{ github.run_number }}/ocis
-
-      - name: Log GUI reports
-        if: ${{ failure() && steps.run_gui_test.outcome == 'failure' }}
-        env:
-          REPORT_DIR: /__w/client/client/test/gui/guiReportUpload
-          SERVER_TYPE: ocis
-        run: bash test/gui/ci/log_reports.sh ${REPORT_DIR} ${GITHUB_REPO} ${GITHUB_RUN_NUMBER} ${SERVER_TYPE}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: gui-report-ocis-${{ github.run_number }}
+          path: test/gui/guiReportUpload
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Description
We used `S3_PUBLIC_CACHE_SERVER` to upload and log the test result. But currently, CI cannot connect to the server and returns the following log:
```console
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   141  100   141    0     0   3751      0 --:--:-- --:--:-- --:--:--  3810

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

100 29.1M  100 29.1M    0     0   167M      0 --:--:-- --:--:-- --:--:--  167M
mc: <ERROR> Unable to initialize new alias from the provided credentials. Get "https://cache.owncloud.com/probe-bsign-znfcyem9plb6frvai2syab2acbzgfh/?location=": dial tcp 116.203.156.14:443: i/o timeout.
Error: Process completed with exit code 1.
```


So, replacing this with `actions/upload-artifact`.