### PR TITLE
fix: read OIDC Prompt from the Prompt key, not the Ports key (#12557) - backport to 7.1

### DIFF
--- a/changelog/unreleased/12557.md
+++ b/changelog/unreleased/12557.md
@@ -1,0 +1,9 @@
+Bugfix: Read OIDC Prompt from the correct system configuration key
+
+The OpenID Connect Prompt value provided through the system configuration was
+read from the Ports key instead of the Prompt key. As a result the
+administrator-provided Prompt was ignored and replaced with the raw Ports
+value, which is not a valid OIDC prompt parameter. The Prompt is now read from
+the Prompt key.
+
+https://github.com/owncloud/client/issues/12557

--- a/src/libsync/config/appconfig.cpp
+++ b/src/libsync/config/appconfig.cpp
@@ -68,7 +68,7 @@ OpenIdConfig AppConfig::loadOpenIdConfigFromSystemConfig(const QSettings &system
     QString clientId = system.value(OidcClientIdKey, QString()).toString();
     QString clientSecret = system.value(OidcClientSecretKey, QString()).toString();
     QString scopes = system.value(OidcScopesKey, QString()).toString();
-    QString prompt = system.value(OidcPortsKey, QString()).toString();
+    QString prompt = system.value(OidcPromptKey, QString()).toString();
 
     QVector<quint16> ports;
     QVariant portsVar = system.value(OidcPortsKey, QString()).toString();

--- a/src/libsync/config/appconfig.h
+++ b/src/libsync/config/appconfig.h
@@ -103,9 +103,16 @@ public:
      */
     static QString configPath(const QOperatingSystemVersion::OSType& os, const Theme& theme);
 
+    /**
+     * Load the OpenID Connect configuration from a system QSettings instance.
+     * @param system the system configuration settings
+     * @return An OpenIdConfig object populated from the [OpenIDConnect] section.
+     * @internal kept public for testing purposes
+     */
+    static OpenIdConfig loadOpenIdConfigFromSystemConfig(const QSettings &system);
+
 private:
     static OpenIdConfig loadOpenIdConfigFromTheme();
-    static OpenIdConfig loadOpenIdConfigFromSystemConfig(const QSettings &system);
 
 private: // System settings keys
     // Setup related keys

--- a/test/testappconfig.cpp
+++ b/test/testappconfig.cpp
@@ -5,6 +5,9 @@
 #include "libsync/owncloudtheme.h"
 #include "libsync/config/appconfig.h"
 
+#include <QSettings>
+#include <QTemporaryDir>
+
 class TestAppConfig : public QObject
 {
     Q_OBJECT
@@ -16,6 +19,33 @@ private Q_SLOTS:
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::Windows, t), QString("HKEY_LOCAL_MACHINE\\Software\\Policies\\ownCloud\\ownCloud"));
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::MacOS, t), QString("/Library/Preferences/com.owncloud.desktopclient/ownCloud.ini"));
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::Unknown, t), QString("/etc/ownCloud/ownCloud.ini"));
+    }
+
+    void testLoadOpenIdConfig()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("system.ini"));
+
+        {
+            QSettings settings(path, QSettings::IniFormat);
+            settings.setValue(QStringLiteral("OpenIDConnect/ClientId"), QStringLiteral("my-client-id"));
+            settings.setValue(QStringLiteral("OpenIDConnect/ClientSecret"), QStringLiteral("my-client-secret"));
+            settings.setValue(QStringLiteral("OpenIDConnect/Ports"), QStringLiteral("8080,8443"));
+            settings.setValue(QStringLiteral("OpenIDConnect/Scopes"), QStringLiteral("openid email"));
+            settings.setValue(QStringLiteral("OpenIDConnect/Prompt"), QStringLiteral("select_account consent"));
+            settings.sync();
+        }
+
+        QSettings settings(path, QSettings::IniFormat);
+        const OCC::OpenIdConfig cfg = OCC::AppConfig::loadOpenIdConfigFromSystemConfig(settings);
+
+        // Prompt must be read from the Prompt key, not the Ports key (regression test for #12557)
+        QCOMPARE(cfg.prompt(), QStringLiteral("select_account consent"));
+        QCOMPARE(cfg.ports(), (QList<quint16>{8080, 8443}));
+        QCOMPARE(cfg.scopes(), QStringLiteral("openid email"));
+        QCOMPARE(cfg.clientId(), QStringLiteral("my-client-id"));
+        QCOMPARE(cfg.clientSecret(), QStringLiteral("my-client-secret"));
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes #12557 on the `7.1` branch (backport of #12559 targeting `master`).

`AppConfig::loadOpenIdConfigFromSystemConfig()` read the OpenID Connect `Prompt` value from `OidcPortsKey` instead of `OidcPromptKey`. As a result, an administrator-provided `Prompt` in the system configuration (`[OpenIDConnect]` section / Windows registry) was ignored, and `prompt` was instead populated with the raw `Ports` string (e.g. `"8080,8443"`), which is not a valid OIDC `prompt` parameter. Since a valid system OIDC config fully replaces the theme config, the configured prompt was unreachable.

## Changes

- Read `prompt` from `OidcPromptKey`.
- Add a regression test (`testLoadOpenIdConfig`) that exercises `loadOpenIdConfigFromSystemConfig()` and asserts `prompt`, `ports`, and `scopes` are each sourced from their own key.
- Make `loadOpenIdConfigFromSystemConfig()` public (mirroring the existing `configPath` testing convention) so it is reachable from the test.
- Add changelog entry.

## Testing

`AppConfigTest` passes locally. The new test fails before the fix (prompt would equal `"8080,8443"`) and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)