### PR TITLE
chore: update ocis docker image

### DIFF
--- a/.github/workflows/gui-tests.yml
+++ b/.github/workflows/gui-tests.yml
@@ -47,7 +47,7 @@ jobs:
         GITHUB_RUN_NUMBER: ${{ github.run_number }}
     services:
       ocis:
-        image: owncloud/ocis-rolling:latest
+        image: owncloud/ocis-rolling:20260610
         ports:
           - 9200:9200
         env:


### PR DESCRIPTION
## Description
Update ocis docker image to `owncloud/ocis-rolling:20260610`. The `latest` is broken.