### PR TITLE
docs: update README to reference ownCloud Infinite Scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-The ownCloud Desktop Client is a tool to synchronize files from ownCloud Server
+The ownCloud Desktop Client is a tool to synchronize files from ownCloud Infinite Scale
 with your computer.
 
 ## Download


### PR DESCRIPTION
Updates the README introduction to state the desktop client synchronizes files from **ownCloud Infinite Scale (oCIS)**.

This repo was part of the cross-repo rebrand (owncloud/docs#5111), but the blanket "ownCloud Server" → "ownCloud Classic" rename does not apply here: the client **dropped support for the legacy server (ownCloud 10 / Classic) in version 7.0** and now targets oCIS (see `changelog/6.0.0_2025-09-08/11742.md`). Per @erikjv's review, the README now references oCIS instead.

Scope: README prose only.