### PR TITLE
chore: Pin GitHub action for macOS to macos-15 (#12577)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             # TODO: align the target with the name
             - name: macos-clang-arm64
               target: macos-clang-arm64
-              os: macos-latest
+              os: macos-15
               container:
               useSonarCloud:
             - name: linux-gcc-x86_64


### PR DESCRIPTION
This can be reverted once we have a new Qt version in place.

(cherry picked from commit 3afac874b5c38ec8d81be1160846288b1ef732a2)