### PR TITLE
fix(networkjob): drain pending events before deleting an aborted reply (#12600)

### DIFF
--- a/changelog/unreleased/12600.md
+++ b/changelog/unreleased/12600.md
@@ -1,0 +1,9 @@
+Bugfix: Fix crash after waking the computer from sleep
+
+We've fixed a crash that could occur about a second after the computer resumed
+from sleep or hibernation. A network reply's internal transfer-timeout timer
+could deliver a queued call to a reply that had already been deleted during the
+reconnect handling, causing a use-after-free. Replies are now drained of any
+pending events before they are deleted.
+
+https://github.com/owncloud/client/issues/12600

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <QAuthenticator>
+#include <QCoreApplication>
 #include <QNetworkRequest>
 
 #include "common/asserts.h"
@@ -30,6 +31,25 @@ using namespace std::chrono_literals;
 
 namespace {
 constexpr int MaxRetryCount = 5;
+
+// Tear down a reply we are abandoning.
+//
+// reply->abort() also stops the reply's internal transfer-timeout QTimer, but a
+// _q_transferTimedOut metacall that this timer already posted (it is connected
+// via a Qt::QueuedConnection with the reply as the *receiver*, a role the plain
+// reply->disconnect() does not cover) would survive deleteLater() and be
+// delivered to freed memory - the wake-from-sleep use-after-free (#12600).
+// removePostedEvents() drains any such pending call before we schedule deletion.
+void severAndDeleteReply(QNetworkReply *reply)
+{
+    if (!reply) {
+        return;
+    }
+    reply->disconnect();
+    reply->abort();
+    QCoreApplication::removePostedEvents(reply);
+    reply->deleteLater();
+}
 }
 
 
@@ -172,9 +192,7 @@ void AbstractNetworkJob::adoptRequest(QPointer<QNetworkReply> reply)
 {
     std::swap(_reply, reply);
     if (reply) {
-        reply->disconnect();
-        reply->abort();
-        reply->deleteLater();
+        severAndDeleteReply(reply.data());
     }
 
     _request = _reply->request();
@@ -289,9 +307,7 @@ AbstractNetworkJob::~AbstractNetworkJob()
         qCCritical(lcNetworkJob) << "Deleting running job" << this;
     }
     if (_reply) {
-        _reply->disconnect();
-        _reply->abort();
-        _reply->deleteLater();
+        severAndDeleteReply(_reply.data());
         _reply.clear();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #12600 — a Windows crash that occurs about a second after the computer
wakes from sleep or hibernation.

The crash is a **deterministic use-after-free of a `QNetworkReplyHttpImpl`** on
the main GUI thread, confirmed from four byte-identical minidumps symbolicated
against the Qt 6.8.3 PDB, and re-verified against the Qt 6 source.

## Mechanism

`AbstractNetworkJob::sendRequest` sets `QNetworkRequest::setTransferTimeout` on
every request. Qt's `QNetworkReplyHttpImplPrivate::setupTransferTimeout()`
creates an internal `QTimer` owned by the reply and connects
`timeout() → _q_transferTimedOut() → abort()` via a **`Qt::QueuedConnection`
with the reply as the *receiver*.**

When we abandon a reply we did:

```cpp
reply->disconnect();   // only drops connections where reply is the *sender*
reply->abort();
reply->deleteLater();
```

The no-arg `reply->disconnect()` only severs connections where the reply is the
**sender**, so the timer→reply connection (reply as **receiver**) survives. If
that timer had already fired, a queued `_q_transferTimedOut` `QMetaCallEvent` is
already sitting in the event queue. `deleteLater()` does **not** flush
already-posted metacalls, so after the reply is freed the metacall is delivered
→ `abort()` → `emit abortHttpRequest()` → `QObjectPrivate::doActivate`
dereferences the freed reply's `d_ptr`.

Dump evidence: faulting `mov rsi,[rcx+8]; mov eax,[rsi+0x30]` with
`d_ptr == 1/2`, signal index (`Rdx`) `== 22 == abortHttpRequest`.

**Why wake-from-sleep makes it deterministic:** single-shot transfer timers
frozen during sleep all fire ~simultaneously on resume, straight into the
reachability-driven teardown storm (`AccountState::onNetworkReachabilityChanged
→ checkConnectivity`, `JobQueue::clear → job->abort()`).

**Regression origin:** commit `27e15bdecd` ("Use buildin timeout handling
provided by Qt", 2022-02-01) removed a job-owned single-shot `QTimer` and
replaced it with `setTransferTimeout` — introducing the reply-internal timer we
cannot sever with `reply->disconnect()`.

## Fix

Both reply-freeing sites (`adoptRequest` and `~AbstractNetworkJob`) now route
through a small file-local helper that drains any already-posted metacall
targeting the reply before scheduling deletion:

```cpp
void severAndDeleteReply(QNetworkReply *reply)
{
    if (!reply) {
        return;
    }
    reply->disconnect();
    reply->abort();                               // also stops the transfer-timeout timer
    QCoreApplication::removePostedEvents(reply);  // drain any queued _q_transferTimedOut
    reply->deleteLater();
}
```

`reply->abort()` already stops the internal transfer-timeout timer
(`abort() → d->finished() → transferTimeout->stop()`), so after `abort()` the
timer cannot re-fire; the only residual hazard is a metacall that was *already*
posted, which `removePostedEvents()` clears.

`abort()` (the normal cancel/retry path) is intentionally left unchanged: there
the reply stays live and is later freed via `slotFinished → deleteLater(job) →
~AbstractNetworkJob`, which now goes through the helper.

## Testing

**No bespoke automated test is added.** The crash is a same-thread
event-ordering race (timer metacall posted, then reply freed before delivery).
It cannot be reproduced deterministically in a unit test: `~QObject` already
purges posted events on normal teardown, and the `FakeReply` test doubles do not
instantiate the real `QNetworkReplyHttpImpl` transfer-timeout timer, so a
fake-based test would pass both before and after the fix.

Instead:

- **Existing regression suite** — the network-job lifecycle tests most likely to
  surface a teardown regression all pass with the change:
  `RemoteDiscoveryTest` (incl. the timeout path), `ConnectionValidatorTest`,
  `JobQueueTest`, `DownloadTest`, `UploadResetTest`, `SyncMoveTest`.
- **Manual Windows validation** (the real-world confirmation, from the issue
  repro): with the bundled crash handler, start sync activity, put the machine
  to sleep (`rundll32 powrprof.dll,SetSuspendState 0,1,0`), wake it, and confirm
  no crash ~1s later.

## Follow-up

A separate follow-up will revert to the pre-`27e15bdecd` **job-owned `QTimer`**
design (job owns the timeout timer instead of `setTransferTimeout`), which
removes the reply-internal timer entirely and eliminates this whole bug class.
Kept separate to keep this hotfix small and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
