### PR TITLE
refactor(networkjob): drive timeouts with a job-owned timer (#12600)

### DIFF
--- a/changelog/unreleased/12600-followup.md
+++ b/changelog/unreleased/12600-followup.md
@@ -1,0 +1,10 @@
+Change: Drive network job timeouts with a job-owned timer
+
+We reworked how network requests enforce their timeout. Instead of relying on
+Qt's request transfer timeout - which is owned by the network reply - each job
+now owns its timeout timer and resets it on transfer progress. This removes the
+reply-internal timer whose queued callback could reach an already-deleted reply
+after waking from sleep, fully eliminating the class of crash addressed by the
+earlier hotfix.
+
+https://github.com/owncloud/client/issues/12600

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -55,6 +55,9 @@ AbstractNetworkJob::AbstractNetworkJob(Account *account, const QUrl &baseUrl, co
     // Since we hold a QSharedPointer to the account, this makes no sense. (issue #6893)
     Q_ASSERT(account != parent);
     Q_ASSERT(baseUrl.isValid());
+
+    _timer.setSingleShot(true);
+    connect(&_timer, &QTimer::timeout, this, &AbstractNetworkJob::slotTimeout);
 }
 
 QUrl AbstractNetworkJob::url() const
@@ -71,6 +74,12 @@ void AbstractNetworkJob::setQuery(const QUrlQuery &query)
 void AbstractNetworkJob::setTimeout(const std::chrono::seconds sec)
 {
     _timeout = sec;
+    // If the timer is already running, restart it with the new interval so a
+    // late setTimeout() (e.g. PropagateUploadCommon::adjustLastJobTimeout) takes
+    // effect immediately.
+    if (_timer.isActive()) {
+        resetTimeout();
+    }
 }
 
 void AbstractNetworkJob::setForceIgnoreCredentialFailure(bool ignore)
@@ -149,11 +158,9 @@ void AbstractNetworkJob::sendRequest(const QByteArray &verb,
     _requestBody = requestBody;
 
     Q_ASSERT(_request.url().isEmpty() || _request.url() == url());
-    Q_ASSERT(_request.transferTimeout() == 0 || _request.transferTimeout() == duration_cast<milliseconds>(_timeout).count());
 
     _request.setUrl(url());
     _request.setPriority(_priority);
-    _request.setTransferTimeout(duration_cast<milliseconds>(_timeout).count());
 
     if (!_isAuthenticationJob && _account->jobQueue()->enqueue(this)) {
         return;
@@ -181,11 +188,23 @@ void AbstractNetworkJob::adoptRequest(QPointer<QNetworkReply> reply)
 
     connect(_reply, &QNetworkReply::finished, this, &AbstractNetworkJob::slotFinished);
 
+    // Reset the idle-timeout timer on every bit of network activity so that a long
+    // but progressing transfer is not aborted; only a stalled connection times out.
+    // This mirrors Qt's own setTransferTimeout re-arm-on-progress behavior, but with
+    // the timer owned by the job (not the reply) so no queued timeout can outlive the
+    // reply - see #12600.
+    connect(_reply, &QNetworkReply::downloadProgress, this, &AbstractNetworkJob::resetTimeout);
+    connect(_reply, &QNetworkReply::uploadProgress, this, &AbstractNetworkJob::resetTimeout);
+
+    // A fresh reply is now driving this job: (re)arm the timeout timer.
+    resetTimeout();
+
     newReplyHook(_reply);
 }
 
 void AbstractNetworkJob::slotFinished()
-{        
+{
+    _timer.stop();
     _finished = true;
 
     if (!_reply || !_account) {
@@ -232,6 +251,27 @@ void AbstractNetworkJob::slotFinished()
     Q_EMIT finishedSignal(AbstractNetworkJob::QPrivateSignal());
     qCDebug(lcNetworkJob) << "Network job finished" << this;
     deleteLater();
+}
+
+void AbstractNetworkJob::resetTimeout()
+{
+    // Single-shot idle timeout: (re)start on every call so an active transfer
+    // keeps pushing the deadline out. std::chrono::seconds converts to the
+    // milliseconds QTimer expects without narrowing.
+    _timer.start(_timeout);
+}
+
+void AbstractNetworkJob::slotTimeout()
+{
+    if (!_reply) {
+        return;
+    }
+    qCWarning(lcNetworkJob) << "Network job timeout" << this << url();
+    // Mark as timed out and abort the reply directly. We deliberately do not go
+    // through abort(), which sets _aborted and would make slotFinished treat this
+    // as a user cancel rather than a timeout (see the _timedout inference there).
+    _timedout = true;
+    _reply->abort();
 }
 
 QByteArray AbstractNetworkJob::responseTimestamp() const
@@ -378,6 +418,7 @@ void AbstractNetworkJob::retry()
 
 void AbstractNetworkJob::abort()
 {
+    _timer.stop();
     if (_reply) {
         // calling abort will trigger the execution of finished()
         // with _reply->error() == QNetworkReply::OperationCanceledError

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -208,6 +208,16 @@ private:
     void adoptRequest(QPointer<QNetworkReply> reply);
     void slotFinished();
 
+    /** Fired by the job-owned timeout timer: marks the job as timed out and aborts the reply. */
+    void slotTimeout();
+
+    /** (Re)start the timeout timer with the configured interval.
+     *
+     * Connected to the reply's upload/download progress so the timer only
+     * fires on an idle (stalled) connection, not on a long but active transfer.
+     */
+    void resetTimeout();
+
     const QUrl _baseUrl;
     const QString _path;
 
@@ -220,6 +230,12 @@ private:
     QNetworkRequest _request;
     QByteArray _verb;
     QPointer<QNetworkReply> _reply; // (QPointer because the NetworkManager may be destroyed before the jobs at exit)
+
+    // Job-owned timeout timer. Owning the timer here (rather than relying on
+    // QNetworkRequest::setTransferTimeout, which creates a timer owned by the
+    // reply) ensures no queued timeout callback can outlive the job and reach a
+    // freed reply - the wake-from-sleep use-after-free (#12600).
+    QTimer _timer;
 
     // Set by the xyzRequest() functions and needed to be able to redirect
     // requests, should it be required.


### PR DESCRIPTION
## Summary

Follow-up to #12600 (hotfix in #12602). This removes the **root cause** of the
wake-from-sleep use-after-free crash class, rather than draining its symptom.

`AbstractNetworkJob` no longer uses `QNetworkRequest::setTransferTimeout`.
Instead the job owns its timeout timer again (the pre-`27e15bdecd` design),
eliminating the reply-internal timer whose queued callback could reach a freed
reply.

## Why

`setTransferTimeout` makes Qt create a `QTimer` **owned by, and connected as
*receiver* to, the network reply**:

```
transferTimeout->timeout() -> reply->_q_transferTimedOut() -> reply->abort()   // Qt::QueuedConnection
```

On the wake-from-sleep resume storm, single-shot transfer timers frozen during
sleep all fire at once into the reachability-driven teardown storm. When we
abandon a reply we call `reply->disconnect(); reply->abort();
reply->deleteLater()`, but:

- `reply->disconnect()` only drops connections where the reply is the **sender**
  — the timer→reply connection (reply as **receiver**) survives.
- `deleteLater()` does **not** flush an already-posted `_q_transferTimedOut`
  metacall.

So a queued `abort()` is delivered to the freed reply → `emit
abortHttpRequest()` → `QObjectPrivate::doActivate` dereferences freed memory.
(#12602 neutralizes this by draining posted events; this PR removes the timer
that posts them.)

## What changed

**Scope: `AbstractNetworkJob` only.**

- **`sendRequest`**: dropped `setTransferTimeout(...)` and its `Q_ASSERT`.
- **New job-owned `QTimer _timer`** (single-shot), connected to a new
  `slotTimeout()`. Its receiver is the job, which outlives its replies and tears
  everything down in its own destructor — no queued timeout can ever target a
  freed reply.
- **Idle-timeout semantics preserved**: the timer is reset on the reply's
  `downloadProgress` / `uploadProgress` (via `resetTimeout()`), so a long but
  *progressing* transfer is never aborted — matching both the pre-2022 behavior
  and Qt's own re-arm-on-progress. A stalled connection still times out.
- The timer is armed in `adoptRequest` (when a reply actually starts driving the
  job — so queue-wait time in `JobQueue` doesn't consume the transfer timeout)
  and stopped in `slotFinished` and `abort()`.
- **`slotTimeout()`** sets `_timedout = true` and aborts the *reply* directly —
  **not** via `abort()`, which would set `_aborted` and defeat the existing
  `OperationCanceledError && !_aborted → _timedout` inference in `slotFinished`.
  Timeouts stay distinguishable from user cancels, so consumers
  (`GETFileJob`, `FetchServerSettings`, `PropagateUploadCommon`) are unchanged.
- **`setTimeout()`** restarts the timer if it is already running, so a late
  `PropagateUploadCommon::adjustLastJobTimeout()` takes effect immediately.

`AbstractCoreJobFactory::makeRequest` and the OAuth flow (`oauth.cpp`)
**intentionally keep** `setTransferTimeout`: they have simpler lifecycles and
were not implicated in the crash.

## Testing

Targeted regression suite — all green, **especially the timeout paths**, which
are now driven by the real job-owned timer (they would hang on the QtTest
watchdog if the timeout no longer fired):

- `RemoteDiscoveryTest` incl. `Vfs::Off:Timeout` (job timer fires at 1s;
  produces "Connection timed out", `timed out` flag set) ✓
- `ConnectionValidatorTest` (timeout rows, `httpTimeout = 1s`) ✓
- `OAuthTest` incl. `testTimeout` (out-of-scope `setTransferTimeout` path still
  works) ✓
- `JobQueueTest`, `DownloadTest`, `UploadResetTest`, `SyncMoveTest`,
  `SyncEngineTest`, `OAuthHtmlPageTest` ✓

`SyncEngineTest` exercises real upload/download progress driving `resetTimeout`
across many operations, confirming no timeout regression for active transfers.

The fake network manager's timeout emulation (keyed off
`request.transferTimeout()`) is left untouched: it is no longer needed for
`AbstractNetworkJob` requests (the real job timer drives them) but is still used
by the out-of-scope OAuth path.

**Manual Windows validation** (the definitive #12600 check, cannot run in CI):
with the bundled crash handler, start sync activity, sleep
(`rundll32 powrprof.dll,SetSuspendState 0,1,0`), wake, and confirm no crash ~1s
later — now with the reply-internal timer gone entirely.

## Relationship to #12602

#12602 is the minimal, low-risk hotfix (drain posted events before deleting an
abandoned reply). This PR removes the reply-internal timer that posts those
events in the first place. The two are independent diffs and can land in either
order; this branches from `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
