### PR TITLE
fix: Load OIDC prompt from the right value (#12597)

### DIFF
--- a/src/libsync/config/appconfig.cpp
+++ b/src/libsync/config/appconfig.cpp
@@ -68,14 +68,21 @@ OpenIdConfig AppConfig::loadOpenIdConfigFromSystemConfig(const QSettings &system
     QString clientId = system.value(OidcClientIdKey, QString()).toString();
     QString clientSecret = system.value(OidcClientSecretKey, QString()).toString();
     QString scopes = system.value(OidcScopesKey, QString()).toString();
-    QString prompt = system.value(OidcPortsKey, QString()).toString();
+    QString prompt = system.value(OidcPromptKey, QString()).toString();
 
     QVector<quint16> ports;
-    QVariant portsVar = system.value(OidcPortsKey, QString()).toString();
-    const auto parts = portsVar.toString().split(QLatin1Char(','), Qt::SkipEmptyParts);
-    for (const QString &p : parts) {
+    QVariant portsVar = system.value(OidcPortsKey);
+    QStringList parts;
+    if (portsVar.typeId() == QMetaType::QString) {
+        // Windows registry: "8080,8888" is a QString
+        parts = portsVar.toString().split(QLatin1Char(','), Qt::SkipEmptyParts);
+    } else {
+        // .ini files (Linux, macOS): "8080,8888" is a QStringlist
+        parts = portsVar.toStringList();
+    }
+    for (const QString &p : std::as_const(parts)) {
         bool ok = false;
-        const quint16 val = static_cast<quint16>(p.trimmed().toUInt(&ok));
+        quint16 val = p.trimmed().toUShort(&ok);
         if (ok) {
             ports.append(val);
         }

--- a/test/testappconfig.cpp
+++ b/test/testappconfig.cpp
@@ -5,9 +5,50 @@
 #include "libsync/owncloudtheme.h"
 #include "libsync/config/appconfig.h"
 
+static const std::string_view iniData{
+    "[Setup]\n"
+    "ServerUrl=https://cloud.example.com\n"
+    "AllowServerUrlChange=false\n"
+    "MoveToTrash=true\n"
+    "\n"
+    "[Updater]\n"
+    "SkipUpdateCheck=true\n"
+    "\n"
+    "[OpenIDConnect]\n"
+    "ClientId=your-client-id\n"
+    "ClientSecret=your-client-secret\n"
+    "Ports=8080,8443\n"
+    "Scopes=openid offline_access email profile\n"
+    "Prompt=select_account consent\n"
+};
+
 class TestAppConfig : public QObject
 {
     Q_OBJECT
+
+    QString _configPath;
+
+    bool createConfigFile(const QByteArray &data) {
+        auto theme = OCC::ownCloudTheme();
+        _configPath = OCC::AppConfig::configPath(QOperatingSystemVersion::Unknown, theme);
+
+        QString parent = QFileInfo(_configPath).path();
+        if (!QDir().mkpath(parent))
+            return false;
+
+        QFile iniFile(_configPath);
+        if (!iniFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qDebug()<<iniFile.errorString();
+            return false;
+        }
+        bool ok = iniFile.write(data) == data.length();
+        iniFile.close();
+        return ok;
+    }
+
+    void cleanupConfigFile() {
+        QFile::remove(_configPath);
+    }
 
 private Q_SLOTS:
     void testConfigPath()
@@ -16,6 +57,26 @@ private Q_SLOTS:
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::Windows, t), QString("HKEY_LOCAL_MACHINE\\Software\\Policies\\ownCloud\\ownCloud"));
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::MacOS, t), QString("/Library/Preferences/com.owncloud.desktopclient/ownCloud.ini"));
         QCOMPARE(OCC::AppConfig::configPath(QOperatingSystemVersion::Unknown, t), QString("/etc/ownCloud/ownCloud.ini"));
+    }
+
+    void testFromFile()
+    {
+        if (!OCC::Utility::isLinux()) {
+            QSKIP("This test only works on Linux");
+        }
+
+        auto cleanup = qScopeGuard([this]() { TestAppConfig::cleanupConfigFile(); });
+        QVERIFY(createConfigFile(QByteArray(iniData)));
+
+        OCC::AppConfig appConfig;
+        QVERIFY(!appConfig.allowServerUrlChange());
+
+        OCC::OpenIdConfig oidCfg = appConfig.openIdConfig();
+        QCOMPARE(oidCfg.clientId(), "your-client-id");
+        QCOMPARE(oidCfg.clientSecret(), "your-client-secret");
+        QCOMPARE(oidCfg.ports(), (QList<quint16>{8080, 8443}));
+        QCOMPARE(oidCfg.scopes(), "openid offline_access email profile");
+        QCOMPARE(oidCfg.prompt(), "select_account consent");
     }
 };
 


### PR DESCRIPTION
Also adds a test for Linux to read the values from an actual file.

(cherry picked from commit fb1c873a7d39a880779076f5fc34ad80c2cbf14e)