### PR TITLE
docs: replace dead drone build badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ownCloud Desktop Client
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/client/status.svg)](https://drone.owncloud.com/owncloud/client) [![Build Status](https://github.com/owncloud/client/workflows/ownCloud%20CI/badge.svg)](https://github.com/owncloud/client/actions)
+[![ownCloud CI](https://github.com/owncloud/client/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/owncloud/client/actions/workflows/main.yml?query=branch%3Amaster)
 
 ## Introduction
 


### PR DESCRIPTION
The `drone.owncloud.com` build badge in the README no longer resolves — CI moved to GitHub Actions, so the badge renders as broken/unknown on the project page.

Both badges on that line are replaced with a single one for the `ownCloud CI` workflow (`.github/workflows/main.yml`):

- file-path based (`actions/workflows/main.yml/badge.svg`) instead of the legacy workflow-*name* based URL, so a rename does not silently break it
- pinned to `?branch=master`, so it reports the status of master rather than the most recent run on any branch
- links to the filtered workflow run list instead of the generic `/actions` page

Verified the new badge URL returns `200 image/svg+xml` and currently renders `passing`.

No changelog entry: docs-only, no user-visible change to the client.

<img width="1432" height="767" alt="image" src="https://github.com/user-attachments/assets/19b36ad1-269a-4368-b309-3bc6c2202acd" />
