### PR TITLE
refactor: [DC-352] allow aborted syncs to finish before commencing final teardown routines

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -143,7 +143,7 @@ void Application::slotCleanup()
     // don't start async credentials jobs during shutdown
     AccountManager::instance()->save();
 
-    FolderMan::instance()->unloadAndDeleteAllFolders();
+    FolderMan::instance()->shutdown();
 
     // Remove the account from the account manager so it can be deleted.
     AccountManager::instance()->shutdown();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -164,11 +164,14 @@ Folder::Folder(const FolderDefinition &definition, AccountState *accountState, S
 Folder::~Folder()
 {
     // If wipeForRemoval() was called vfs has already shut down, and the journal has been closed.
-    // any sync the engine was running should have been paused/aborted in folderman as prep to remove the folder.
+    // any sync the engine that was running should have been paused/aborted in folderman as prep to remove the folder.
     // this feels very sketchy to me and I'm not really sure we should outsource all of that responsibility!
     // I think the main question is whether the child cleanup routines can finish in time before the pointers are deleted.
-    // this is especially true for sync engine (if it's running on dtr) but any of them could get humg up, in theory
-    // discuss with cohorts.
+
+    // Update: the assert below was being triggered on shutdown, as folderman was not aborting running syncs before deleting the folder!
+    // added sync abort + wait loop to ensure there is really no activity at the point we delete the folder. I think this is now
+    // fairly stable but in principle it substantiates my concern above.
+    // final eval needs to be a future todo.
     if (_vfs)
         _vfs->stop();
     if (_engine)
@@ -733,17 +736,17 @@ void Folder::slotTerminateSync(const QString &reason)
 
 void Folder::wipeForRemoval()
 {
-    // note we don't have to abort any running sync here as the folderman pauses the folder before this function is ever called.
-    Q_ASSERT(!isSyncRunning());
-
-    // I don't understand this logic so I'm removing it for now
-    // the setupError condition is related to failure to start vfs as far as I can tell.
-    // that doesn't mean the members don't exist, to the contrary! they are likely instantiated so let's
-    // let the wipe proceed.
-    // we can't acces those variables
-    // if (hasSetupError()) {
-    //   return;
-    // }
+    // note we don't have to abort any running sync here as the folderman aborts and pauses the folder before this function is ever called.
+    // however, using an assert I identified that at this stage the sync may still be running as it has not finished aborting yet.
+    // key to the delayed finish seems to be the OwncloudPropagator which runs it's abort async and has potentially many child jobs already in flight.
+    // replacing the old assert with waitLoop to let it really finish before proceeding with teardown.
+    // ensuring the aborts are really finished is required when we are permantently deleting the folder (either remove folder sync or delete account)
+    // so it's appropriate to add it here.
+    if (_engine && _engine->isSyncRunning()) {
+        QEventLoop waitLoop;
+        QObject::connect(_engine, &SyncEngine::finished, &waitLoop, &QEventLoop::quit);
+        waitLoop.exec();
+    }
 
     // prevent interaction with the db etc
     _vfsIsReady = false;
@@ -758,11 +761,7 @@ void Folder::wipeForRemoval()
     _journal->close(); // close the sync journal
 
     // Remove db and temporaries
-    // what is this? the engine's journal IS THE SAME as the folder member journal!!!!
-    // const QString stateDbFile = _engine->journal()->databaseFilePath();
     const QString stateDbFile = _journal->databaseFilePath();
-
-
     QFile file(stateDbFile);
     if (file.exists()) {
         if (!file.remove()) {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -126,7 +126,12 @@ FolderMan *FolderMan::instance()
 
 FolderMan::~FolderMan()
 {
-    unloadAndDeleteAllFolders();
+    // note we used to call shutdown here, but imo this is risky because it does quite a lot, and actually happens
+    // "too late" for it to be effective anyway. Instead we must ensure shutdown is called by the app when quit is
+    // underway.
+    // hopefully pointless reality check that shutdown was called before destruction:
+    Q_ASSERT(_folders.isEmpty());
+
     _instance = nullptr;
 }
 
@@ -147,10 +152,13 @@ QList<Folder *> FolderMan::foldersForAccount(const QUuid &accountId)
     return {};
 }
 
-void FolderMan::unloadAndDeleteAllFolders()
+void FolderMan::shutdown()
 {
     if (_folders.isEmpty())
         return;
+
+    // ensure no new syncs are started from this point on
+    setSyncEnabled(false);
 
     // notify interested parties *before* the folders are actually deleted - this is important in eg etagwatcher and the activity
     // tabs because they need the original folder pointers to update themselves. todo: review the use of the folder pointers in these
@@ -165,6 +173,13 @@ void FolderMan::unloadAndDeleteAllFolders()
     QList<QUuid> accountIds = _folders.keys();
     for (auto id : std::as_const(accountIds)) {
         for (Folder *folder : std::as_const(_folders[id])) {
+            // kill any running sync and wait for abort to finish
+            if (folder->isSyncRunning()) {
+                folder->slotTerminateSync(tr("Application shutting down"));
+                QEventLoop waitLoop;
+                QObject::connect(folder, &Folder::syncFinished, &waitLoop, &QEventLoop::quit);
+                waitLoop.exec();
+            }
             saveFolder(folder, settings);
             _socketApi->slotUnregisterPath(folder);
             folder->deleteLater();
@@ -193,8 +208,7 @@ std::optional<qsizetype> FolderMan::setupFoldersFromConfig()
 {
     setSyncEnabled(false);
 
-    // todo: #9
-    unloadAndDeleteAllFolders();
+    Q_ASSERT(_folders.isEmpty());
 
     auto settings = ConfigFile::makeQSettings();
     settings.beginGroup("Accounts");
@@ -931,7 +945,7 @@ void FolderMan::deleteFolderSync(Folder *f)
         f->slotTerminateSync(tr("Folder is about to be removed"));
     }
 
-    // this aborts any running sync so the sync engine should be idle 
+    // this prevents any new sync from starting
     f->setSyncPaused(true);
 
     // this function includes the stuff to remove the database files.

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -253,12 +253,18 @@ public:
     /// This slot will tell all sync engines to reload the sync options.
     void updateMoveToTrash(bool trashIt);
 
-    /** Simple save and remove all folders on shut down
+    /** Shut down routine
      *
-     *  emits folderListChanged
+     *  first disable syncs
+     *
+     *  emits folderListChanged to empty set
+     *
+     *  Then save and remove all folders.
+     *
+     *  Includes routine to abort any running sync and waits for the abort to finish, for safety.
      *
      */
-    void unloadAndDeleteAllFolders();
+    void shutdown();
 
     /**
      * If enabled is set to false, no new folders will start to sync.


### PR DESCRIPTION
see https://kiteworks.atlassian.net/browse/DC-352